### PR TITLE
Update embedded webview to share process pool

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -27,6 +27,8 @@
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDAppExtensionUtil.h"
 
+static WKWebViewConfiguration *s_webConfig;
+
 @interface MSIDWebviewUIController ( )
 {
     UIActivityIndicatorView *_loadingIndicator;
@@ -39,6 +41,14 @@
 @end
 
 @implementation MSIDWebviewUIController
+
++ (void)initialize
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        s_webConfig = [WKWebViewConfiguration new];
+    });
+}
 
 - (id)initWithContext:(id<MSIDRequestContext>)context
 {
@@ -86,8 +96,7 @@
     [rootView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
     
     // Prepare the WKWebView
-    WKWebViewConfiguration *webConfiguration = [WKWebViewConfiguration new];
-    WKWebView *webView = [[WKWebView alloc] initWithFrame:rootView.frame configuration:webConfiguration];
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:rootView.frame configuration:s_webConfig];
     [webView setAccessibilityIdentifier:@"MSID_SIGN_IN_WEBVIEW"];
     
     // Customize the UI

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -28,6 +28,8 @@
 #define DEFAULT_WINDOW_WIDTH 420
 #define DEFAULT_WINDOW_HEIGHT 650
 
+static WKWebViewConfiguration *s_webConfig;
+
 @interface MSIDWebviewUIController ( ) <NSWindowDelegate>
 {
     NSProgressIndicator *_loadingIndicator;
@@ -36,6 +38,14 @@
 @end
 
 @implementation MSIDWebviewUIController
+
++ (void)initialize
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        s_webConfig = [WKWebViewConfiguration new];
+    });
+}
 
 - (id)initWithContext:(id<MSIDRequestContext>)context
 {
@@ -60,8 +70,7 @@
     NSView *rootView = window.contentView;
     
     // Prepare the WKWebView
-    WKWebViewConfiguration *webConfiguration = [WKWebViewConfiguration new];
-    WKWebView *webView = [[WKWebView alloc] initWithFrame:rootView.frame configuration:webConfiguration];
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:rootView.frame configuration:s_webConfig];
     [webView setAccessibilityIdentifier:@"MSID_SIGN_IN_WEBVIEW"];
     
     // Customize the UI


### PR DESCRIPTION
WKWebView caching update, applies to both iOS and macOS.
For session cookies, WKWebView’s caching is per process pool. This process pool is created per configuration.
Thus, in order for us to have our SDK treat session as per app launch, we should either have WKProcessPool  or configuration static.
Having config static makes sense as this config really shouldn't change per app launch.
If one wants to change this, they will have to use passed in webview.
