### PR TITLE
Renamed ADFS token to legacy single resource token

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -147,13 +147,13 @@
 		B251CC202040F6C6005E0179 /* MSIDDefaultTokenCacheKey.h in Headers */ = {isa = PBXBuildFile; fileRef = B251CC1E2040F6C6005E0179 /* MSIDDefaultTokenCacheKey.h */; };
 		B251CC212040F6C6005E0179 /* MSIDDefaultTokenCacheKey.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC1F2040F6C6005E0179 /* MSIDDefaultTokenCacheKey.m */; };
 		B251CC222040F6C6005E0179 /* MSIDDefaultTokenCacheKey.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC1F2040F6C6005E0179 /* MSIDDefaultTokenCacheKey.m */; };
-		B251CC392041058D005E0179 /* MSIDAdfsToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC332041058D005E0179 /* MSIDAdfsToken.m */; };
-		B251CC3A2041058D005E0179 /* MSIDAdfsToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC332041058D005E0179 /* MSIDAdfsToken.m */; };
+		B251CC392041058D005E0179 /* MSIDLegacySingleResourceToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC332041058D005E0179 /* MSIDLegacySingleResourceToken.m */; };
+		B251CC3A2041058D005E0179 /* MSIDLegacySingleResourceToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC332041058D005E0179 /* MSIDLegacySingleResourceToken.m */; };
 		B251CC3B2041058D005E0179 /* MSIDRefreshToken.h in Headers */ = {isa = PBXBuildFile; fileRef = B251CC342041058D005E0179 /* MSIDRefreshToken.h */; };
 		B251CC3C2041058D005E0179 /* MSIDAccessToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC352041058D005E0179 /* MSIDAccessToken.m */; };
 		B251CC3D2041058D005E0179 /* MSIDAccessToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC352041058D005E0179 /* MSIDAccessToken.m */; };
 		B251CC3E2041058D005E0179 /* MSIDAccessToken.h in Headers */ = {isa = PBXBuildFile; fileRef = B251CC362041058D005E0179 /* MSIDAccessToken.h */; };
-		B251CC3F2041058D005E0179 /* MSIDAdfsToken.h in Headers */ = {isa = PBXBuildFile; fileRef = B251CC372041058D005E0179 /* MSIDAdfsToken.h */; };
+		B251CC3F2041058D005E0179 /* MSIDLegacySingleResourceToken.h in Headers */ = {isa = PBXBuildFile; fileRef = B251CC372041058D005E0179 /* MSIDLegacySingleResourceToken.h */; };
 		B251CC402041058D005E0179 /* MSIDRefreshToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC382041058D005E0179 /* MSIDRefreshToken.m */; };
 		B251CC412041058D005E0179 /* MSIDRefreshToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC382041058D005E0179 /* MSIDRefreshToken.m */; };
 		B251CC47204105A7005E0179 /* MSIDRefreshableToken.h in Headers */ = {isa = PBXBuildFile; fileRef = B251CC42204105A6005E0179 /* MSIDRefreshableToken.h */; };
@@ -232,8 +232,8 @@
 		B2DD5B9C20475E780084313F /* MSIDBaseTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2321532C1FDF4FD800C6960D /* MSIDBaseTokenTests.m */; };
 		B2DD5B9E204761550084313F /* MSIDAccessTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD5B9D204761550084313F /* MSIDAccessTokenTests.m */; };
 		B2DD5B9F204761550084313F /* MSIDAccessTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD5B9D204761550084313F /* MSIDAccessTokenTests.m */; };
-		B2DD5BA1204761660084313F /* MSIDAdfsTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD5BA0204761660084313F /* MSIDAdfsTokenTests.m */; };
-		B2DD5BA2204761660084313F /* MSIDAdfsTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD5BA0204761660084313F /* MSIDAdfsTokenTests.m */; };
+		B2DD5BA1204761660084313F /* MSIDLegacySingleResourceTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD5BA0204761660084313F /* MSIDLegacySingleResourceTokenTests.m */; };
+		B2DD5BA2204761660084313F /* MSIDLegacySingleResourceTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD5BA0204761660084313F /* MSIDLegacySingleResourceTokenTests.m */; };
 		B2DD5BA4204761720084313F /* MSIDRefreshTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD5BA3204761720084313F /* MSIDRefreshTokenTests.m */; };
 		B2DD5BA5204761720084313F /* MSIDRefreshTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD5BA3204761720084313F /* MSIDRefreshTokenTests.m */; };
 		B2DD5BA620477E280084313F /* MSIDBaseTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530F1203A36E100A276FF /* MSIDBaseTokenIntegrationTests.m */; };
@@ -242,8 +242,8 @@
 		B2DD5BA920477FE70084313F /* MSIDAccessTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530F4203A36FD00A276FF /* MSIDAccessTokenIntegrationTests.m */; };
 		B2DD5BAA204780680084313F /* MSIDRefreshTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530F7203A371000A276FF /* MSIDRefreshTokenIntegrationTests.m */; };
 		B2DD5BAB204780680084313F /* MSIDRefreshTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530F7203A371000A276FF /* MSIDRefreshTokenIntegrationTests.m */; };
-		B2DD5BAC2047806F0084313F /* MSIDAdfsTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530FA203A371F00A276FF /* MSIDAdfsTokenIntegrationTests.m */; };
-		B2DD5BAD204780700084313F /* MSIDAdfsTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530FA203A371F00A276FF /* MSIDAdfsTokenIntegrationTests.m */; };
+		B2DD5BAC2047806F0084313F /* MSIDLegacyTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530FA203A371F00A276FF /* MSIDLegacyTokenIntegrationTests.m */; };
+		B2DD5BAD204780700084313F /* MSIDLegacyTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530FA203A371F00A276FF /* MSIDLegacyTokenIntegrationTests.m */; };
 		B2DD5BAE2047807F0084313F /* MSIDIdTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530FD203A372F00A276FF /* MSIDIdTokenIntegrationTests.m */; };
 		B2DD5BAF204780800084313F /* MSIDIdTokenIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29530FD203A372F00A276FF /* MSIDIdTokenIntegrationTests.m */; };
 		B2DD5BB1204789FB0084313F /* MSIDIdTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD5BB0204789FB0084313F /* MSIDIdTokenTests.m */; };
@@ -495,11 +495,11 @@
 		B251CC1A2040F6B5005E0179 /* MSIDLegacyTokenCacheKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLegacyTokenCacheKey.m; sourceTree = "<group>"; };
 		B251CC1E2040F6C6005E0179 /* MSIDDefaultTokenCacheKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDDefaultTokenCacheKey.h; sourceTree = "<group>"; };
 		B251CC1F2040F6C6005E0179 /* MSIDDefaultTokenCacheKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDDefaultTokenCacheKey.m; sourceTree = "<group>"; };
-		B251CC332041058D005E0179 /* MSIDAdfsToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDAdfsToken.m; sourceTree = "<group>"; };
+		B251CC332041058D005E0179 /* MSIDLegacySingleResourceToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDLegacySingleResourceToken.m; sourceTree = "<group>"; };
 		B251CC342041058D005E0179 /* MSIDRefreshToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDRefreshToken.h; sourceTree = "<group>"; };
 		B251CC352041058D005E0179 /* MSIDAccessToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDAccessToken.m; sourceTree = "<group>"; };
 		B251CC362041058D005E0179 /* MSIDAccessToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDAccessToken.h; sourceTree = "<group>"; };
-		B251CC372041058D005E0179 /* MSIDAdfsToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDAdfsToken.h; sourceTree = "<group>"; };
+		B251CC372041058D005E0179 /* MSIDLegacySingleResourceToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDLegacySingleResourceToken.h; sourceTree = "<group>"; };
 		B251CC382041058D005E0179 /* MSIDRefreshToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDRefreshToken.m; sourceTree = "<group>"; };
 		B251CC42204105A6005E0179 /* MSIDRefreshableToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDRefreshableToken.h; sourceTree = "<group>"; };
 		B251CC43204105A6005E0179 /* MSIDBaseToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDBaseToken.h; sourceTree = "<group>"; };
@@ -523,7 +523,7 @@
 		B29530F1203A36E100A276FF /* MSIDBaseTokenIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBaseTokenIntegrationTests.m; sourceTree = "<group>"; };
 		B29530F4203A36FD00A276FF /* MSIDAccessTokenIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccessTokenIntegrationTests.m; sourceTree = "<group>"; };
 		B29530F7203A371000A276FF /* MSIDRefreshTokenIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDRefreshTokenIntegrationTests.m; sourceTree = "<group>"; };
-		B29530FA203A371F00A276FF /* MSIDAdfsTokenIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAdfsTokenIntegrationTests.m; sourceTree = "<group>"; };
+		B29530FA203A371F00A276FF /* MSIDLegacyTokenIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLegacyTokenIntegrationTests.m; sourceTree = "<group>"; };
 		B29530FD203A372F00A276FF /* MSIDIdTokenIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIdTokenIntegrationTests.m; sourceTree = "<group>"; };
 		B29CB6B41FEC6F4700F880ED /* MSIDSharedTokenCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSharedTokenCache.h; sourceTree = "<group>"; };
 		B29CB6B51FEC6F4700F880ED /* MSIDSharedTokenCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSharedTokenCache.m; sourceTree = "<group>"; };
@@ -560,7 +560,7 @@
 		B2DD5B932047564C0084313F /* MSIDTokenTypeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTokenTypeTests.m; sourceTree = "<group>"; };
 		B2DD5B96204756580084313F /* MSIDAccountTypeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountTypeTests.m; sourceTree = "<group>"; };
 		B2DD5B9D204761550084313F /* MSIDAccessTokenTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccessTokenTests.m; sourceTree = "<group>"; };
-		B2DD5BA0204761660084313F /* MSIDAdfsTokenTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAdfsTokenTests.m; sourceTree = "<group>"; };
+		B2DD5BA0204761660084313F /* MSIDLegacySingleResourceTokenTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLegacySingleResourceTokenTests.m; sourceTree = "<group>"; };
 		B2DD5BA3204761720084313F /* MSIDRefreshTokenTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDRefreshTokenTests.m; sourceTree = "<group>"; };
 		B2DD5BB0204789FB0084313F /* MSIDIdTokenTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDIdTokenTests.m; sourceTree = "<group>"; };
 		B2EF14381FF2F21D005DC1C0 /* MSIDAADV2TokenResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV2TokenResponse.m; sourceTree = "<group>"; };
@@ -719,7 +719,7 @@
 				B29530F1203A36E100A276FF /* MSIDBaseTokenIntegrationTests.m */,
 				B29530F4203A36FD00A276FF /* MSIDAccessTokenIntegrationTests.m */,
 				B29530F7203A371000A276FF /* MSIDRefreshTokenIntegrationTests.m */,
-				B29530FA203A371F00A276FF /* MSIDAdfsTokenIntegrationTests.m */,
+				B29530FA203A371F00A276FF /* MSIDLegacyTokenIntegrationTests.m */,
 				B29530FD203A372F00A276FF /* MSIDIdTokenIntegrationTests.m */,
 				23F32F221FFDAB9D00B2905E /* MSIDTokenCacheDataSourceIntegrationTests.m */,
 			);
@@ -948,8 +948,8 @@
 				B251CC46204105A7005E0179 /* MSIDIdToken.m */,
 				B251CC362041058D005E0179 /* MSIDAccessToken.h */,
 				B251CC352041058D005E0179 /* MSIDAccessToken.m */,
-				B251CC372041058D005E0179 /* MSIDAdfsToken.h */,
-				B251CC332041058D005E0179 /* MSIDAdfsToken.m */,
+				B251CC372041058D005E0179 /* MSIDLegacySingleResourceToken.h */,
+				B251CC332041058D005E0179 /* MSIDLegacySingleResourceToken.m */,
 				B251CC342041058D005E0179 /* MSIDRefreshToken.h */,
 				B251CC382041058D005E0179 /* MSIDRefreshToken.m */,
 				B251CC42204105A6005E0179 /* MSIDRefreshableToken.h */,
@@ -1168,7 +1168,7 @@
 				B2DD5B96204756580084313F /* MSIDAccountTypeTests.m */,
 				2321532C1FDF4FD800C6960D /* MSIDBaseTokenTests.m */,
 				B2DD5B9D204761550084313F /* MSIDAccessTokenTests.m */,
-				B2DD5BA0204761660084313F /* MSIDAdfsTokenTests.m */,
+				B2DD5BA0204761660084313F /* MSIDLegacySingleResourceTokenTests.m */,
 				B2DD5BA3204761720084313F /* MSIDRefreshTokenTests.m */,
 				B2DD5BB0204789FB0084313F /* MSIDIdTokenTests.m */,
 				2361DE8A2048B6F8005FD48A /* MSIDAccountTests.m */,
@@ -1240,7 +1240,7 @@
 				B2CDB5791FE33A46003A4B5C /* MSIDAccount.h in Headers */,
 				B251CC49204105A7005E0179 /* MSIDIdToken.h in Headers */,
 				B20657A51FC91C1600412B7D /* MSIDTelemetryDispatcher.h in Headers */,
-				B251CC3F2041058D005E0179 /* MSIDAdfsToken.h in Headers */,
+				B251CC3F2041058D005E0179 /* MSIDLegacySingleResourceToken.h in Headers */,
 				B210F44D1FDDF5AA005A8F76 /* MSIDClientInfo.h in Headers */,
 				B20657DF1FCA208C00412B7D /* NSDate+MSIDExtensions.h in Headers */,
 				B251CC3B2041058D005E0179 /* MSIDRefreshToken.h in Headers */,
@@ -1508,7 +1508,7 @@
 				23BDA6691FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */,
 				B2DD5BC220479D9C0084313F /* MSIDKeyedArchiverSerializerTests.m in Sources */,
 				B2DD5BAE2047807F0084313F /* MSIDIdTokenIntegrationTests.m in Sources */,
-				B2DD5BAC2047806F0084313F /* MSIDAdfsTokenIntegrationTests.m in Sources */,
+				B2DD5BAC2047806F0084313F /* MSIDLegacyTokenIntegrationTests.m in Sources */,
 				B210F42E1FDDE6A5005A8F76 /* MSIDJsonObjectTests.m in Sources */,
 				B253BD7920487C8A00D07F31 /* MSIDLegacyTokenCacheIntegrationTests.m in Sources */,
 				B2DD5B97204756580084313F /* MSIDAccountTypeTests.m in Sources */,
@@ -1540,7 +1540,7 @@
 				B23ECEFC1FF304250015FC1D /* MSIDTestTokenResponse.m in Sources */,
 				B2DD5BC020479AA80084313F /* MSIDJsonSerializerTests.m in Sources */,
 				B2DD5B7720461F510084313F /* MSIDTokenCacheItemTests.m in Sources */,
-				B2DD5BA1204761660084313F /* MSIDAdfsTokenTests.m in Sources */,
+				B2DD5BA1204761660084313F /* MSIDLegacySingleResourceTokenTests.m in Sources */,
 				D6D9A4BE1FBE712900EFA430 /* MSIDStringExtensionsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1549,7 +1549,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B251CC3A2041058D005E0179 /* MSIDAdfsToken.m in Sources */,
+				B251CC3A2041058D005E0179 /* MSIDLegacySingleResourceToken.m in Sources */,
 				B20657A91FC91ECC00412B7D /* MSIDTelemetry.m in Sources */,
 				B25A356F1FC4D70300C7FD43 /* MSIDLogger.m in Sources */,
 				B210F44C1FDDF5A7005A8F76 /* MSIDClientInfo.m in Sources */,
@@ -1618,7 +1618,7 @@
 				23CC944920465CEC00AA0551 /* MSIDTokenCacheDataSourceIntegrationTests.m in Sources */,
 				B23ECF011FF306110015FC1D /* MSIDTestRequestParams.m in Sources */,
 				B2DD5BAF204780800084313F /* MSIDIdTokenIntegrationTests.m in Sources */,
-				B2DD5BAD204780700084313F /* MSIDAdfsTokenIntegrationTests.m in Sources */,
+				B2DD5BAD204780700084313F /* MSIDLegacyTokenIntegrationTests.m in Sources */,
 				B2DD5B7520461F410084313F /* MSIDCacheItemTests.m in Sources */,
 				B2DD5B98204756580084313F /* MSIDAccountTypeTests.m in Sources */,
 				B210F4661FDF1CB8005A8F76 /* MSIDURLFormObjectTests.m in Sources */,
@@ -1653,7 +1653,7 @@
 				B2DD5BB2204789FB0084313F /* MSIDIdTokenTests.m in Sources */,
 				B20657D01FC92B8F00412B7D /* MSIDTelemetryUIEventTests.m in Sources */,
 				B23ECEFD1FF304250015FC1D /* MSIDTestTokenResponse.m in Sources */,
-				B2DD5BA2204761660084313F /* MSIDAdfsTokenTests.m in Sources */,
+				B2DD5BA2204761660084313F /* MSIDLegacySingleResourceTokenTests.m in Sources */,
 				D6D9A4BF1FBE712900EFA430 /* MSIDStringExtensionsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1690,7 +1690,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B251CC392041058D005E0179 /* MSIDAdfsToken.m in Sources */,
+				B251CC392041058D005E0179 /* MSIDLegacySingleResourceToken.m in Sources */,
 				9641B52A1FCF3F3A00AFA0EC /* MSIDKeyedArchiverSerializer.m in Sources */,
 				23BDA66E1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m in Sources */,
 				B210F44B1FDDF5A6005A8F76 /* MSIDClientInfo.m in Sources */,

--- a/IdentityCore/src/MSIDOAuth2Constants.h
+++ b/IdentityCore/src/MSIDOAuth2Constants.h
@@ -101,6 +101,6 @@ extern NSString *const MSID_LAST_NAME_CACHE_KEY;
 
 extern NSString *const MSID_ACCESS_TOKEN_CACHE_TYPE;
 extern NSString *const MSID_REFRESH_TOKEN_CACHE_TYPE;
-extern NSString *const MSID_ADFS_TOKEN_CACHE_TYPE;
+extern NSString *const MSID_LEGACY_TOKEN_CACHE_TYPE;
 extern NSString *const MSID_ID_TOKEN_CACHE_TYPE;
 extern NSString *const MSID_GENERAL_TOKEN_CACHE_TYPE;

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -101,6 +101,6 @@ NSString *const MSID_LAST_NAME_CACHE_KEY                 = @"last_name";
 
 NSString *const MSID_ACCESS_TOKEN_CACHE_TYPE             = @"AccessToken";
 NSString *const MSID_REFRESH_TOKEN_CACHE_TYPE            = @"RefreshToken";
-NSString *const MSID_ADFS_TOKEN_CACHE_TYPE               = @"LegacyADFSToken";
+NSString *const MSID_LEGACY_TOKEN_CACHE_TYPE             = @"LegacySingleResourceToken";
 NSString *const MSID_ID_TOKEN_CACHE_TYPE                 = @"IdToken";
 NSString *const MSID_GENERAL_TOKEN_CACHE_TYPE            = @"Token";

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -24,7 +24,7 @@
 #import "MSIDLegacyTokenCacheAccessor.h"
 #import "MSIDKeyedArchiverSerializer.h"
 #import "MSIDAccount.h"
-#import "MSIDAdfsToken.h"
+#import "MSIDLegacySingleResourceToken.h"
 #import "MSIDAccessToken.h"
 #import "MSIDRefreshToken.h"
 #import "MSIDTelemetry+Internal.h"
@@ -101,13 +101,13 @@
     }
     else
     {
-        MSIDAdfsToken *adfsToken = [[MSIDAdfsToken alloc] initWithTokenResponse:response
-                                                                        request:requestParams];
+        MSIDLegacySingleResourceToken *legacyToken = [[MSIDLegacySingleResourceToken alloc] initWithTokenResponse:response
+                                                                                                          request:requestParams];
         
         account.legacyUserId = @"";
         
-        // Save token for ADFS
-        return [self saveToken:adfsToken
+        // Save token for legacy single resource token
+        return [self saveToken:legacyToken
                        account:account
                        context:context
                          error:error];

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -354,7 +354,7 @@
         MSIDLegacyTokenCacheKey *key = [MSIDLegacyTokenCacheKey keyWithAuthority:alias
                                                                         clientId:clientId
                                                                         resource:resource
-                                                                             legacyUserId:legacyUserId];
+                                                                    legacyUserId:legacyUserId];
         if (!key)
         {
             return nil;

--- a/IdentityCore/src/cache/accessor/MSIDSharedTokenCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDSharedTokenCache.h
@@ -54,6 +54,11 @@
                              context:(id<MSIDRequestContext>)context
                                error:(NSError **)error;
 
+- (MSIDLegacySingleResourceToken *)getLegacyTokenForAccount:(MSIDAccount *)account
+                                              requestParams:(MSIDRequestParameters *)parameters
+                                                    context:(id<MSIDRequestContext>)context
+                                                      error:(NSError **)error;
+
 - (MSIDLegacySingleResourceToken *)getLegacyTokenWithRequestParams:(MSIDRequestParameters *)parameters
                                                            context:(id<MSIDRequestContext>)context
                                                              error:(NSError **)error;

--- a/IdentityCore/src/cache/accessor/MSIDSharedTokenCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDSharedTokenCache.h
@@ -31,7 +31,7 @@
 
 @class MSIDAccessToken;
 @class MSIDRefreshToken;
-@class MSIDAdfsToken;
+@class MSIDLegacySingleResourceToken;
 @class MSIDBaseToken;
 
 @interface MSIDSharedTokenCache : NSObject
@@ -54,9 +54,9 @@
                              context:(id<MSIDRequestContext>)context
                                error:(NSError **)error;
 
-- (MSIDAdfsToken *)getADFSTokenWithRequestParams:(MSIDRequestParameters *)parameters
-                                         context:(id<MSIDRequestContext>)context
-                                           error:(NSError **)error;
+- (MSIDLegacySingleResourceToken *)getLegacyTokenWithRequestParams:(MSIDRequestParameters *)parameters
+                                                           context:(id<MSIDRequestContext>)context
+                                                             error:(NSError **)error;
 
 /*!
  Returns a Multi-Resource Refresh Token (MRRT) Cache Item for the given parameters. A MRRT can
@@ -84,7 +84,7 @@
                                          context:(id<MSIDRequestContext>)context
                                            error:(NSError **)error;
 
-// Removal operations for RT or ADFS RT
+// Removal operations for RT or legacy single resource RT
 - (BOOL)removeRTForAccount:(MSIDAccount *)account
                      token:(MSIDBaseToken<MSIDRefreshableToken> *)token
                    context:(id<MSIDRequestContext>)context

--- a/IdentityCore/src/cache/accessor/MSIDSharedTokenCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDSharedTokenCache.m
@@ -26,7 +26,7 @@
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDTelemetry+Internal.h"
 #import "MSIDAccount.h"
-#import "MSIDAdfsToken.h"
+#import "MSIDLegacySingleResourceToken.h"
 #import "MSIDAccessToken.h"
 #import "MSIDRefreshToken.h"
 #import "MSIDBaseToken.h"
@@ -159,15 +159,15 @@
                                                            error:error];
 }
 
-- (MSIDAdfsToken *)getADFSTokenWithRequestParams:(MSIDRequestParameters *)parameters
-                                         context:(id<MSIDRequestContext>)context
-                                           error:(NSError **)error
+- (MSIDLegacySingleResourceToken *)getLegacyTokenWithRequestParams:(MSIDRequestParameters *)parameters
+                                                           context:(id<MSIDRequestContext>)context
+                                                             error:(NSError **)error
 {
-    return (MSIDAdfsToken *)[_primaryAccessor getTokenWithType:MSIDTokenTypeLegacyADFSToken
-                                                       account:nil
-                                                 requestParams:parameters
-                                                       context:context
-                                                         error:error];
+    return (MSIDLegacySingleResourceToken *)[_primaryAccessor getTokenWithType:MSIDTokenTypeLegacySingleResourceToken
+                                                                       account:nil
+                                                                 requestParams:parameters
+                                                                       context:context
+                                                                         error:error];
 }
 
 - (MSIDRefreshToken *)getRTForAccount:(MSIDAccount *)account

--- a/IdentityCore/src/cache/accessor/MSIDSharedTokenCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDSharedTokenCache.m
@@ -159,12 +159,26 @@
                                                            error:error];
 }
 
+- (MSIDLegacySingleResourceToken *)getLegacyTokenForAccount:(MSIDAccount *)account
+                                              requestParams:(MSIDRequestParameters *)parameters
+                                                    context:(id<MSIDRequestContext>)context
+                                                      error:(NSError **)error
+{
+    return (MSIDLegacySingleResourceToken *)[_primaryAccessor getTokenWithType:MSIDTokenTypeLegacySingleResourceToken
+                                                                       account:account
+                                                                 requestParams:parameters
+                                                                       context:context
+                                                                         error:error];
+}
+
 - (MSIDLegacySingleResourceToken *)getLegacyTokenWithRequestParams:(MSIDRequestParameters *)parameters
                                                            context:(id<MSIDRequestContext>)context
                                                              error:(NSError **)error
 {
+    MSIDAccount *account = [[MSIDAccount alloc] initWithLegacyUserId:@"" uniqueUserId:nil];
+    
     return (MSIDLegacySingleResourceToken *)[_primaryAccessor getTokenWithType:MSIDTokenTypeLegacySingleResourceToken
-                                                                       account:nil
+                                                                       account:account
                                                                  requestParams:parameters
                                                                        context:context
                                                                          error:error];

--- a/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.h
+++ b/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.h
@@ -30,9 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  Key for ADFS user tokens, account will be @""
  */
-+ (MSIDLegacyTokenCacheKey *)keyForAdfsUserTokenWithAuthority:(NSURL *)authority
-                                                     clientId:(NSString *)clientId
-                                                     resource:(NSString *)resource;
++ (MSIDLegacyTokenCacheKey *)keyForLegacySingleResourceTokenWithAuthority:(NSURL *)authority
+                                                                 clientId:(NSString *)clientId
+                                                                 resource:(NSString *)resource;
 
 /*!
  Key for ADAL tokens

--- a/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
+++ b/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
@@ -59,9 +59,9 @@ static NSString *const s_adalLibraryString = @"MSOpenTech.ADAL.1";
 
 #pragma mark - Legacy keys
 
-+ (MSIDLegacyTokenCacheKey *)keyForAdfsUserTokenWithAuthority:(NSURL *)authority
-                                                     clientId:(NSString *)clientId
-                                                     resource:(NSString *)resource
++ (MSIDLegacyTokenCacheKey *)keyForLegacySingleResourceTokenWithAuthority:(NSURL *)authority
+                                                                 clientId:(NSString *)clientId
+                                                                 resource:(NSString *)resource
 {
     NSString *service = [self.class serviceWithAuthority:authority
                                                 resource:resource

--- a/IdentityCore/src/cache/token/MSIDTokenCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDTokenCacheItem.m
@@ -30,7 +30,7 @@
 #import "MSIDBaseToken.h"
 #import "MSIDAccessToken.h"
 #import "MSIDRefreshToken.h"
-#import "MSIDAdfsToken.h"
+#import "MSIDLegacySingleResourceToken.h"
 #import "MSIDIdToken.h"
 
 @implementation MSIDTokenCacheItem
@@ -117,7 +117,7 @@
     
     if (rtPresent && atPresent)
     {
-        _tokenType = MSIDTokenTypeLegacyADFSToken;
+        _tokenType = MSIDTokenTypeLegacySingleResourceToken;
     }
     else if (rtPresent)
     {
@@ -200,7 +200,7 @@
             _accessToken = json[MSID_TOKEN_CACHE_KEY];
             break;
         }
-        case MSIDTokenTypeLegacyADFSToken:
+        case MSIDTokenTypeLegacySingleResourceToken:
         {
             _accessToken = json[MSID_TOKEN_CACHE_KEY];
             _refreshToken = json[MSID_RESOURCE_RT_CACHE_KEY];
@@ -260,7 +260,7 @@
             dictionary[MSID_ID_TOKEN_CACHE_KEY] = _idToken;
             break;
         }
-        case MSIDTokenTypeLegacyADFSToken:
+        case MSIDTokenTypeLegacySingleResourceToken:
         {
             dictionary[MSID_TOKEN_CACHE_KEY] = _accessToken;
             dictionary[MSID_RESOURCE_RT_CACHE_KEY] = _refreshToken;
@@ -292,9 +292,9 @@
         {
             return [[MSIDRefreshToken alloc] initWithTokenCacheItem:self];
         }
-        case MSIDTokenTypeLegacyADFSToken:
+        case MSIDTokenTypeLegacySingleResourceToken:
         {
-            return [[MSIDAdfsToken alloc] initWithTokenCacheItem:self];
+            return [[MSIDLegacySingleResourceToken alloc] initWithTokenCacheItem:self];
         }
         case MSIDTokenTypeIDToken:
         {

--- a/IdentityCore/src/oauth2/token/MSIDLegacySingleResourceToken.h
+++ b/IdentityCore/src/oauth2/token/MSIDLegacySingleResourceToken.h
@@ -24,7 +24,7 @@
 #import "MSIDAccessToken.h"
 #import "MSIDRefreshableToken.h"
 
-@interface MSIDAdfsToken : MSIDAccessToken <MSIDRefreshableToken>
+@interface MSIDLegacySingleResourceToken : MSIDAccessToken <MSIDRefreshableToken>
 
 @property (readonly) NSString *refreshToken;
 

--- a/IdentityCore/src/oauth2/token/MSIDLegacySingleResourceToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDLegacySingleResourceToken.m
@@ -21,16 +21,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "MSIDAdfsToken.h"
+#import "MSIDLegacySingleResourceToken.h"
 #import "MSIDTokenResponse.h"
 
-@implementation MSIDAdfsToken
+@implementation MSIDLegacySingleResourceToken
 
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    MSIDAdfsToken *item = [super copyWithZone:zone];
+    MSIDLegacySingleResourceToken *item = [super copyWithZone:zone];
     item->_refreshToken = [_refreshToken copyWithZone:zone];
     
     return item;
@@ -45,12 +45,12 @@
         return YES;
     }
     
-    if (![object isKindOfClass:MSIDAdfsToken.class])
+    if (![object isKindOfClass:MSIDLegacySingleResourceToken.class])
     {
         return NO;
     }
     
-    return [self isEqualToItem:(MSIDAdfsToken *)object];
+    return [self isEqualToItem:(MSIDLegacySingleResourceToken *)object];
 }
 
 - (NSUInteger)hash
@@ -60,7 +60,7 @@
     return hash;
 }
 
-- (BOOL)isEqualToItem:(MSIDAdfsToken *)token
+- (BOOL)isEqualToItem:(MSIDLegacySingleResourceToken *)token
 {
     if (!token)
     {
@@ -85,7 +85,7 @@
         
         if (!_refreshToken)
         {
-            MSID_LOG_ERROR(nil, @"Trying to initialize ADFS token when missing refresh token field");
+            MSID_LOG_ERROR(nil, @"Trying to initialize legacy single resource token when missing refresh token field");
             return nil;
         }
     }
@@ -114,7 +114,7 @@
     
     if (!_refreshToken)
     {
-        MSID_LOG_ERROR(nil, @"Trying to initialize ADFS token when missing refresh token field");
+        MSID_LOG_ERROR(nil, @"Trying to initialize legacy single resource token when missing refresh token field");
         return nil;
     }
     
@@ -125,7 +125,7 @@
 
 - (MSIDTokenType)tokenType
 {
-    return MSIDTokenTypeLegacyADFSToken;
+    return MSIDTokenTypeLegacySingleResourceToken;
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDTokenType.h
+++ b/IdentityCore/src/oauth2/token/MSIDTokenType.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSInteger, MSIDTokenType)
     MSIDTokenTypeAccessToken = 1,
     MSIDTokenTypeRefreshToken = 2,
     MSIDTokenTypeIDToken = 3,
-    MSIDTokenTypeLegacyADFSToken = 4
+    MSIDTokenTypeLegacySingleResourceToken = 4
 };
 
 @interface MSIDTokenTypeHelpers : NSObject

--- a/IdentityCore/src/oauth2/token/MSIDTokenType.m
+++ b/IdentityCore/src/oauth2/token/MSIDTokenType.m
@@ -35,8 +35,8 @@
         case MSIDTokenTypeRefreshToken:
             return MSID_REFRESH_TOKEN_CACHE_TYPE;
             
-        case MSIDTokenTypeLegacyADFSToken:
-            return MSID_ADFS_TOKEN_CACHE_TYPE;
+        case MSIDTokenTypeLegacySingleResourceToken:
+            return MSID_LEGACY_TOKEN_CACHE_TYPE;
             
         case MSIDTokenTypeIDToken:
             return MSID_ID_TOKEN_CACHE_TYPE;
@@ -56,7 +56,7 @@ static NSDictionary *sTokenTypes = nil;
         
         sTokenTypes = @{MSID_ACCESS_TOKEN_CACHE_TYPE: @(MSIDTokenTypeAccessToken),
                         MSID_REFRESH_TOKEN_CACHE_TYPE: @(MSIDTokenTypeRefreshToken),
-                        MSID_ADFS_TOKEN_CACHE_TYPE: @(MSIDTokenTypeLegacyADFSToken),
+                        MSID_LEGACY_TOKEN_CACHE_TYPE: @(MSIDTokenTypeLegacySingleResourceToken),
                         MSID_ID_TOKEN_CACHE_TYPE: @(MSIDTokenTypeIDToken),
                         MSID_GENERAL_TOKEN_CACHE_TYPE: @(MSIDTokenTypeOther)
                         };

--- a/IdentityCore/src/telemetry/MSIDTelemetryCacheEvent.m
+++ b/IdentityCore/src/telemetry/MSIDTelemetryCacheEvent.m
@@ -56,7 +56,7 @@
             [self setProperty:MSID_TELEMETRY_KEY_TOKEN_TYPE value:MSID_TELEMETRY_VALUE_REFRESH_TOKEN];
             break;
             
-        case MSIDTokenTypeLegacyADFSToken:
+        case MSIDTokenTypeLegacySingleResourceToken:
             [self setProperty:MSID_TELEMETRY_KEY_TOKEN_TYPE value:MSID_TELEMETRY_VALUE_ADFS_TOKEN];
             break;
             

--- a/IdentityCore/tests/MSIDLegacySingleResourceTokenTests.m
+++ b/IdentityCore/tests/MSIDLegacySingleResourceTokenTests.m
@@ -23,171 +23,171 @@
 
 #import <XCTest/XCTest.h>
 #import "NSDictionary+MSIDTestUtil.h"
-#import "MSIDAdfsToken.h"
+#import "MSIDLegacySingleResourceToken.h"
 
-@interface MSIDAdfsTokenTests : XCTestCase
+@interface MSIDLegacySingleResourceTokenTests : XCTestCase
 
 @end
 
-@implementation MSIDAdfsTokenTests
+@implementation MSIDLegacySingleResourceTokenTests
 
 #pragma mark - Copy tests
 
 - (void)testCopy_whenAllPropertiesAreSet_shouldReturnEqualCopy
 {
-    MSIDAdfsToken *token = [self createToken];
-    MSIDAdfsToken *tokenCopy = [token copy];
+    MSIDLegacySingleResourceToken *token = [self createToken];
+    MSIDLegacySingleResourceToken *tokenCopy = [token copy];
     
     XCTAssertEqualObjects(tokenCopy, token);
 }
 
 #pragma mark - isEqual tests
 
-- (void)testADFSTokenIsEqual_whenAllPropertiesAreEqual_shouldReturnTrue
+- (void)testLegacyTokenIsEqual_whenAllPropertiesAreEqual_shouldReturnTrue
 {
-    MSIDAdfsToken *lhs = [self createToken];
-    MSIDAdfsToken *rhs = [self createToken];
+    MSIDLegacySingleResourceToken *lhs = [self createToken];
+    MSIDLegacySingleResourceToken *rhs = [self createToken];
     
     XCTAssertEqualObjects(lhs, rhs);
 }
 
-#pragma mark - MSIDAdfsToken
+#pragma mark - MSIDLegacySingleResourceToken
 
-- (void)testADFSTokenIsEqual_whenTokenIsNotEqual_shouldReturnFalse
+- (void)testLegacyTokenIsEqual_whenTokenIsNotEqual_shouldReturnFalse
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"token 1" forKey:@"accessToken"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"token 2" forKey:@"accessToken"];
     
     XCTAssertNotEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenTokenIsEqual_shouldReturnTrue
+- (void)testLegacyTokenIsEqual_whenTokenIsEqual_shouldReturnTrue
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"token 1" forKey:@"accessToken"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"token 1" forKey:@"accessToken"];
     
     XCTAssertEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenIdTokenIsNotEqual_shouldReturnFalse
+- (void)testLegacyTokenIsEqual_whenIdTokenIsNotEqual_shouldReturnFalse
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"value 1" forKey:@"idToken"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"value 2" forKey:@"idToken"];
     
     XCTAssertNotEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenIdTokenIsEqual_shouldReturnTrue
+- (void)testLegacyTokenIsEqual_whenIdTokenIsEqual_shouldReturnTrue
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"value 1" forKey:@"idToken"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"value 1" forKey:@"idToken"];
     
     XCTAssertEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenExpiresOnIsNotEqual_shouldReturnFalse
+- (void)testLegacyTokenIsEqual_whenExpiresOnIsNotEqual_shouldReturnFalse
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"expiresOn"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:[NSDate dateWithTimeIntervalSince1970:2000000000] forKey:@"expiresOn"];
     
     XCTAssertNotEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenExpiresOnIsEqual_shouldReturnTrue
+- (void)testLegacyTokenIsEqual_whenExpiresOnIsEqual_shouldReturnTrue
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"expiresOn"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"expiresOn"];
     
     XCTAssertEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenCachedAtIsNotEqual_shouldReturnFalse
+- (void)testLegacyTokenIsEqual_whenCachedAtIsNotEqual_shouldReturnFalse
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"cachedAt"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:[NSDate dateWithTimeIntervalSince1970:2000000000] forKey:@"cachedAt"];
     
     XCTAssertNotEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenCachedAtIsEqual_shouldReturnTrue
+- (void)testLegacyTokenIsEqual_whenCachedAtIsEqual_shouldReturnTrue
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"cachedAt"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:[NSDate dateWithTimeIntervalSince1970:1500000000] forKey:@"cachedAt"];
     
     XCTAssertEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenScopesIsNotEqual_shouldReturnFalse
+- (void)testLegacyTokenIsEqual_whenScopesIsNotEqual_shouldReturnFalse
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"1 2" forKey:@"target"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"1 3" forKey:@"target"];
     
     XCTAssertNotEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenScopesIsEqual_shouldReturnTrue
+- (void)testLegacyTokenIsEqual_whenScopesIsEqual_shouldReturnTrue
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"1 2" forKey:@"target"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"1 2" forKey:@"target"];
     
     XCTAssertEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenResourceIsNotEqual_shouldReturnFalse
+- (void)testLegacyTokenIsEqual_whenResourceIsNotEqual_shouldReturnFalse
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"value 1" forKey:@"target"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"value 2" forKey:@"target"];
     
     XCTAssertNotEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenResourceIsEqual_shouldReturnTrue
+- (void)testLegacyTokenIsEqual_whenResourceIsEqual_shouldReturnTrue
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"value 1" forKey:@"target"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"value 1" forKey:@"target"];
     
     XCTAssertEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenRefreshTokenIsNotEqual_shouldReturnFalse
+- (void)testLegacyTokenIsEqual_whenRefreshTokenIsNotEqual_shouldReturnFalse
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"value 1" forKey:@"refreshToken"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"value 2" forKey:@"refreshToken"];
     
     XCTAssertNotEqualObjects(lhs, rhs);
 }
 
-- (void)testADFSTokenIsEqual_whenRefreshTokenIsEqual_shouldReturnTrue
+- (void)testLegacyTokenIsEqual_whenRefreshTokenIsEqual_shouldReturnTrue
 {
-    MSIDAdfsToken *lhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *lhs = [MSIDLegacySingleResourceToken new];
     [lhs setValue:@"value 1" forKey:@"refreshToken"];
-    MSIDAdfsToken *rhs = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *rhs = [MSIDLegacySingleResourceToken new];
     [rhs setValue:@"value 1" forKey:@"refreshToken"];
     
     XCTAssertEqualObjects(lhs, rhs);
@@ -197,7 +197,7 @@
 
 - (void)testInitWithTokenCacheItem_whenNilCacheItem_shouldReturnNil
 {
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenCacheItem:nil];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenCacheItem:nil];
     XCTAssertNil(token);
 }
 
@@ -206,7 +206,7 @@
     MSIDTokenCacheItem *cacheItem = [MSIDTokenCacheItem new];
     cacheItem.tokenType = MSIDTokenTypeIDToken;
     
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenCacheItem:cacheItem];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenCacheItem:cacheItem];
     XCTAssertNil(token);
 }
 
@@ -223,14 +223,14 @@
     cacheItem.target = @"target";
     cacheItem.accessToken = @"token";
     
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenCacheItem:cacheItem];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenCacheItem:cacheItem];
     XCTAssertNil(token);
 }
 
 - (void)testInitWithTokenCacheItem_whenAllFieldsSet_shouldReturnToken
 {
     MSIDTokenCacheItem *cacheItem = [MSIDTokenCacheItem new];
-    cacheItem.tokenType = MSIDTokenTypeLegacyADFSToken;
+    cacheItem.tokenType = MSIDTokenTypeLegacySingleResourceToken;
     cacheItem.authority = [NSURL URLWithString:@"https://login.microsoftonline.com/common"];
     cacheItem.clientInfo = [self createClientInfo:@{@"key" : @"value"}];
     cacheItem.additionalInfo = @{@"test": @"test2"};
@@ -248,7 +248,7 @@
     cacheItem.target = @"target";
     cacheItem.refreshToken = @"refresh token";
     
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenCacheItem:cacheItem];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenCacheItem:cacheItem];
     XCTAssertNotNil(token);
     XCTAssertEqualObjects(token.authority, [NSURL URLWithString:@"https://login.microsoftonline.com/common"]);
     XCTAssertEqualObjects(token.clientId, @"client id");
@@ -270,9 +270,9 @@
 
 #pragma mark - Private
 
-- (MSIDAdfsToken *)createToken
+- (MSIDLegacySingleResourceToken *)createToken
 {
-    MSIDAdfsToken *token = [MSIDAdfsToken new];
+    MSIDLegacySingleResourceToken *token = [MSIDLegacySingleResourceToken new];
     [token setValue:[NSURL URLWithString:@"https://contoso.com/common"] forKey:@"authority"];
     [token setValue:@"some clientId" forKey:@"clientId"];
     [token setValue:[self createClientInfo:@{@"key" : @"value"}] forKey:@"clientInfo"];

--- a/IdentityCore/tests/MSIDTokenCacheItemTests.m
+++ b/IdentityCore/tests/MSIDTokenCacheItemTests.m
@@ -163,11 +163,11 @@
     XCTAssertEqualObjects(cacheItem.jsonDictionary, expectedDictionary);
 }
 
-- (void)testJSONDictionary_whenADFSToken_andAllFieldsSet_shouldReturnJSONDictionary
+- (void)testJSONDictionary_whenLegacyToken_andAllFieldsSet_shouldReturnJSONDictionary
 {
     MSIDTokenCacheItem *cacheItem = [MSIDTokenCacheItem new];
     cacheItem.authority = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY];
-    cacheItem.tokenType = MSIDTokenTypeLegacyADFSToken;
+    cacheItem.tokenType = MSIDTokenTypeLegacySingleResourceToken;
     cacheItem.clientId = DEFAULT_TEST_CLIENT_ID;
     cacheItem.refreshToken = DEFAULT_TEST_REFRESH_TOKEN;
     cacheItem.idToken = DEFAULT_TEST_ID_TOKEN;
@@ -185,7 +185,7 @@
     NSString *expiresOnString = [NSString stringWithFormat:@"%ld", (long)[expiresOn timeIntervalSince1970]];
     
     NSDictionary *expectedDictionary = @{@"authority": DEFAULT_TEST_AUTHORITY,
-                                         @"credential_type": @"LegacyADFSToken",
+                                         @"credential_type": @"LegacySingleResourceToken",
                                          @"client_id": DEFAULT_TEST_CLIENT_ID,
                                          @"target": DEFAULT_TEST_RESOURCE,
                                          @"cached_at": cachedAtString,
@@ -261,7 +261,7 @@
     XCTAssertEqualObjects(cacheItem.familyId, DEFAULT_TEST_FAMILY_ID);
 }
 
-- (void)testInitWithJSONDictionary_whenADFSToken_andAllFieldsSet_shouldReturnADFSTokenCacheItem
+- (void)testInitWithJSONDictionary_whenLegacyToken_andAllFieldsSet_shouldReturnLegacyTokenCacheItem
 {
     NSDate *expiresOn = [NSDate dateWithTimeIntervalSince1970:(long)[NSDate date]];
     NSDate *cachedAt = [NSDate dateWithTimeIntervalSince1970:(long)[NSDate date]];
@@ -270,7 +270,7 @@
     NSString *expiresOnString = [NSString stringWithFormat:@"%ld", (long)[expiresOn timeIntervalSince1970]];
     
     NSDictionary *jsonDictionary = @{@"authority": DEFAULT_TEST_AUTHORITY,
-                                     @"credential_type": @"LegacyADFSToken",
+                                     @"credential_type": @"LegacySingleResourceToken",
                                      @"client_id": DEFAULT_TEST_CLIENT_ID,
                                      @"target": DEFAULT_TEST_RESOURCE,
                                      @"cached_at": cachedAtString,
@@ -288,7 +288,7 @@
     XCTAssertNotNil(cacheItem);
     NSURL *expectedAuthority = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY];
     XCTAssertEqualObjects(cacheItem.authority, expectedAuthority);
-    XCTAssertEqual(cacheItem.tokenType, MSIDTokenTypeLegacyADFSToken);
+    XCTAssertEqual(cacheItem.tokenType, MSIDTokenTypeLegacySingleResourceToken);
     XCTAssertEqualObjects(cacheItem.clientId, DEFAULT_TEST_CLIENT_ID);
     XCTAssertEqualObjects(cacheItem.target, DEFAULT_TEST_RESOURCE);
     XCTAssertEqualObjects(cacheItem.expiresOn, expiresOn);

--- a/IdentityCore/tests/MSIDTokenTypeTests.m
+++ b/IdentityCore/tests/MSIDTokenTypeTests.m
@@ -48,10 +48,10 @@
     XCTAssertEqualObjects(result, @"IdToken");
 }
 
-- (void)testTokenTypeAsString_whenADFSTokenType_shouldReturnADFSTokenString
+- (void)testTokenTypeAsString_whenLegacyTokenType_shouldReturnLegacyTokenString
 {
-    NSString *result = [MSIDTokenTypeHelpers tokenTypeAsString:MSIDTokenTypeLegacyADFSToken];
-    XCTAssertEqualObjects(result, @"LegacyADFSToken");
+    NSString *result = [MSIDTokenTypeHelpers tokenTypeAsString:MSIDTokenTypeLegacySingleResourceToken];
+    XCTAssertEqualObjects(result, @"LegacySingleResourceToken");
 }
 
 - (void)testTokenTypeAsString_whenOtherTokenType_shouldReturnOtherTokenString
@@ -78,10 +78,10 @@
     XCTAssertEqual(result, MSIDTokenTypeIDToken);
 }
 
-- (void)testTokenTypeFromString_whenADFSTokenString_shouldReturnADFSTokenType
+- (void)testTokenTypeFromString_whenLegacyTokenString_shouldReturnLegacyTokenType
 {
-    MSIDTokenType result = [MSIDTokenTypeHelpers tokenTypeFromString:@"LegacyADFSToken"];
-    XCTAssertEqual(result, MSIDTokenTypeLegacyADFSToken);
+    MSIDTokenType result = [MSIDTokenTypeHelpers tokenTypeFromString:@"LegacySingleResourceToken"];
+    XCTAssertEqual(result, MSIDTokenTypeLegacySingleResourceToken);
 }
 
 - (void)testTokenTypeFromString_whenOtherTokenString_shouldReturnOtherTokenType

--- a/IdentityCore/tests/integration/MSIDLegacyTokenCacheIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDLegacyTokenCacheIntegrationTests.m
@@ -31,7 +31,7 @@
 #import "MSIDTestCacheIdentifiers.h"
 #import "MSIDAADV1TokenResponse.h"
 #import "MSIDAADV2TokenResponse.h"
-#import "MSIDAdfsToken.h"
+#import "MSIDLegacySingleResourceToken.h"
 #import "MSIDUserInformation.h"
 #import "MSIDAccessToken.h"
 #import "MSIDRefreshToken.h"
@@ -99,7 +99,7 @@
     XCTAssertEqual([accessTokensInCache count], 0);
 }
 
-- (void)testSaveTokensWithRequestParams_withADFSTokenAndAccount_shouldSaveToken
+- (void)testSaveTokensWithRequestParams_withLegacyTokenAndAccount_shouldSaveToken
 {
     MSIDAccount *account = [[MSIDAccount alloc] initWithLegacyUserId:@"" uniqueUserId:@"some id"];
     
@@ -113,13 +113,13 @@
     XCTAssertNil(error);
     XCTAssertTrue(result);
     
-    NSArray *accessTokensInCache = [_dataSource allLegacyADFSTokens];
-    XCTAssertEqual([accessTokensInCache count], 1);
+    NSArray *legacyTokensInCache = [_dataSource allLegacySingleResourceTokens];
+    XCTAssertEqual([legacyTokensInCache count], 1);
     
-    MSIDAdfsToken *adfsToken = accessTokensInCache[0];
-    XCTAssertEqual(adfsToken.tokenType, MSIDTokenTypeLegacyADFSToken);
-    XCTAssertEqualObjects(adfsToken.accessToken, DEFAULT_TEST_ACCESS_TOKEN);
-    XCTAssertEqualObjects(adfsToken.refreshToken, DEFAULT_TEST_REFRESH_TOKEN);
+    MSIDLegacySingleResourceToken *legacyToken = legacyTokensInCache[0];
+    XCTAssertEqual(legacyToken.tokenType, MSIDTokenTypeLegacySingleResourceToken);
+    XCTAssertEqualObjects(legacyToken.accessToken, DEFAULT_TEST_ACCESS_TOKEN);
+    XCTAssertEqualObjects(legacyToken.refreshToken, DEFAULT_TEST_REFRESH_TOKEN);
 }
 
 - (void)testSaveRefreshTokenForAccount_withMRRT_shouldSaveOneEntry
@@ -470,12 +470,12 @@
     XCTAssertEqual([allAccessTokens count], 2);
 }
 
-- (void)testGetADFSToken_withCorrectAccountAndParameters_shouldReturnToken
+- (void)testGetLegacyToken_withCorrectAccountAndParameters_shouldReturnToken
 {
     MSIDAccount *account = [[MSIDAccount alloc] initWithLegacyUserId:@""
                                                        uniqueUserId:nil];
     
-    // Save ADFS token response
+    // Save legacy token response
     NSError *error = nil;
     BOOL result = [_legacyAccessor saveTokensWithRequestParams:[MSIDTestRequestParams v1DefaultParams]
                                                        account:account
@@ -486,7 +486,7 @@
     XCTAssertNil(error);
     XCTAssertTrue(result);
     
-    MSIDAdfsToken *returnedToken = (MSIDAdfsToken *) [_legacyAccessor getTokenWithType:MSIDTokenTypeLegacyADFSToken
+    MSIDLegacySingleResourceToken *returnedToken = (MSIDLegacySingleResourceToken *) [_legacyAccessor getTokenWithType:MSIDTokenTypeLegacySingleResourceToken
                                                                                account:account
                                                                          requestParams:[MSIDTestRequestParams v1DefaultParams]
                                                                                context:nil
@@ -495,7 +495,7 @@
     XCTAssertNil(error);
     XCTAssertNotNil(returnedToken);
     
-    XCTAssertEqual(returnedToken.tokenType, MSIDTokenTypeLegacyADFSToken);
+    XCTAssertEqual(returnedToken.tokenType, MSIDTokenTypeLegacySingleResourceToken);
     XCTAssertEqualObjects(returnedToken.accessToken, DEFAULT_TEST_ACCESS_TOKEN);
     XCTAssertEqualObjects(returnedToken.refreshToken, DEFAULT_TEST_REFRESH_TOKEN);
 }

--- a/IdentityCore/tests/integration/MSIDLegacyTokenIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDLegacyTokenIntegrationTests.m
@@ -23,7 +23,7 @@
 
 #import <XCTest/XCTest.h>
 #import "MSIDTestTokenResponse.h"
-#import "MSIDAdfsToken.h"
+#import "MSIDLegacySingleResourceToken.h"
 #import "MSIDTestCacheIdentifiers.h"
 #import "MSIDTestRequestParams.h"
 #import "MSIDAADV1TokenResponse.h"
@@ -33,11 +33,11 @@
 #import "MSIDRequestParameters.h"
 #import "MSIDRequestParameters.h"
 
-@interface MSIDAdfsTokenIntegrationTests : XCTestCase
+@interface MSIDLegacyTokenIntegrationTests : XCTestCase
 
 @end
 
-@implementation MSIDAdfsTokenIntegrationTests
+@implementation MSIDLegacyTokenIntegrationTests
 
 #pragma mark - Init
 
@@ -51,7 +51,7 @@
     
     MSIDRequestParameters *params = [MSIDTestRequestParams defaultParams];
     
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenResponse:response request:params];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenResponse:response request:params];
     
     XCTAssertEqualObjects(token.authority, params.authority);
     XCTAssertEqualObjects(token.clientId, params.clientId);
@@ -77,7 +77,7 @@
     MSIDAADV1TokenResponse *response = [MSIDTestTokenResponse v1DefaultTokenResponse];
     MSIDRequestParameters *params = [MSIDTestRequestParams v1DefaultParams];
     
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenResponse:response request:params];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenResponse:response request:params];
     
     XCTAssertEqualObjects(token.authority, params.authority);
     XCTAssertEqualObjects(token.clientId, params.clientId);
@@ -106,7 +106,7 @@
     MSIDAADV1TokenResponse *response = [MSIDTestTokenResponse v1DefaultTokenResponse];
     MSIDRequestParameters *params = [MSIDTestRequestParams v2DefaultParams];
     
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenResponse:response request:params];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenResponse:response request:params];
     
     XCTAssertEqualObjects(token.authority, params.authority);
     XCTAssertEqualObjects(token.clientId, params.clientId);
@@ -135,7 +135,7 @@
     MSIDAADV2TokenResponse *response = [MSIDTestTokenResponse v2DefaultTokenResponse];
     MSIDRequestParameters *params = [MSIDTestRequestParams v1DefaultParams];
     
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenResponse:response request:params];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenResponse:response request:params];
     
     XCTAssertEqualObjects(token.authority, params.authority);
     XCTAssertEqualObjects(token.clientId, params.clientId);
@@ -167,7 +167,7 @@
     MSIDAADV2TokenResponse *response = [MSIDTestTokenResponse v2DefaultTokenResponse];
     MSIDRequestParameters *params = [MSIDTestRequestParams v2DefaultParams];
     
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenResponse:response request:params];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenResponse:response request:params];
     
     XCTAssertEqualObjects(token.authority, params.authority);
     XCTAssertEqualObjects(token.clientId, params.clientId);

--- a/IdentityCore/tests/integration/MSIDSharedTokenCacheIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDSharedTokenCacheIntegrationTests.m
@@ -30,7 +30,7 @@
 #import "MSIDTestRequestParams.h"
 #import "MSIDAccount.h"
 #import "MSIDTestCacheIdentifiers.h"
-#import "MSIDAdfsToken.h"
+#import "MSIDLegacySingleResourceToken.h"
 #import "MSIDRefreshToken.h"
 #import "MSIDAccessToken.h"
 #import "MSIDTestBrokerResponse.h"
@@ -335,13 +335,13 @@
     XCTAssertNil(returnedToken);
 }
 
-- (void)testGetADFSTokenForAccount_whenATPresentInPrimaryCache_returnsToken
+- (void)testGetLegacyTokenForAccount_whenATPresentInPrimaryCache_returnsToken
 {
     MSIDSharedTokenCache *tokenCache = [[MSIDSharedTokenCache alloc] initWithPrimaryCacheAccessor:_primaryAccessor
                                                                               otherCacheAccessors:@[_secondaryAccessor]];
     
-    MSIDAdfsToken *token = [[MSIDAdfsToken alloc] initWithTokenResponse:[MSIDTestTokenResponse v1SingleResourceTokenResponse]
-                                                                request:[MSIDTestRequestParams v1DefaultParams]];
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenResponse:[MSIDTestTokenResponse v1SingleResourceTokenResponse]
+                                                                                                request:[MSIDTestRequestParams v1DefaultParams]];
     
     MSIDAccount *account = [[MSIDAccount alloc] initWithLegacyUserId:@""
                                                         uniqueUserId:nil];
@@ -350,9 +350,9 @@
     
     // Check that AT is returned
     NSError *error = nil;
-    MSIDAdfsToken *returnedToken = [tokenCache getADFSTokenWithRequestParams:[MSIDTestRequestParams v1DefaultParams]
-                                                                     context:nil
-                                                                       error:&error];
+    MSIDLegacySingleResourceToken *returnedToken = [tokenCache getLegacyTokenWithRequestParams:[MSIDTestRequestParams v1DefaultParams]
+                                                                                       context:nil
+                                                                                         error:&error];
     
     XCTAssertNil(error);
     XCTAssertNotNil(token);

--- a/IdentityCore/tests/integration/MSIDSharedTokenCacheIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDSharedTokenCacheIntegrationTests.m
@@ -335,7 +335,7 @@
     XCTAssertNil(returnedToken);
 }
 
-- (void)testGetLegacyTokenForAccount_whenATPresentInPrimaryCache_returnsToken
+- (void)testGetLegacyTokenWithoutAccount_whenLegacyTokenPresentInPrimaryCache_returnsToken
 {
     MSIDSharedTokenCache *tokenCache = [[MSIDSharedTokenCache alloc] initWithPrimaryCacheAccessor:_primaryAccessor
                                                                               otherCacheAccessors:@[_secondaryAccessor]];
@@ -353,6 +353,31 @@
     MSIDLegacySingleResourceToken *returnedToken = [tokenCache getLegacyTokenWithRequestParams:[MSIDTestRequestParams v1DefaultParams]
                                                                                        context:nil
                                                                                          error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertNotNil(token);
+    XCTAssertEqualObjects(token, returnedToken);
+}
+
+- (void)testGetLegacySingleResourceTokenWithAccount_whenLegacyTokenPresentInPrimaryCache_returnsToken
+{
+    MSIDSharedTokenCache *tokenCache = [[MSIDSharedTokenCache alloc] initWithPrimaryCacheAccessor:_primaryAccessor
+                                                                              otherCacheAccessors:@[_secondaryAccessor]];
+    
+    MSIDLegacySingleResourceToken *token = [[MSIDLegacySingleResourceToken alloc] initWithTokenResponse:[MSIDTestTokenResponse v1SingleResourceTokenResponse]
+                                                                                                request:[MSIDTestRequestParams v1DefaultParams]];
+    
+    MSIDAccount *account = [[MSIDAccount alloc] initWithLegacyUserId:@"legacy ID"
+                                                        uniqueUserId:nil];
+    
+    [_primaryAccessor addToken:token forAccount:account];
+    
+    // Check that AT is returned
+    NSError *error = nil;
+    MSIDLegacySingleResourceToken *returnedToken = [tokenCache getLegacyTokenForAccount:account
+                                                                          requestParams:[MSIDTestRequestParams v1DefaultParams]
+                                                                                context:nil
+                                                                                  error:&error];
     
     XCTAssertNil(error);
     XCTAssertNotNil(token);

--- a/IdentityCore/tests/util/MSIDTestCacheDataSource.h
+++ b/IdentityCore/tests/util/MSIDTestCacheDataSource.h
@@ -30,7 +30,7 @@
 
 - (void)reset;
 
-- (NSArray *)allLegacyADFSTokens;
+- (NSArray *)allLegacySingleResourceTokens;
 - (NSArray *)allLegacyAccessTokens;
 - (NSArray *)allLegacyRefreshTokens;
 

--- a/IdentityCore/tests/util/MSIDTestCacheDataSource.m
+++ b/IdentityCore/tests/util/MSIDTestCacheDataSource.m
@@ -25,7 +25,7 @@
 #import "MSIDTokenCacheKey.h"
 #import "MSIDKeyedArchiverSerializer.h"
 #import "MSIDJsonSerializer.h"
-#import "MSIDAdfsToken.h"
+#import "MSIDLegacySingleResourceToken.h"
 #import "MSIDAccessToken.h"
 #import "MSIDRefreshToken.h"
 #import "MSIDIdToken.h"
@@ -397,9 +397,9 @@
     }
 }
 
-- (NSArray *)allLegacyADFSTokens
+- (NSArray *)allLegacySingleResourceTokens
 {
-    return [self allTokensWithType:MSIDTokenTypeLegacyADFSToken
+    return [self allTokensWithType:MSIDTokenTypeLegacySingleResourceToken
                         serializer:[[MSIDKeyedArchiverSerializer alloc] init]];
 }
 

--- a/IdentityCore/tests/util/cache/MSIDTestCacheAccessor.m
+++ b/IdentityCore/tests/util/cache/MSIDTestCacheAccessor.m
@@ -261,16 +261,7 @@
                                clientId:(NSString *)clientId
                               authority:(NSURL *)authority
 {
-    NSString *userIdentifier = nil;
-    
-    if (!account)
-    {
-        userIdentifier = @"";
-    }
-    else
-    {
-        userIdentifier = account.userIdentifier ? account.userIdentifier : account.legacyUserId;
-    }
+    NSString *userIdentifier = account.userIdentifier ? account.userIdentifier : account.legacyUserId;
     
     NSString *cloudIdentifier = tokenType == MSIDTokenTypeRefreshToken ? authority.msidHostWithPortIfNecessary : authority.absoluteString;
     


### PR DESCRIPTION
Because ADFS tokens can also be multi resource, it was misleading to call single resource tokens "ADFS tokens". So, I renamed it across the project and also added ability to get single resource tokens for an account as we might need it. 