### PR TITLE
Fix Certificate Choose Crash

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDCertificateChooser.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDCertificateChooser.m
@@ -87,7 +87,6 @@
     }
     
     SecIdentityRef identity = _panel.identity;
-    _panel = nil;
     _completionHandler(identity);
     _completionHandler = nil;
     //[[NSNotificationCenter defaultCenter] removeObserver:self name:ADWebAuthDidFailNotification object:nil];

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDCertificateChooser.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDCertificateChooser.m
@@ -23,6 +23,7 @@
 
 #import <SecurityInterface/SFChooseIdentityPanel.h>
 #import "MSIDCertificateChooser.h"
+#import <MSIDNotifications.h>
 
 @implementation MSIDCertificateChooserHelper
 {
@@ -61,7 +62,7 @@
                      identities:identities
                         message:message];
     
-    //[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(webAuthDidFail:) name:ADWebAuthDidFailNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(webAuthDidFail:) name:MSIDNotifications.webAuthDidFailNotificationName object:nil];
 }
 
 - (void)showCertSelectionSheet:(NSArray *)identities
@@ -89,7 +90,7 @@
     SecIdentityRef identity = _panel.identity;
     _completionHandler(identity);
     _completionHandler = nil;
-    //[[NSNotificationCenter defaultCenter] removeObserver:self name:ADWebAuthDidFailNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:MSIDNotifications.webAuthDidFailNotificationName object:nil];
 }
 
 - (void)webAuthDidFail:(__unused NSNotification *)aNotification


### PR DESCRIPTION
The CBA chooser crashes because it shouldn't nil out the caller in the callback.
I.e., it calls the following with the caller being `_panel` and callback being `sheetDidEnd:returnCode:contextInfo:`:
```
[_panel beginSheetForWindow:_window
                   modalDelegate:self
                  didEndSelector:@selector(sheetDidEnd:returnCode:contextInfo:)	                  
                     contextInfo:NULL
                      identities:identities
                         message:message];
```
(line 57).
 
However, `_panel`is nil out right in the callback `sheetDidEnd:returnCode:contextInfo:` (at line 90).

XCode Instruments showed that, `@selector(_okClicked:)` was sent to a deallocated `_panel`, which means even after/during the callback, system is still doing something to `_panel`. So we shouldn't nil it out.
(Tested on macOS 0.11, 10.12, 10.13 and 10.14)

Besides, we forgot to update notification using the MSIDNotifications. Now fixed.


