### PR TITLE
Telemetry Fix and Oii Rules

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -42,8 +42,8 @@
 		23F32F1A1FFD635600B2905E /* MSIDTestIdTokenUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B2CDB57F1FE33F64003A4B5C /* MSIDTestIdTokenUtil.m */; };
 		23F32F251FFDAF1900B2905E /* MSIDTestBrokerResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D81BBD1FF5C7460093859A /* MSIDTestBrokerResponse.m */; };
 		23F32F261FFDAF1A00B2905E /* MSIDTestBrokerResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D81BBD1FF5C7460093859A /* MSIDTestBrokerResponse.m */; };
-		6035CD8C207EA67300369E69 /* MSIDTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6035CD8B207EA67300369E69 /* MSIDTelemetryTests.m */; };
-		6035CD8D207EA67300369E69 /* MSIDTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6035CD8B207EA67300369E69 /* MSIDTelemetryTests.m */; };
+		6035CD8C207EA67300369E69 /* MSIDTelemetryIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6035CD8B207EA67300369E69 /* MSIDTelemetryIntegrationTests.m */; };
+		6035CD8D207EA67300369E69 /* MSIDTelemetryIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6035CD8B207EA67300369E69 /* MSIDTelemetryIntegrationTests.m */; };
 		60BF06042051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 60BF06032051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m */; };
 		60BF06052051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 60BF06032051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m */; };
 		60BF06072052023900DE7C1C /* MSIDWipeDataTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60BF06062052023900DE7C1C /* MSIDWipeDataTelemetryTests.m */; };
@@ -438,7 +438,7 @@
 		23BDA6791FCE693800FE14BE /* MSIDKeychainUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDKeychainUtil.m; sourceTree = "<group>"; };
 		23F32F151FF72CE400B2905E /* MSIDMacTokenCacheIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDMacTokenCacheIntegrationTests.m; sourceTree = "<group>"; };
 		23F32F221FFDAB9D00B2905E /* MSIDTokenCacheDataSourceIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDTokenCacheDataSourceIntegrationTests.m; sourceTree = "<group>"; };
-		6035CD8B207EA67300369E69 /* MSIDTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryTests.m; sourceTree = "<group>"; };
+		6035CD8B207EA67300369E69 /* MSIDTelemetryIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryIntegrationTests.m; sourceTree = "<group>"; };
 		60BF06022051F95B00DE7C1C /* MSIDTelemetryTestDispatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryTestDispatcher.h; sourceTree = "<group>"; };
 		60BF06032051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryTestDispatcher.m; sourceTree = "<group>"; };
 		60BF06062052023900DE7C1C /* MSIDWipeDataTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWipeDataTelemetryTests.m; sourceTree = "<group>"; };
@@ -775,6 +775,7 @@
 		231CE9BD1FE8710A00E95D3E /* integration */ = {
 			isa = PBXGroup;
 			children = (
+				6035CD8B207EA67300369E69 /* MSIDTelemetryIntegrationTests.m */,
 				B23ECEF21FF2FA300015FC1D /* MSIDSharedTokenCacheIntegrationTests.m */,
 				B23ECF041FF33AE70015FC1D /* MSIDLegacyTokenCacheIntegrationTests.m */,
 				965981041FF4C9B400E31CDE /* MSIDDefaultTokenCacheIntegrationTests.m */,
@@ -1259,7 +1260,6 @@
 				B26A0B922072B824006BD95A /* MSIDAADOauth2StrategyTests.m */,
 				B26A0B952072B9CB006BD95A /* MSIDAADV1Oauth2StrategyTests.m */,
 				B26A0B982072BABD006BD95A /* MSIDAADV2Oauth2StrategyTests.m */,
-				6035CD8B207EA67300369E69 /* MSIDTelemetryTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -1600,7 +1600,7 @@
 				234858E020490F00004FBC3C /* MSIDDefaultTokenCacheIntegrationTests.m in Sources */,
 				B2808004204CB2A700944D89 /* MSIDAADV1TokenResponseTests.m in Sources */,
 				B210F4651FDF1CB8005A8F76 /* MSIDURLFormObjectTests.m in Sources */,
-				6035CD8C207EA67300369E69 /* MSIDTelemetryTests.m in Sources */,
+				6035CD8C207EA67300369E69 /* MSIDTelemetryIntegrationTests.m in Sources */,
 				23CC944A20465CF100AA0551 /* MSIDTokenCacheDataSourceIntegrationTests.m in Sources */,
 				23BDA6691FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */,
 				B2DD5BC220479D9C0084313F /* MSIDKeyedArchiverSerializerTests.m in Sources */,
@@ -1729,7 +1729,7 @@
 				23CC944920465CEC00AA0551 /* MSIDTokenCacheDataSourceIntegrationTests.m in Sources */,
 				B23ECF011FF306110015FC1D /* MSIDTestRequestParams.m in Sources */,
 				B2808002204CB29900944D89 /* MSIDAADTokenResponseTests.m in Sources */,
-				6035CD8D207EA67300369E69 /* MSIDTelemetryTests.m in Sources */,
+				6035CD8D207EA67300369E69 /* MSIDTelemetryIntegrationTests.m in Sources */,
 				B2DD5B7520461F410084313F /* MSIDCacheItemTests.m in Sources */,
 				B2DD5B98204756580084313F /* MSIDAccountTypeTests.m in Sources */,
 				B210F4661FDF1CB8005A8F76 /* MSIDURLFormObjectTests.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		23F32F1A1FFD635600B2905E /* MSIDTestIdTokenUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B2CDB57F1FE33F64003A4B5C /* MSIDTestIdTokenUtil.m */; };
 		23F32F251FFDAF1900B2905E /* MSIDTestBrokerResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D81BBD1FF5C7460093859A /* MSIDTestBrokerResponse.m */; };
 		23F32F261FFDAF1A00B2905E /* MSIDTestBrokerResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D81BBD1FF5C7460093859A /* MSIDTestBrokerResponse.m */; };
+		6035CD8C207EA67300369E69 /* MSIDTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6035CD8B207EA67300369E69 /* MSIDTelemetryTests.m */; };
+		6035CD8D207EA67300369E69 /* MSIDTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6035CD8B207EA67300369E69 /* MSIDTelemetryTests.m */; };
 		60BF06042051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 60BF06032051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m */; };
 		60BF06052051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 60BF06032051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m */; };
 		60BF06072052023900DE7C1C /* MSIDWipeDataTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60BF06062052023900DE7C1C /* MSIDWipeDataTelemetryTests.m */; };
@@ -70,9 +72,9 @@
 		B20657A91FC91ECC00412B7D /* MSIDTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = B206578E1FC91BDF00412B7D /* MSIDTelemetry.m */; };
 		B20657AA1FC91ECC00412B7D /* MSIDTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = B206578E1FC91BDF00412B7D /* MSIDTelemetry.m */; };
 		B20657AB1FC91F6400412B7D /* MSIDTelemetry+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B20657A01FC91BE100412B7D /* MSIDTelemetry+Internal.h */; };
-		B20657AC1FC91FB100412B7D /* MSIDTelemetryPiiRules.m in Sources */ = {isa = PBXBuildFile; fileRef = B206579A1FC91BE000412B7D /* MSIDTelemetryPiiRules.m */; };
-		B20657AD1FC91FB100412B7D /* MSIDTelemetryPiiRules.m in Sources */ = {isa = PBXBuildFile; fileRef = B206579A1FC91BE000412B7D /* MSIDTelemetryPiiRules.m */; };
-		B20657AE1FC91FB700412B7D /* MSIDTelemetryPiiRules.h in Headers */ = {isa = PBXBuildFile; fileRef = B206579F1FC91BE100412B7D /* MSIDTelemetryPiiRules.h */; };
+		B20657AC1FC91FB100412B7D /* MSIDTelemetryPiiOiiRules.m in Sources */ = {isa = PBXBuildFile; fileRef = B206579A1FC91BE000412B7D /* MSIDTelemetryPiiOiiRules.m */; };
+		B20657AD1FC91FB100412B7D /* MSIDTelemetryPiiOiiRules.m in Sources */ = {isa = PBXBuildFile; fileRef = B206579A1FC91BE000412B7D /* MSIDTelemetryPiiOiiRules.m */; };
+		B20657AE1FC91FB700412B7D /* MSIDTelemetryPiiOiiRules.h in Headers */ = {isa = PBXBuildFile; fileRef = B206579F1FC91BE100412B7D /* MSIDTelemetryPiiOiiRules.h */; };
 		B20657AF1FC91FC900412B7D /* MSIDTelemetryEventStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = B206578D1FC91BDF00412B7D /* MSIDTelemetryEventStrings.h */; };
 		B20657B01FC91FD100412B7D /* MSIDTelemetryEventStrings.m in Sources */ = {isa = PBXBuildFile; fileRef = B206579E1FC91BE100412B7D /* MSIDTelemetryEventStrings.m */; };
 		B20657B11FC91FD100412B7D /* MSIDTelemetryEventStrings.m in Sources */ = {isa = PBXBuildFile; fileRef = B206579E1FC91BE100412B7D /* MSIDTelemetryEventStrings.m */; };
@@ -436,6 +438,7 @@
 		23BDA6791FCE693800FE14BE /* MSIDKeychainUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDKeychainUtil.m; sourceTree = "<group>"; };
 		23F32F151FF72CE400B2905E /* MSIDMacTokenCacheIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDMacTokenCacheIntegrationTests.m; sourceTree = "<group>"; };
 		23F32F221FFDAB9D00B2905E /* MSIDTokenCacheDataSourceIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDTokenCacheDataSourceIntegrationTests.m; sourceTree = "<group>"; };
+		6035CD8B207EA67300369E69 /* MSIDTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryTests.m; sourceTree = "<group>"; };
 		60BF06022051F95B00DE7C1C /* MSIDTelemetryTestDispatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryTestDispatcher.h; sourceTree = "<group>"; };
 		60BF06032051F9A200DE7C1C /* MSIDTelemetryTestDispatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryTestDispatcher.m; sourceTree = "<group>"; };
 		60BF06062052023900DE7C1C /* MSIDWipeDataTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWipeDataTelemetryTests.m; sourceTree = "<group>"; };
@@ -475,11 +478,11 @@
 		B20657971FC91BE000412B7D /* MSIDTelemetryAPIEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryAPIEvent.m; sourceTree = "<group>"; };
 		B20657981FC91BE000412B7D /* MSIDTelemetryEventInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryEventInterface.h; sourceTree = "<group>"; };
 		B20657991FC91BE000412B7D /* MSIDTelemetryHttpEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryHttpEvent.m; sourceTree = "<group>"; };
-		B206579A1FC91BE000412B7D /* MSIDTelemetryPiiRules.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryPiiRules.m; sourceTree = "<group>"; };
+		B206579A1FC91BE000412B7D /* MSIDTelemetryPiiOiiRules.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryPiiOiiRules.m; sourceTree = "<group>"; };
 		B206579B1FC91BE000412B7D /* MSIDTelemetryUIEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryUIEvent.h; sourceTree = "<group>"; };
 		B206579C1FC91BE000412B7D /* MSIDTelemetryHttpEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryHttpEvent.h; sourceTree = "<group>"; };
 		B206579E1FC91BE100412B7D /* MSIDTelemetryEventStrings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryEventStrings.m; sourceTree = "<group>"; };
-		B206579F1FC91BE100412B7D /* MSIDTelemetryPiiRules.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryPiiRules.h; sourceTree = "<group>"; };
+		B206579F1FC91BE100412B7D /* MSIDTelemetryPiiOiiRules.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryPiiOiiRules.h; sourceTree = "<group>"; };
 		B20657A01FC91BE100412B7D /* MSIDTelemetry+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDTelemetry+Internal.h"; sourceTree = "<group>"; };
 		B20657A41FC91C1600412B7D /* MSIDTelemetryDispatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryDispatcher.h; sourceTree = "<group>"; };
 		B20657A71FC91DA900412B7D /* MSIDTelemetry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetry.h; sourceTree = "<group>"; };
@@ -865,8 +868,8 @@
 				B206579E1FC91BE100412B7D /* MSIDTelemetryEventStrings.m */,
 				B206579C1FC91BE000412B7D /* MSIDTelemetryHttpEvent.h */,
 				B20657991FC91BE000412B7D /* MSIDTelemetryHttpEvent.m */,
-				B206579F1FC91BE100412B7D /* MSIDTelemetryPiiRules.h */,
-				B206579A1FC91BE000412B7D /* MSIDTelemetryPiiRules.m */,
+				B206579F1FC91BE100412B7D /* MSIDTelemetryPiiOiiRules.h */,
+				B206579A1FC91BE000412B7D /* MSIDTelemetryPiiOiiRules.m */,
 				B206579B1FC91BE000412B7D /* MSIDTelemetryUIEvent.h */,
 				B206578B1FC91BDF00412B7D /* MSIDTelemetryUIEvent.m */,
 			);
@@ -1256,6 +1259,7 @@
 				B26A0B922072B824006BD95A /* MSIDAADOauth2StrategyTests.m */,
 				B26A0B952072B9CB006BD95A /* MSIDAADV1Oauth2StrategyTests.m */,
 				B26A0B982072BABD006BD95A /* MSIDAADV2Oauth2StrategyTests.m */,
+				6035CD8B207EA67300369E69 /* MSIDTelemetryTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -1303,7 +1307,7 @@
 				B20657A81FC91EC900412B7D /* MSIDTelemetry.h in Headers */,
 				B251CC202040F6C6005E0179 /* MSIDDefaultTokenCacheKey.h in Headers */,
 				B20657A61FC91C9A00412B7D /* MSIDTelemetryEventInterface.h in Headers */,
-				B20657AE1FC91FB700412B7D /* MSIDTelemetryPiiRules.h in Headers */,
+				B20657AE1FC91FB700412B7D /* MSIDTelemetryPiiOiiRules.h in Headers */,
 				B2964BE1205103920000BC95 /* MSIDTokenFilteringHelper.h in Headers */,
 				B26A0B7D2071ADCE006BD95A /* MSIDOauth2Strategy.h in Headers */,
 				B20657C81FC926AE00412B7D /* MSIDTelemetryHttpEvent.h in Headers */,
@@ -1596,6 +1600,7 @@
 				234858E020490F00004FBC3C /* MSIDDefaultTokenCacheIntegrationTests.m in Sources */,
 				B2808004204CB2A700944D89 /* MSIDAADV1TokenResponseTests.m in Sources */,
 				B210F4651FDF1CB8005A8F76 /* MSIDURLFormObjectTests.m in Sources */,
+				6035CD8C207EA67300369E69 /* MSIDTelemetryTests.m in Sources */,
 				23CC944A20465CF100AA0551 /* MSIDTokenCacheDataSourceIntegrationTests.m in Sources */,
 				23BDA6691FC7775200FE14BE /* MSIDDictionaryExtensionsTests.m in Sources */,
 				B2DD5BC220479D9C0084313F /* MSIDKeyedArchiverSerializerTests.m in Sources */,
@@ -1705,7 +1710,7 @@
 				B26A0B892071B752006BD95A /* MSIDAADV2Oauth2Strategy.m in Sources */,
 				B20657CA1FC926B200412B7D /* MSIDTelemetryHttpEvent.m in Sources */,
 				B20657C31FC9262700412B7D /* NSString+MSIDTelemetryExtensions.m in Sources */,
-				B20657AC1FC91FB100412B7D /* MSIDTelemetryPiiRules.m in Sources */,
+				B20657AC1FC91FB100412B7D /* MSIDTelemetryPiiOiiRules.m in Sources */,
 				B210F42A1FDDE19B005A8F76 /* MSIDJsonObject.m in Sources */,
 				B29CB6BD1FEC7CE900F880ED /* MSIDRequestParameters.m in Sources */,
 				B251CC52204105AE005E0179 /* MSIDTokenType.m in Sources */,
@@ -1724,6 +1729,7 @@
 				23CC944920465CEC00AA0551 /* MSIDTokenCacheDataSourceIntegrationTests.m in Sources */,
 				B23ECF011FF306110015FC1D /* MSIDTestRequestParams.m in Sources */,
 				B2808002204CB29900944D89 /* MSIDAADTokenResponseTests.m in Sources */,
+				6035CD8D207EA67300369E69 /* MSIDTelemetryTests.m in Sources */,
 				B2DD5B7520461F410084313F /* MSIDCacheItemTests.m in Sources */,
 				B2DD5B98204756580084313F /* MSIDAccountTypeTests.m in Sources */,
 				B210F4661FDF1CB8005A8F76 /* MSIDURLFormObjectTests.m in Sources */,
@@ -1866,7 +1872,7 @@
 				B20657C41FC9262800412B7D /* NSString+MSIDTelemetryExtensions.m in Sources */,
 				B210F4291FDDE19B005A8F76 /* MSIDJsonObject.m in Sources */,
 				B251CC51204105AE005E0179 /* MSIDTokenType.m in Sources */,
-				B20657AD1FC91FB100412B7D /* MSIDTelemetryPiiRules.m in Sources */,
+				B20657AD1FC91FB100412B7D /* MSIDTelemetryPiiOiiRules.m in Sources */,
 				04930F851FEC8E6800FC4DCD /* MSIDAadAuthorityCache.m in Sources */,
 				B2B1D57320425DFD00DD81F0 /* MSIDAccountCacheItem.m in Sources */,
 				B20657CC1FC9271000412B7D /* MSIDTelemetryUIEvent.m in Sources */,

--- a/IdentityCore/src/cache/mac/MSIDMacTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacTokenCache.m
@@ -128,7 +128,7 @@ return NO; \
         cache = [unarchiver decodeObjectOfClass:NSDictionary.class forKey:NSKeyedArchiveRootObjectKey];
         [unarchiver finishDecoding];
     }
-    @catch (id expection)
+    @catch (id exception)
     {
         if (error) {
             *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorCacheBadFormat, @"Failed to unarchive data blob from -deserialize!", nil, nil, nil, nil, nil);

--- a/IdentityCore/src/telemetry/MSIDTelemetry.m
+++ b/IdentityCore/src/telemetry/MSIDTelemetry.m
@@ -26,7 +26,7 @@
 #import "MSIDTelemetryEventInterface.h"
 #import "MSIDTelemetryDispatcher.h"
 #import "MSIDTelemetryEventStrings.h"
-#import "MSIDTelemetryPiiRules.h"
+#import "MSIDTelemetryPiiOiiRules.h"
 
 static NSString* const s_delimiter = @"|";
 
@@ -182,9 +182,10 @@ static NSString* const s_delimiter = @"|";
         {
             for (NSString *propertyName in [event.propertyMap allKeys])
             {
-                BOOL isPii = [MSIDTelemetryPiiRules isPii:propertyName];
+                BOOL isPii = [MSIDTelemetryPiiOiiRules isPii:propertyName];
+                BOOL isOii = [MSIDTelemetryPiiOiiRules isOii:propertyName];
                 
-                if (isPii && !self.piiEnabled)
+                if ((isPii || isOii) && !self.piiEnabled)
                 {
                     [event deleteProperty:propertyName];
                 }

--- a/IdentityCore/src/telemetry/MSIDTelemetry.m
+++ b/IdentityCore/src/telemetry/MSIDTelemetry.m
@@ -182,10 +182,9 @@ static NSString* const s_delimiter = @"|";
         {
             for (NSString *propertyName in [event.propertyMap allKeys])
             {
-                BOOL isPii = [MSIDTelemetryPiiOiiRules isPii:propertyName];
-                BOOL isOii = [MSIDTelemetryPiiOiiRules isOii:propertyName];
+                BOOL isPiiOrOii = [MSIDTelemetryPiiOiiRules isPiiOrOii:propertyName];
                 
-                if ((isPii || isOii) && !self.piiEnabled)
+                if (isPiiOrOii && !self.piiEnabled)
                 {
                     [event deleteProperty:propertyName];
                 }

--- a/IdentityCore/src/telemetry/MSIDTelemetryBaseEvent.m
+++ b/IdentityCore/src/telemetry/MSIDTelemetryBaseEvent.m
@@ -24,7 +24,7 @@
 #import "MSIDTelemetryBaseEvent.h"
 #import "NSDate+MSIDExtensions.h"
 #import "NSMutableDictionary+MSIDExtensions.h"
-#import "MSIDTelemetryPiiRules.h"
+#import "MSIDTelemetryPiiOiiRules.h"
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDVersion.h"
 
@@ -70,12 +70,12 @@
         return;
     }
     
-    if ([MSIDTelemetryPiiRules isPii:name])
+    if ([MSIDTelemetryPiiOiiRules isPii:name])
     {
         value = [value msidComputeSHA256];
     }
     
-    [_propertyMap setValue:value forKey:TELEMETRY_KEY(name)];
+    [_propertyMap setValue:value forKey:name];
 }
 
 - (NSString *)propertyWithName:(NSString *)name
@@ -85,7 +85,7 @@
         return nil;
     }
     
-    return _propertyMap[TELEMETRY_KEY(name)];
+    return _propertyMap[name];
 }
 
 - (void)deleteProperty:(NSString  *)name
@@ -95,7 +95,7 @@
         return;
     }
     
-    [_propertyMap removeObjectForKey:TELEMETRY_KEY(name)];
+    [_propertyMap removeObjectForKey:name];
 }
 
 - (NSDictionary *)getProperties
@@ -148,17 +148,17 @@
         NSString *applicationVersion = [MSIDDeviceId applicationVersion];
         
         [s_defaultParameters msidSetObjectIfNotNil:deviceId
-                                            forKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_DEVICE_ID)];
+                                            forKey:MSID_TELEMETRY_KEY_DEVICE_ID];
         [s_defaultParameters msidSetObjectIfNotNil:applicationName
-                                            forKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_NAME)];
+                                            forKey:MSID_TELEMETRY_KEY_APPLICATION_NAME];
         [s_defaultParameters msidSetObjectIfNotNil:applicationVersion
-                                            forKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_VERSION)];
+                                            forKey:MSID_TELEMETRY_KEY_APPLICATION_VERSION];
         
         NSDictionary *adalId = [MSIDDeviceId deviceId];
         
         for (NSString *key in adalId)
         {
-            NSString *propertyName = TELEMETRY_KEY([[key lowercaseString] stringByReplacingOccurrencesOfString:@"-" withString:@"_"]);
+            NSString *propertyName = [[key lowercaseString] stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
             [s_defaultParameters msidSetObjectIfNotNil:[adalId objectForKey:key] forKey:propertyName];
         }
     });

--- a/IdentityCore/src/telemetry/MSIDTelemetryEventStrings.h
+++ b/IdentityCore/src/telemetry/MSIDTelemetryEventStrings.h
@@ -25,7 +25,7 @@
 
 #import "MSIDVersion.h"
 
-#define TELEMETRY_KEY(_KEY) [NSString stringWithFormat:@"%@%@", [MSIDVersion telemetryEventPrefix], _KEY]
+#define TELEMETRY_KEY(_KEY) ([NSString stringWithFormat:@"%@%@", [MSIDVersion telemetryEventPrefix], _KEY])
 
 extern NSString *const MSID_TELEMETRY_EVENT_DEFAULT_EVENT;
 extern NSString *const MSID_TELEMETRY_EVENT_API_EVENT;

--- a/IdentityCore/src/telemetry/MSIDTelemetryPiiOiiRules.h
+++ b/IdentityCore/src/telemetry/MSIDTelemetryPiiOiiRules.h
@@ -27,5 +27,6 @@
 
 + (BOOL)isPii:(NSString *)propertyName;
 + (BOOL)isOii:(NSString *)propertyName;
++ (BOOL)isPiiOrOii:(NSString *)propertyName;
 
 @end

--- a/IdentityCore/src/telemetry/MSIDTelemetryPiiOiiRules.h
+++ b/IdentityCore/src/telemetry/MSIDTelemetryPiiOiiRules.h
@@ -23,8 +23,9 @@
 
 #import <Foundation/Foundation.h>
 
-@interface MSIDTelemetryPiiRules : NSObject
+@interface MSIDTelemetryPiiOiiRules : NSObject
 
 + (BOOL)isPii:(NSString *)propertyName;
++ (BOOL)isOii:(NSString *)propertyName;
 
 @end

--- a/IdentityCore/src/telemetry/MSIDTelemetryPiiOiiRules.m
+++ b/IdentityCore/src/telemetry/MSIDTelemetryPiiOiiRules.m
@@ -50,12 +50,27 @@ static NSSet *_oiiFields;
 
 + (BOOL)isPii:(NSString *)propertyName
 {
+    if (!propertyName)
+    {
+        return NO;
+    }
+    
     return [_piiFields containsObject:propertyName];
 }
 
 + (BOOL)isOii:(NSString *)propertyName
 {
+    if (!propertyName)
+    {
+        return NO;
+    }
+    
     return [_oiiFields containsObject:propertyName];
+}
+
++ (BOOL)isPiiOrOii:(NSString *)propertyName
+{
+    return [self isPii:propertyName] || [self isOii:propertyName];
 }
 
 @end

--- a/IdentityCore/src/telemetry/MSIDTelemetryPiiOiiRules.m
+++ b/IdentityCore/src/telemetry/MSIDTelemetryPiiOiiRules.m
@@ -21,24 +21,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "MSIDTelemetryPiiRules.h"
+#import "MSIDTelemetryPiiOiiRules.h"
 #import "MSIDTelemetryEventStrings.h"
 
 static NSSet *_piiFields;
+static NSSet *_oiiFields;
 
-@implementation MSIDTelemetryPiiRules
+@implementation MSIDTelemetryPiiOiiRules
 
 + (void)initialize
 {
-    _piiFields = [[NSSet alloc] initWithArray:@[MSID_TELEMETRY_KEY_TENANT_ID,
-                                               MSID_TELEMETRY_KEY_USER_ID,
+    _piiFields = [[NSSet alloc] initWithArray:@[MSID_TELEMETRY_KEY_USER_ID,
                                                MSID_TELEMETRY_KEY_DEVICE_ID,
                                                MSID_TELEMETRY_KEY_LOGIN_HINT,
-                                               MSID_TELEMETRY_KEY_CLIENT_ID,
                                                MSID_TELEMETRY_KEY_ERROR_DESCRIPTION,
-                                               MSID_TELEMETRY_KEY_HTTP_PATH,
-                                               MSID_TELEMETRY_KEY_REQUEST_QUERY_PARAMS,
-                                               MSID_TELEMETRY_KEY_AUTHORITY]];
+                                               MSID_TELEMETRY_KEY_REQUEST_QUERY_PARAMS]];
+    
+    _oiiFields = [[NSSet alloc] initWithArray:@[MSID_TELEMETRY_KEY_TENANT_ID,
+                                                MSID_TELEMETRY_KEY_CLIENT_ID,
+                                                MSID_TELEMETRY_KEY_HTTP_PATH,
+                                                MSID_TELEMETRY_KEY_AUTHORITY,
+                                                MSID_TELEMETRY_KEY_IDP,
+                                                MSID_TELEMETRY_KEY_APPLICATION_NAME,
+                                                MSID_TELEMETRY_KEY_APPLICATION_VERSION]];
 }
 
 #pragma mark - Public
@@ -46,6 +51,11 @@ static NSSet *_piiFields;
 + (BOOL)isPii:(NSString *)propertyName
 {
     return [_piiFields containsObject:propertyName];
+}
+
++ (BOOL)isOii:(NSString *)propertyName
+{
+    return [_oiiFields containsObject:propertyName];
 }
 
 @end

--- a/IdentityCore/src/util/NSString+MSIDTelemetryExtensions.m
+++ b/IdentityCore/src/util/NSString+MSIDTelemetryExtensions.m
@@ -30,14 +30,14 @@
 #define CHECK_AND_SET_OBJ(_DICT, _OBJECT, _KEY) \
     if (![NSString msidIsStringNilOrBlank:_OBJECT]) \
     { \
-        NSString *key = [NSString stringWithFormat:@"%@%@", [MSIDVersion telemetryEventPrefix], _KEY]; \
+        NSString *key = [NSString stringWithFormat:@"%@",_KEY]; \
         [_DICT setObject:_OBJECT forKey:key]; \
     } \
 
 #define CHECK_AND_SET_OBJ_IF_NOT_ZERO(_DICT, _OBJECT, _KEY) \
     if (![NSString msidIsStringNilOrBlank:_OBJECT] && ![_OBJECT isEqualToString:@"0"]) \
     { \
-        NSString *key = [NSString stringWithFormat:@"%@%@", [MSIDVersion telemetryEventPrefix], _KEY]; \
+        NSString *key = [NSString stringWithFormat:@"%@", _KEY]; \
         [_DICT setObject:_OBJECT forKey:key]; \
     } \
 

--- a/IdentityCore/tests/MSIDTelemetryCacheEventTests.m
+++ b/IdentityCore/tests/MSIDTelemetryCacheEventTests.m
@@ -30,6 +30,7 @@
 #import "MSIDAccessToken.h"
 #import "MSIDLegacySingleResourceToken.h"
 #import "MSIDRefreshToken.h"
+#import "MSIDTelemetryEventStrings.h"
 
 @interface MSIDTelemetryCacheEventTests : XCTestCase
 
@@ -57,8 +58,8 @@
     
     NSDictionary *properties = [cacheEvent getProperties];
     XCTAssertEqual([[properties allKeys] count], 6);
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.spe_info"], @"I");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.token_type"], @"access_token");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_SPE_INFO], @"I");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_TOKEN_TYPE], @"access_token");
 }
 
 - (void)testSetToken_withLegacySingleResourceToken_shouldSaveTokenTypeSPEInfoAndRTStatus
@@ -72,10 +73,10 @@
     
     NSDictionary *properties = [cacheEvent getProperties];
     XCTAssertEqual([[properties allKeys] count], 7);
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.spe_info"], @"I");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.token_type"], @"ADFS_access_token_refresh_token");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.is_rt"], @"yes");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.token_rt_status"], @"tried");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_SPE_INFO], @"I");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_TOKEN_TYPE], @"ADFS_access_token_refresh_token");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_IS_RT], @"yes");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_RT_STATUS], @"tried");
 }
 
 - (void)testSetToken_withMRRTToken_shouldSaveTokenTypeSPEInfoAndMRRTStatus
@@ -91,10 +92,10 @@
     
     NSDictionary *properties = [cacheEvent getProperties];
     XCTAssertEqual([[properties allKeys] count], 7);
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.spe_info"], @"I");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.token_type"], @"refresh_token");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.is_mrrt"], @"yes");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.token_mrrt_status"], @"tried");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_SPE_INFO], @"I");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_TOKEN_TYPE], @"refresh_token");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_IS_MRRT], @"yes");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_MRRT_STATUS], @"tried");
 }
 
 - (void)testSetToken_withFRTToken_shouldSaveTokenTypeSPEInfoAndFRTStatus
@@ -110,10 +111,10 @@
     
     NSDictionary *properties = [cacheEvent getProperties];
     XCTAssertEqual([[properties allKeys] count], 7);
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.spe_info"], @"I");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.token_type"], @"refresh_token");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.is_frt"], @"yes");
-    XCTAssertEqualObjects(properties[@"Microsoft.Test.token_frt_status"], @"tried");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_SPE_INFO], @"I");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_TOKEN_TYPE], @"refresh_token");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_IS_FRT], @"yes");
+    XCTAssertEqualObjects(properties[MSID_TELEMETRY_KEY_FRT_STATUS], @"tried");
 }
 
 @end

--- a/IdentityCore/tests/MSIDTelemetryExtensionsTests.m
+++ b/IdentityCore/tests/MSIDTelemetryExtensionsTests.m
@@ -25,6 +25,7 @@
 #import "NSString+MSIDTelemetryExtensions.h"
 #import "MSIDTelemetry.h"
 #import "MSIDTelemetry+Internal.h"
+#import "MSIDTelemetryEventStrings.h"
 
 @interface MSIDTelemetryExtensionsTests : XCTestCase
 
@@ -79,10 +80,10 @@
     NSDictionary *parsedTelemetry = [clientTelemetry parsedClientTelemetry];
     
     XCTAssertNotNil(parsedTelemetry);
-    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.Test.spe_info"]);
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.server_error_code"], @"123");
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.server_sub_error_code"], @"1234");
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.rt_age"], @"255.0643");
+    XCTAssertNil([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SPE_INFO]);
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SERVER_ERROR_CODE], @"123");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SERVER_SUBERROR_CODE], @"1234");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_RT_AGE], @"255.0643");
 }
 
 - (void)testParsedClientTelemetry_whenAllComponentsNoSPEInfoNoRTAge_shouldReturnAllOtherPropertiesNilSPEInfoNilRTAge
@@ -92,8 +93,8 @@
     NSDictionary *parsedTelemetry = [clientTelemetry parsedClientTelemetry];
     
     XCTAssertNotNil(parsedTelemetry);
-    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.Test.spe_info"]);
-    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.Test.rt_age"]);
+    XCTAssertNil([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SPE_INFO]);
+    XCTAssertNil([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_RT_AGE]);
 }
 
 - (void)testParsedClientTelemetry_whenAllComponentsWithSPEInfo_shouldReturnAllProperties
@@ -103,10 +104,10 @@
     NSDictionary *parsedTelemetry = [clientTelemetry parsedClientTelemetry];
     
     XCTAssertNotNil(parsedTelemetry);
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.server_error_code"], @"123");
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.server_sub_error_code"], @"1234");
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.rt_age"], @"255.0643");
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.spe_info"], @"I");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SERVER_ERROR_CODE], @"123");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SERVER_SUBERROR_CODE], @"1234");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_RT_AGE], @"255.0643");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SPE_INFO], @"I");
 }
 
 - (void)testParsedClientTelemetry_whenErrorSubErrorHaveZeroesRtAgeEmpty_shouldReturnOnlySpeInfo
@@ -116,10 +117,10 @@
     NSDictionary *parsedTelemetry = [clientTelemetry parsedClientTelemetry];
     
     XCTAssertNotNil(parsedTelemetry);
-    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.Test.server_error_code"]);
-    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.Test.server_sub_error_code"]);
-    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.Test.rt_age"]);
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.spe_info"], @"I");
+    XCTAssertNil([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SERVER_ERROR_CODE]);
+    XCTAssertNil([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SERVER_SUBERROR_CODE]);
+    XCTAssertNil([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_RT_AGE]);
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SPE_INFO], @"I");
 }
 
 - (void)testParsedClientTelemetry_whenErrorHasZeroes_shouldReturnAllPropertiesButErrorCode
@@ -129,10 +130,10 @@
     NSDictionary *parsedTelemetry = [clientTelemetry parsedClientTelemetry];
     
     XCTAssertNotNil(parsedTelemetry);
-    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.Test.server_error_code"]);
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.server_sub_error_code"], @"5");
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.rt_age"], @"200.5");
-    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.Test.spe_info"], @"I");
+    XCTAssertNil([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SERVER_ERROR_CODE]);
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SERVER_SUBERROR_CODE], @"5");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_RT_AGE], @"200.5");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:MSID_TELEMETRY_KEY_SPE_INFO], @"I");
 }
 
 @end

--- a/IdentityCore/tests/MSIDTelemetryTests.m
+++ b/IdentityCore/tests/MSIDTelemetryTests.m
@@ -1,0 +1,110 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <XCTest/XCTest.h>
+#import "MSIDTelemetryTestDispatcher.h"
+#import "MSIDTelemetry+Internal.h"
+#import "MSIDTelemetryEventStrings.h"
+#import "MSIDTelemetryAPIEvent.h"
+
+@interface MSIDTelemetryTests : XCTestCase
+{
+    NSMutableArray *_receivedEvents;
+}
+
+@end
+
+@implementation MSIDTelemetryTests
+
+- (void)setUp
+{
+    [super setUp];
+    _receivedEvents = [NSMutableArray array];
+    
+    MSIDTelemetryTestDispatcher* dispatcher = [MSIDTelemetryTestDispatcher new];
+    [dispatcher setTestCallback:^(id<MSIDTelemetryEventInterface> event)
+     {
+         [_receivedEvents addObject:event];
+     }];
+    
+    // register the dispatcher
+    [[MSIDTelemetry sharedInstance] addDispatcher:dispatcher];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    
+    _receivedEvents = nil;
+    [[MSIDTelemetry sharedInstance] removeAllDispatchers];
+    [MSIDTelemetry sharedInstance].piiEnabled = NO;
+}
+
+- (void)testDispatchEvent_whenPiiEnabled_shouldReturnUnhashedOiiAndHashedPii
+{
+    [MSIDTelemetry sharedInstance].piiEnabled = YES;
+    
+    NSString *requestId = [[MSIDTelemetry sharedInstance] generateRequestId];
+    [[MSIDTelemetry sharedInstance] startEvent:requestId
+                                     eventName:MSID_TELEMETRY_EVENT_API_EVENT];
+    
+    MSIDTelemetryAPIEvent *event = [[MSIDTelemetryAPIEvent alloc] initWithName:MSID_TELEMETRY_EVENT_API_EVENT
+                                                                     requestId:requestId
+                                                                 correlationId:nil];
+    [event setUserId:@"user"]; //Pii
+    [event setClientId:@"clientid"]; //Oii
+    [[MSIDTelemetry sharedInstance] stopEvent:requestId event:event];
+    
+    XCTAssertEqual(_receivedEvents.count, 1);
+    //expect hashed Pii
+    XCTAssertEqualObjects([_receivedEvents[0] propertyWithName:MSID_TELEMETRY_KEY_USER_ID], [@"user" msidComputeSHA256]);
+    //expect unhashed Oii
+    XCTAssertEqualObjects([_receivedEvents[0] propertyWithName:MSID_TELEMETRY_KEY_CLIENT_ID], @"clientid");
+}
+
+- (void)testDispatchEvent_whenPiiDisabled_shouldNotReturnOiiPii
+{
+    [MSIDTelemetry sharedInstance].piiEnabled = NO;
+    
+    NSString *requestId = [[MSIDTelemetry sharedInstance] generateRequestId];
+    [[MSIDTelemetry sharedInstance] startEvent:requestId
+                                     eventName:MSID_TELEMETRY_EVENT_API_EVENT];
+    
+    MSIDTelemetryAPIEvent *event = [[MSIDTelemetryAPIEvent alloc] initWithName:MSID_TELEMETRY_EVENT_API_EVENT
+                                                                     requestId:requestId
+                                                                 correlationId:nil];
+    [event setUserId:@"user"]; //Pii
+    [event setClientId:@"clientid"]; //Oii
+    [[MSIDTelemetry sharedInstance] stopEvent:requestId event:event];
+    
+    XCTAssertEqual(_receivedEvents.count, 1);
+    //no Pii or Oii is returned
+    XCTAssertEqualObjects([_receivedEvents[0] propertyWithName:MSID_TELEMETRY_KEY_USER_ID], nil);
+    XCTAssertEqualObjects([_receivedEvents[0] propertyWithName:MSID_TELEMETRY_KEY_CLIENT_ID], nil);
+}
+
+@end

--- a/IdentityCore/tests/integration/MSIDTelemetryIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDTelemetryIntegrationTests.m
@@ -31,14 +31,14 @@
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDTelemetryAPIEvent.h"
 
-@interface MSIDTelemetryTests : XCTestCase
+@interface MSIDTelemetryIntegrationTests : XCTestCase
 {
     NSMutableArray *_receivedEvents;
 }
 
 @end
 
-@implementation MSIDTelemetryTests
+@implementation MSIDTelemetryIntegrationTests
 
 - (void)setUp
 {

--- a/IdentityCore/tests/integration/ios/MSIDWipeDataTelemetryTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDWipeDataTelemetryTests.m
@@ -125,18 +125,18 @@
     
     
     // test if wipe data is logged in telemetry
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Find wipe data in telemetry."];
     for (id<MSIDTelemetryEventInterface> event in receivedEvents)
     {
-        if ([event.propertyMap[@"Microsoft.Test.event_name"] isEqualToString:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP]
-            && [event.propertyMap[@"Microsoft.Test.wipe_app"] isEqualToString:@"com.microsoft.MSIDTestsHostApp"]
-            && event.propertyMap[@"Microsoft.Test.wipe_time"])
+        if ([event.propertyMap[MSID_TELEMETRY_KEY_EVENT_NAME] isEqualToString:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP]
+            && [event.propertyMap[MSID_TELEMETRY_KEY_WIPE_APP] isEqualToString:@"com.microsoft.MSIDTestsHostApp"]
+            && event.propertyMap[MSID_TELEMETRY_KEY_WIPE_TIME])
         {
-            XCTAssertTrue(YES);
-            return;
+            [expectation fulfill];
         }
     }
     
-    XCTAssertTrue(NO);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testWipeDataTelemetry_whenGetAllTokensOfTypeButNoneForLegacyCache_shouldLogWipeDataInTelemetry
@@ -190,18 +190,18 @@
     
     
     // test if wipe data is logged in telemetry
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Find wipe data in telemetry."];
     for (id<MSIDTelemetryEventInterface> event in receivedEvents)
     {
-        if ([event.propertyMap[@"Microsoft.Test.event_name"] isEqualToString:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP]
-            && [event.propertyMap[@"Microsoft.Test.wipe_app"] isEqualToString:@"com.microsoft.MSIDTestsHostApp"]
-            && event.propertyMap[@"Microsoft.Test.wipe_time"])
+        if ([event.propertyMap[MSID_TELEMETRY_KEY_EVENT_NAME] isEqualToString:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP]
+            && [event.propertyMap[MSID_TELEMETRY_KEY_WIPE_APP] isEqualToString:@"com.microsoft.MSIDTestsHostApp"]
+            && event.propertyMap[MSID_TELEMETRY_KEY_WIPE_TIME])
         {
-            XCTAssertTrue(YES);
-            return;
+            [expectation fulfill];
         }
     }
     
-    XCTAssertTrue(NO);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testWipeDataTelemetry_whenGetTokenWithTypeButNoneForDefaultCache_shouldLogWipeDataInTelemetry
@@ -256,18 +256,18 @@
     
     
     // test if wipe data is logged in telemetry
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Find wipe data in telemetry."];
     for (id<MSIDTelemetryEventInterface> event in receivedEvents)
     {
-        if ([event.propertyMap[@"Microsoft.Test.event_name"] isEqualToString:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP]
-            && [event.propertyMap[@"Microsoft.Test.wipe_app"] isEqualToString:@"com.microsoft.MSIDTestsHostApp"]
-            && event.propertyMap[@"Microsoft.Test.wipe_time"])
+        if ([event.propertyMap[MSID_TELEMETRY_KEY_EVENT_NAME] isEqualToString:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP]
+            && [event.propertyMap[MSID_TELEMETRY_KEY_WIPE_APP] isEqualToString:@"com.microsoft.MSIDTestsHostApp"]
+            && event.propertyMap[MSID_TELEMETRY_KEY_WIPE_TIME])
         {
-            XCTAssertTrue(YES);
-            return;
+            [expectation fulfill];
         }
     }
     
-    XCTAssertTrue(NO);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testWipeDataTelemetry_whenGetAllTokensOfTypeButNoneForDefaultCache_shouldLogWipeDataInTelemetry
@@ -319,18 +319,18 @@
     XCTAssertEqual(returnedTokens.count, 0);
     
     // test if wipe data is logged in telemetry
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Find wipe data in telemetry."];
     for (id<MSIDTelemetryEventInterface> event in receivedEvents)
     {
-        if ([event.propertyMap[@"Microsoft.Test.event_name"] isEqualToString:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP]
-            && [event.propertyMap[@"Microsoft.Test.wipe_app"] isEqualToString:@"com.microsoft.MSIDTestsHostApp"]
-            && event.propertyMap[@"Microsoft.Test.wipe_time"])
+        if ([event.propertyMap[MSID_TELEMETRY_KEY_EVENT_NAME] isEqualToString:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP]
+            && [event.propertyMap[MSID_TELEMETRY_KEY_WIPE_APP] isEqualToString:@"com.microsoft.MSIDTestsHostApp"]
+            && event.propertyMap[MSID_TELEMETRY_KEY_WIPE_TIME])
         {
-            XCTAssertTrue(YES);
-            return;
+            [expectation fulfill];
         }
     }
     
-    XCTAssertTrue(NO);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end


### PR DESCRIPTION
Bug fixed:
- Pii filtering not working because some functions expect Telemetry prefix (like "Microsoft.ADAL." while the argument we pass in doesn't have it. 
Since there is no clear clue on when to use `TELEMETRY_KEY()` to add prefix and when not to use, it could be error-prone and cause confusion. Now we simply not use prefix in common core at all. Only we finally dispatch the events in ADAL/MSAL to developers, we add the prefix.
- Pii filtering is added for defaultParameters. Previously we forgot to filter for that.
 
Besides,
- Oii rules are added. If a property is Oii, it won't be hashed and will only be returned if PiiEnabled is true.
- UTs added.

The corresponding ADAL PR is [here](https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/1193).