### PR TITLE
Update base64 encoding/decoding implementation

### DIFF
--- a/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
+++ b/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
@@ -40,7 +40,7 @@ static NSString *const s_adalServiceFormat = @"%@|%@|%@|%@";
 //We should not put nil keys in the keychain. The method substitutes nil with a special GUID:
 - (NSString *)getAttributeName:(NSString *)attribute
 {
-    return ([NSString msidIsStringNilOrBlank:attribute]) ? s_nilKey : [attribute msidBase64UrlEncode].stringByRemovingPadding;
+    return ([NSString msidIsStringNilOrBlank:attribute]) ? s_nilKey : attribute.msidBase64UrlEncode;
 }
 
 - (NSString *)serviceWithAuthority:(NSURL *)authority
@@ -56,9 +56,9 @@ static NSString *const s_adalServiceFormat = @"%@|%@|%@|%@";
 
     return [NSString stringWithFormat:s_adalServiceFormat,
             s_adalLibraryString,
-            authorityString.msidBase64UrlEncode.stringByRemovingPadding,
+            authorityString.msidBase64UrlEncode,
             [self getAttributeName:resource],
-            clientId.msidBase64UrlEncode.stringByRemovingPadding];
+            clientId.msidBase64UrlEncode];
 }
 
 - (instancetype)initWithAccount:(NSString *)account
@@ -96,12 +96,12 @@ static NSString *const s_adalServiceFormat = @"%@|%@|%@|%@";
 
 - (NSString *)account
 {
-    return _account ? _account : [self adalAccountWithUserId:self.legacyUserId].stringByRemovingPadding;
+    return _account ? _account : [self adalAccountWithUserId:self.legacyUserId];
 }
 
 - (NSString *)service
 {
-    return _service ? _service : [self serviceWithAuthority:self.authority resource:self.resource clientId:self.clientId].stringByRemovingPadding;
+    return _service ? _service : [self serviceWithAuthority:self.authority resource:self.resource clientId:self.clientId];
 }
 
 - (NSData *)generic

--- a/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
+++ b/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
@@ -40,7 +40,7 @@ static NSString *const s_adalServiceFormat = @"%@|%@|%@|%@";
 //We should not put nil keys in the keychain. The method substitutes nil with a special GUID:
 - (NSString *)getAttributeName:(NSString *)attribute
 {
-    return ([NSString msidIsStringNilOrBlank:attribute]) ? s_nilKey : [attribute msidBase64UrlEncode];
+    return ([NSString msidIsStringNilOrBlank:attribute]) ? s_nilKey : [attribute msidBase64UrlEncode].stringByRemovingPadding;
 }
 
 - (NSString *)serviceWithAuthority:(NSURL *)authority
@@ -56,9 +56,9 @@ static NSString *const s_adalServiceFormat = @"%@|%@|%@|%@";
 
     return [NSString stringWithFormat:s_adalServiceFormat,
             s_adalLibraryString,
-            authorityString.msidBase64UrlEncode,
+            authorityString.msidBase64UrlEncode.stringByRemovingPadding,
             [self getAttributeName:resource],
-            clientId.msidBase64UrlEncode];
+            clientId.msidBase64UrlEncode.stringByRemovingPadding];
 }
 
 - (instancetype)initWithAccount:(NSString *)account
@@ -96,12 +96,12 @@ static NSString *const s_adalServiceFormat = @"%@|%@|%@|%@";
 
 - (NSString *)account
 {
-    return _account ? _account : [self adalAccountWithUserId:self.legacyUserId];
+    return _account ? _account : [self adalAccountWithUserId:self.legacyUserId].stringByRemovingPadding;
 }
 
 - (NSString *)service
 {
-    return _service ? _service : [self serviceWithAuthority:self.authority resource:self.resource clientId:self.clientId];
+    return _service ? _service : [self serviceWithAuthority:self.authority resource:self.resource clientId:self.clientId].stringByRemovingPadding;
 }
 
 - (NSData *)generic
@@ -256,5 +256,11 @@ static NSString *const s_adalServiceFormat = @"%@|%@|%@|%@";
         }
     }
 }
+
+- (NSString *)removePaddingFromDecodedString:(NSString *)paddedString
+{
+    return [paddedString stringByReplacingOccurrencesOfString:@"=" withString:@""];
+}
+
 
 @end

--- a/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
+++ b/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
@@ -257,10 +257,5 @@ static NSString *const s_adalServiceFormat = @"%@|%@|%@|%@";
     }
 }
 
-- (NSString *)removePaddingFromDecodedString:(NSString *)paddedString
-{
-    return [paddedString stringByReplacingOccurrencesOfString:@"=" withString:@""];
-}
-
 
 @end

--- a/IdentityCore/src/cache/key/MSIDLegacyTokenCacheQuery.m
+++ b/IdentityCore/src/cache/key/MSIDLegacyTokenCacheQuery.m
@@ -29,7 +29,7 @@
 {
     if (self.legacyUserId)
     {
-        return [self adalAccountWithUserId:self.legacyUserId].stringByRemovingPadding;
+        return [self adalAccountWithUserId:self.legacyUserId];
     }
 
     return nil;
@@ -40,7 +40,7 @@
     if (self.authority
         && self.clientId)
     {
-        return [self serviceWithAuthority:self.authority resource:self.resource clientId:self.clientId].stringByRemovingPadding;
+        return [self serviceWithAuthority:self.authority resource:self.resource clientId:self.clientId];
     }
 
     return nil;

--- a/IdentityCore/src/cache/key/MSIDLegacyTokenCacheQuery.m
+++ b/IdentityCore/src/cache/key/MSIDLegacyTokenCacheQuery.m
@@ -29,7 +29,7 @@
 {
     if (self.legacyUserId)
     {
-        return [self adalAccountWithUserId:self.legacyUserId];
+        return [self adalAccountWithUserId:self.legacyUserId].stringByRemovingPadding;
     }
 
     return nil;
@@ -40,7 +40,7 @@
     if (self.authority
         && self.clientId)
     {
-        return [self serviceWithAuthority:self.authority resource:self.resource clientId:self.clientId];
+        return [self serviceWithAuthority:self.authority resource:self.resource clientId:self.clientId].stringByRemovingPadding;
     }
 
     return nil;

--- a/IdentityCore/src/oauth2/MSIDIdTokenClaims.m
+++ b/IdentityCore/src/oauth2/MSIDIdTokenClaims.m
@@ -63,6 +63,7 @@ MSID_JSON_ACCESSOR(ID_TOKEN_EMAIL, email)
     }
     
     NSData *decoded =  [[parts[1] msidBase64UrlDecode] dataUsingEncoding:NSUTF8StringEncoding];
+    
     NSError *error = nil;
     if (!(self = [super initWithJSONData:decoded error:&error]))
     {

--- a/IdentityCore/src/util/NSString+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.h
@@ -43,7 +43,7 @@
 - (NSString *)msidUrlFormEncode;
 
 /*! Converts base64 String to NSData */
-+ (NSData *)msidBase64UrlDecodeData:(NSString *)encodedString;
+//+ (NSData *)msidBase64UrlDecodeData:(NSString *)encodedString;
 
 /*! Converts NSData to base64 String */
 + (NSString *)msidBase64UrlEncodeData:(NSData *)data;
@@ -60,5 +60,8 @@
 - (NSOrderedSet<NSString *> *)scopeSet;
 
 - (BOOL)msidIsEquivalentWithAnyAlias:(NSArray<NSString *> *)aliases;
+
+/*! Removes padding for Base64 encoded string */
+- (NSString *)stringByRemovingPadding;
 
 @end

--- a/IdentityCore/src/util/NSString+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.h
@@ -43,7 +43,7 @@
 - (NSString *)msidUrlFormEncode;
 
 /*! Converts base64 String to NSData */
-//+ (NSData *)msidBase64UrlDecodeData:(NSString *)encodedString;
++ (NSData *)msidBase64UrlDecodeData:(NSString *)encodedString;
 
 /*! Converts NSData to base64 String */
 + (NSString *)msidBase64UrlEncodeData:(NSData *)data;

--- a/IdentityCore/src/util/NSString+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.h
@@ -62,6 +62,6 @@
 - (BOOL)msidIsEquivalentWithAnyAlias:(NSArray<NSString *> *)aliases;
 
 /*! Removes padding for Base64 encoded string */
-- (NSString *)stringByRemovingPadding;
+- (NSString *)msidStringByRemovingPadding;
 
 @end

--- a/IdentityCore/src/util/NSString+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.m
@@ -42,9 +42,7 @@ typedef unsigned char byte;
     NSUInteger paddedLength = encodedString.length + (4 - (encodedString.length % 4));
     NSString *paddedString = [encodedString stringByPaddingToLength:paddedLength withString:@"=" startingAtIndex:0];
     
-    NSData *data = [[NSData alloc]
-                    initWithBase64EncodedString:paddedString
-                    options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:paddedString options:0];
     
     return data;
 }
@@ -59,18 +57,15 @@ typedef unsigned char byte;
 /// </remarks>
 - (NSString *)msidBase64UrlDecode
 {
-    NSUInteger paddedLength = self.length + (4 - (self.length % 4));
-    NSString *paddedString = [self stringByPaddingToLength:paddedLength withString:@"=" startingAtIndex:0];
-    
-    NSData *data = [[NSData alloc]
-                    initWithBase64EncodedString:paddedString
-                    options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *data = [self.class msidBase64UrlDecodeData:self];
     
     if (!data) return nil;
     
     char lastByte;
-    [data getBytes:&lastByte range:NSMakeRange([data length]-1, 1)];
+    [data getBytes:&lastByte range:NSMakeRange([data length] - 1, 1)];
     
+    // We need to check for null terminated string data by looking at the last bit.
+    // If we call initWithData on null-terminated, we get back a nil string.
     if (lastByte == 0x0) {
         //string is null-terminated
         return [NSString stringWithUTF8String:[data bytes]];
@@ -92,14 +87,14 @@ typedef unsigned char byte;
 + (NSString *)msidBase64UrlEncodeData:(NSData *)data
 {
     NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    return [[string dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed].stringByRemovingPadding;
+    return [[string dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed].msidStringByRemovingPadding;
 }
 
 
 // Base64 URL encodes a string
 - (NSString *)msidBase64UrlEncode
 {
-    return [[self dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed].stringByRemovingPadding;
+    return [[self dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed].msidStringByRemovingPadding;
 }
 
 
@@ -218,7 +213,7 @@ typedef unsigned char byte;
     return NO;
 }
 
-- (NSString *)stringByRemovingPadding
+- (NSString *)msidStringByRemovingPadding
 {
     return [self stringByReplacingOccurrencesOfString:@"=" withString:@""];
 }

--- a/IdentityCore/src/util/NSString+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.m
@@ -27,39 +27,39 @@
 
 typedef unsigned char byte;
 
-static char base64UrlEncodeTable[64] =
-{
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-    'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
-    'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-    'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
-};
+//static char base64UrlEncodeTable[64] =
+//{
+//    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+//    'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+//    'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+//    'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
+//};
+//
+//#define NA (255)
 
-#define NA (255)
-
-static byte rgbDecodeTable[128] = {                         // character code
-    NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA,  // 0-15
-    NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA,  // 16-31
-    NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 62, NA, NA,  // 32-47
-    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, NA, NA, NA,  0, NA, NA,  // 48-63
-    NA,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,  // 64-79
-    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, NA, NA, NA, NA, 63,  // 80-95
-    NA, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,  // 96-111
-    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, NA, NA, NA, NA, NA,  // 112-127
-};
+//static byte rgbDecodeTable[128] = {                         // character code
+//    NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA,  // 0-15
+//    NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA,  // 16-31
+//    NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 62, NA, NA,  // 32-47
+//    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, NA, NA, NA,  0, NA, NA,  // 48-63
+//    NA,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,  // 64-79
+//    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, NA, NA, NA, NA, 63,  // 80-95
+//    NA, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,  // 96-111
+//    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, NA, NA, NA, NA, NA,  // 112-127
+//};
 
 //Checks that all bytes inside the format are valid base64 characters:
-static BOOL validBase64Characters(const byte* data, const int size)
-{
-    for (int i = 0; i < size; ++i)
-    {
-        if (data[i] >= sizeof(rgbDecodeTable) || rgbDecodeTable[data[i]] == NA)
-        {
-            return false;
-        }
-    }
-    return true;
-}
+//static BOOL validBase64Characters(const byte* data, const int size)
+//{
+//    for (int i = 0; i < size; ++i)
+//    {
+//        if (data[i] >= sizeof(rgbDecodeTable) || rgbDecodeTable[data[i]] == NA)
+//        {
+//            return false;
+//        }
+//    }
+//    return true;
+//}
 
 @implementation NSString (MSIDExtensions)
 
@@ -72,115 +72,154 @@ static BOOL validBase64Characters(const byte* data, const int size)
 /// </remarks>
 + (NSData *)msidBase64UrlDecodeData:(NSString *)encodedString
 {
-    if ( nil == encodedString )
-    {
-        return nil;
-    }
+    NSUInteger paddedLength = encodedString.length + (4 - (encodedString.length % 4));
+    NSString *paddedString = [encodedString stringByPaddingToLength:paddedLength withString:@"=" startingAtIndex:0];
     
-    NSData      *encodedBytes = [encodedString dataUsingEncoding:NSUTF8StringEncoding];
-    const byte  *pbEncoded    = [encodedBytes bytes];
-    const int    cbEncoded    = (int)[encodedBytes length];
-    if (!validBase64Characters(pbEncoded, cbEncoded))
-    {
-        return nil;
-    }
-    
-    int   cbDecodedSize;
-    int   ich;
-    int   ib;
-    byte  b0, b1, b2, b3;
-    
-    // The input string lacks the usual '=' padding at the end, so the valid end sequences
-    // are:
-    //      ........XX           (cbEncodedSize % 4) == 2    (2 chars of virtual padding)
-    //      ........XXX          (cbEncodedSize % 4) == 3    (1 char of virtual padding)
-    //      ........XXXX         (cbEncodedSize % 4) == 0    (no virtual padding)
-    // Invalid sequences are:
-    //      ........X            (cbEncodedSize % 4) == 1
-    
-    // Input string is not sized correctly to be base64 URL encoded.
-    if ( ( 0 == cbEncoded ) || ( 1 == ( cbEncoded % 4 ) ) )
-    {
-        return nil;
-    }
-    
-    // 'virtual padding' is how many trailing '=' characters we would have
-    // had under 'normal' base-64 encoding
-    int virtualPadding = ( ( cbEncoded % 4 ) == 2 ) ? 2 : ( ( cbEncoded % 4 ) == 3 ) ? 1 : 0;
-    
-    // Calculate decoded buffer size.
-    cbDecodedSize = (cbEncoded + virtualPadding + 3) / 4 * 3;
-    cbDecodedSize -= virtualPadding;
-    
-    byte *pbDecoded = (byte *)calloc( cbDecodedSize, sizeof(byte) );
-    
-    if(!pbDecoded) {
-        return nil;
-    }
-    
-    // Decode each four-byte cluster into the corresponding three data bytes,
-    // allowing for the fact that the last cluster may be less than four bytes
-    // (virtual padding).
-    ich = ib = 0;
-    
-    int end4 = (cbEncoded/4)*4;
-    //Quick loop, no boundary checks:
-    for(; ich < end4; )
-    {
-        b0 = rgbDecodeTable[pbEncoded[ich++]];
-        b1 = rgbDecodeTable[pbEncoded[ich++]];
-        b2 = rgbDecodeTable[pbEncoded[ich++]];
-        b3 = rgbDecodeTable[pbEncoded[ich++]];
-        
-        pbDecoded[ib++] = (b0 << 2) | (b1 >> 4);
-        pbDecoded[ib++] = (b1 << 4) | (b2 >> 2);
-        pbDecoded[ib++] = (b2 << 6) | b3;
-    }
-    
-    //Beyond the padding to 4. Requires boundary checks,
-    //but the inner side shouldn't be executed more than 3 times:
-    while ( ich < cbEncoded )
-    {
-        b0 = rgbDecodeTable[pbEncoded[ich++]];
-        b1 = (ich < cbEncoded) ? rgbDecodeTable[pbEncoded[ich++]] : 0;
-        b2 = (ich < cbEncoded) ? rgbDecodeTable[pbEncoded[ich++]] : 0;
-        b3 = (ich < cbEncoded) ? rgbDecodeTable[pbEncoded[ich++]] : 0;
-        
-        pbDecoded[ib++] = (b0 << 2) | (b1 >> 4);
-        
-        if (ib < cbDecodedSize) {
-            pbDecoded[ib++] = (b1 << 4) | (b2 >> 2);
-            
-            if (ib < cbDecodedSize) {
-                pbDecoded[ib++] = (b2 << 6) | b3;
-            }
-        }
-    }
-    
-    // Place the result in a NSData object and then free it.
-    NSData *result = [NSData dataWithBytes:pbDecoded length:cbDecodedSize];
-    
-    free( pbDecoded );
-    
-    return result;
+    NSData *data = [[NSData alloc]
+                    initWithBase64EncodedString:paddedString
+                    options:NSDataBase64DecodingIgnoreUnknownCharacters];
+
+    return data;
 }
+
+
+
+
+/// <summary>
+/// Base64 URL decode a set of bytes.
+/// </summary>
+/// <remarks>
+/// See RFC 4648, Section 5 plus switch characters 62 and 63 and no padding.
+/// For a good overview of Base64 encoding, see http://en.wikipedia.org/wiki/Base64
+/// </remarks>
+//+ (NSData *)msidBase64UrlDecodeData:(NSString *)encodedString
+//{
+//    if ( nil == encodedString )
+//    {
+//        return nil;
+//    }
+//
+//    NSData      *encodedBytes = [encodedString dataUsingEncoding:NSUTF8StringEncoding];
+//    const byte  *pbEncoded    = [encodedBytes bytes];
+//    const int    cbEncoded    = (int)[encodedBytes length];
+//    if (!validBase64Characters(pbEncoded, cbEncoded))
+//    {
+//        return nil;
+//    }
+//
+//    int   cbDecodedSize;
+//    int   ich;
+//    int   ib;
+//    byte  b0, b1, b2, b3;
+//
+//    // The input string lacks the usual '=' padding at the end, so the valid end sequences
+//    // are:
+//    //      ........XX           (cbEncodedSize % 4) == 2    (2 chars of virtual padding)
+//    //      ........XXX          (cbEncodedSize % 4) == 3    (1 char of virtual padding)
+//    //      ........XXXX         (cbEncodedSize % 4) == 0    (no virtual padding)
+//    // Invalid sequences are:
+//    //      ........X            (cbEncodedSize % 4) == 1
+//
+//    // Input string is not sized correctly to be base64 URL encoded.
+//    if ( ( 0 == cbEncoded ) || ( 1 == ( cbEncoded % 4 ) ) )
+//    {
+//        return nil;
+//    }
+//
+//    // 'virtual padding' is how many trailing '=' characters we would have
+//    // had under 'normal' base-64 encoding
+//    int virtualPadding = ( ( cbEncoded % 4 ) == 2 ) ? 2 : ( ( cbEncoded % 4 ) == 3 ) ? 1 : 0;
+//
+//    // Calculate decoded buffer size.
+//    cbDecodedSize = (cbEncoded + virtualPadding + 3) / 4 * 3;
+//    cbDecodedSize -= virtualPadding;
+//
+//    byte *pbDecoded = (byte *)calloc( cbDecodedSize, sizeof(byte) );
+//
+//    if(!pbDecoded) {
+//        return nil;
+//    }
+//
+//    // Decode each four-byte cluster into the corresponding three data bytes,
+//    // allowing for the fact that the last cluster may be less than four bytes
+//    // (virtual padding).
+//    ich = ib = 0;
+//
+//    int end4 = (cbEncoded/4)*4;
+//    //Quick loop, no boundary checks:
+//    for(; ich < end4; )
+//    {
+//        b0 = rgbDecodeTable[pbEncoded[ich++]];
+//        b1 = rgbDecodeTable[pbEncoded[ich++]];
+//        b2 = rgbDecodeTable[pbEncoded[ich++]];
+//        b3 = rgbDecodeTable[pbEncoded[ich++]];
+//
+//        pbDecoded[ib++] = (b0 << 2) | (b1 >> 4);
+//        pbDecoded[ib++] = (b1 << 4) | (b2 >> 2);
+//        pbDecoded[ib++] = (b2 << 6) | b3;
+//    }
+//
+//    //Beyond the padding to 4. Requires boundary checks,
+//    //but the inner side shouldn't be executed more than 3 times:
+//    while ( ich < cbEncoded )
+//    {
+//        b0 = rgbDecodeTable[pbEncoded[ich++]];
+//        b1 = (ich < cbEncoded) ? rgbDecodeTable[pbEncoded[ich++]] : 0;
+//        b2 = (ich < cbEncoded) ? rgbDecodeTable[pbEncoded[ich++]] : 0;
+//        b3 = (ich < cbEncoded) ? rgbDecodeTable[pbEncoded[ich++]] : 0;
+//
+//        pbDecoded[ib++] = (b0 << 2) | (b1 >> 4);
+//
+//        if (ib < cbDecodedSize) {
+//            pbDecoded[ib++] = (b1 << 4) | (b2 >> 2);
+//
+//            if (ib < cbDecodedSize) {
+//                pbDecoded[ib++] = (b2 << 6) | b3;
+//            }
+//        }
+//    }
+//
+//    // Place the result in a NSData object and then free it.
+//    NSData *result = [NSData dataWithBytes:pbDecoded length:cbDecodedSize];
+//
+//    free( pbDecoded );
+//
+//    return result;
+//}
 
 - (NSString *)msidBase64UrlDecode
 {
-    NSData *decodedData = [self.class msidBase64UrlDecodeData:self];
+    NSUInteger paddedLength = self.length + (4 - (self.length % 4));
+    NSString *paddedString = [self stringByPaddingToLength:paddedLength withString:@"=" startingAtIndex:0];
+
+    NSData *data = [[NSData alloc]
+                    initWithBase64EncodedString:paddedString
+                    options:NSDataBase64DecodingIgnoreUnknownCharacters];
+
+    if (!data) return nil;
     
-    return [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
+    char lastByte;
+    [data getBytes:&lastByte range:NSMakeRange([data length]-1, 1)];
+
+    if (lastByte == 0x0) {
+        //string is null-terminated
+        return [NSString stringWithUTF8String:[data bytes]];
+    } else {
+        //string is not null-terminated
+        return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    }
 }
+
 
 //Helper method to encode 3 bytes into a sequence of 4 bytes:
 //"static inline" is the way declare inline methods in LLVM
-static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
-{
-    output[0] = base64UrlEncodeTable[b0 >> 2];                                  // 6 MSB from byte 0
-    output[1] = base64UrlEncodeTable[((b0 << 4) & 0x30) | ((b1 >> 4) & 0x0f)];  // 2 LSB from byte 0 and 4 MSB from byte 1
-    output[2] = base64UrlEncodeTable[((b1 << 2) & 0x3c) | ((b2 >> 6) & 0x03)];  // 4 LSB from byte 1 and 2 MSB from byte 2
-    output[3] = base64UrlEncodeTable[b2 & 0x3f];
-}
+//static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
+//{
+//    output[0] = base64UrlEncodeTable[b0 >> 2];                                  // 6 MSB from byte 0
+//    output[1] = base64UrlEncodeTable[((b0 << 4) & 0x30) | ((b1 >> 4) & 0x0f)];  // 2 LSB from byte 0 and 4 MSB from byte 1
+//    output[2] = base64UrlEncodeTable[((b1 << 2) & 0x3c) | ((b2 >> 6) & 0x03)];  // 4 LSB from byte 1 and 2 MSB from byte 2
+//    output[3] = base64UrlEncodeTable[b2 & 0x3f];
+//}
 
 /// <summary>
 /// Base64 URL encode a set of bytes.
@@ -189,87 +228,95 @@ static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
 /// See RFC 4648, Section 5 plus switch characters 62 and 63 and no padding.
 /// For a good overview of Base64 encoding, see http://en.wikipedia.org/wiki/Base64
 /// </remarks>
+
 + (NSString *)msidBase64UrlEncodeData:(NSData *)data
 {
-    if ( nil == data )
-        return nil;
-    
-    const byte *pbBytes = [data bytes];
-    int         cbBytes = (int)[data length];
-    
-    // Calculate encoded string size including padding. This may be more than is actually
-    // required since we will not pad and instead will terminate with null. The computation
-    // is the number of byte triples times 4 radix64 characters plus 1 for null termination.
-    int   encodedSize = 1 + ( cbBytes + 2 ) / 3 * 4;
-    char *pbEncoded = (char *)calloc( encodedSize, sizeof(char) );
-    
-    if(!pbEncoded){
-        return nil;
-    }
-    
-    // Encode data byte triplets into four-byte clusters.
-    int   iBytes;      // raw byte index
-    int   iEncoded;    // encoded byte index
-    byte  b0, b1, b2;  // individual bytes for triplet
-    
-    iBytes = iEncoded = 0;
-    
-    int end3 = (cbBytes/3)*3;
-    //Fast loop, no bounderies check:
-    for ( ; iBytes < end3; )
-    {
-        b0 = pbBytes[iBytes++];
-        b1 = pbBytes[iBytes++];
-        b2 = pbBytes[iBytes++];
-        
-        Encode3bytesTo4bytes(pbEncoded + iEncoded, b0, b1, b2);
-        iEncoded += 4;
-    }
-    
-    //Slower loop should execute no more than 3 times:
-    while ( iBytes < cbBytes )
-    {
-        b0 = pbBytes[iBytes++];
-        b1 = (iBytes < cbBytes) ? pbBytes[iBytes++] : 0;                                        // Add extra zero byte if needed
-        b2 = (iBytes < cbBytes) ? pbBytes[iBytes++] : 0;                                        // Add extra zero byte if needed
-        
-        Encode3bytesTo4bytes(pbEncoded + iEncoded, b0, b1, b2);
-        iEncoded += 4;
-    }
-    
-    // Where we would have padded it, we instead truncate the string
-    switch ( cbBytes % 3 )
-    {
-        case 0:
-            // No left overs, nothing to pad
-            break;
-            
-        case 1:
-            // One left over, normally pad 2
-            pbEncoded[iEncoded - 2] = '\0';
-            // fall through
-            
-        case 2:
-            pbEncoded[iEncoded - 1] = '\0';
-            break;
-    }
-    
-    // Null terminate, convert to NSString and free the buffer
-    pbEncoded[iEncoded++] = '\0';
-    
-    NSString *result = [NSString stringWithCString:pbEncoded encoding:NSUTF8StringEncoding];
-    
-    free(pbEncoded);
-    
-    return result;
+
+    NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    return [[string dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
+
+//
+//    if ( nil == data )
+//        return nil;
+//
+//    const byte *pbBytes = [data bytes];
+//    int         cbBytes = (int)[data length];
+//
+//    // Calculate encoded string size including padding. This may be more than is actually
+//    // required since we will not pad and instead will terminate with null. The computation
+//    // is the number of byte triples times 4 radix64 characters plus 1 for null termination.
+//    int   encodedSize = 1 + ( cbBytes + 2 ) / 3 * 4;
+//    char *pbEncoded = (char *)calloc( encodedSize, sizeof(char) );
+//
+//    if(!pbEncoded){
+//        return nil;
+//    }
+//
+//    // Encode data byte triplets into four-byte clusters.
+//    int   iBytes;      // raw byte index
+//    int   iEncoded;    // encoded byte index
+//    byte  b0, b1, b2;  // individual bytes for triplet
+//
+//    iBytes = iEncoded = 0;
+//
+//    int end3 = (cbBytes/3)*3;
+//    //Fast loop, no bounderies check:
+//    for ( ; iBytes < end3; )
+//    {
+//        b0 = pbBytes[iBytes++];
+//        b1 = pbBytes[iBytes++];
+//        b2 = pbBytes[iBytes++];
+//
+//        Encode3bytesTo4bytes(pbEncoded + iEncoded, b0, b1, b2);
+//        iEncoded += 4;
+//    }
+//
+//    //Slower loop should execute no more than 3 times:
+//    while ( iBytes < cbBytes )
+//    {
+//        b0 = pbBytes[iBytes++];
+//        b1 = (iBytes < cbBytes) ? pbBytes[iBytes++] : 0;                                        // Add extra zero byte if needed
+//        b2 = (iBytes < cbBytes) ? pbBytes[iBytes++] : 0;                                        // Add extra zero byte if needed
+//
+//        Encode3bytesTo4bytes(pbEncoded + iEncoded, b0, b1, b2);
+//        iEncoded += 4;
+//    }
+//
+//    // Where we would have padded it, we instead truncate the string
+//    switch ( cbBytes % 3 )
+//    {
+//        case 0:
+//            // No left overs, nothing to pad
+//            break;
+//
+//        case 1:
+//            // One left over, normally pad 2
+//            pbEncoded[iEncoded - 2] = '\0';
+//            // fall through
+//
+//        case 2:
+//            pbEncoded[iEncoded - 1] = '\0';
+//            break;
+//    }
+//
+//    // Null terminate, convert to NSString and free the buffer
+//    pbEncoded[iEncoded++] = '\0';
+//
+//    NSString *result = [NSString stringWithCString:pbEncoded encoding:NSUTF8StringEncoding];
+//
+//    free(pbEncoded);
+//
+//    return result;
 }
 
 // Base64 URL encodes a string
 - (NSString *)msidBase64UrlEncode
 {
-    NSData *decodedData = [self dataUsingEncoding:NSUTF8StringEncoding];
+//    NSData *decodedData = [self dataUsingEncoding:NSUTF8StringEncoding];
+
+//    return [self.class msidBase64UrlEncodeData:decodedData];
     
-    return [self.class msidBase64UrlEncodeData:decodedData];
+    return [[self dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
 }
 
 + (BOOL)msidIsStringNilOrBlank:(NSString *)string
@@ -382,6 +429,11 @@ static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
         }
     }
     return NO;
+}
+
+- (NSString *)stringByRemovingPadding
+{
+    return [self stringByReplacingOccurrencesOfString:@"=" withString:@""];
 }
 
 @end

--- a/IdentityCore/src/util/NSString+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.m
@@ -27,39 +27,6 @@
 
 typedef unsigned char byte;
 
-//static char base64UrlEncodeTable[64] =
-//{
-//    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-//    'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
-//    'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-//    'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
-//};
-//
-//#define NA (255)
-
-//static byte rgbDecodeTable[128] = {                         // character code
-//    NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA,  // 0-15
-//    NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA,  // 16-31
-//    NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 62, NA, NA,  // 32-47
-//    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, NA, NA, NA,  0, NA, NA,  // 48-63
-//    NA,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,  // 64-79
-//    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, NA, NA, NA, NA, 63,  // 80-95
-//    NA, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,  // 96-111
-//    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, NA, NA, NA, NA, NA,  // 112-127
-//};
-
-//Checks that all bytes inside the format are valid base64 characters:
-//static BOOL validBase64Characters(const byte* data, const int size)
-//{
-//    for (int i = 0; i < size; ++i)
-//    {
-//        if (data[i] >= sizeof(rgbDecodeTable) || rgbDecodeTable[data[i]] == NA)
-//        {
-//            return false;
-//        }
-//    }
-//    return true;
-//}
 
 @implementation NSString (MSIDExtensions)
 
@@ -78,11 +45,9 @@ typedef unsigned char byte;
     NSData *data = [[NSData alloc]
                     initWithBase64EncodedString:paddedString
                     options:NSDataBase64DecodingIgnoreUnknownCharacters];
-
+    
     return data;
 }
-
-
 
 
 /// <summary>
@@ -92,115 +57,20 @@ typedef unsigned char byte;
 /// See RFC 4648, Section 5 plus switch characters 62 and 63 and no padding.
 /// For a good overview of Base64 encoding, see http://en.wikipedia.org/wiki/Base64
 /// </remarks>
-//+ (NSData *)msidBase64UrlDecodeData:(NSString *)encodedString
-//{
-//    if ( nil == encodedString )
-//    {
-//        return nil;
-//    }
-//
-//    NSData      *encodedBytes = [encodedString dataUsingEncoding:NSUTF8StringEncoding];
-//    const byte  *pbEncoded    = [encodedBytes bytes];
-//    const int    cbEncoded    = (int)[encodedBytes length];
-//    if (!validBase64Characters(pbEncoded, cbEncoded))
-//    {
-//        return nil;
-//    }
-//
-//    int   cbDecodedSize;
-//    int   ich;
-//    int   ib;
-//    byte  b0, b1, b2, b3;
-//
-//    // The input string lacks the usual '=' padding at the end, so the valid end sequences
-//    // are:
-//    //      ........XX           (cbEncodedSize % 4) == 2    (2 chars of virtual padding)
-//    //      ........XXX          (cbEncodedSize % 4) == 3    (1 char of virtual padding)
-//    //      ........XXXX         (cbEncodedSize % 4) == 0    (no virtual padding)
-//    // Invalid sequences are:
-//    //      ........X            (cbEncodedSize % 4) == 1
-//
-//    // Input string is not sized correctly to be base64 URL encoded.
-//    if ( ( 0 == cbEncoded ) || ( 1 == ( cbEncoded % 4 ) ) )
-//    {
-//        return nil;
-//    }
-//
-//    // 'virtual padding' is how many trailing '=' characters we would have
-//    // had under 'normal' base-64 encoding
-//    int virtualPadding = ( ( cbEncoded % 4 ) == 2 ) ? 2 : ( ( cbEncoded % 4 ) == 3 ) ? 1 : 0;
-//
-//    // Calculate decoded buffer size.
-//    cbDecodedSize = (cbEncoded + virtualPadding + 3) / 4 * 3;
-//    cbDecodedSize -= virtualPadding;
-//
-//    byte *pbDecoded = (byte *)calloc( cbDecodedSize, sizeof(byte) );
-//
-//    if(!pbDecoded) {
-//        return nil;
-//    }
-//
-//    // Decode each four-byte cluster into the corresponding three data bytes,
-//    // allowing for the fact that the last cluster may be less than four bytes
-//    // (virtual padding).
-//    ich = ib = 0;
-//
-//    int end4 = (cbEncoded/4)*4;
-//    //Quick loop, no boundary checks:
-//    for(; ich < end4; )
-//    {
-//        b0 = rgbDecodeTable[pbEncoded[ich++]];
-//        b1 = rgbDecodeTable[pbEncoded[ich++]];
-//        b2 = rgbDecodeTable[pbEncoded[ich++]];
-//        b3 = rgbDecodeTable[pbEncoded[ich++]];
-//
-//        pbDecoded[ib++] = (b0 << 2) | (b1 >> 4);
-//        pbDecoded[ib++] = (b1 << 4) | (b2 >> 2);
-//        pbDecoded[ib++] = (b2 << 6) | b3;
-//    }
-//
-//    //Beyond the padding to 4. Requires boundary checks,
-//    //but the inner side shouldn't be executed more than 3 times:
-//    while ( ich < cbEncoded )
-//    {
-//        b0 = rgbDecodeTable[pbEncoded[ich++]];
-//        b1 = (ich < cbEncoded) ? rgbDecodeTable[pbEncoded[ich++]] : 0;
-//        b2 = (ich < cbEncoded) ? rgbDecodeTable[pbEncoded[ich++]] : 0;
-//        b3 = (ich < cbEncoded) ? rgbDecodeTable[pbEncoded[ich++]] : 0;
-//
-//        pbDecoded[ib++] = (b0 << 2) | (b1 >> 4);
-//
-//        if (ib < cbDecodedSize) {
-//            pbDecoded[ib++] = (b1 << 4) | (b2 >> 2);
-//
-//            if (ib < cbDecodedSize) {
-//                pbDecoded[ib++] = (b2 << 6) | b3;
-//            }
-//        }
-//    }
-//
-//    // Place the result in a NSData object and then free it.
-//    NSData *result = [NSData dataWithBytes:pbDecoded length:cbDecodedSize];
-//
-//    free( pbDecoded );
-//
-//    return result;
-//}
-
 - (NSString *)msidBase64UrlDecode
 {
     NSUInteger paddedLength = self.length + (4 - (self.length % 4));
     NSString *paddedString = [self stringByPaddingToLength:paddedLength withString:@"=" startingAtIndex:0];
-
+    
     NSData *data = [[NSData alloc]
                     initWithBase64EncodedString:paddedString
                     options:NSDataBase64DecodingIgnoreUnknownCharacters];
-
+    
     if (!data) return nil;
     
     char lastByte;
     [data getBytes:&lastByte range:NSMakeRange([data length]-1, 1)];
-
+    
     if (lastByte == 0x0) {
         //string is null-terminated
         return [NSString stringWithUTF8String:[data bytes]];
@@ -210,16 +80,6 @@ typedef unsigned char byte;
     }
 }
 
-
-//Helper method to encode 3 bytes into a sequence of 4 bytes:
-//"static inline" is the way declare inline methods in LLVM
-//static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
-//{
-//    output[0] = base64UrlEncodeTable[b0 >> 2];                                  // 6 MSB from byte 0
-//    output[1] = base64UrlEncodeTable[((b0 << 4) & 0x30) | ((b1 >> 4) & 0x0f)];  // 2 LSB from byte 0 and 4 MSB from byte 1
-//    output[2] = base64UrlEncodeTable[((b1 << 2) & 0x3c) | ((b2 >> 6) & 0x03)];  // 4 LSB from byte 1 and 2 MSB from byte 2
-//    output[3] = base64UrlEncodeTable[b2 & 0x3f];
-//}
 
 /// <summary>
 /// Base64 URL encode a set of bytes.
@@ -231,93 +91,17 @@ typedef unsigned char byte;
 
 + (NSString *)msidBase64UrlEncodeData:(NSData *)data
 {
-
     NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    return [[string dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
-
-//
-//    if ( nil == data )
-//        return nil;
-//
-//    const byte *pbBytes = [data bytes];
-//    int         cbBytes = (int)[data length];
-//
-//    // Calculate encoded string size including padding. This may be more than is actually
-//    // required since we will not pad and instead will terminate with null. The computation
-//    // is the number of byte triples times 4 radix64 characters plus 1 for null termination.
-//    int   encodedSize = 1 + ( cbBytes + 2 ) / 3 * 4;
-//    char *pbEncoded = (char *)calloc( encodedSize, sizeof(char) );
-//
-//    if(!pbEncoded){
-//        return nil;
-//    }
-//
-//    // Encode data byte triplets into four-byte clusters.
-//    int   iBytes;      // raw byte index
-//    int   iEncoded;    // encoded byte index
-//    byte  b0, b1, b2;  // individual bytes for triplet
-//
-//    iBytes = iEncoded = 0;
-//
-//    int end3 = (cbBytes/3)*3;
-//    //Fast loop, no bounderies check:
-//    for ( ; iBytes < end3; )
-//    {
-//        b0 = pbBytes[iBytes++];
-//        b1 = pbBytes[iBytes++];
-//        b2 = pbBytes[iBytes++];
-//
-//        Encode3bytesTo4bytes(pbEncoded + iEncoded, b0, b1, b2);
-//        iEncoded += 4;
-//    }
-//
-//    //Slower loop should execute no more than 3 times:
-//    while ( iBytes < cbBytes )
-//    {
-//        b0 = pbBytes[iBytes++];
-//        b1 = (iBytes < cbBytes) ? pbBytes[iBytes++] : 0;                                        // Add extra zero byte if needed
-//        b2 = (iBytes < cbBytes) ? pbBytes[iBytes++] : 0;                                        // Add extra zero byte if needed
-//
-//        Encode3bytesTo4bytes(pbEncoded + iEncoded, b0, b1, b2);
-//        iEncoded += 4;
-//    }
-//
-//    // Where we would have padded it, we instead truncate the string
-//    switch ( cbBytes % 3 )
-//    {
-//        case 0:
-//            // No left overs, nothing to pad
-//            break;
-//
-//        case 1:
-//            // One left over, normally pad 2
-//            pbEncoded[iEncoded - 2] = '\0';
-//            // fall through
-//
-//        case 2:
-//            pbEncoded[iEncoded - 1] = '\0';
-//            break;
-//    }
-//
-//    // Null terminate, convert to NSString and free the buffer
-//    pbEncoded[iEncoded++] = '\0';
-//
-//    NSString *result = [NSString stringWithCString:pbEncoded encoding:NSUTF8StringEncoding];
-//
-//    free(pbEncoded);
-//
-//    return result;
+    return [[string dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed].stringByRemovingPadding;
 }
+
 
 // Base64 URL encodes a string
 - (NSString *)msidBase64UrlEncode
 {
-//    NSData *decodedData = [self dataUsingEncoding:NSUTF8StringEncoding];
-
-//    return [self.class msidBase64UrlEncodeData:decodedData];
-    
-    return [[self dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
+    return [[self dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed].stringByRemovingPadding;
 }
+
 
 + (BOOL)msidIsStringNilOrBlank:(NSString *)string
 {
@@ -326,7 +110,7 @@ typedef unsigned char byte;
         return YES;
     }
     
-    static NSCharacterSet* nonWhiteCharSet;
+    static NSCharacterSet *nonWhiteCharSet;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
         nonWhiteCharSet = [[NSCharacterSet whitespaceAndNewlineCharacterSet] invertedSet];
@@ -338,9 +122,10 @@ typedef unsigned char byte;
 - (NSString *)msidTrimmedString
 {
     //The white characters set is cached by the system:
-    NSCharacterSet* set = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+    NSCharacterSet *set = [NSCharacterSet whitespaceAndNewlineCharacterSet];
     return [self stringByTrimmingCharactersInSet:set];
 }
+
 
 - (NSString *)msidUrlFormDecode
 {
@@ -349,17 +134,18 @@ typedef unsigned char byte;
     CFStringFindAndReplace( decodedString, CFSTR("+"), CFSTR(" "), CFRangeMake( 0, CFStringGetLength( decodedString ) ), kCFCompareCaseInsensitive );
     
     CFStringRef unescapedString = CFURLCreateStringByReplacingPercentEscapes( NULL,                    // Allocator
-                                                                                          decodedString,           // Original string
-                                                                                          CFSTR("")); // Encoding
+                                                                             decodedString,           // Original string
+                                                                             CFSTR("")); // Encoding
     CFRelease( decodedString );
     
     return CFBridgingRelease(unescapedString);
 }
 
+
 - (NSString *)msidUrlFormEncode
 {
-    static NSCharacterSet* set = nil;
- 
+    static NSCharacterSet *set = nil;
+    
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         
@@ -374,12 +160,13 @@ typedef unsigned char byte;
     return [encodedString stringByReplacingOccurrencesOfString:@" " withString:@"+"];
 }
 
+
 - (NSString*)msidComputeSHA256
 {
-    const char* inputStr = [self UTF8String];
+    const char *inputStr = [self UTF8String];
     unsigned char hash[CC_SHA256_DIGEST_LENGTH];
     CC_SHA256(inputStr, (int)strlen(inputStr), hash);
-    NSMutableString* toReturn = [[NSMutableString alloc] initWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
+    NSMutableString *toReturn = [[NSMutableString alloc] initWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
     for (int i = 0; i < sizeof(hash)/sizeof(hash[0]); ++i)
     {
         [toReturn appendFormat:@"%02x", hash[i]];
@@ -403,7 +190,7 @@ typedef unsigned char byte;
 - (NSOrderedSet<NSString *> *)scopeSet
 {
     NSMutableOrderedSet<NSString *> *scope = [NSMutableOrderedSet<NSString *> new];
-    NSArray* parts = [self componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" "]];
+    NSArray *parts = [self componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" "]];
     for (NSString *part in parts)
     {
         if (![NSString msidIsStringNilOrBlank:part])
@@ -420,7 +207,7 @@ typedef unsigned char byte;
     {
         return NO;
     }
-
+    
     for (NSString *alias in aliases)
     {
         if ([self caseInsensitiveCompare:alias] == NSOrderedSame)
@@ -437,3 +224,4 @@ typedef unsigned char byte;
 }
 
 @end
+

--- a/IdentityCore/tests/MSIDStringExtensionsTests.m
+++ b/IdentityCore/tests/MSIDStringExtensionsTests.m
@@ -111,6 +111,35 @@
     XCTAssertEqualObjects(decoded, _ORIGINAL); \
 }
 
+- (void)testBase64
+{
+    NSString* encodeEmpty = [@"" msidBase64UrlEncode];
+    XCTAssertEqualObjects(encodeEmpty, @"");
+    
+    NSString* decodeEmpty = [@"" msidBase64UrlDecode];
+    XCTAssertEqualObjects(decodeEmpty, @"");
+    
+    //15 characters, aka 3k:
+    NSString* test1 = @"1$)=- \t\r\nfoo%^!";
+    VERIFY_BASE64(test1, @"MSQpPS0gCQ0KZm9vJV4h");
+    
+    //16 characters, aka 3k + 1:
+    NSString* test2 = [test1 stringByAppendingString:@"@"];
+    VERIFY_BASE64(test2, @"MSQpPS0gCQ0KZm9vJV4hQA");
+    
+    //17 characters, aka 3k + 2:
+    NSString* test3 = [test2 stringByAppendingString:@"<"];
+    VERIFY_BASE64(test3, @"MSQpPS0gCQ0KZm9vJV4hQDw");
+    
+    //Ensure that URL encoded is in place through encoding correctly the '+' and '/' signs (just in case)
+    VERIFY_BASE64(@"++++/////", @"KysrKy8vLy8v");
+    
+    //Decode invalid:
+    XCTAssertFalse([@" " msidBase64UrlDecode].length, "Contains non-suppurted character < 128");
+    XCTAssertFalse([@"™" msidBase64UrlDecode].length, "Contains characters beyond 128");
+    XCTAssertFalse([@"денят" msidBase64UrlDecode].length, "Contains unicode characters.");
+}
+
 
 - (void)testmsidURLFormDecode
 {

--- a/IdentityCore/tests/MSIDStringExtensionsTests.m
+++ b/IdentityCore/tests/MSIDStringExtensionsTests.m
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
+#import "MSIDIdTokenClaims.h"
 
 @interface ADTestNSStringHelperMethods : XCTestCase
 
@@ -110,34 +111,6 @@
     XCTAssertEqualObjects(decoded, _ORIGINAL); \
 }
 
-- (void)testBase64
-{
-    NSString* encodeEmpty = [@"" msidBase64UrlEncode];
-    XCTAssertEqualObjects(encodeEmpty, @"");
-    
-    NSString* decodeEmpty = [@"" msidBase64UrlDecode];
-    XCTAssertEqualObjects(decodeEmpty, @"");
-    
-    //15 characters, aka 3k:
-    NSString* test1 = @"1$)=- \t\r\nfoo%^!";
-    VERIFY_BASE64(test1, @"MSQpPS0gCQ0KZm9vJV4h");
-    
-    //16 characters, aka 3k + 1:
-    NSString* test2 = [test1 stringByAppendingString:@"@"];
-    VERIFY_BASE64(test2, @"MSQpPS0gCQ0KZm9vJV4hQA");
-    
-    //17 characters, aka 3k + 2:
-    NSString* test3 = [test2 stringByAppendingString:@"<"];
-    VERIFY_BASE64(test3, @"MSQpPS0gCQ0KZm9vJV4hQDw");
-    
-    //Ensure that URL encoded is in place through encoding correctly the '+' and '/' signs (just in case)
-    VERIFY_BASE64(@"++++/////", @"KysrKy8vLy8v");
-    
-    //Decode invalid:
-    XCTAssertFalse([@" " msidBase64UrlDecode].length, "Contains non-suppurted character < 128");
-    XCTAssertFalse([@"™" msidBase64UrlDecode].length, "Contains characters beyond 128");
-    XCTAssertFalse([@"денят" msidBase64UrlDecode].length, "Contains unicode characters.");
-}
 
 - (void)testmsidURLFormDecode
 {


### PR DESCRIPTION
We use our own implementation for base64 encode/decode, 
Here proposed is using Apple's implementation with padding protection mechanism.

Fix should still apply for https://github.com/AzureAD/azure-activedirectory-library-for-objc/issues/443