### PR TITLE
Don't force ADAL to have WebKit dependency

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -3582,6 +3582,7 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
+					"$(MSID_WEBKIT)",
 					"$(MSID_SYSTEMWV)",
 				);
 			};
@@ -3591,7 +3592,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4E9C1FC3626B00CD70C5 /* identitycore__release.xcconfig */;
 			buildSettings = {
-				GCC_PREPROCESSOR_DEFINITIONS = "$(MSID_SYSTEMWV)";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(MSID_SYSTEMWV)",
+					"$(MSID_WEBKIT)",
+				);
 			};
 			name = Release;
 		};

--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.h
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.h
@@ -31,8 +31,10 @@
 
 @interface MSIDWebviewFactory : NSObject
 
+#if !MSID_EXCLUDE_WEBKIT
 // Webviews creation
 - (MSIDWebviewSession *)embeddedWebviewSessionFromConfiguration:(MSIDWebviewConfiguration *)configuration customWebview:(WKWebView *)webview context:(id<MSIDRequestContext>)context;
+#endif
 
 #if TARGET_OS_IPHONE && !MSID_EXCLUDE_SYSTEMWV
 - (MSIDWebviewSession *)systemWebviewSessionFromConfiguration:(MSIDWebviewConfiguration *)configuration context:(id<MSIDRequestContext>)context;
@@ -55,4 +57,5 @@
                responseURL:(NSURL *)url
                      error:(NSError **)error;
 - (NSString *)generateStateValue;
+
 @end

--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.m
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.m
@@ -33,6 +33,8 @@
 
 @implementation MSIDWebviewFactory
 
+#if !MSID_EXCLUDE_WEBKIT
+
 #pragma mark - Webview creation
 
 - (MSIDWebviewSession *)embeddedWebviewSessionFromConfiguration:(MSIDWebviewConfiguration *)configuration customWebview:(WKWebView *)webview context:(id<MSIDRequestContext>)context
@@ -54,6 +56,8 @@
                                                                             verifyState:configuration.verifyState];
     return session;
 }
+
+#endif
 
 #if TARGET_OS_IPHONE && !MSID_EXCLUDE_SYSTEMWV
 - (MSIDWebviewSession *)systemWebviewSessionFromConfiguration:(MSIDWebviewConfiguration *)configuration context:(id<MSIDRequestContext>)context

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
@@ -70,6 +70,8 @@
     return parameters;
 }
 
+#if !MSID_EXCLUDE_WEBKIT
+
 - (MSIDWebviewSession *)embeddedWebviewSessionFromConfiguration:(MSIDWebviewConfiguration *)configuration customWebview:(WKWebView *)webview context:(id<MSIDRequestContext>)context
 {
     NSString *state = [self generateStateValue];
@@ -89,6 +91,8 @@
                                                                             verifyState:configuration.verifyState];
     return session;
 }
+
+#endif
 
 - (MSIDWebviewResponse *)responseWithURL:(NSURL *)url
                                  context:(id<MSIDRequestContext>)context

--- a/IdentityCore/src/webview/MSIDWebviewAuthorization.h
+++ b/IdentityCore/src/webview/MSIDWebviewAuthorization.h
@@ -40,6 +40,8 @@ typedef void (^MSIDWebviewAuthCompletionHandler)(MSIDWebviewResponse *response, 
 
 @interface MSIDWebviewAuthorization : NSObject
 
+#if !MSID_EXCLUDE_WEBKIT
+
 + (void)startEmbeddedWebviewAuthWithConfiguration:(MSIDWebviewConfiguration *)configuration
                                     oauth2Factory:(MSIDOauth2Factory *)oauth2Factory
                                           context:(id<MSIDRequestContext>)context
@@ -51,6 +53,8 @@ typedef void (^MSIDWebviewAuthCompletionHandler)(MSIDWebviewResponse *response, 
                                                  context:(id<MSIDRequestContext>)context
                                        completionHandler:(MSIDWebviewAuthCompletionHandler)completionHandler;
 
+#endif
+
 #if TARGET_OS_IPHONE && !MSID_EXCLUDE_SYSTEMWV
 + (void)startSystemWebviewWebviewAuthWithConfiguration:(MSIDWebviewConfiguration *)configuration
                                          oauth2Factory:(MSIDOauth2Factory *)oauth2Factory
@@ -58,14 +62,15 @@ typedef void (^MSIDWebviewAuthCompletionHandler)(MSIDWebviewResponse *response, 
                                      completionHandler:(MSIDWebviewAuthCompletionHandler)completionHandler;
 #endif
 
-
-+ (BOOL)setCurrentSession:(MSIDWebviewSession *)session;
-+ (void)cancelCurrentSession;
-
 #if TARGET_OS_IPHONE && !MSID_EXCLUDE_SYSTEMWV
 // This is for system webview auth session on iOS 10 - Thus, a SafariViewController
 + (BOOL)handleURLResponseForSystemWebviewController:(NSURL *)url;
 #endif
+
+#if !MSID_EXCLUDE_WEBKIT
+
++ (BOOL)setCurrentSession:(MSIDWebviewSession *)session;
++ (void)cancelCurrentSession;
 
 // This can be utilized for having a custom webview controller, and for testing.
 + (void)startSession:(MSIDWebviewSession *)session
@@ -73,6 +78,8 @@ typedef void (^MSIDWebviewAuthCompletionHandler)(MSIDWebviewResponse *response, 
    completionHandler:(MSIDWebviewAuthCompletionHandler)completionHandler;
 
 @property (class, readonly) MSIDWebviewSession *currentSession;
+
+#endif
 
 @end
 

--- a/IdentityCore/src/webview/MSIDWebviewAuthorization.m
+++ b/IdentityCore/src/webview/MSIDWebviewAuthorization.m
@@ -39,6 +39,8 @@
 
 static MSIDWebviewSession *s_currentSession = nil;
 
+#if !MSID_EXCLUDE_WEBKIT
+
 + (void)startEmbeddedWebviewAuthWithConfiguration:(MSIDWebviewConfiguration *)configuration
                                     oauth2Factory:(MSIDOauth2Factory *)oauth2Factory
                                           context:(id<MSIDRequestContext>)context
@@ -63,6 +65,8 @@ static MSIDWebviewSession *s_currentSession = nil;
     [self startSession:session context:context completionHandler:completionHandler];
 }
 
+#endif
+
 #if TARGET_OS_IPHONE && !MSID_EXCLUDE_SYSTEMWV
 + (void)startSystemWebviewWebviewAuthWithConfiguration:(MSIDWebviewConfiguration *)configuration
                                          oauth2Factory:(MSIDOauth2Factory *)oauth2Factory
@@ -75,6 +79,8 @@ static MSIDWebviewSession *s_currentSession = nil;
     [self startSession:session context:context completionHandler:completionHandler];
 }
 #endif
+
+#if !MSID_EXCLUDE_WEBKIT
 
 + (void)startSession:(MSIDWebviewSession *)session
              context:(id<MSIDRequestContext>)context
@@ -116,7 +122,6 @@ static MSIDWebviewSession *s_currentSession = nil;
     
     [s_currentSession.webviewController startWithCompletionHandler:startCompletionBlock];
 }
-
 
 + (BOOL)setCurrentSession:(MSIDWebviewSession *)session
 {
@@ -168,6 +173,8 @@ static MSIDWebviewSession *s_currentSession = nil;
         }
     }
 }
+
+#endif
 
 #if TARGET_OS_IPHONE && !MSID_EXCLUDE_SYSTEMWV
 + (BOOL)handleURLResponseForSystemWebviewController:(NSURL *)url;

--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.h
@@ -27,8 +27,12 @@
 
 #import "MSIDOAuth2EmbeddedWebviewController.h"
 
+#if !MSID_EXCLUDE_WEBKIT
+
 @interface MSIDAADOAuthEmbeddedWebviewController : MSIDOAuth2EmbeddedWebviewController
 
 - (id)init NS_UNAVAILABLE;
 
 @end
+
+#endif

--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -33,6 +33,8 @@
 #import "MSIDAppExtensionUtil.h"
 #endif
 
+#if !MSID_EXCLUDE_WEBKIT
+
 @implementation MSIDAADOAuthEmbeddedWebviewController
 
 - (id)initWithStartURL:(NSURL *)startURL
@@ -124,3 +126,5 @@
 }
 
 @end
+
+#endif

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
@@ -25,6 +25,8 @@
 //
 //------------------------------------------------------------------------------
 
+#if !MSID_EXCLUDE_WEBKIT
+
 #import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
 #import "MSIDWebviewInteracting.h"
@@ -51,3 +53,5 @@ MSIDWebviewUIController <MSIDWebviewInteracting, WKNavigationDelegate>
 @property (readonly) NSURL *startURL;
 
 @end
+
+#endif

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -31,6 +31,8 @@
 #import "MSIDAuthority.h"
 #import "MSIDWorkPlaceJoinConstants.h"
 
+#if !MSID_EXCLUDE_WEBKIT
+
 @implementation MSIDOAuth2EmbeddedWebviewController
 {
     NSURL *_endURL;
@@ -349,3 +351,5 @@
 }
 
 @end
+
+#endif

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -21,6 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if !MSID_EXCLUDE_WEBKIT
+
 #import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
 
@@ -51,3 +53,5 @@ NSWindowController
 - (void)userCancel;
 
 @end
+
+#endif

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -21,6 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if !MSID_EXCLUDE_WEBKIT
+
 #import "MSIDWebviewUIController.h"
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDAppExtensionUtil.h"
@@ -286,3 +288,5 @@
 }
 
 @end
+
+#endif

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -23,6 +23,8 @@
 
 #import "MSIDWebviewUIController.h"
 
+#if !MSID_EXCLUDE_WEBKIT
+
 #define DEFAULT_WINDOW_WIDTH 420
 #define DEFAULT_WINDOW_HEIGHT 650
 
@@ -179,3 +181,5 @@
 
 
 @end
+
+#endif

--- a/IdentityCore/tests/MSIDOAuth2EmbeddedWebviewControllerTests.m
+++ b/IdentityCore/tests/MSIDOAuth2EmbeddedWebviewControllerTests.m
@@ -28,6 +28,8 @@
 #import <XCTest/XCTest.h>
 #import "MSIDOAuth2EmbeddedWebviewController.h"
 
+#if !MSID_EXCLUDE_WEBKIT
+
 @interface MSIDOAuth2EmbeddedWebviewControllerTests : XCTestCase
 
 @end
@@ -74,3 +76,5 @@
 }
 
 @end
+
+#endif

--- a/IdentityCore/tests/MSIDWebviewAuthorizationTests.m
+++ b/IdentityCore/tests/MSIDWebviewAuthorizationTests.m
@@ -27,6 +27,8 @@
 #import "MSIDOauth2Factory.h"
 #import "MSIDWebviewFactory.h"
 
+#if !MSID_EXCLUDE_WEBKIT
+
 @interface MSIDWebviewAuthorizationTests : XCTestCase
 
 @end
@@ -241,3 +243,5 @@
 #endif
 
 @end
+
+#endif


### PR DESCRIPTION
Because we still haven't added WKWebView support to ADAL, we shouldn't force WebKit dependency on the first ADAL release