### PR TITLE
Fixed mac cache synchronization issues

### DIFF
--- a/IdentityCore/src/cache/MSIDMacTokenCache.m
+++ b/IdentityCore/src/cache/MSIDMacTokenCache.m
@@ -57,6 +57,7 @@ return NO; \
     
     NSString *queueName = [NSString stringWithFormat:@"com.microsoft.msidmactokencache-%@", [NSUUID UUID].UUIDString];
     _synchronizationQueue = dispatch_queue_create([queueName cStringUsingEncoding:NSASCIIStringEncoding], DISPATCH_QUEUE_CONCURRENT);
+    [self clear];
     
     return self;
 }
@@ -172,7 +173,8 @@ return NO; \
 - (void)clear
 {
     dispatch_barrier_sync(self.synchronizationQueue, ^{
-        self.cache = nil;
+        _cache = [NSMutableDictionary new];
+        _cache[@"tokens"] = [NSMutableDictionary new];
     });
 }
 


### PR DESCRIPTION
Found a couple of issues:
* self.cache actually modified _cache sometimes, so it's unsafe to use self.cache in reading scenarios (replaced with _cache)
* clear cache didn't have any synchronization
* Data could be modified in setItem while serialization is in progress when serialize/deserialize routines are in use, so returned data was invalid at the time of return, which caused data integrity issues. 