### PR TITLE
Account lookup fixes

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -271,18 +271,18 @@
 
     if (!filteredAccountsSet)
     {
-        MSID_LOG_INFO(context, @"No accounts found, returning!");
+        MSID_LOG_INFO(context, @"Failed accounts lookup, returning");
         [MSIDTelemetry stopCacheEvent:event withItem:nil success:NO context:context];
         return @[];
     }
 
-    if ([filteredAccountsSet count] == 0)
+    if ([filteredAccountsSet count])
     {
-        [MSIDTelemetry stopFailedCacheEvent:event wipeData:[_accountCredentialCache wipeInfoWithContext:context error:error] context:context];
+        [MSIDTelemetry stopCacheEvent:event withItem:nil success:YES context:context];
     }
     else
     {
-        [MSIDTelemetry stopCacheEvent:event withItem:nil success:YES context:context];
+        [MSIDTelemetry stopFailedCacheEvent:event wipeData:[_accountCredentialCache wipeInfoWithContext:context error:error] context:context];
     }
 
     for (id<MSIDCacheAccessor> accessor in _otherAccessors)

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -271,7 +271,7 @@
 
     if (!filteredAccountsSet)
     {
-        MSID_LOG_INFO(context, @"Failed accounts lookup, returning");
+        MSID_LOG_ERROR(context, @"(Default accessor) Failed accounts lookup");
         [MSIDTelemetry stopCacheEvent:event withItem:nil success:NO context:context];
         return @[];
     }
@@ -282,6 +282,7 @@
     }
     else
     {
+        MSID_LOG_INFO(context, @"(Default accessor) No accounts found in default accessor");
         [MSIDTelemetry stopFailedCacheEvent:event wipeData:[_accountCredentialCache wipeInfoWithContext:context error:error] context:context];
     }
 

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -42,6 +42,7 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDTelemetry+Cache.h"
 #import "MSIDAuthorityFactory.h"
+#import "NSURL+MSIDExtensions.h"
 
 @interface MSIDLegacyTokenCacheAccessor()
 {
@@ -271,9 +272,8 @@
         __auto_type account = [MSIDAccount new];
         account.accountIdentifier = refreshToken.accountIdentifier;
         account.username = refreshToken.accountIdentifier.legacyAccountId;
-        // TODO: Should we skip account if authority is nil?
-        __auto_type authority = [self.authorityFactory authorityFromUrl:refreshToken.authority.url rawTenant:refreshToken.realm context:context error:nil];
-        account.authority = authority;
+        NSURL *rtAuthority = [refreshToken.authority.url msidURLForPreferredHost:environment context:context error:error];
+        account.authority = [self.authorityFactory authorityFromUrl:rtAuthority rawTenant:refreshToken.realm context:context error:nil];
         account.accountType = MSIDAccountTypeMSSTS;
         [resultAccounts addObject:account];
     }

--- a/IdentityCore/src/oauth2/account/MSIDAccount.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccount.m
@@ -74,10 +74,11 @@
 - (NSUInteger)hash
 {
     NSUInteger hash = 0;
-    hash = hash * 31 + self.accountIdentifier.hash;
+    hash = hash * 31 + self.accountIdentifier.legacyAccountId.hash;
     hash = hash * 31 + self.accountType;
     hash = hash * 31 + self.authority.hash;
     hash = hash * 31 + self.alternativeAccountId.hash;
+    hash = hash * 31 + self.username.hash;
     return hash;
 }
 
@@ -89,10 +90,23 @@
     }
     
     BOOL result = YES;
-    result &= (!self.accountIdentifier && !account.accountIdentifier) || [self.accountIdentifier isEqual:account.accountIdentifier];
+
+    if (self.accountIdentifier.homeAccountId && account.accountIdentifier.homeAccountId)
+    {
+        // In case we have 2 accounts in cache, but one of them doesn't have home account identifier,
+        // we'll compare those accounts by legacy account ID instead to avoid duplicates being returned
+        // due to presence of multiple caches
+        result &= [self.accountIdentifier isEqual:account.accountIdentifier];
+    }
+    else
+    {
+        result &= [self.accountIdentifier.legacyAccountId isEqual:account.accountIdentifier.legacyAccountId];
+    }
+
     result &= self.accountType == account.accountType;
     result &= (!self.alternativeAccountId && !account.alternativeAccountId) || [self.alternativeAccountId isEqualToString:account.alternativeAccountId];
     result &= (!self.authority && !account.authority) || [self.authority isEqual:account.authority];
+    result &= (!self.username && !account.username) || [self.username isEqualToString:account.username];
     return result;
 }
 

--- a/IdentityCore/tests/integration/ios/MSIDWipeDataTelemetryTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDWipeDataTelemetryTests.m
@@ -286,8 +286,6 @@
     [[MSIDTelemetry sharedInstance] addDispatcher:dispatcher];
     
     // save a refresh token to keychain token cache
-    MSIDAADV1Oauth2Factory *factory = [MSIDAADV1Oauth2Factory new];
-    MSIDRefreshToken *token = [factory refreshTokenFromResponse:[MSIDTestTokenResponse v1DefaultTokenResponse] configuration:[MSIDTestConfiguration v1DefaultConfiguration]];
     MSIDTestRequestContext *reqContext = [MSIDTestRequestContext new];
     [reqContext setTelemetryRequestId:[[MSIDTelemetry sharedInstance] generateRequestId]];
     NSError *error = nil;
@@ -298,10 +296,15 @@
                                                                  error:nil];
     XCTAssertNil(error);
     
-    // remove the refresh token to trigger wipe data being written
-    result = [_defaultCacheAccessor validateAndRemoveRefreshToken:token
-                                                          context:reqContext
-                                                            error:&error];
+    // remove the account to trigger wipe data being written
+    NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithLegacyAccountId:DEFAULT_TEST_ID_TOKEN_USERNAME
+                                                                              homeAccountId:homeAccountId];
+    result = [_defaultCacheAccessor clearCacheForAccount:account
+                                             environment:@"login.microsoftonline.com"
+                                                clientId:@"test_client_id"
+                                                 context:nil
+                                                   error:&error];
     XCTAssertNil(error);
     
     // read the refresh token in order to log wipe data in telemetry


### PR DESCRIPTION
1. Reverted the change of not saving under preferred_cache in default accessor for consistency with ADAL
2. Removed refresh token existence check for accounts lookup, because we never remove refresh tokens without accounts for MSAL
3. Changed isEqual method to avoid returning duplicate accounts in case we have accounts in legacy cache without uid.utid
4. Added integration tests for those scenarios