### PR TITLE
PKeyAuth handling and scopes handling fix

### DIFF
--- a/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
@@ -38,16 +38,6 @@
     NSMutableDictionary<NSString *, NSString *> *parameters = [super authorizationParametersFromConfiguration:configuration
                                                                                                  requestState:state];
 
-    NSMutableOrderedSet<NSString *> *allScopes = parameters[MSID_OAUTH2_SCOPE].scopeSet.mutableCopy;
-    
-    if (!allScopes)
-    {
-        allScopes = [NSMutableOrderedSet new];
-    }
-    
-    [allScopes addObject:MSID_OAUTH2_SCOPE_OPENID_VALUE];
-    
-    parameters[MSID_OAUTH2_SCOPE] = allScopes.msidToString;
     parameters[MSID_OAUTH2_PROMPT] = configuration.promptBehavior;
     
     if (configuration.correlationId)

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2WebviewFactory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2WebviewFactory.m
@@ -35,6 +35,12 @@
                                                                                                  requestState:state];
  
     NSMutableOrderedSet<NSString *> *allScopes = parameters[MSID_OAUTH2_SCOPE].scopeSet.mutableCopy;
+    if (!allScopes)
+    {
+        allScopes = [NSMutableOrderedSet new];
+    }
+    
+    [allScopes addObject:MSID_OAUTH2_SCOPE_OPENID_VALUE];
     [allScopes addObject:MSID_OAUTH2_SCOPE_OFFLINE_ACCESS_VALUE];
     [allScopes addObject:MSID_OAUTH2_SCOPE_PROFILE_VALUE];
     

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -78,7 +78,7 @@
     [queryDict setValue:MSIDDeviceId.deviceId[MSID_VERSION_KEY] forKey:MSID_VERSION_KEY];
     responseUrlComp.percentEncodedQuery = [queryDict msidURLFormEncode];
     
-    NSMutableURLRequest *responseReq = [[NSMutableURLRequest alloc]initWithURL:responseUrlComp.URL];
+    NSMutableURLRequest *responseReq = [[NSMutableURLRequest alloc] initWithURL:responseUrlComp.URL];
     [responseReq setValue:kMSIDPKeyAuthHeaderVersion forHTTPHeaderField:kMSIDPKeyAuthHeader];
     [responseReq setValue:authHeader forHTTPHeaderField:MSID_OAUTH2_AUTHORIZATION];
     completionHandler(responseReq, nil);

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -67,7 +67,7 @@
         return NO;
     }
     
-    // Attach client version to response url
+    // Add header values
     NSMutableURLRequest *responseReq = [[NSMutableURLRequest alloc]initWithURL:[NSURL URLWithString:submitUrl]];
     [responseReq setValue:kMSIDPKeyAuthHeaderVersion forHTTPHeaderField:kMSIDPKeyAuthHeader];
     [responseReq setValue:authHeader forHTTPHeaderField:MSID_OAUTH2_AUTHORIZATION];

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -29,6 +29,7 @@
 #import "MSIDError.h"
 #import "MSIDDeviceId.h"
 #import "MSIDConstants.h"
+#import "NSDictionary+MSIDExtensions.h"
 
 @implementation MSIDPKeyAuthHandler
 
@@ -67,14 +68,10 @@
     }
     
     // Attach client version to response url
-    NSURLComponents *responseUrlComp = [[NSURLComponents alloc] initWithURL:[NSURL URLWithString:submitUrl] resolvingAgainstBaseURL:NO];
-    NSMutableArray *queryItems = responseUrlComp.queryItems ? [responseUrlComp.queryItems mutableCopy] : [NSMutableArray new];
-    [queryItems addObject:[[NSURLQueryItem alloc] initWithName:MSID_VERSION_KEY value:MSIDDeviceId.deviceId[MSID_VERSION_KEY]]];
-    responseUrlComp.queryItems = queryItems;
-    
-    NSMutableURLRequest *responseReq = [[NSMutableURLRequest alloc]initWithURL:responseUrlComp.URL];
+    NSMutableURLRequest *responseReq = [[NSMutableURLRequest alloc]initWithURL:[NSURL URLWithString:submitUrl]];
     [responseReq setValue:kMSIDPKeyAuthHeaderVersion forHTTPHeaderField:kMSIDPKeyAuthHeader];
     [responseReq setValue:authHeader forHTTPHeaderField:MSID_OAUTH2_AUTHORIZATION];
+    
     completionHandler(responseReq, nil);
     return YES;
 }

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -67,11 +67,20 @@
         return NO;
     }
     
-    // Add header values
-    NSMutableURLRequest *responseReq = [[NSMutableURLRequest alloc]initWithURL:[NSURL URLWithString:submitUrl]];
+    // Attach client version to response url
+    NSURLComponents *responseUrlComp = [[NSURLComponents alloc] initWithURL:[NSURL URLWithString:submitUrl] resolvingAgainstBaseURL:NO];
+    NSMutableDictionary *queryDict = [NSMutableDictionary new];
+    
+    for (NSURLQueryItem *item in responseUrlComp.queryItems)
+    {
+        [queryDict setValue:item.value forKey:item.name];
+    }
+    [queryDict setValue:MSIDDeviceId.deviceId[MSID_VERSION_KEY] forKey:MSID_VERSION_KEY];
+    responseUrlComp.percentEncodedQuery = [queryDict msidURLFormEncode];
+    
+    NSMutableURLRequest *responseReq = [[NSMutableURLRequest alloc]initWithURL:responseUrlComp.URL];
     [responseReq setValue:kMSIDPKeyAuthHeaderVersion forHTTPHeaderField:kMSIDPKeyAuthHeader];
     [responseReq setValue:authHeader forHTTPHeaderField:MSID_OAUTH2_AUTHORIZATION];
-    
     completionHandler(responseReq, nil);
     return YES;
 }

--- a/IdentityCore/tests/MSIDAADV1WebviewFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADV1WebviewFactoryTests.m
@@ -87,9 +87,56 @@
                                           @"client-request-id" : correlationId.UUIDString,
                                           @"login_hint" : @"fakeuser@contoso.com",
                                           @"state" : requestState.msidBase64UrlEncode,
-                                          @"scope" : @"openid",
                                           @"prompt" : @"login",
                                           @"haschrome" : @"1"
+                                          }];
+    
+    [expectedQPs addEntriesFromDictionary:[MSIDDeviceId deviceId]];
+    [expectedQPs addEntriesFromDictionary:DEFAULT_TEST_SLICE_PARAMS_DICT];
+    
+    XCTAssertTrue([expectedQPs compareAndPrintDiff:params]);
+}
+
+- (void)testAuthorizationParametersFromConfiguration_withValidParamsWithScopes_shouldContainAADV1ConfigurationWithScopes
+{
+    __block NSUUID *correlationId = [NSUUID new];
+    
+    MSIDWebviewConfiguration *config = [[MSIDWebviewConfiguration alloc] initWithAuthorizationEndpoint:[NSURL URLWithString:DEFAULT_TEST_AUTHORIZATION_ENDPOINT]
+                                                                                           redirectUri:DEFAULT_TEST_REDIRECT_URI
+                                                                                              clientId:DEFAULT_TEST_CLIENT_ID
+                                                                                              resource:DEFAULT_TEST_RESOURCE
+                                                                                                scopes:[NSOrderedSet orderedSetWithObjects:@"scope1", nil]
+                                                                                         correlationId:correlationId
+                                                                                            enablePkce:NO];
+    
+    config.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    config.promptBehavior = @"login";
+    config.claims = @"claims";
+    config.sliceParameters = DEFAULT_TEST_SLICE_PARAMS_DICT;
+    config.loginHint = @"fakeuser@contoso.com";
+    
+    NSString *requestState = @"state";
+    
+    MSIDAADV1WebviewFactory *factory = [MSIDAADV1WebviewFactory new];
+    
+    NSDictionary *params = [factory authorizationParametersFromConfiguration:config requestState:requestState];
+    
+    NSMutableDictionary *expectedQPs = [NSMutableDictionary dictionaryWithDictionary:
+                                        @{
+                                          @"client_id" : DEFAULT_TEST_CLIENT_ID,
+                                          @"redirect_uri" : DEFAULT_TEST_REDIRECT_URI,
+                                          @"resource" : DEFAULT_TEST_RESOURCE,
+                                          @"response_type" : @"code",
+                                          @"eqp1" : @"val1",
+                                          @"eqp2" : @"val2",
+                                          @"claims" : @"claims",
+                                          @"return-client-request-id" : @"true",
+                                          @"client-request-id" : correlationId.UUIDString,
+                                          @"login_hint" : @"fakeuser@contoso.com",
+                                          @"state" : requestState.msidBase64UrlEncode,
+                                          @"prompt" : @"login",
+                                          @"haschrome" : @"1",
+                                          @"scope" : @"scope1"
                                           }];
     
     [expectedQPs addEntriesFromDictionary:[MSIDDeviceId deviceId]];

--- a/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
@@ -81,10 +81,11 @@
                                           @"client-request-id" : correlationId.UUIDString,
                                           @"login_hint" : @"fakeuser@contoso.com",
                                           @"state" : requestState.msidBase64UrlEncode,
-                                          @"scope" : @"scope1 openid",
                                           @"prompt" : @"login",
                                           @"slice": @"myslice",
-                                          @"haschrome" : @"1"
+                                          @"haschrome" : @"1",
+                                          @"scope" : @"scope1"
+                                          
                                           }];
     [expectedQPs addEntriesFromDictionary:[MSIDDeviceId deviceId]];
     [expectedQPs addEntriesFromDictionary:DEFAULT_TEST_SLICE_PARAMS_DICT];


### PR DESCRIPTION
PKeyAuth handler no longer creates url components to append version check and decoding.

Move scopes addition logic from AAD base webview factory to V2 specific.