### PR TITLE
Don't require client info for V1 response

### DIFF
--- a/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
@@ -144,18 +144,6 @@ MSID_JSON_ACCESSOR(MSID_TELEMETRY_KEY_SPE_INFO, speInfo)
                            error:(NSError **)error
 {
     [self checkCorrelationId:context.correlationId];
-    
-    if (!self.clientInfo)
-    {
-        MSID_LOG_ERROR(context, @"Client info was not returned in the server response");
-        MSID_LOG_ERROR_PII(context, @"Client info was not returned in the server response");
-        if (error)
-        {
-            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Client info was not returned in the server response", nil, nil, nil, context.correlationId, nil);
-        }
-        return NO;
-    }
-    
     return YES;
 }
 

--- a/IdentityCore/src/oauth2/aad_v1/MSIDAADV1TokenResponse.m
+++ b/IdentityCore/src/oauth2/aad_v1/MSIDAADV1TokenResponse.m
@@ -50,6 +50,18 @@ MSID_JSON_ACCESSOR(MSID_OAUTH2_RESOURCE, resource)
     return MSIDAccountTypeAADV1;
 }
 
+- (BOOL)verifyExtendedProperties:(id<MSIDRequestContext>)context
+                           error:(NSError **)error
+{
+    if (!self.clientInfo)
+    {
+        MSID_LOG_WARN(context, @"Client info was not returned in the server response");
+        MSID_LOG_WARN_PII(context, @"Client info was not returned in the server response");
+    }
+    
+    return [super verifyExtendedProperties:context error:error];
+}
+
 - (NSError *)getOAuthError:(id<MSIDRequestContext>)context
           fromRefreshToken:(BOOL)fromRefreshToken
 {

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2TokenResponse.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2TokenResponse.m
@@ -55,6 +55,23 @@
                            nil);
 }
 
+- (BOOL)verifyExtendedProperties:(id<MSIDRequestContext>)context
+                           error:(NSError **)error
+{
+    if (!self.clientInfo)
+    {
+        MSID_LOG_ERROR(context, @"Client info was not returned in the server response");
+        MSID_LOG_ERROR_PII(context, @"Client info was not returned in the server response");
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Client info was not returned in the server response", nil, nil, nil, context.correlationId, nil);
+        }
+        return NO;
+    }
+    
+    return [super verifyExtendedProperties:context error:error];
+}
+
 - (NSString *)targetWithAdditionFromRequest:(MSIDRequestParameters *)requestParams
 {
     // Add additional scopes from request parameters in case they are not returned from server

--- a/IdentityCore/tests/MSIDTokenResponseHandlerTests.m
+++ b/IdentityCore/tests/MSIDTokenResponseHandlerTests.m
@@ -125,7 +125,7 @@
 
 - (void)testVerifyResponse_whenNoUserInfo_shouldReturnError
 {
-    MSIDAADTokenResponse *response = [[MSIDAADV1TokenResponse alloc] initWithJSONDictionary:@{@"access_token":@"fake_access_token",
+    MSIDAADV2TokenResponse *response = [[MSIDAADV2TokenResponse alloc] initWithJSONDictionary:@{@"access_token":@"fake_access_token",
                                                                                               @"refresh_token":@"fake_refresh_token"}
                                                                                       error:nil];
     NSError *error = nil;


### PR DESCRIPTION
We still have a valid case where clientInfo is not returned (broker), so we shouldn't be requiring clientInfo for that case for now