### PR TITLE
Revise hashing at NSData and NSString extensions

### DIFF
--- a/IdentityCore/src/telemetry/MSIDTelemetryBaseEvent.m
+++ b/IdentityCore/src/telemetry/MSIDTelemetryBaseEvent.m
@@ -29,6 +29,7 @@
 #import "MSIDDeviceId.h"
 #import "MSIDVersion.h"
 #import "MSIDTelemetry.h"
+#import "NSData+MSIDExtensions.h"
 
 @implementation MSIDTelemetryBaseEvent
 
@@ -71,7 +72,7 @@
     
     if ([MSIDTelemetryPiiOiiRules isPii:name])
     {
-        value = [value msidComputeSHA256];
+        value = [[value.msidData msidSHA256] hexString];
     }
     
     [_propertyMap setValue:value forKey:name];
@@ -151,7 +152,7 @@
         NSString *value = rawParameters[key];
         if ([MSIDTelemetryPiiOiiRules isPii:key])
         {
-            value = [value msidComputeSHA256];
+            value = [[value.msidData msidSHA256] hexString];
         }
         
         [defaultParameters setValue:value forKey:key];

--- a/IdentityCore/src/util/NSData+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSData+MSIDExtensions.h
@@ -26,8 +26,11 @@
 @interface NSData (MSIDExtensions)
 
 - (NSDictionary *)msidToJsonDictionary:(NSError **)error;
-- (NSString *)msidComputeSHA256;
-- (NSString *)msidComputeSHA1;
-- (NSString *)msidComputeSHA1Base64Encoded;
+
+- (NSData *)msidSHA1;
+- (NSData *)msidSHA256;
+
+- (NSString *)hexString;
+- (NSString *)base64EncodedString;
 
 @end

--- a/IdentityCore/src/util/NSData+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSData+MSIDExtensions.m
@@ -26,35 +26,42 @@
 
 @implementation NSData (MSIDExtensions)
 
-- (NSString *)msidComputeSHA256
-{
-    unsigned char hash[CC_SHA256_DIGEST_LENGTH];
-    CC_SHA256(self.bytes, (CC_LONG)self.length, hash);
-    NSMutableString* toReturn = [[NSMutableString alloc] initWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
-    for (int i = 0; i < sizeof(hash)/sizeof(hash[0]); ++i)
-    {
-        [toReturn appendFormat:@"%02x", hash[i]];
-    }
-    return toReturn;
-}
-
-- (NSString *)msidComputeSHA1
+- (NSData *)msidSHA1
 {
     unsigned char hash[CC_SHA1_DIGEST_LENGTH];
     CC_SHA1(self.bytes, (CC_LONG)self.length, hash);
-    NSMutableString* toReturn = [[NSMutableString alloc] initWithCapacity:CC_SHA1_DIGEST_LENGTH*2];
-    for (int i = 0; i < sizeof(hash)/sizeof(hash[0]); ++i)
-    {
-        [toReturn appendFormat:@"%02x", hash[i]];
-    }
-    return toReturn;
+    
+    return [NSData dataWithBytes:hash length:CC_SHA1_DIGEST_LENGTH];
 }
 
-- (NSString *)msidComputeSHA1Base64Encoded
+- (NSData *)msidSHA256
 {
-    NSMutableData *hashData = [NSMutableData dataWithLength:CC_SHA1_DIGEST_LENGTH];
-    CC_SHA1(self.bytes, (CC_LONG)self.length, [hashData mutableBytes]);
-    return [hashData base64EncodedStringWithOptions:0];
+    unsigned char hash[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(self.bytes, (CC_LONG)self.length, hash);
+    
+    return [NSData dataWithBytes:hash length:CC_SHA256_DIGEST_LENGTH];
+}
+
+- (NSString *)hexString
+{
+    const unsigned char *charBytes = (const unsigned char *)self.bytes;
+    
+    if (!charBytes) return nil;
+    
+    NSUInteger dataLength = self.length;
+    NSMutableString *result = [NSMutableString stringWithCapacity:dataLength];
+    
+    for (int i = 0; i < dataLength; i++)
+    {
+        [result appendFormat:@"%02x", charBytes[i]];
+    }
+    
+    return result;
+}
+
+- (NSString *)base64EncodedString
+{
+    return [self base64EncodedStringWithOptions:0];
 }
 
 - (NSDictionary *)msidToJsonDictionary:(NSError **)error

--- a/IdentityCore/src/util/NSString+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.h
@@ -48,10 +48,11 @@
 /*! Converts NSData to base64 String */
 + (NSString *)msidBase64UrlEncodeData:(NSData *)data;
 
-- (NSString*)msidComputeSHA256;
-
 /*! Converts string to url */
 - (NSURL *)msidUrl;
+
+/*! Converts string to NSData */
+- (NSData *)msidData;
 
 /*! Calculates a hash of the passed string. Useful for logging tokens, where we do not log
  the actual contents, but still want to log something that can be correlated. */

--- a/IdentityCore/src/util/NSString+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.m
@@ -21,9 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <CommonCrypto/CommonDigest.h>
-
 #import "NSString+MSIDExtensions.h"
+#import "NSData+MSIDExtensions.h"
 
 typedef unsigned char byte;
 
@@ -327,27 +326,20 @@ static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
     return [encodedString stringByReplacingOccurrencesOfString:@" " withString:@"+"];
 }
 
-- (NSString*)msidComputeSHA256
-{
-    const char* inputStr = [self UTF8String];
-    unsigned char hash[CC_SHA256_DIGEST_LENGTH];
-    CC_SHA256(inputStr, (int)strlen(inputStr), hash);
-    NSMutableString* toReturn = [[NSMutableString alloc] initWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
-    for (int i = 0; i < sizeof(hash)/sizeof(hash[0]); ++i)
-    {
-        [toReturn appendFormat:@"%02x", hash[i]];
-    }
-    return toReturn;
-}
-
 - (NSURL *)msidUrl
 {
     return [[NSURL alloc] initWithString:self];
 }
 
+- (NSData *)msidData
+{
+    const char *str = [self UTF8String];
+    return [NSData dataWithBytes:str length:strlen(str)];
+}
+
 - (NSString *)msidTokenHash
 {
-    NSMutableString *returnStr = [[self msidComputeSHA256] mutableCopy];
+    NSString *returnStr = [[[self msidData] msidSHA256] hexString];
     
     // 7 characters is sufficient to differentiate tokens in the log, otherwise the hashes start making log lines hard to read
     return [returnStr substringToIndex:7];

--- a/IdentityCore/tests/MSIDTelemetryUIEventTests.m
+++ b/IdentityCore/tests/MSIDTelemetryUIEventTests.m
@@ -25,6 +25,7 @@
 #import "MSIDTelemetryUIEvent.h"
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDVersion.h"
+#import "NSData+MSIDExtensions.h"
 
 @interface MSIDTelemetryUIEventTests : XCTestCase
 
@@ -40,7 +41,7 @@
     
     [event setLoginHint:@"eric_cartman@contoso.com"];
     
-    XCTAssertEqualObjects([event propertyWithName:MSID_TELEMETRY_KEY_LOGIN_HINT], [@"eric_cartman@contoso.com" msidComputeSHA256]);
+    XCTAssertEqualObjects([event propertyWithName:MSID_TELEMETRY_KEY_LOGIN_HINT], [[@"eric_cartman@contoso.com".msidData msidSHA256] hexString]);
 }
 
 @end

--- a/IdentityCore/tests/integration/MSIDTelemetryIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDTelemetryIntegrationTests.m
@@ -30,6 +30,7 @@
 #import "MSIDTelemetry+Internal.h"
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDTelemetryAPIEvent.h"
+#import "NSData+MSIDExtensions.h"
 
 @interface MSIDTelemetryIntegrationTests : XCTestCase
 {
@@ -81,7 +82,7 @@
     
     XCTAssertEqual(_receivedEvents.count, 1);
     //expect hashed Pii
-    XCTAssertEqualObjects([_receivedEvents[0] propertyWithName:MSID_TELEMETRY_KEY_USER_ID], [@"user" msidComputeSHA256]);
+    XCTAssertEqualObjects([_receivedEvents[0] propertyWithName:MSID_TELEMETRY_KEY_USER_ID], [[@"user".msidData msidSHA256] hexString]);
     //expect unhashed Oii
     XCTAssertEqualObjects([_receivedEvents[0] propertyWithName:MSID_TELEMETRY_KEY_CLIENT_ID], @"clientid");
 }


### PR DESCRIPTION
- Remove hashing from NSString extensions
- Add convenience converting method for NSString -> NSData
- Modify NSData extensions to handle hashing, modulized.
- Add stringify methods to NSData.

example calls
```
NSString *sha256Hex = @"string".msidData.msidSHA256.hexString;
NSString *sha256Base64 =  @"string".msidData.msidSHA256.base64EncodedString;
NSString *sha256Base64UrlEncoded = @"string".msidData.msidSHA256.base64EncodedString.mdmsidBase64UrlEncode;
```
