### PR TITLE
Catch more errors for embedded web view

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -272,6 +272,11 @@
     [self webAuthFailWithError:error];
 }
 
+- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error
+{
+    [self webAuthFailWithError:error];
+}
+
 - (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(ChallengeCompletionHandler)completionHandler
 {
     NSString *authMethod = [challenge.protectionSpace.authenticationMethod lowercaseString];


### PR DESCRIPTION
Did some testing together with JK to catch "timeout error" and "not connected to network error" for embedded webview. 

We find that our embedded webview didn't catch them as we only listen to `didFailNavigation` but not `didFailProvisionalNavigation`. Those errors are sent to `didFailProvisionalNavigation` but not `didFailNavigation`.

However, there is no clear documentation telling the difference between them and what errors could be sent to which. I added that delegate but later removed it in my original PR. Seems we do need it.

We want to make sure we only fail the auth flow only necessary. E.g., we don't want to fail due to page javascript error, picture not being able to load, etc.
Apple support ticket has been created to have a better understanding of what error could be sent to which delegate method.

(PS: I think later we might need to redo some of the testing as now more errors could cause the flow to fail, thoughts? :) )
