### PR TITLE
Added token cache optimizations

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -118,9 +118,10 @@
     MSID_LOG_VERBOSE(context, @"(Legacy accessor) Saving SSO state");
 
     BOOL result = [self saveRefreshTokenWithConfiguration:configuration response:response context:context error:error];
-    result &= [self saveAccountWithConfiguration:configuration response:response context:context error:error];
 
-    return result;
+    if (!result) return NO;
+
+    return [self saveAccountWithConfiguration:configuration response:response context:context error:error];
 }
 
 - (MSIDRefreshToken *)getRefreshTokenWithAccount:(MSIDAccountIdentifier *)account
@@ -780,7 +781,7 @@
 
     if (familyId)
     {
-        // If family ID is provided, we don't need ti lookup by a specific client ID only
+        // If family ID is provided, we don't need to lookup by a specific client ID
         clientIdForQueries = nil;
     }
 

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -776,15 +776,17 @@
 
     NSArray<NSString *> *aliases = [_factory cacheAliasesForEnvironment:authority.msidHostWithPortIfNecessary];
 
-    MSIDDefaultCredentialCacheQuery *idTokensQuery = [MSIDDefaultCredentialCacheQuery new];
-    idTokensQuery.environmentAliases = aliases;
+    NSString *clientIdForQueries = clientId;
 
-    if (!familyId)
+    if (familyId)
     {
-        // If no family ID is provided, lookup by a specific client ID only
-        idTokensQuery.clientId = clientId;
+        // If family ID is provided, we don't need ti lookup by a specific client ID only
+        clientIdForQueries = nil;
     }
 
+    MSIDDefaultCredentialCacheQuery *idTokensQuery = [MSIDDefaultCredentialCacheQuery new];
+    idTokensQuery.environmentAliases = aliases;
+    idTokensQuery.clientId = clientIdForQueries;
     idTokensQuery.credentialType = MSIDIDTokenType;
 
     NSArray<MSIDCredentialCacheItem *> *matchedIdTokens = [_accountCredentialCache getCredentialsWithQuery:idTokensQuery
@@ -803,9 +805,8 @@
         MSIDDefaultCredentialCacheQuery *rtQuery = [MSIDDefaultCredentialCacheQuery new];
         rtQuery.homeAccountId = homeAccountId;
         rtQuery.environmentAliases = aliases;
-        rtQuery.clientId = clientId;
+        rtQuery.clientId = clientIdForQueries;
         rtQuery.familyId = familyId;
-        rtQuery.clientIdMatchingOptions = MSIDSuperSet;
         rtQuery.credentialType = MSIDRefreshTokenType;
 
         NSArray<MSIDCredentialCacheItem *> *rtCacheItems = [_accountCredentialCache getCredentialsWithQuery:rtQuery

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -316,6 +316,7 @@
         {
             return YES;
         }
+        else return NO;
     }
     else
     {

--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.m
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.m
@@ -122,7 +122,6 @@
     NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:configuration.authorizationEndpoint resolvingAgainstBaseURL:NO];
     NSDictionary *parameters = [self authorizationParametersFromConfiguration:configuration requestState:state];
     
-    urlComponents.queryItems = [parameters urlQueryItemsArray];
     urlComponents.percentEncodedQuery = [parameters msidURLFormEncode];
     
     return urlComponents.URL;

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2IdTokenClaims.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2IdTokenClaims.m
@@ -52,7 +52,16 @@ MSID_JSON_ACCESSOR(ID_TOKEN_HOME_OBJECT_ID, homeObjectId)
     }
 
     _uniqueId = [MSIDHelpers normalizeUserId:uniqueId];
-    _userId = [MSIDHelpers normalizeUserId:self.preferredUsername];
+
+    // Set userId
+    NSString *userId = self.preferredUsername;
+
+    if ([NSString msidIsStringNilOrBlank:userId])
+    {
+        userId = self.subject;
+    }
+
+    _userId = [MSIDHelpers normalizeUserId:userId];
     _userIdDisplayable = YES;
 }
 

--- a/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
@@ -201,7 +201,7 @@
     XCTAssertEqualObjects(account.authority.absoluteString, @"https://login.microsoftonline.com/tenantId.onmicrosoft.com");
 }
 
-- (void)testSaveTokensWithFactory_whenMultiResourceResponse_savesTokensToBothAccessors
+- (void)testSaveTokensWithFactory_whenMultiResourceResponse_savesTokensOnlyToDefaultAccessor
 {
     NSString *idToken = [MSIDTestIdTokenUtil idTokenWithPreferredUsername:@"upn@test.com" subject:@"subject" givenName:@"Hello" familyName:@"World" name:@"Hello World" version:@"2.0" tid:@"tenantId.onmicrosoft.com"];
 
@@ -283,21 +283,10 @@
     XCTAssertEqual([legacyAccessTokens count], 0);
 
     NSArray *legacyRefreshTokens = [self getAllLegacyRefreshTokens];
-    XCTAssertEqual([legacyRefreshTokens count], 1);
-
-    MSIDLegacyRefreshToken *legacyRefreshToken = legacyRefreshTokens[0];
-    XCTAssertEqualObjects(legacyRefreshToken.idToken, idToken);
-    XCTAssertEqualObjects(legacyRefreshToken.accountIdentifier.legacyAccountId, @"upn@test.com");
-    XCTAssertEqualObjects(legacyRefreshToken.refreshToken, @"refresh token");
-    XCTAssertNil(legacyRefreshToken.familyId);
-    XCTAssertEqual(legacyRefreshToken.credentialType, MSIDRefreshTokenType);
-    XCTAssertEqualObjects(legacyRefreshToken.authority.absoluteString, @"https://login.microsoftonline.com/common");
-    XCTAssertEqualObjects(legacyRefreshToken.clientId, @"test_client_id");
-    XCTAssertEqualObjects(legacyRefreshToken.accountIdentifier.homeAccountId, @"uid.utid");
-    XCTAssertEqualObjects(legacyRefreshToken.additionalServerInfo, [NSDictionary dictionary]);
+    XCTAssertEqual([legacyRefreshTokens count], 0);
 }
 
-- (void)testSaveTokensWithFactory_whenMultiResourceFOCIResponse_savesTokensToBothAccessors
+- (void)testSaveTokensWithFactory_whenMultiResourceFOCIResponse_savesTokensOnlyToDefaultAccessor
 {
     NSString *idToken = [MSIDTestIdTokenUtil idTokenWithPreferredUsername:@"upn@test.com" subject:@"subject" givenName:@"Hello" familyName:@"World" name:@"Hello World" version:@"2.0" tid:@"tenantId.onmicrosoft.com"];
 
@@ -322,16 +311,7 @@
     XCTAssertEqual([legacyAccessTokens count], 0);
 
     NSArray *legacyRefreshTokens = [self getAllLegacyRefreshTokens];
-    XCTAssertEqual([legacyRefreshTokens count], 2);
-    XCTAssertNotEqualObjects(legacyRefreshTokens[0], legacyRefreshTokens[1]);
-
-    MSIDLegacyRefreshToken *refreshToken1 = legacyRefreshTokens[0];
-    MSIDLegacyRefreshToken *refreshToken2 = legacyRefreshTokens[1];
-
-    XCTAssertEqualObjects(refreshToken1.familyId, @"2");
-    XCTAssertEqualObjects(refreshToken2.familyId, @"2");
-    XCTAssertEqualObjects(refreshToken1.clientId, @"test_client_id");
-    XCTAssertEqualObjects(refreshToken2.clientId, @"foci-2");
+    XCTAssertEqual([legacyRefreshTokens count], 0);
 
     NSArray *defaultAccessTokens = [self getAllAccessTokens];
     XCTAssertEqual([defaultAccessTokens count], 1);
@@ -361,7 +341,7 @@
                                                                 context:nil
                                                                   error:&error];
 
-    XCTAssertEqual([clientAccounts count], 1);
+    XCTAssertEqual([clientAccounts count], 0);
 
     NSArray *familyAccounts = [_otherAccessor allAccountsForEnvironment:@"login.microsoftonline.com"
                                                                clientId:nil
@@ -369,7 +349,7 @@
                                                                 context:nil
                                                                   error:&error];
 
-    XCTAssertEqual([familyAccounts count], 1);
+    XCTAssertEqual([familyAccounts count], 0);
 
     NSArray *allAccounts = [_otherAccessor allAccountsForEnvironment:@"login.microsoftonline.com"
                                                             clientId:@"test_client_id"
@@ -377,7 +357,7 @@
                                                              context:nil
                                                                error:&error];
 
-    XCTAssertEqual([allAccounts count], 1);
+    XCTAssertEqual([allAccounts count], 0);
 }
 
 

--- a/IdentityCore/tests/integration/MSIDDefaultTokenCacheIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDDefaultTokenCacheIntegrationTests.m
@@ -559,11 +559,10 @@
 
 - (void)testGetTokenWithType_whenTypeRefreshAccountWithLegacyIDProvided_shouldReturnToken
 {
-    [_cacheAccessor saveSSOStateWithConfiguration:[MSIDTestConfiguration v2DefaultConfiguration]
-                                         response:[MSIDTestTokenResponse v2DefaultTokenResponse]
-                                          context:nil
-                                            error:nil];
-
+    [_cacheAccessor saveTokensWithConfiguration:[MSIDTestConfiguration v2DefaultConfiguration]
+                                       response:[MSIDTestTokenResponse v2DefaultTokenResponse]
+                                        context:nil
+                                          error:nil];
 
     MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithLegacyAccountId:DEFAULT_TEST_ID_TOKEN_USERNAME
                                                                               homeAccountId:nil];

--- a/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
@@ -247,15 +247,7 @@
     XCTAssertEqualObjects(defaultRefreshToken.additionalServerInfo, [NSDictionary dictionary]);
 
     NSArray *defaultIDTokens = [self getAllIDTokens];
-    XCTAssertEqual([defaultIDTokens count], 1);
-
-    MSIDIdToken *defaultIDToken = defaultIDTokens[0];
-    XCTAssertEqualObjects(defaultIDToken.rawIdToken, idToken);
-    XCTAssertEqual(defaultIDToken.credentialType, MSIDIDTokenType);
-    XCTAssertEqualObjects(defaultIDToken.authority.absoluteString, @"https://login.microsoftonline.com/tid");
-    XCTAssertEqualObjects(defaultIDToken.clientId, @"test_client_id");
-    XCTAssertEqualObjects(defaultIDToken.accountIdentifier.homeAccountId, @"uid.utid");
-    XCTAssertEqualObjects(defaultIDToken.additionalServerInfo, [NSDictionary dictionary]);
+    XCTAssertEqual([defaultIDTokens count], 0);
 
     NSArray *accounts = [_otherAccessor allAccountsForEnvironment:@"login.microsoftonline.com" clientId:@"test_client_id" familyId:nil  context:nil error:&error];
     XCTAssertNotNil(accounts);
@@ -325,7 +317,7 @@
     XCTAssertEqualObjects(defaultRefreshToken2.clientId, @"test_client_id");
 
     NSArray *defaultIDTokens = [self getAllIDTokens];
-    XCTAssertEqual([defaultIDTokens count], 1);
+    XCTAssertEqual([defaultIDTokens count], 0);
 
     NSArray *clientAccounts = [_otherAccessor allAccountsForEnvironment:@"login.microsoftonline.com"
                                                                clientId:@"test_client_id"
@@ -573,15 +565,7 @@
     XCTAssertEqualObjects(defaultRefreshToken.additionalServerInfo, [NSDictionary dictionary]);
 
     NSArray *defaultIDTokens = [self getAllIDTokens];
-    XCTAssertEqual([defaultIDTokens count], 1);
-
-    MSIDIdToken *defaultIDToken = defaultIDTokens[0];
-    XCTAssertEqualObjects(defaultIDToken.rawIdToken, idToken);
-    XCTAssertEqual(defaultIDToken.credentialType, MSIDIDTokenType);
-    XCTAssertEqualObjects(defaultIDToken.authority.absoluteString, @"https://login.microsoftonline.com/tid");
-    XCTAssertEqualObjects(defaultIDToken.clientId, @"test_client_id");
-    XCTAssertEqualObjects(defaultIDToken.accountIdentifier.homeAccountId, @"uid.utid");
-    XCTAssertEqualObjects(defaultIDToken.additionalServerInfo, [NSDictionary dictionary]);
+    XCTAssertEqual([defaultIDTokens count], 0);
 
     NSArray *accounts = [_otherAccessor allAccountsForEnvironment:@"login.microsoftonline.com" clientId:@"test_client_id" familyId:nil context:nil error:&error];
     XCTAssertNotNil(accounts);
@@ -667,15 +651,7 @@
     XCTAssertEqualObjects(defaultRefreshToken.additionalServerInfo, [NSDictionary dictionary]);
 
     NSArray *defaultIDTokens = [self getAllIDTokens];
-    XCTAssertEqual([defaultIDTokens count], 1);
-
-    MSIDIdToken *defaultIDToken = defaultIDTokens[0];
-    XCTAssertEqualObjects(defaultIDToken.rawIdToken, idToken);
-    XCTAssertEqual(defaultIDToken.credentialType, MSIDIDTokenType);
-    XCTAssertEqualObjects(defaultIDToken.authority.absoluteString, @"https://login.microsoftonline.com/tid");
-    XCTAssertEqualObjects(defaultIDToken.clientId, @"test_client_id");
-    XCTAssertEqualObjects(defaultIDToken.accountIdentifier.homeAccountId, @"uid.utid");
-    XCTAssertEqualObjects(defaultIDToken.additionalServerInfo, [NSDictionary dictionary]);
+    XCTAssertEqual([defaultIDTokens count], 0);
 
     NSArray *accounts = [_otherAccessor allAccountsForEnvironment:@"login.microsoftonline.com" clientId:@"test_client_id" familyId:nil context:nil error:&error];
     XCTAssertNotNil(accounts);
@@ -1422,7 +1398,7 @@
     NSArray *allDefaultTokens = [_otherAccessor allTokensWithContext:nil error:&error];
     XCTAssertNotNil(allDefaultTokens);
     XCTAssertNil(error);
-    XCTAssertEqual([allDefaultTokens count], 3);
+    XCTAssertEqual([allDefaultTokens count], 2);
 
     NSArray *allAccounts = [_otherAccessor allAccountsForEnvironment:@"login.windows.net" clientId:@"test_client_id" familyId:@"1" context:nil error:&error];
     XCTAssertNil(error);


### PR DESCRIPTION
Main change here is for default accessor not to save tokens to legacy format. Because legacy cache can already read from default format, it's unnecessary. 

+ Also optimized getRefreshTokenByLegacyUserId to look by environment aliases and not by each alias separately for better performance

Accompanying ADAL PR to update submodule: https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/1263
This PR goes to 1.0.0 release branch and this one merges 1.0.0 to dev: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/203