### PR TITLE
add MSIDHTTPResponseCodeKey to MSIDError

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -26,6 +26,7 @@ extern NSString *MSIDOAuthErrorKey;
 extern NSString *MSIDOAuthSubErrorKey;
 extern NSString *MSIDCorrelationIdKey;
 extern NSString *MSIDHTTPHeadersKey;
+extern NSString *MSIDHTTPResponseCodeKey;
 
 /*!
  ADAL and MSAL use different error domains and error codes.

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -26,6 +26,7 @@ NSString *MSIDOAuthErrorKey = @"MSIDOAuthErrorKey";
 NSString *MSIDOAuthSubErrorKey = @"MSIDOAuthSubErrorKey";
 NSString *MSIDCorrelationIdKey = @"MSIDCorrelationIdKey";
 NSString *MSIDHTTPHeadersKey = @"MSIDHTTPHeadersKey";
+NSString *MSIDHTTPResponseCodeKey = @"MSIDHTTPResponseCodeKey";
 
 NSString *MSIDErrorDomain = @"MSIDErrorDomain";
 


### PR DESCRIPTION
MSIDHTTPResponseCodeKey is added for storing http response code in error object.