### PR TITLE
Changed cached environment in default accessor and removed dependency on openid config endpoint for AAD resolver

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -391,10 +391,12 @@
 
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_DELETE context:context];
 
+    NSArray *aliases = [_factory defaultCacheAliasesForEnvironment:environment];
+
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
     query.clientId = clientId;
     query.homeAccountId = account.homeAccountId;
-    query.environment = environment;
+    query.environmentAliases = aliases;
     query.matchAnyCredentialType = YES;
 
     BOOL result = [_accountCredentialCache removeCredetialsWithQuery:query context:context error:error];
@@ -407,7 +409,7 @@
 
     MSIDDefaultAccountCacheQuery *accountsQuery = [MSIDDefaultAccountCacheQuery new];
     accountsQuery.homeAccountId = account.homeAccountId;
-    accountsQuery.environment = environment;
+    accountsQuery.environmentAliases = aliases;
 
     result = [_accountCredentialCache removeAccountsWithQuery:accountsQuery context:context error:error];
     [MSIDTelemetry stopCacheEvent:event withItem:nil success:result context:context];
@@ -852,11 +854,7 @@
     }
 
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_WRITE context:context];
-
-    MSIDCredentialCacheItem *cacheItem = token.tokenCacheItem;
-    cacheItem.environment = [_factory cacheEnvironmentFromEnvironment:cacheItem.environment context:context];
-
-    BOOL result = [_accountCredentialCache saveCredential:cacheItem context:context error:error];
+    BOOL result = [_accountCredentialCache saveCredential:token.tokenCacheItem context:context error:error];
     [MSIDTelemetry stopCacheEvent:event withItem:token success:result context:context];
     return result;
 }
@@ -871,10 +869,7 @@
     }
 
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_WRITE context:context];
-    MSIDAccountCacheItem *cacheItem = account.accountCacheItem;
-    cacheItem.environment = [_factory cacheEnvironmentFromEnvironment:account.authority.environment context:context];
-
-    BOOL result = [_accountCredentialCache saveAccount:cacheItem context:context error:error];
+    BOOL result = [_accountCredentialCache saveAccount:account.accountCacheItem context:context error:error];
     [MSIDTelemetry stopCacheEvent:event withItem:nil success:result context:context];
     return result;
 }

--- a/IdentityCore/src/validation/MSIDAadAuthorityCache.m
+++ b/IdentityCore/src/validation/MSIDAadAuthorityCache.m
@@ -132,9 +132,9 @@ openIdConfigEndpoint:(NSURL *)openIdConfigEndpoint
         {
             VERIFY_HOST_STRING(alias, @"aliases", YES);
         }
-        
+
         record.openIdConfigurationEndpoint = openIdConfigEndpoint;
-        
+
         [recordsToAdd addObject:record];
     }
     

--- a/IdentityCore/src/validation/MSIDAadAuthorityResolver.m
+++ b/IdentityCore/src/validation/MSIDAadAuthorityResolver.m
@@ -70,7 +70,7 @@ static dispatch_queue_t s_aadValidationQueue;
     MSIDAadAuthorityCacheRecord *record = [self.aadCache objectForKey:authority.environment];
     if (record)
     {
-        [self handleRecord:record completionBlock:completionBlock];
+        [self handleRecord:record authority:authority completionBlock:completionBlock];
         return;
     }
     
@@ -118,7 +118,7 @@ static dispatch_queue_t s_aadValidationQueue;
     MSIDAadAuthorityCacheRecord *record = [self.aadCache objectForKey:authority.environment];
     if (record)
     {
-        [self handleRecord:record completionBlock:completionBlock];
+        [self handleRecord:record authority:authority completionBlock:completionBlock];
         return;
     }
     
@@ -155,7 +155,8 @@ static dispatch_queue_t s_aadValidationQueue;
          {
              if (result)
              {
-                 completionBlock(response.openIdConfigurationEndpoint, YES, nil);
+                 __auto_type endpoint = [MSIDAADNetworkConfiguration.defaultConfiguration.endpointProvider openIdConfigurationEndpointWithUrl:authority.url];
+                 completionBlock(endpoint, YES, nil);
              }
              else
              {
@@ -166,11 +167,14 @@ static dispatch_queue_t s_aadValidationQueue;
 }
 
 - (void)handleRecord:(MSIDAadAuthorityCacheRecord *)record
+           authority:(MSIDAuthority *)authority
      completionBlock:(MSIDAuthorityInfoBlock)completionBlock
 {
     NSParameterAssert(completionBlock);
+
+    __auto_type endpoint = [MSIDAADNetworkConfiguration.defaultConfiguration.endpointProvider openIdConfigurationEndpointWithUrl:authority.url];
     
-    completionBlock(record.openIdConfigurationEndpoint, record.validated, record.error);
+    completionBlock(endpoint, record.validated, record.error);
 }
 
 @end

--- a/IdentityCore/tests/automation/MSIDTestAutomationConfiguration.m
+++ b/IdentityCore/tests/automation/MSIDTestAutomationConfiguration.m
@@ -119,7 +119,8 @@
             _username = response[@"DomainAccount"];
         }
 
-        _homeTenantId = response[@"hometenantId"];
+        // TODO: lab doesn't return home tenant ID for non guest users...
+        _homeTenantId = [response[@"hometenantId"] length] ? response[@"hometenantId"] : response[@"tenantId"];
         _targetTenantId = response[@"tenantId"];
         _homeObjectId = response[@"objectId"];
         _password = response[@"password"];

--- a/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
@@ -68,7 +68,7 @@
     __auto_type openIdConfigurationUrl = [[NSURL alloc] initWithString:@"https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"];
     __auto_type httpResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL new] statusCode:200 HTTPVersion:nil headerFields:nil];
     
-    __auto_type requestUrl = [@"https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration" msidUrl];
+    __auto_type requestUrl = [@"https://example.com/common/.well-known/openid-configuration" msidUrl];
 
     MSIDTestURLResponse *response = [MSIDTestURLResponse request:requestUrl
                                                          reponse:httpResponse];
@@ -123,7 +123,7 @@
 {
     __auto_type openIdConfigurationUrl = [[NSURL alloc] initWithString:@"https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"];
     __auto_type httpResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL new] statusCode:200 HTTPVersion:nil headerFields:nil];
-    __auto_type requestUrl = [@"https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration" msidUrl];
+    __auto_type requestUrl = [@"https://example.com/common/.well-known/openid-configuration" msidUrl];
 
     MSIDTestURLResponse *responseWithError = [MSIDTestURLResponse request:requestUrl
                                                          respondWithError:[NSError new]];
@@ -444,7 +444,7 @@
     XCTAssertTrue([MSIDTestURLSession noResponsesLeft]);
 }
 
-- (void)testDiscoverAuthority_whenAuthroityIsInvalid_shoulStoreInvalidRecordInCache
+- (void)testDiscoverAuthority_whenAuthorityIsInvalid_shoulStoreInvalidRecordInCache
 {
     __auto_type authorityUrl = [@"https://example.com/common/qwe" msidUrl];
     __auto_type authority = [[MSIDAADAuthority alloc] initWithURL:authorityUrl context:nil error:nil];
@@ -475,7 +475,7 @@
     expectation = [self expectationWithDescription:@"Read Invalid Authority From Cache"];
     [authority resolveAndValidate:YES userPrincipalName:nil context:nil completionBlock:^(NSURL * openIdConfigurationEndpoint, BOOL validated, NSError *error)
      {
-         XCTAssertNil(openIdConfigurationEndpoint.absoluteString);
+         XCTAssertEqualObjects(openIdConfigurationEndpoint.absoluteString, @"https://example.com/common/.well-known/openid-configuration");
          XCTAssertFalse(validated);
          XCTAssertNotNil(error);
          [expectation fulfill];
@@ -515,7 +515,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Discover AAD Authority"];
     [authority resolveAndValidate:YES userPrincipalName:nil context:nil completionBlock:^(NSURL * openIdConfigurationEndpoint, BOOL validated, NSError *error)
      {
-         XCTAssertEqualObjects(@"https://login.microsoftonline.com/common/.well-known/openid-configuration", openIdConfigurationEndpoint.absoluteString);
+         XCTAssertEqualObjects(@"https://example.com/common/v2.0/.well-known/openid-configuration", openIdConfigurationEndpoint.absoluteString);
          XCTAssertTrue(validated);
          XCTAssertNil(error);
          [expectation fulfill];


### PR DESCRIPTION
* Always use composed OIDC endpoint for AAD resolver (as opposed to resolved)
* Don't use preferred_cache alias for MSAL default accessor

I'm still adding some more tests for those changes.