### PR TITLE
Implement MSIDKeyedArchiverSerializer

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		2321531B1FDA101900C6960D /* MSIDUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 232153191FDA101900C6960D /* MSIDUserInformation.m */; };
 		2321531C1FDA101900C6960D /* MSIDUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 232153191FDA101900C6960D /* MSIDUserInformation.m */; };
 		2321531E1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2321531D1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m */; };
+		2321532D1FDF4FD800C6960D /* MSIDTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2321532C1FDF4FD800C6960D /* MSIDTokenTests.m */; };
+		2321532E1FDF4FF200C6960D /* MSIDTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2321532C1FDF4FD800C6960D /* MSIDTokenTests.m */; };
 		23BDA6691FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */; };
 		23BDA66A1FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */; };
 		23BDA66E1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA66D1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m */; };
@@ -184,6 +186,7 @@
 		232153181FDA101900C6960D /* MSIDUserInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDUserInformation.h; sourceTree = "<group>"; };
 		232153191FDA101900C6960D /* MSIDUserInformation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDUserInformation.m; sourceTree = "<group>"; };
 		2321531D1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDKeyedArchiverSerializerTests.m; sourceTree = "<group>"; };
+		2321532C1FDF4FD800C6960D /* MSIDTokenTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDTokenTests.m; sourceTree = "<group>"; };
 		23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDDictionaryExtensionsTests.m; sourceTree = "<group>"; };
 		23BDA66C1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+MSIDExtensions.h"; sourceTree = "<group>"; };
 		23BDA66D1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableDictionary+MSIDExtensions.m"; sourceTree = "<group>"; };
@@ -586,6 +589,7 @@
 				23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */,
 				B20657C51FC9265800412B7D /* MSIDTelemetryExtensionsTests.m */,
 				2321531D1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m */,
+				2321532C1FDF4FD800C6960D /* MSIDTokenTests.m */,
 				D626FFE91FBD200A00EE4487 /* util */,
 				B2C17AEF1FC7A1BF0070A514 /* MSIDLoggerTests.m */,
 			);
@@ -833,6 +837,7 @@
 			files = (
 				23BDA6691FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */,
 				B2C17AF01FC7A1BF0070A514 /* MSIDLoggerTests.m in Sources */,
+				2321532D1FDF4FD800C6960D /* MSIDTokenTests.m in Sources */,
 				B20657C61FC9265800412B7D /* MSIDTelemetryExtensionsTests.m in Sources */,
 				2321531E1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m in Sources */,
 				D6D9A4BC1FBE712900EFA430 /* MSIDURLExtensionsTests.m in Sources */,
@@ -886,6 +891,7 @@
 				B2C17AF51FC7A6BD0070A514 /* MSIDTestLogger.m in Sources */,
 				B20E3CB31FC4FA550029C097 /* MSIDVersion.m in Sources */,
 				B20657D01FC92B8F00412B7D /* MSIDTelemetryUIEventTests.m in Sources */,
+				2321532E1FDF4FF200C6960D /* MSIDTokenTests.m in Sources */,
 				D6D9A4BF1FBE712900EFA430 /* MSIDStringExtensionsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		04D32CB21FD62141000B123E /* MSIDError.m in Sources */ = {isa = PBXBuildFile; fileRef = 04D32CB11FD62141000B123E /* MSIDError.m */; };
 		04D32CB31FD62141000B123E /* MSIDError.m in Sources */ = {isa = PBXBuildFile; fileRef = 04D32CB11FD62141000B123E /* MSIDError.m */; };
+		2321531B1FDA101900C6960D /* MSIDUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 232153191FDA101900C6960D /* MSIDUserInformation.m */; };
+		2321531C1FDA101900C6960D /* MSIDUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 232153191FDA101900C6960D /* MSIDUserInformation.m */; };
+		2321531E1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2321531D1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m */; };
 		23BDA6691FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */; };
 		23BDA66A1FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */; };
 		23BDA66E1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA66D1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m */; };
@@ -178,6 +181,9 @@
 /* Begin PBXFileReference section */
 		04D32CB01FD6212F000B123E /* MSIDError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDError.h; sourceTree = "<group>"; };
 		04D32CB11FD62141000B123E /* MSIDError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDError.m; sourceTree = "<group>"; };
+		232153181FDA101900C6960D /* MSIDUserInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDUserInformation.h; sourceTree = "<group>"; };
+		232153191FDA101900C6960D /* MSIDUserInformation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDUserInformation.m; sourceTree = "<group>"; };
+		2321531D1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDKeyedArchiverSerializerTests.m; sourceTree = "<group>"; };
 		23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDDictionaryExtensionsTests.m; sourceTree = "<group>"; };
 		23BDA66C1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+MSIDExtensions.h"; sourceTree = "<group>"; };
 		23BDA66D1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableDictionary+MSIDExtensions.m"; sourceTree = "<group>"; };
@@ -354,6 +360,8 @@
 				9641B5081FCF3E4400AFA0EC /* MSIDTokenCacheKey.m */,
 				9641B50C1FCF3E6400AFA0EC /* MSIDTokenCache.h */,
 				9641B50D1FCF3E6400AFA0EC /* MSIDTokenCache.m */,
+				232153181FDA101900C6960D /* MSIDUserInformation.h */,
+				232153191FDA101900C6960D /* MSIDUserInformation.m */,
 				9641B5261FCF3F2600AFA0EC /* serializers */,
 				9641B51D1FCF3EB800AFA0EC /* ios */,
 				9641B5211FCF3EE200AFA0EC /* mac */,
@@ -577,6 +585,7 @@
 				D6D9A4BA1FBE712900EFA430 /* MSIDURLExtensionsTests.m */,
 				23BDA6671FC7774300FE14BE /* MSIDDictionaryExtensionsTests.m */,
 				B20657C51FC9265800412B7D /* MSIDTelemetryExtensionsTests.m */,
+				2321531D1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m */,
 				D626FFE91FBD200A00EE4487 /* util */,
 				B2C17AEF1FC7A1BF0070A514 /* MSIDLoggerTests.m */,
 			);
@@ -825,6 +834,7 @@
 				23BDA6691FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */,
 				B2C17AF01FC7A1BF0070A514 /* MSIDLoggerTests.m in Sources */,
 				B20657C61FC9265800412B7D /* MSIDTelemetryExtensionsTests.m in Sources */,
+				2321531E1FDA1AF100C6960D /* MSIDKeyedArchiverSerializerTests.m in Sources */,
 				D6D9A4BC1FBE712900EFA430 /* MSIDURLExtensionsTests.m in Sources */,
 				B2C17AF41FC7A6BC0070A514 /* MSIDTestLogger.m in Sources */,
 				B20E3CB21FC4FA550029C097 /* MSIDVersion.m in Sources */,
@@ -856,6 +866,7 @@
 				B20657BF1FC9254900412B7D /* MSIDTelemetryCacheEvent.m in Sources */,
 				B2908C091FCA29EB00AFE98E /* MSIDTelemetryBaseEvent.m in Sources */,
 				D62600171FBD380500EE4487 /* NSDictionary+MSIDExtensions.m in Sources */,
+				2321531C1FDA101900C6960D /* MSIDUserInformation.m in Sources */,
 				B2893CB11FCF6A8C00E348E9 /* NSMutableDictionary+MSIDExtensions.m in Sources */,
 				B20657CA1FC926B200412B7D /* MSIDTelemetryHttpEvent.m in Sources */,
 				B20657C31FC9262700412B7D /* NSString+MSIDTelemetryExtensions.m in Sources */,
@@ -926,6 +937,7 @@
 				B20657E01FCA208C00412B7D /* NSDate+MSIDExtensions.m in Sources */,
 				B20657BE1FC9254800412B7D /* MSIDTelemetryCacheEvent.m in Sources */,
 				B2908C081FCA29EB00AFE98E /* MSIDTelemetryBaseEvent.m in Sources */,
+				2321531B1FDA101900C6960D /* MSIDUserInformation.m in Sources */,
 				D62600161FBD380500EE4487 /* NSDictionary+MSIDExtensions.m in Sources */,
 				B20657C91FC926B200412B7D /* MSIDTelemetryHttpEvent.m in Sources */,
 				B20657C41FC9262800412B7D /* NSString+MSIDTelemetryExtensions.m in Sources */,
@@ -964,6 +976,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4E961FC3626A00CD70C5 /* identitycore__tests__ios.xcconfig */;
 			buildSettings = {
+				GCC_OPTIMIZATION_LEVEL = 0;
 			};
 			name = Debug;
 		};

--- a/IdentityCore/IdentityCore.xcodeproj/xcshareddata/xcschemes/IdentityCore iOS.xcscheme
+++ b/IdentityCore/IdentityCore.xcodeproj/xcshareddata/xcschemes/IdentityCore iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0910"
-   version = "1.3">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -56,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/IdentityCore/src/cache/MSIDToken.h
+++ b/IdentityCore/src/cache/MSIDToken.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSInteger, MSIDTokenType)
     MSIDTokenTypeRefreshToken
 };
 
-@interface MSIDToken : NSObject <NSCoding>
+@interface MSIDToken : NSObject <NSSecureCoding>
 
 @property (readonly) NSString *token;
 @property (readonly) NSString *idToken;

--- a/IdentityCore/src/cache/MSIDToken.h
+++ b/IdentityCore/src/cache/MSIDToken.h
@@ -23,22 +23,22 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(uint32_t, MSIDTokenType)
+typedef NS_ENUM(NSInteger, MSIDTokenType)
 {
-    MSIDTokenTypeAccessToken =  'acTk',
-    MSIDTokenTypeRefreshToken = 'rfTk'
+    MSIDTokenTypeAccessToken,
+    MSIDTokenTypeRefreshToken
 };
 
-@interface MSIDToken : NSObject
+@interface MSIDToken : NSObject <NSCoding>
 
 @property (readonly) NSString *token;
-
 @property (readonly) NSString *idToken;
 @property (readonly) NSDate *expiresOn;
 @property (readonly) NSString *familyId;
 @property (readonly) NSDictionary *clientInfo;
 @property (readonly) NSDictionary *additionalServerInfo;
-
 @property (readonly) MSIDTokenType tokenType;
+
+- (BOOL)isEqualToToken:(MSIDToken *)token;
 
 @end

--- a/IdentityCore/src/cache/MSIDToken.h
+++ b/IdentityCore/src/cache/MSIDToken.h
@@ -38,6 +38,10 @@ typedef NS_ENUM(NSInteger, MSIDTokenType)
 @property (readonly) NSDictionary *clientInfo;
 @property (readonly) NSDictionary *additionalServerInfo;
 @property (readonly) MSIDTokenType tokenType;
+@property (readonly) NSString *resource;
+@property (readonly) NSString *authority;
+@property (readonly) NSString *clientId;
+@property (readonly) NSData *sessionKey;
 
 - (BOOL)isEqualToToken:(MSIDToken *)token;
 

--- a/IdentityCore/src/cache/MSIDToken.h
+++ b/IdentityCore/src/cache/MSIDToken.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSInteger, MSIDTokenType)
 @property (readonly) NSString *resource;
 @property (readonly) NSString *authority;
 @property (readonly) NSString *clientId;
+@property (readonly) NSOrderedSet<NSString *> *scopes;
 
 - (BOOL)isEqualToToken:(MSIDToken *)token;
 

--- a/IdentityCore/src/cache/MSIDToken.h
+++ b/IdentityCore/src/cache/MSIDToken.h
@@ -41,7 +41,6 @@ typedef NS_ENUM(NSInteger, MSIDTokenType)
 @property (readonly) NSString *resource;
 @property (readonly) NSString *authority;
 @property (readonly) NSString *clientId;
-@property (readonly) NSData *sessionKey;
 
 - (BOOL)isEqualToToken:(MSIDToken *)token;
 

--- a/IdentityCore/src/cache/MSIDToken.m
+++ b/IdentityCore/src/cache/MSIDToken.m
@@ -113,7 +113,7 @@
     }
     
     _additionalServerInfo = [coder decodeObjectOfClass:[NSDictionary class] forKey:@"additionalServer"];
-    _clientInfo = [coder decodeObjectOfClass:[NSMutableDictionary class] forKey:@"additionalClient"];
+    _clientInfo = [coder decodeObjectOfClass:[NSMutableDictionary class] forKey:@"clientInfo"];
     _idToken = [[coder decodeObjectOfClass:[MSIDUserInformation class] forKey:@"userInformation"] rawIdToken];
     _resource = [coder decodeObjectOfClass:[NSString class] forKey:@"resource"];
     _authority = [coder decodeObjectOfClass:[NSString class] forKey:@"authority"];
@@ -136,7 +136,7 @@
         [coder encodeObject:_token forKey:@"accessToken"];
     }
     
-    [coder encodeObject:_clientInfo forKey:@"additionalClient"];
+    [coder encodeObject:_clientInfo forKey:@"clientInfo"];
     [coder encodeObject:_additionalServerInfo forKey:@"additionalServer"];
     
     MSIDUserInformation *userInformation = [MSIDUserInformation new];

--- a/IdentityCore/src/cache/MSIDToken.m
+++ b/IdentityCore/src/cache/MSIDToken.m
@@ -83,7 +83,12 @@
     return hash;
 }
 
-#pragma mark - NSCoding
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {

--- a/IdentityCore/src/cache/MSIDToken.m
+++ b/IdentityCore/src/cache/MSIDToken.m
@@ -117,8 +117,6 @@
     _clientId = [coder decodeObjectOfClass:[NSString class] forKey:@"clientId"];
     _sessionKey = [coder decodeObjectOfClass:[NSData class] forKey:@"sessionKey"];
     
-//    _accessTokenType = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"accessTokenType"]; // Bearer?
-    
     return self;
 }
 
@@ -147,8 +145,6 @@
     [coder encodeObject:_authority forKey:@"authority"];
     [coder encodeObject:_clientId forKey:@"clientId"];
     [coder encodeObject:_sessionKey forKey:@"sessionKey"];
-    
-//    [aCoder encodeObject:_accessTokenType forKey:@"accessTokenType"];
 }
 
 @end

--- a/IdentityCore/src/cache/MSIDToken.m
+++ b/IdentityCore/src/cache/MSIDToken.m
@@ -115,7 +115,7 @@
     }
     
     _additionalServerInfo = [coder decodeObjectOfClass:[NSDictionary class] forKey:@"additionalServer"];
-    _clientInfo = [coder decodeObjectOfClass:[NSMutableDictionary class] forKey:@"clientInfo"];
+    _clientInfo = [coder decodeObjectOfClass:[NSDictionary class] forKey:@"clientInfo"];
     _idToken = [[coder decodeObjectOfClass:[MSIDUserInformation class] forKey:@"userInformation"] rawIdToken];
     _resource = [coder decodeObjectOfClass:[NSString class] forKey:@"resource"];
     _authority = [coder decodeObjectOfClass:[NSString class] forKey:@"authority"];

--- a/IdentityCore/src/cache/MSIDToken.m
+++ b/IdentityCore/src/cache/MSIDToken.m
@@ -44,7 +44,6 @@
     result &= (!self.resource && !token.resource) || [self.resource isEqualToString:token.resource];
     result &= (!self.authority && !token.authority) || [self.authority isEqualToString:token.authority];
     result &= (!self.clientId && !token.clientId) || [self.clientId isEqualToString:token.clientId];
-    result &= (!self.sessionKey && !token.sessionKey) || [self.sessionKey isEqualToData:token.sessionKey];
     
     return result;
 }
@@ -78,7 +77,6 @@
     hash ^= self.resource.hash;
     hash ^= self.authority.hash;
     hash ^= self.clientId.hash;
-    hash ^= self.sessionKey.hash;
     
     return hash;
 }
@@ -120,7 +118,6 @@
     _resource = [coder decodeObjectOfClass:[NSString class] forKey:@"resource"];
     _authority = [coder decodeObjectOfClass:[NSString class] forKey:@"authority"];
     _clientId = [coder decodeObjectOfClass:[NSString class] forKey:@"clientId"];
-    _sessionKey = [coder decodeObjectOfClass:[NSData class] forKey:@"sessionKey"];
     
     return self;
 }
@@ -149,7 +146,6 @@
     [coder encodeObject:_resource forKey:@"resource"];
     [coder encodeObject:_authority forKey:@"authority"];
     [coder encodeObject:_clientId forKey:@"clientId"];
-    [coder encodeObject:_sessionKey forKey:@"sessionKey"];
 }
 
 @end

--- a/IdentityCore/src/cache/MSIDToken.m
+++ b/IdentityCore/src/cache/MSIDToken.m
@@ -41,18 +41,15 @@
     result &= (!self.clientInfo && !token.clientInfo) || [self.clientInfo isEqualToDictionary:token.clientInfo];
     result &= (!self.additionalServerInfo && !token.additionalServerInfo) || [self.additionalServerInfo isEqualToDictionary:token.additionalServerInfo];
     result &= self.tokenType == token.tokenType;
+    result &= (!self.resource && !token.resource) || [self.resource isEqualToString:token.resource];
+    result &= (!self.authority && !token.authority) || [self.authority isEqualToString:token.authority];
+    result &= (!self.clientId && !token.clientId) || [self.clientId isEqualToString:token.clientId];
+    result &= (!self.sessionKey && !token.sessionKey) || [self.sessionKey isEqualToData:token.sessionKey];
     
     return result;
 }
 
 #pragma mark - NSObject
-
-+ (void)load
-{
-    // Maintain backward compatibility with ADAL.
-    [NSKeyedArchiver setClassName:@"ADTokenCacheStoreItem" forClass:self];
-    [NSKeyedUnarchiver setClass:self forClassName:@"ADTokenCacheStoreItem"];
-}
 
 - (BOOL)isEqual:(id)object
 {
@@ -68,6 +65,7 @@
     
     return [self isEqualToToken:(MSIDToken *)object];
 }
+
 - (NSUInteger)hash
 {
     NSUInteger hash = self.token.hash;
@@ -77,6 +75,10 @@
     hash ^= self.clientInfo.hash;
     hash ^= self.additionalServerInfo.hash;
     hash ^= self.tokenType;
+    hash ^= self.resource.hash;
+    hash ^= self.authority.hash;
+    hash ^= self.clientId.hash;
+    hash ^= self.sessionKey.hash;
     
     return hash;
 }
@@ -110,12 +112,12 @@
     _additionalServerInfo = [coder decodeObjectOfClass:[NSDictionary class] forKey:@"additionalServer"];
     _clientInfo = [coder decodeObjectOfClass:[NSMutableDictionary class] forKey:@"additionalClient"];
     _idToken = [[coder decodeObjectOfClass:[MSIDUserInformation class] forKey:@"userInformation"] rawIdToken];
+    _resource = [coder decodeObjectOfClass:[NSString class] forKey:@"resource"];
+    _authority = [coder decodeObjectOfClass:[NSString class] forKey:@"authority"];
+    _clientId = [coder decodeObjectOfClass:[NSString class] forKey:@"clientId"];
+    _sessionKey = [coder decodeObjectOfClass:[NSData class] forKey:@"sessionKey"];
     
-//    _resource = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"resource"];
-//    _authority = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"authority"];
-//    _clientId = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"clientId"];
-//    _accessTokenType = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"accessTokenType"];
-//    _sessionKey = [aDecoder decodeObjectOfClass:[NSData class] forKey:@"sessionKey"];
+//    _accessTokenType = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"accessTokenType"]; // Bearer?
     
     return self;
 }
@@ -141,11 +143,12 @@
     userInformation.rawIdToken = self.idToken;
     [coder encodeObject:userInformation forKey:@"userInformation"];
     
-//    [aCoder encodeObject:_resource forKey:@"resource"];
-//    [aCoder encodeObject:_authority forKey:@"authority"];
-//    [aCoder encodeObject:_clientId forKey:@"clientId"];
+    [coder encodeObject:_resource forKey:@"resource"];
+    [coder encodeObject:_authority forKey:@"authority"];
+    [coder encodeObject:_clientId forKey:@"clientId"];
+    [coder encodeObject:_sessionKey forKey:@"sessionKey"];
+    
 //    [aCoder encodeObject:_accessTokenType forKey:@"accessTokenType"];
-//    [aCoder encodeObject:_sessionKey forKey:@"sessionKey"];
 }
 
 @end

--- a/IdentityCore/src/cache/MSIDToken.m
+++ b/IdentityCore/src/cache/MSIDToken.m
@@ -44,6 +44,7 @@
     result &= (!self.resource && !token.resource) || [self.resource isEqualToString:token.resource];
     result &= (!self.authority && !token.authority) || [self.authority isEqualToString:token.authority];
     result &= (!self.clientId && !token.clientId) || [self.clientId isEqualToString:token.clientId];
+    result &= (!self.scopes && !token.scopes) || [self.scopes isEqualToOrderedSet:token.scopes];
     
     return result;
 }
@@ -77,6 +78,7 @@
     hash ^= self.resource.hash;
     hash ^= self.authority.hash;
     hash ^= self.clientId.hash;
+    hash ^= self.scopes.hash;
     
     return hash;
 }
@@ -118,6 +120,7 @@
     _resource = [coder decodeObjectOfClass:[NSString class] forKey:@"resource"];
     _authority = [coder decodeObjectOfClass:[NSString class] forKey:@"authority"];
     _clientId = [coder decodeObjectOfClass:[NSString class] forKey:@"clientId"];
+    _scopes = [coder decodeObjectOfClass:[NSOrderedSet class] forKey:@"scopes"];
     
     return self;
 }
@@ -146,6 +149,7 @@
     [coder encodeObject:_resource forKey:@"resource"];
     [coder encodeObject:_authority forKey:@"authority"];
     [coder encodeObject:_clientId forKey:@"clientId"];
+    [coder encodeObject:_scopes forKey:@"scopes"];
 }
 
 @end

--- a/IdentityCore/src/cache/MSIDToken.m
+++ b/IdentityCore/src/cache/MSIDToken.m
@@ -22,7 +22,130 @@
 // THE SOFTWARE.
 
 #import "MSIDToken.h"
+#import "MSIDUserInformation.h"
 
 @implementation MSIDToken
+
+- (BOOL)isEqualToToken:(MSIDToken *)token
+{
+    if (!token)
+    {
+        return NO;
+    }
+    
+    BOOL result = YES;
+    result &= (!self.token && !token.token) || [self.token isEqualToString:token.token];
+    result &= (!self.idToken && !token.idToken) || [self.idToken isEqualToString:token.idToken];
+    result &= (!self.expiresOn && !token.expiresOn) || [self.expiresOn isEqualToDate:token.expiresOn];
+    result &= (!self.familyId && !token.familyId) || [self.familyId isEqualToString:token.familyId];
+    result &= (!self.clientInfo && !token.clientInfo) || [self.clientInfo isEqualToDictionary:token.clientInfo];
+    result &= (!self.additionalServerInfo && !token.additionalServerInfo) || [self.additionalServerInfo isEqualToDictionary:token.additionalServerInfo];
+    result &= self.tokenType == token.tokenType;
+    
+    return result;
+}
+
+#pragma mark - NSObject
+
++ (void)load
+{
+    // Maintain backward compatibility with ADAL.
+    [NSKeyedArchiver setClassName:@"ADTokenCacheStoreItem" forClass:self];
+    [NSKeyedUnarchiver setClass:self forClassName:@"ADTokenCacheStoreItem"];
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+    {
+        return YES;
+    }
+    
+    if (![object isKindOfClass:MSIDToken.class])
+    {
+        return NO;
+    }
+    
+    return [self isEqualToToken:(MSIDToken *)object];
+}
+- (NSUInteger)hash
+{
+    NSUInteger hash = self.token.hash;
+    hash ^= self.idToken.hash;
+    hash ^= self.expiresOn.hash;
+    hash ^= self.familyId.hash;
+    hash ^= self.clientInfo.hash;
+    hash ^= self.additionalServerInfo.hash;
+    hash ^= self.tokenType;
+    
+    return hash;
+}
+
+#pragma mark - NSCoding
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    if (!(self = [super init]))
+    {
+        return nil;
+    }
+    
+    _familyId = [coder decodeObjectOfClass:[NSString class] forKey:@"familyId"];
+    _expiresOn = [coder decodeObjectOfClass:[NSDate class] forKey:@"expiresOn"];
+    
+    NSString *accessToken = [coder decodeObjectOfClass:[NSString class] forKey:@"accessToken"];
+    NSString *refreshToken = [coder decodeObjectOfClass:[NSString class] forKey:@"refreshToken"];
+    
+    if (refreshToken)
+    {
+        _token = refreshToken;
+        _tokenType = MSIDTokenTypeRefreshToken;
+    }
+    else
+    {
+        _token = accessToken;
+        _tokenType = MSIDTokenTypeAccessToken;
+    }
+    
+    _additionalServerInfo = [coder decodeObjectOfClass:[NSDictionary class] forKey:@"additionalServer"];
+    _clientInfo = [coder decodeObjectOfClass:[NSMutableDictionary class] forKey:@"additionalClient"];
+    _idToken = [[coder decodeObjectOfClass:[MSIDUserInformation class] forKey:@"userInformation"] rawIdToken];
+    
+//    _resource = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"resource"];
+//    _authority = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"authority"];
+//    _clientId = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"clientId"];
+//    _accessTokenType = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"accessTokenType"];
+//    _sessionKey = [aDecoder decodeObjectOfClass:[NSData class] forKey:@"sessionKey"];
+    
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [coder encodeObject:_familyId forKey:@"familyId"];
+    [coder encodeObject:_expiresOn forKey:@"expiresOn"];
+    
+    if (self.tokenType == MSIDTokenTypeRefreshToken)
+    {
+        [coder encodeObject:_token forKey:@"refreshToken"];
+    }
+    else
+    {
+        [coder encodeObject:_token forKey:@"accessToken"];
+    }
+    
+    [coder encodeObject:_clientInfo forKey:@"additionalClient"];
+    [coder encodeObject:_additionalServerInfo forKey:@"additionalServer"];
+    
+    MSIDUserInformation *userInformation = [MSIDUserInformation new];
+    userInformation.rawIdToken = self.idToken;
+    [coder encodeObject:userInformation forKey:@"userInformation"];
+    
+//    [aCoder encodeObject:_resource forKey:@"resource"];
+//    [aCoder encodeObject:_authority forKey:@"authority"];
+//    [aCoder encodeObject:_clientId forKey:@"clientId"];
+//    [aCoder encodeObject:_accessTokenType forKey:@"accessTokenType"];
+//    [aCoder encodeObject:_sessionKey forKey:@"sessionKey"];
+}
 
 @end

--- a/IdentityCore/src/cache/MSIDUserInformation.h
+++ b/IdentityCore/src/cache/MSIDUserInformation.h
@@ -23,7 +23,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface MSIDUserInformation : NSObject <NSCoding>
+@interface MSIDUserInformation : NSObject <NSSecureCoding>
 
 @property (nonatomic) NSString *rawIdToken;
 

--- a/IdentityCore/src/cache/MSIDUserInformation.h
+++ b/IdentityCore/src/cache/MSIDUserInformation.h
@@ -1,10 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
 //
-//  MSIDUserInformation.h
-//  IdentityCore
+// This code is licensed under the MIT License.
 //
-//  Created by Sergey Demchenko on 12/7/17.
-//  Copyright © 2017 Microsoft. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 

--- a/IdentityCore/src/cache/MSIDUserInformation.h
+++ b/IdentityCore/src/cache/MSIDUserInformation.h
@@ -1,0 +1,15 @@
+//
+//  MSIDUserInformation.h
+//  IdentityCore
+//
+//  Created by Sergey Demchenko on 12/7/17.
+//  Copyright © 2017 Microsoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MSIDUserInformation : NSObject <NSCoding>
+
+@property (nonatomic) NSString *rawIdToken;
+
+@end

--- a/IdentityCore/src/cache/MSIDUserInformation.m
+++ b/IdentityCore/src/cache/MSIDUserInformation.m
@@ -1,10 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
 //
-//  MSIDUserInformation.m
-//  IdentityCore
+// This code is licensed under the MIT License.
 //
-//  Created by Sergey Demchenko on 12/7/17.
-//  Copyright © 2017 Microsoft. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import "MSIDUserInformation.h"
 

--- a/IdentityCore/src/cache/MSIDUserInformation.m
+++ b/IdentityCore/src/cache/MSIDUserInformation.m
@@ -1,0 +1,32 @@
+//
+//  MSIDUserInformation.m
+//  IdentityCore
+//
+//  Created by Sergey Demchenko on 12/7/17.
+//  Copyright © 2017 Microsoft. All rights reserved.
+//
+
+#import "MSIDUserInformation.h"
+
+@implementation MSIDUserInformation
+
+#pragma mark - NSCoding
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    if (!(self = [super init]))
+    {
+        return nil;
+    }
+    
+    _rawIdToken = [coder decodeObjectOfClass:[NSString class] forKey:@"rawIdToken"];
+    
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [coder encodeObject:_rawIdToken forKey:@"rawIdToken"];
+}
+
+@end

--- a/IdentityCore/src/cache/MSIDUserInformation.m
+++ b/IdentityCore/src/cache/MSIDUserInformation.m
@@ -25,7 +25,12 @@
 
 @implementation MSIDUserInformation
 
-#pragma mark - NSCoding
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {

--- a/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
+++ b/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
@@ -35,13 +35,27 @@
 
 - (NSData *)serialize:(MSIDToken *)token
 {
-    return [NSKeyedArchiver archivedDataWithRootObject:token];
+    NSMutableData *data = [NSMutableData data];
+    
+    // In order to customize the archiving process Apple recommends to create an instance of the archiver and
+    // customize it (instead of using share NSKeyedArchiver).
+    // See here: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Archiving/Articles/creating.html
+    NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
+    // Maintain backward compatibility with ADAL.
+    [archiver setClassName:@"ADUserInformation" forClass:MSIDUserInformation.class];
+    [archiver setClassName:@"ADTokenCacheStoreItem" forClass:MSIDToken.class];
+    [archiver encodeObject:token forKey:NSKeyedArchiveRootObjectKey];
+    [archiver finishEncoding];
+    
+    return data;
 }
 
 - (MSIDToken *)deserialize:(NSData *)data
 {
     NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
+    // Maintain backward compatibility with ADAL.
     [unarchiver setClass:MSIDUserInformation.class forClassName:@"ADUserInformation"];
+    [unarchiver setClass:MSIDToken.class forClassName:@"ADTokenCacheStoreItem"];
     MSIDToken *token = [unarchiver decodeObjectOfClass:MSIDToken.class forKey:NSKeyedArchiveRootObjectKey];
     [unarchiver finishDecoding];
     

--- a/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
+++ b/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
@@ -23,17 +23,29 @@
 
 #import "MSIDKeyedArchiverSerializer.h"
 #import "MSIDToken.h"
+#import "MSIDUserInformation.h"
+
+@interface MSIDKeyedArchiverSerializer ()
+
+@end
 
 @implementation MSIDKeyedArchiverSerializer
 
+#pragma mark - MSIDTokenSerializer
+
 - (NSData *)serialize:(MSIDToken *)token
 {
-    return nil;
+    return [NSKeyedArchiver archivedDataWithRootObject:token];
 }
 
 - (MSIDToken *)deserialize:(NSData *)data
 {
-    return nil;
+    NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
+    [unarchiver setClass:MSIDUserInformation.class forClassName:@"ADUserInformation"];
+    MSIDToken *token = [unarchiver decodeObjectOfClass:MSIDToken.class forKey:NSKeyedArchiveRootObjectKey];
+    [unarchiver finishDecoding];
+    
+    return token;
 }
 
 @end

--- a/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
+++ b/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
@@ -57,6 +57,11 @@
 
 - (MSIDToken *)deserialize:(NSData *)data
 {
+    if (!data)
+    {
+        return nil;
+    }
+    
     NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
     // Maintain backward compatibility with ADAL.
     [unarchiver setClass:MSIDUserInformation.class forClassName:@"ADUserInformation"];

--- a/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
+++ b/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
@@ -35,6 +35,11 @@
 
 - (NSData *)serialize:(MSIDToken *)token
 {
+    if (!token)
+    {
+        return nil;
+    }
+    
     NSMutableData *data = [NSMutableData data];
     
     // In order to customize the archiving process Apple recommends to create an instance of the archiver and

--- a/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
+++ b/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
@@ -1,10 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
 //
-//  MSIDKeyedArchiverSerializerTests.m
-//  IdentityCore
+// This code is licensed under the MIT License.
 //
-//  Created by Sergey Demchenko on 12/7/17.
-//  Copyright © 2017 Microsoft. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
 #import "MSIDKeyedArchiverSerializer.h"

--- a/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
+++ b/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
@@ -29,7 +29,6 @@
 - (void)test_whenSerializeToken_shouldReturnSameTokenOnDeserialize
 {
     MSIDKeyedArchiverSerializer *serializer = [MSIDKeyedArchiverSerializer new];
-    
     MSIDToken *expectedToken = [MSIDToken new];
     [expectedToken setValue:@"access token value" forKey:@"token"];
     [expectedToken setValue:@"id token value" forKey:@"idToken"];
@@ -37,6 +36,7 @@
     [expectedToken setValue:@"familyId value" forKey:@"familyId"];
     [expectedToken setValue:@{@"key" : @"value"} forKey:@"clientInfo"];
     [expectedToken setValue:@{@"key2" : @"value2"} forKey:@"additionalServerInfo"];
+    [expectedToken setValue:[@"test" dataUsingEncoding:NSUTF8StringEncoding] forKey:@"sessionKey"];
     
     NSData *data = [serializer serialize:expectedToken];
     MSIDToken *resultToken = [serializer deserialize:data];

--- a/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
+++ b/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
@@ -63,4 +63,23 @@
     XCTAssertNotNil(data);
 }
 
+- (void)testDeserialize_whenDataNilNil_shouldReturnNil
+{
+    MSIDKeyedArchiverSerializer *serializer = [MSIDKeyedArchiverSerializer new];
+    
+    MSIDToken *token = [serializer deserialize:nil];
+    
+    XCTAssertNil(token);
+}
+
+- (void)testDeserialize_whenDataInvalid_shouldReturnNil
+{
+    MSIDKeyedArchiverSerializer *serializer = [MSIDKeyedArchiverSerializer new];
+    NSData *data = [@"some" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    MSIDToken *token = [serializer deserialize:data];
+    
+    XCTAssertNil(token);
+}
+
 @end

--- a/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
+++ b/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
@@ -1,0 +1,48 @@
+//
+//  MSIDKeyedArchiverSerializerTests.m
+//  IdentityCore
+//
+//  Created by Sergey Demchenko on 12/7/17.
+//  Copyright © 2017 Microsoft. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "MSIDKeyedArchiverSerializer.h"
+#import "MSIDToken.h"
+
+@interface MSIDKeyedArchiverSerializerTests : XCTestCase
+
+@end
+
+@implementation MSIDKeyedArchiverSerializerTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)test_whenSerializeToken_shouldReturnSameTokenOnDeserialize
+{
+    MSIDKeyedArchiverSerializer *serializer = [MSIDKeyedArchiverSerializer new];
+    
+    MSIDToken *expectedToken = [MSIDToken new];
+    [expectedToken setValue:@"access token value" forKey:@"token"];
+    [expectedToken setValue:@"id token value" forKey:@"idToken"];
+    [expectedToken setValue:[NSDate new] forKey:@"expiresOn"];
+    [expectedToken setValue:@"familyId value" forKey:@"familyId"];
+    [expectedToken setValue:@{@"key" : @"value"} forKey:@"clientInfo"];
+    [expectedToken setValue:@{@"key2" : @"value2"} forKey:@"additionalServerInfo"];
+    
+    NSData *data = [serializer serialize:expectedToken];
+    MSIDToken *resultToken = [serializer deserialize:data];
+    
+    XCTAssertNotNil(data);
+    XCTAssertEqualObjects(resultToken, expectedToken);
+}
+
+@end

--- a/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
+++ b/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
@@ -36,7 +36,6 @@
     [expectedToken setValue:@"familyId value" forKey:@"familyId"];
     [expectedToken setValue:@{@"key" : @"value"} forKey:@"clientInfo"];
     [expectedToken setValue:@{@"key2" : @"value2"} forKey:@"additionalServerInfo"];
-    [expectedToken setValue:[@"test" dataUsingEncoding:NSUTF8StringEncoding] forKey:@"sessionKey"];
     
     NSData *data = [serializer serialize:expectedToken];
     MSIDToken *resultToken = [serializer deserialize:data];

--- a/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
+++ b/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
@@ -51,6 +51,9 @@
     [expectedToken setValue:@"familyId value" forKey:@"familyId"];
     [expectedToken setValue:@{@"key" : @"value"} forKey:@"clientInfo"];
     [expectedToken setValue:@{@"key2" : @"value2"} forKey:@"additionalServerInfo"];
+    [expectedToken setValue:@"some resource" forKey:@"resource"];
+    [expectedToken setValue:@"some authority" forKey:@"authority"];
+    [expectedToken setValue:@"some clientId" forKey:@"clientId"];
     
     NSData *data = [serializer serialize:expectedToken];
     MSIDToken *resultToken = [serializer deserialize:data];

--- a/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
+++ b/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
@@ -45,4 +45,22 @@
     XCTAssertEqualObjects(resultToken, expectedToken);
 }
 
+- (void)testSerialize_whenTokenNil_shouldReturnNil
+{
+    MSIDKeyedArchiverSerializer *serializer = [MSIDKeyedArchiverSerializer new];
+    
+    NSData *data = [serializer serialize:nil];
+    
+    XCTAssertNil(data);
+}
+
+- (void)testSerialize_whenTokenWithDefaultProperties_shouldReturnNotNilData
+{
+    MSIDKeyedArchiverSerializer *serializer = [MSIDKeyedArchiverSerializer new];
+    
+    NSData *data = [serializer serialize:[MSIDToken new]];
+    
+    XCTAssertNotNil(data);
+}
+
 @end

--- a/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
+++ b/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
@@ -54,6 +54,7 @@
     [expectedToken setValue:@"some resource" forKey:@"resource"];
     [expectedToken setValue:@"some authority" forKey:@"authority"];
     [expectedToken setValue:@"some clientId" forKey:@"clientId"];
+    [expectedToken setValue:[[NSOrderedSet alloc] initWithArray:@[@1, @2]] forKey:@"scopes"];
     
     NSData *data = [serializer serialize:expectedToken];
     MSIDToken *resultToken = [serializer deserialize:data];

--- a/IdentityCore/tests/MSIDTokenTests.m
+++ b/IdentityCore/tests/MSIDTokenTests.m
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDToken.h"
+
+@interface MSIDTokenTests : XCTestCase
+
+@end
+
+@implementation MSIDTokenTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+#pragma mark - isEqual tests
+
+- (void)testIsEqual_whenAllPropertiesAreEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [self createToken];
+    MSIDToken *rhs = [self createToken];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenTokenIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"token 1" forKey:@"token"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"token 2" forKey:@"token"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenTokenIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"token 1" forKey:@"token"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"token 1" forKey:@"token"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenIdTokenIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"idToken"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 2" forKey:@"idToken"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenIdTokenIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"idToken"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 1" forKey:@"idToken"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenExpiresOnIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"expiresOn"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:[NSDate dateWithTimeIntervalSince1970:2000000000] forKey:@"expiresOn"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenExpiresOnIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"expiresOn"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"expiresOn"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenFamilyIdIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"familyId"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 2" forKey:@"familyId"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenFamilyIdIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"familyId"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 1" forKey:@"familyId"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenClientInfoIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@{@"key1" : @"value1"} forKey:@"clientInfo"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@{@"key2" : @"value2"} forKey:@"clientInfo"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenClientInfoIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@{@"key" : @"value"} forKey:@"clientInfo"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@{@"key" : @"value"} forKey:@"clientInfo"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenAdditionalServerInfoIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@{@"key1" : @"value1"} forKey:@"additionalServerInfo"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@{@"key2" : @"value2"} forKey:@"additionalServerInfo"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenAdditionalServerInfoIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@{@"key" : @"value"} forKey:@"additionalServerInfo"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@{@"key" : @"value"} forKey:@"additionalServerInfo"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenTokenTypeIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@0 forKey:@"tokenType"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@1 forKey:@"tokenType"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenTokenTypeIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@0 forKey:@"tokenType"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@0 forKey:@"tokenType"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenResourceIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"resource"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 2" forKey:@"resource"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenResourceIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"resource"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 1" forKey:@"resource"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenAuthorityIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"authority"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 2" forKey:@"authority"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenAuthorityIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"authority"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 1" forKey:@"authority"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenClientIdIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"clientId"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 2" forKey:@"clientId"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenClientIdIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:@"value 1" forKey:@"clientId"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:@"value 1" forKey:@"clientId"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+#pragma mark - Private
+
+- (MSIDToken *)createToken
+{
+    MSIDToken *token = [MSIDToken new];
+    [token setValue:@"access token value" forKey:@"token"];
+    [token setValue:@"id token value" forKey:@"idToken"];
+    [token setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"expiresOn"];
+    [token setValue:@"familyId value" forKey:@"familyId"];
+    [token setValue:@{@"key" : @"value"} forKey:@"clientInfo"];
+    [token setValue:@{@"key2" : @"value2"} forKey:@"additionalServerInfo"];
+    [token setValue:@"some resource" forKey:@"resource"];
+    [token setValue:@"some authority" forKey:@"authority"];
+    [token setValue:@"some clientId" forKey:@"clientId"];
+    
+    return token;
+}
+
+@end

--- a/IdentityCore/tests/MSIDTokenTests.m
+++ b/IdentityCore/tests/MSIDTokenTests.m
@@ -250,6 +250,26 @@
     XCTAssertEqualObjects(lhs, rhs);
 }
 
+- (void)testIsEqual_whenScopesIsNotEqual_shouldReturnFalse
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:[[NSOrderedSet alloc] initWithArray:@[@1, @2]] forKey:@"scopes"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:[[NSOrderedSet alloc] initWithArray:@[@1, @3]] forKey:@"scopes"];
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testIsEqual_whenScopesIsEqual_shouldReturnTrue
+{
+    MSIDToken *lhs = [MSIDToken new];
+    [lhs setValue:[[NSOrderedSet alloc] initWithArray:@[@1, @2]] forKey:@"scopes"];
+    MSIDToken *rhs = [MSIDToken new];
+    [rhs setValue:[[NSOrderedSet alloc] initWithArray:@[@1, @2]] forKey:@"scopes"];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
 #pragma mark - Private
 
 - (MSIDToken *)createToken
@@ -264,6 +284,7 @@
     [token setValue:@"some resource" forKey:@"resource"];
     [token setValue:@"some authority" forKey:@"authority"];
     [token setValue:@"some clientId" forKey:@"clientId"];
+    [token setValue:[[NSOrderedSet alloc] initWithArray:@[@1, @2]] forKey:@"scopes"];
     
     return token;
 }


### PR DESCRIPTION
Final version. Added new properties to MSIDToken:
- resource
- authority
- clientId
- scopes

Ignore *accessTokenType* when map to/from MSIDToken.  Seems that *accessTokenType* always has "Bearer" type, moreover, we parse it and store in cache in ADAL, but never use. Please correct me if I missed something.

In case if *ADTokenCacheItem* has both AT&RT we map it to *MSIDToken* with type *MSIDTokenTypeRefreshToken* and we ignore value of AT. If we need to get MSIDToken with type *MSIDTokenTypeAccessToken*, RT in *ADTokenCacheItem* should be nil. Added tests that cover this logic.