### PR TITLE
Add unified way to create NSError

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04D32CB21FD62141000B123E /* MSIDError.m in Sources */ = {isa = PBXBuildFile; fileRef = 04D32CB11FD62141000B123E /* MSIDError.m */; };
+		04D32CB31FD62141000B123E /* MSIDError.m in Sources */ = {isa = PBXBuildFile; fileRef = 04D32CB11FD62141000B123E /* MSIDError.m */; };
 		23BDA6691FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */; };
 		23BDA66A1FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */; };
 		23BDA66E1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA66D1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m */; };
@@ -174,6 +176,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		04D32CB01FD6212F000B123E /* MSIDError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDError.h; sourceTree = "<group>"; };
+		04D32CB11FD62141000B123E /* MSIDError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDError.m; sourceTree = "<group>"; };
 		23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDDictionaryExtensionsTests.m; sourceTree = "<group>"; };
 		23BDA66C1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+MSIDExtensions.h"; sourceTree = "<group>"; };
 		23BDA66D1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableDictionary+MSIDExtensions.m"; sourceTree = "<group>"; };
@@ -558,6 +562,8 @@
 				B25A35681FC4D6B600C7FD43 /* logger */,
 				D62600091FBD305800EE4487 /* util */,
 				D6D9A4B91FBE6D1C00EFA430 /* IdentityCore.pch */,
+				04D32CB01FD6212F000B123E /* MSIDError.h */,
+				04D32CB11FD62141000B123E /* MSIDError.m */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -844,6 +850,7 @@
 				B20657B11FC91FD100412B7D /* MSIDTelemetryEventStrings.m in Sources */,
 				D6D9A4521FBD3FB800EFA430 /* NSURL+MSIDExtensions.m in Sources */,
 				9641B5251FCF3EEF00AFA0EC /* MSIDMacTokenCache.m in Sources */,
+				04D32CB31FD62141000B123E /* MSIDError.m in Sources */,
 				9641B52B1FCF3F3A00AFA0EC /* MSIDKeyedArchiverSerializer.m in Sources */,
 				B20657E11FCA208C00412B7D /* NSDate+MSIDExtensions.m in Sources */,
 				B20657BF1FC9254900412B7D /* MSIDTelemetryCacheEvent.m in Sources */,
@@ -913,6 +920,7 @@
 				B2C17AEC1FC796E60070A514 /* MSIDDeviceId.m in Sources */,
 				23BDA67A1FCE693800FE14BE /* MSIDKeychainUtil.m in Sources */,
 				B2C17AED1FC796FE0070A514 /* MSIDOAuth2Constants.m in Sources */,
+				04D32CB21FD62141000B123E /* MSIDError.m in Sources */,
 				B20657B01FC91FD100412B7D /* MSIDTelemetryEventStrings.m in Sources */,
 				D6D9A4511FBD3FB800EFA430 /* NSURL+MSIDExtensions.m in Sources */,
 				B20657E01FCA208C00412B7D /* NSDate+MSIDExtensions.m in Sources */,

--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+extern NSString *MSIDErrorDescriptionKey;
+extern NSString *MSIDOAuthErrorKey;
+extern NSString *MSIDOAuthSubErrorKey;
+
+/*!
+ ADAL and MSAL use different error domains and error codes.
+ When extracting shared code to common core, we unify those error domains
+ and error codes to be MSID error domains/codes and listed them below. Besides,
+ domain mapping and error code mapping should be added to ADALErrorConvertor
+ and MSALErrorConvetor in corresponding project.
+ */
+extern NSString * MSIDErrorDomain;
+
+typedef NS_ENUM(NSInteger, MSIDErrorCode)
+{
+    removeMeWhenThingsAreAdded = -10000,
+};
+

--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -29,8 +29,8 @@ extern NSString *MSIDOAuthSubErrorKey;
  ADAL and MSAL use different error domains and error codes.
  When extracting shared code to common core, we unify those error domains
  and error codes to be MSID error domains/codes and list them below. Besides,
- domain mapping and error code mapping should be added to ADALErrorConvertor
- and MSALErrorConvetor in corresponding project.
+ domain mapping and error code mapping should be added to ADAuthenticationErrorConverter
+ and MSALErrorConveter in corresponding project.
  */
 extern NSString * MSIDErrorDomain;
 

--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -32,7 +32,7 @@ extern NSString *MSIDOAuthSubErrorKey;
  domain mapping and error code mapping should be added to ADAuthenticationErrorConverter
  and MSALErrorConveter in corresponding project.
  */
-extern NSString * MSIDErrorDomain;
+extern NSString *MSIDErrorDomain;
 
 typedef NS_ENUM(NSInteger, MSIDErrorCode)
 {

--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -28,7 +28,7 @@ extern NSString *MSIDOAuthSubErrorKey;
 /*!
  ADAL and MSAL use different error domains and error codes.
  When extracting shared code to common core, we unify those error domains
- and error codes to be MSID error domains/codes and listed them below. Besides,
+ and error codes to be MSID error domains/codes and list them below. Besides,
  domain mapping and error code mapping should be added to ADALErrorConvertor
  and MSALErrorConvetor in corresponding project.
  */

--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -39,3 +39,5 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     removeMeWhenThingsAreAdded = -10000,
 };
 
+extern NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError);
+

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -27,14 +27,14 @@ NSString *MSIDOAuthSubErrorKey = @"MSIDOAuthSubErrorKey";
 
 NSString *MSIDErrorDomain = @"MSIDErrorDomain";
 
-NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError* underlyingError)
+NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError)
 {
-    NSMutableDictionary* userInfo = [NSMutableDictionary new];
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
     userInfo[MSIDErrorDescriptionKey] = errorDescription;
     userInfo[MSIDOAuthErrorKey] = oauthError;
     userInfo[MSIDOAuthSubErrorKey] = subError;
     userInfo[NSUnderlyingErrorKey]  = underlyingError;
     
-    return [NSError errorWithDomain:domain code:code userInfo:[NSDictionary dictionaryWithDictionary:userInfo]];
+    return [NSError errorWithDomain:domain code:code userInfo:userInfo];
 }
 

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+NSString *MSIDErrorDescriptionKey = @"MSIDErrorDescriptionKey";
+NSString *MSIDOAuthErrorKey = @"MSIDOAuthErrorKey";
+NSString *MSIDOAuthSubErrorKey = @"MSIDOAuthSubErrorKey";
+
+NSString *MSIDErrorDomain = @"MSIDErrorDomain";
+
+NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError* underlyingError)
+{
+    NSMutableDictionary* userInfo = [NSMutableDictionary new];
+    userInfo[MSIDErrorDescriptionKey] = errorDescription;
+    userInfo[MSIDOAuthErrorKey] = oauthError;
+    userInfo[MSIDOAuthSubErrorKey] = subError;
+    userInfo[NSUnderlyingErrorKey]  = underlyingError;
+    
+    return [NSError errorWithDomain:domain code:code userInfo:[NSDictionary dictionaryWithDictionary:userInfo]];
+}
+


### PR DESCRIPTION
The mapping between MSID error and MSALError is here: 
https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/244

Mapping between MSID error and ADAL error will be added later.