### PR TITLE
Add http headers field to MSIDError

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -24,6 +24,7 @@
 extern NSString *MSIDErrorDescriptionKey;
 extern NSString *MSIDOAuthErrorKey;
 extern NSString *MSIDOAuthSubErrorKey;
+extern NSString *MSIDCorrelationIdKey;
 extern NSString *MSIDHTTPHeadersKey;
 
 /*!
@@ -40,5 +41,5 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     removeMeWhenThingsAreAdded = -10000,
 };
 
-extern NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSDictionary *additionalUserInfo);
+extern NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSUUID *correlationId, NSDictionary *additionalUserInfo);
 

--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -24,6 +24,7 @@
 extern NSString *MSIDErrorDescriptionKey;
 extern NSString *MSIDOAuthErrorKey;
 extern NSString *MSIDOAuthSubErrorKey;
+extern NSString *MSIDHTTPHeadersKey;
 
 /*!
  ADAL and MSAL use different error domains and error codes.
@@ -39,5 +40,5 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     removeMeWhenThingsAreAdded = -10000,
 };
 
-extern NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError);
+extern NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSDictionary *httpHeaders);
 

--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -40,5 +40,5 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     removeMeWhenThingsAreAdded = -10000,
 };
 
-extern NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSDictionary *httpHeaders);
+extern NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSDictionary *additionalUserInfo);
 

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -24,17 +24,19 @@
 NSString *MSIDErrorDescriptionKey = @"MSIDErrorDescriptionKey";
 NSString *MSIDOAuthErrorKey = @"MSIDOAuthErrorKey";
 NSString *MSIDOAuthSubErrorKey = @"MSIDOAuthSubErrorKey";
+NSString *MSIDCorrelationIdKey = @"MSIDCorrelationIdKey";
 NSString *MSIDHTTPHeadersKey = @"MSIDHTTPHeadersKey";
 
 NSString *MSIDErrorDomain = @"MSIDErrorDomain";
 
-NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSDictionary *additionalUserInfo)
+NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSUUID *correlationId, NSDictionary *additionalUserInfo)
 {
     NSMutableDictionary *userInfo = [NSMutableDictionary new];
     userInfo[MSIDErrorDescriptionKey] = errorDescription;
     userInfo[MSIDOAuthErrorKey] = oauthError;
     userInfo[MSIDOAuthSubErrorKey] = subError;
     userInfo[NSUnderlyingErrorKey]  = underlyingError;
+    userInfo[MSIDCorrelationIdKey] = correlationId;
     if (additionalUserInfo)
     {
         [userInfo addEntriesFromDictionary:additionalUserInfo];

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -28,14 +28,17 @@ NSString *MSIDHTTPHeadersKey = @"MSIDHTTPHeadersKey";
 
 NSString *MSIDErrorDomain = @"MSIDErrorDomain";
 
-NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSDictionary *httpHeaders)
+NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSDictionary *additionalUserInfo)
 {
     NSMutableDictionary *userInfo = [NSMutableDictionary new];
     userInfo[MSIDErrorDescriptionKey] = errorDescription;
     userInfo[MSIDOAuthErrorKey] = oauthError;
     userInfo[MSIDOAuthSubErrorKey] = subError;
     userInfo[NSUnderlyingErrorKey]  = underlyingError;
-    userInfo[MSIDHTTPHeadersKey] = httpHeaders;
+    if (additionalUserInfo)
+    {
+        [userInfo addEntriesFromDictionary:additionalUserInfo];
+    }
     
     return [NSError errorWithDomain:domain code:code userInfo:userInfo];
 }

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -24,16 +24,18 @@
 NSString *MSIDErrorDescriptionKey = @"MSIDErrorDescriptionKey";
 NSString *MSIDOAuthErrorKey = @"MSIDOAuthErrorKey";
 NSString *MSIDOAuthSubErrorKey = @"MSIDOAuthSubErrorKey";
+NSString *MSIDHTTPHeadersKey = @"MSIDHTTPHeadersKey";
 
 NSString *MSIDErrorDomain = @"MSIDErrorDomain";
 
-NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError)
+NSError *MSIDCreateError(NSString *domain, NSInteger code, NSString *errorDescription, NSString *oauthError, NSString *subError, NSError *underlyingError, NSDictionary *httpHeaders)
 {
     NSMutableDictionary *userInfo = [NSMutableDictionary new];
     userInfo[MSIDErrorDescriptionKey] = errorDescription;
     userInfo[MSIDOAuthErrorKey] = oauthError;
     userInfo[MSIDOAuthSubErrorKey] = subError;
     userInfo[NSUnderlyingErrorKey]  = underlyingError;
+    userInfo[MSIDHTTPHeadersKey] = httpHeaders;
     
     return [NSError errorWithDomain:domain code:code userInfo:userInfo];
 }


### PR DESCRIPTION
ADAL will return http headers in error object. Therefore we need to add a field in common core to store it.