### PR TITLE
Added msid equivalent authority host method that checks only host

### DIFF
--- a/IdentityCore/src/util/NSURL+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSURL+MSIDExtensions.h
@@ -25,7 +25,22 @@
 
 @property (readonly, nonatomic) NSDictionary *msidFragmentParameters;
 
+/*
+ Checks that authority is equivalent by checking:
+    * scheme
+    * host
+    * post
+    * path
+ */
 - (BOOL)msidIsEquivalentAuthority:(NSURL *)aURL;
+
+/*
+ Checks that authority is equivalent by checking:
+    * scheme
+    * host
+    * post
+ */
+- (BOOL)msidIsEquivalentAuthorityHost:(NSURL *)aURL;
 
 - (NSString *)msidHostWithPortIfNecessary;
 - (NSString *)msidTenant;

--- a/IdentityCore/src/util/NSURL+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSURL+MSIDExtensions.h
@@ -29,7 +29,7 @@
  Checks that authority is equivalent by checking:
     * scheme
     * host
-    * post
+    * port
     * path
  */
 - (BOOL)msidIsEquivalentAuthority:(NSURL *)aURL;
@@ -38,7 +38,7 @@
  Checks that authority is equivalent by checking:
     * scheme
     * host
-    * post
+    * port
  */
 - (BOOL)msidIsEquivalentAuthorityHost:(NSURL *)aURL;
 

--- a/IdentityCore/src/util/NSURL+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSURL+MSIDExtensions.m
@@ -47,35 +47,9 @@ const unichar queryStringSeparator = '?';
 
 - (BOOL)msidIsEquivalentAuthority:(NSURL *)aURL
 {
-    
-    // Check if equal
-    if ([self isEqual:aURL])
-    {
-        return YES;
-    }
-    
-    // Check scheme and host
-    if (!self.scheme ||
-        !aURL.scheme ||
-        [self.scheme caseInsensitiveCompare:aURL.scheme] != NSOrderedSame)
+    if (![self msidIsEquivalentAuthorityHost:aURL])
     {
         return NO;
-    }
-    
-    if (!self.host ||
-        !aURL.host ||
-        [self.host caseInsensitiveCompare:aURL.host] != NSOrderedSame)
-    {
-        return NO;
-    }
-    
-    // Check port
-    if (self.port || aURL.port)
-    {
-        if (![self.port isEqual:aURL.port])
-        {
-            return NO;
-        }
     }
     
     // Check path
@@ -87,6 +61,41 @@ const unichar queryStringSeparator = '?';
         }
     }
     
+    return YES;
+}
+
+- (BOOL)msidIsEquivalentAuthorityHost:(NSURL *)aURL
+{
+    // Check if equal
+    if ([self isEqual:aURL])
+    {
+        return YES;
+    }
+
+    // Check scheme and host
+    if (!self.scheme ||
+        !aURL.scheme ||
+        [self.scheme caseInsensitiveCompare:aURL.scheme] != NSOrderedSame)
+    {
+        return NO;
+    }
+
+    if (!self.host ||
+        !aURL.host ||
+        [self.host caseInsensitiveCompare:aURL.host] != NSOrderedSame)
+    {
+        return NO;
+    }
+
+    // Check port
+    if (self.port || aURL.port)
+    {
+        if (![self.port isEqual:aURL.port])
+        {
+            return NO;
+        }
+    }
+
     return YES;
 }
 

--- a/IdentityCore/tests/MSIDURLExtensionsTests.m
+++ b/IdentityCore/tests/MSIDURLExtensionsTests.m
@@ -172,6 +172,90 @@
     XCTAssertEqualObjects(tenant, @"contoso.onmicrosoft.com");
 }
 
+#pragma mark - Equivalent authority
 
+- (void)testMsidIsEquivalentAuthority_whenSameAuthority_shouldReturnTrue
+{
+    NSURL *authority = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.com"];
+    XCTAssertTrue([authority msidIsEquivalentAuthority:authority]);
+}
+
+- (void)testMsidIsEquivalentAuthority_whenEquivalentAuthority_shouldReturnTrue
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.com?test=test"];
+    XCTAssertTrue([authority1 msidIsEquivalentAuthority:authority2]);
+}
+
+- (void)testMsidIsEquivalentAuthority_whenEquivalentAuthorityButSchemeDifferent_shouldReturnFalse
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com:88/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"http://login.microsoftonline.com:88/contoso.com?test=test"];
+    XCTAssertFalse([authority1 msidIsEquivalentAuthority:authority2]);
+}
+
+- (void)testMsidIsEquivalentAuthority_whenEquivalentAuthorityButHostDifferent_shouldReturnFalse
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"https://login.windows.net/contoso.com?test=test"];
+    XCTAssertFalse([authority1 msidIsEquivalentAuthority:authority2]);
+}
+
+- (void)testMsidIsEquivalentAuthority_whenEquivalentAuthorityButPortDifferent_shouldReturnFalse
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com:89/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"https://login.microsoftonline.com:88/contoso.com?test=test"];
+    XCTAssertFalse([authority1 msidIsEquivalentAuthority:authority2]);
+}
+
+- (void)testMsidIsEquivalentAuthority_whenEquivalentAuthorityButPathDifferent_shouldReturnFalse
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com:88/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"https://login.microsoftonline.com:88/contoso2.com?test=test"];
+    XCTAssertFalse([authority1 msidIsEquivalentAuthority:authority2]);
+}
+
+#pragma mark - Equivalent authority host
+
+- (void)testMsidIsEquivalentAuthorityHost_whenSameAuthority_shouldReturnTrue
+{
+    NSURL *authority = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.com"];
+    XCTAssertTrue([authority msidIsEquivalentAuthorityHost:authority]);
+}
+
+- (void)testMsidIsEquivalentAuthorityHost_whenEquivalentAuthority_shouldReturnTrue
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.com?test=test"];
+    XCTAssertTrue([authority1 msidIsEquivalentAuthorityHost:authority2]);
+}
+
+- (void)testMsidIsEquivalentAuthorityHost_whenEquivalentAuthorityButSchemeDifferent_shouldReturnFalse
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com:88/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"http://login.microsoftonline.com:88/contoso.com?test=test"];
+    XCTAssertFalse([authority1 msidIsEquivalentAuthorityHost:authority2]);
+}
+
+- (void)testMsidIsEquivalentAuthorityHost_whenEquivalentAuthorityButHostDifferent_shouldReturnFalse
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"https://login.windows.net/contoso.com?test=test"];
+    XCTAssertFalse([authority1 msidIsEquivalentAuthorityHost:authority2]);
+}
+
+- (void)testMsidIsEquivalentAuthorityHost_whenEquivalentAuthorityButPortDifferent_shouldReturnFalse
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com:89/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"https://login.microsoftonline.com:88/contoso.com?test=test"];
+    XCTAssertFalse([authority1 msidIsEquivalentAuthorityHost:authority2]);
+}
+
+- (void)testMsidIsEquivalentAuthorityHost_whenEquivalentAuthorityButPathDifferent_shouldReturnTrue
+{
+    NSURL *authority1 = [NSURL URLWithString:@"https://login.microsoftonline.com:88/contoso.com"];
+    NSURL *authority2 = [NSURL URLWithString:@"https://login.microsoftonline.com:88/contoso2.com?test=test"];
+    XCTAssertTrue([authority1 msidIsEquivalentAuthorityHost:authority2]);
+}
 
 @end


### PR DESCRIPTION
Found that ADFSv4 authority validation is broken, because it uses msidIsEquivalentAuthority method, but expects authorities to be equal even if path is not the same. 
* Added a new method with more appropriate name to be used in ADFS authority validation.
* Added tests for both of the methods