### PR TITLE
add shared credential object

### DIFF
--- a/IdentityCore/src/cache/token/MSIDCommonCredential.h
+++ b/IdentityCore/src/cache/token/MSIDCommonCredential.h
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDCredentialType.h"
+#import "MSIDJsonSerializable.h"
+
+@class MSIDClientInfo;
+
+@interface MSIDCommonCredential : NSObject <NSCopying, MSIDJsonSerializable>
+
+// Client id
+@property (readwrite, nonnull, strong) NSString *clientId;
+
+// Token type
+@property (readwrite) MSIDCredentialType credentialType;
+
+// Token
+@property (readwrite, nonnull, strong) NSString *secret;
+
+// Target
+@property (readwrite, nullable, strong) NSString *target;
+
+// Realm
+@property (readwrite, nullable, strong) NSString *realm;
+
+// Environment
+@property (readwrite, nullable, strong) NSString *environment;
+
+// Dates
+@property (readwrite, nullable, strong) NSDate *cachedAt;
+@property (readwrite, nullable, strong) NSDate *expiresOn;
+@property (readwrite, nullable, strong) NSDate *extendedExpiresOn;
+
+// Family ID
+@property (readwrite, nullable, strong) NSString *familyId;
+
+// Unique user ID
+@property (readwrite, nonnull, strong) NSString *homeAccountId;
+
+// Client Info
+@property (readwrite, nullable, strong) MSIDClientInfo *clientInfo;
+
+// Additional fields
+@property (readwrite, nullable, strong) NSDictionary *additionalFields;
+
+- (nullable instancetype)initWithType:(MSIDCredentialType)credentialType
+                        homeAccountId:(nonnull NSString *)homeAccountId
+                          environment:(nonnull NSString *)environment
+                             clientId:(nullable NSString *)clientId
+                               secret:(nullable NSString *)secret
+                             familyId:(nullable NSString *)familyId
+                               target:(nullable NSString *)target
+                           clientInfo:(nullable MSIDClientInfo *)clientInfo
+                                realm:(nullable NSString *)realm
+                     additionalFields:(nullable NSDictionary *)additionalFields;
+
+- (BOOL)isEqualToItem:(nullable MSIDCommonCredential *)item;
+
+@end

--- a/IdentityCore/src/cache/token/MSIDCommonCredential.h
+++ b/IdentityCore/src/cache/token/MSIDCommonCredential.h
@@ -67,12 +67,15 @@
 - (nullable instancetype)initWithType:(MSIDCredentialType)credentialType
                         homeAccountId:(nonnull NSString *)homeAccountId
                           environment:(nonnull NSString *)environment
+                                realm:(nullable NSString *)realm
                              clientId:(nullable NSString *)clientId
+                               target:(nullable NSString *)target
+                             cachedAt:(nullable NSDate *)cachedAt
+                            expiresOn:(nullable NSDate *)expiresOn
+                    extendedExpiresOn:(nullable NSDate *)extendedExpiresOn
                                secret:(nullable NSString *)secret
                              familyId:(nullable NSString *)familyId
-                               target:(nullable NSString *)target
                            clientInfo:(nullable MSIDClientInfo *)clientInfo
-                                realm:(nullable NSString *)realm
                      additionalFields:(nullable NSDictionary *)additionalFields;
 
 - (BOOL)isEqualToItem:(nullable MSIDCommonCredential *)item;

--- a/IdentityCore/src/cache/token/MSIDCommonCredential.m
+++ b/IdentityCore/src/cache/token/MSIDCommonCredential.m
@@ -1,0 +1,217 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDClientInfo.h"
+#import "MSIDCommonCredential.h"
+#import "MSIDCommonLogger.h"
+#import "MSIDCommonStorageConstants.h"
+#import "MSIDCredentialType.h"
+#import "NSDate+MSIDExtensions.h"
+
+@interface MSIDCommonCredential ()
+
+@property (readwrite) NSDictionary *json;
+
+@end
+
+@implementation MSIDCommonCredential
+
+- (nullable instancetype)init {
+    self = [super init];
+    if (self) {
+        // defaults...
+    }
+
+    return self;
+}
+
+- (nullable instancetype)initWithType:(MSIDCredentialType)credentialType
+                        homeAccountId:(nonnull NSString *)homeAccountId
+                          environment:(nonnull NSString *)environment
+                             clientId:(nullable NSString *)clientId
+                               secret:(nullable NSString *)secret
+                             familyId:(nullable NSString *)familyId
+                               target:(nullable NSString *)target
+                           clientInfo:(nullable MSIDClientInfo *)clientInfo
+                                realm:(nullable NSString *)realm
+                     additionalFields:(nullable NSDictionary *)additionalFields {
+    MSID_TRACE;
+    self.credentialType = credentialType;
+    self.homeAccountId = homeAccountId;
+    self.environment = environment;
+    self.clientId = clientId;
+    self.secret = secret;
+    self.familyId = familyId;
+    self.target = target;
+    self.clientInfo = clientInfo;
+    self.realm = realm;
+    self.additionalFields = additionalFields;
+
+    return self;
+}
+
+- (BOOL)isEqual:(id)object {
+    if (self == object) {
+        return YES;
+    }
+
+    if (![object isKindOfClass:self.class]) {
+        return NO;
+    }
+
+    return [self isEqualToItem:(MSIDCommonCredential *)object];
+}
+
+- (BOOL)isEqualToItem:(MSIDCommonCredential *)item {
+    BOOL result = (self.credentialType == item.credentialType)
+        && (self.clientId == item.clientId || [self.clientId isEqualToString:item.clientId])
+        && (self.secret == item.secret || [self.secret isEqualToString:item.secret])
+        && (self.target == item.target || [self.target isEqualToString:item.target])
+        && (self.realm == item.realm || [self.realm isEqualToString:item.realm])
+        && (self.environment == item.environment || [self.environment isEqualToString:item.environment])
+        && (self.expiresOn == item.expiresOn || [self.expiresOn isEqual:item.expiresOn])
+        && (self.cachedAt == item.cachedAt || [self.cachedAt isEqual:item.cachedAt])
+        && (self.familyId == item.familyId || [self.familyId isEqualToString:item.familyId])
+        && (self.homeAccountId == item.homeAccountId || [self.homeAccountId isEqualToString:item.homeAccountId])
+        && (self.clientInfo == item.clientInfo ||
+            [self.clientInfo.rawClientInfo isEqualToString:item.clientInfo.rawClientInfo])
+        && (self.additionalFields == item.additionalFields || [self.additionalFields isEqual:item.additionalFields]);
+    return result;
+}
+
+#pragma mark - NSObject
+
+- (NSUInteger)hash {
+    NSUInteger hash = [super hash];
+    hash = hash * 31 + self.clientId.hash;
+    hash = hash * 31 + self.credentialType;
+    hash = hash * 31 + self.secret.hash;
+    hash = hash * 31 + self.target.hash;
+    hash = hash * 31 + self.realm.hash;
+    hash = hash * 31 + self.environment.hash;
+    hash = hash * 31 + self.expiresOn.hash;
+    hash = hash * 31 + self.cachedAt.hash;
+    hash = hash * 31 + self.familyId.hash;
+    hash = hash * 31 + self.homeAccountId.hash;
+    hash = hash * 31 + self.clientInfo.hash;
+    hash = hash * 31 + self.additionalFields.hash;
+    return hash;
+}
+
+#pragma mark - NSCopying
+
+- (nonnull instancetype)copyWithZone:(NSZone *)zone {
+    MSIDCommonCredential *item = [[self class] allocWithZone:zone];
+    item.clientId = [self.clientId copyWithZone:zone];
+    item.credentialType = self.credentialType;
+    item.secret = [self.secret copyWithZone:zone];
+    item.target = [self.target copyWithZone:zone];
+    item.realm = [self.realm copyWithZone:zone];
+    item.environment = [self.environment copyWithZone:zone];
+    item.expiresOn = [self.expiresOn copyWithZone:zone];
+    item.cachedAt = [self.cachedAt copyWithZone:zone];
+    item.familyId = [self.familyId copyWithZone:zone];
+    item.homeAccountId = [self.homeAccountId copyWithZone:zone];
+    item.clientInfo = [self.clientInfo copyWithZone:zone];
+    item.additionalFields = [self.additionalFields copyWithZone:zone];
+    return item;
+}
+
+#pragma mark - JSON
+
+- (nullable instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error {
+    MSID_TRACE;
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    if (!json) {
+        MSID_LOG_WARN(nil, @"Tried to decode a credential cache item from nil json");
+        return nil;
+    }
+
+    _json = json;
+
+    _clientId = json[MSID_CLIENT_ID_CACHE_KEY];
+    _credentialType = [MSIDCredentialTypeHelpers credentialTypeFromString:json[MSID_CREDENTIAL_TYPE_CACHE_KEY]];
+    _secret = json[MSID_TOKEN_CACHE_KEY];
+
+    if (!_secret) {
+        MSID_LOG_WARN(nil, @"No secret present in the credential");
+        return nil;
+    }
+
+    _target = json[MSID_TARGET_CACHE_KEY];
+    _realm = json[MSID_REALM_CACHE_KEY];
+    _environment = json[MSID_ENVIRONMENT_CACHE_KEY];
+
+    _expiresOn = [NSDate msidDateFromTimeStamp:json[MSID_EXPIRES_ON_CACHE_KEY]];
+    _cachedAt = [NSDate msidDateFromTimeStamp:json[MSID_CACHED_AT_CACHE_KEY]];
+    _extendedExpiresOn = [NSDate msidDateFromTimeStamp:json[MSID_EXTENDED_EXPIRES_ON_CACHE_KEY]];
+
+    _familyId = json[MSID_FAMILY_ID_CACHE_KEY];
+    _homeAccountId = json[MSID_HOME_ACCOUNT_ID_CACHE_KEY];
+    _clientInfo = [[MSIDClientInfo alloc] initWithRawClientInfo:json[MSID_CLIENT_INFO_CACHE_KEY] error:nil];
+
+    // Additional Fields
+    NSString *speInfo = json[MSID_SPE_INFO_CACHE_KEY];
+    NSMutableDictionary *additionalFields = [NSMutableDictionary dictionary];
+    additionalFields[MSID_SPE_INFO_CACHE_KEY] = speInfo;
+    if ([additionalFields count]) {
+        _additionalFields = additionalFields;
+    }
+
+#pragma unused(error)
+    return self;
+}
+
+- (nonnull NSDictionary *)jsonDictionary {
+    MSID_TRACE;
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+
+    if (_json) {
+        [dictionary addEntriesFromDictionary:_json];
+    }
+
+    if (_additionalFields) {
+        [dictionary addEntriesFromDictionary:_additionalFields];
+    }
+
+    dictionary[MSID_CLIENT_ID_CACHE_KEY] = _clientId;
+    dictionary[MSID_CREDENTIAL_TYPE_CACHE_KEY] = [MSIDCredentialTypeHelpers credentialTypeAsString:self.credentialType];
+    dictionary[MSID_TOKEN_CACHE_KEY] = _secret;
+    dictionary[MSID_TARGET_CACHE_KEY] = _target;
+    dictionary[MSID_REALM_CACHE_KEY] = _realm;
+    dictionary[MSID_ENVIRONMENT_CACHE_KEY] = _environment;
+    dictionary[MSID_EXPIRES_ON_CACHE_KEY] = _expiresOn.msidDateToTimestamp;
+    dictionary[MSID_CACHED_AT_CACHE_KEY] = _cachedAt.msidDateToTimestamp;
+    dictionary[MSID_EXTENDED_EXPIRES_ON_CACHE_KEY] = _extendedExpiresOn.msidDateToTimestamp;
+    dictionary[MSID_FAMILY_ID_CACHE_KEY] = _familyId;
+    dictionary[MSID_HOME_ACCOUNT_ID_CACHE_KEY] = _homeAccountId;
+    dictionary[MSID_CLIENT_INFO_CACHE_KEY] = _clientInfo.rawClientInfo;
+    dictionary[MSID_SPE_INFO_CACHE_KEY] = _additionalFields[MSID_SPE_INFO_CACHE_KEY];
+    return dictionary;
+}
+
+@end

--- a/IdentityCore/src/cache/token/MSIDCommonCredential.m
+++ b/IdentityCore/src/cache/token/MSIDCommonCredential.m
@@ -49,24 +49,31 @@
 - (nullable instancetype)initWithType:(MSIDCredentialType)credentialType
                         homeAccountId:(nonnull NSString *)homeAccountId
                           environment:(nonnull NSString *)environment
+                                realm:(nullable NSString *)realm
                              clientId:(nullable NSString *)clientId
+                               target:(nullable NSString *)target
+                             cachedAt:(nullable NSDate *)cachedAt
+                            expiresOn:(nullable NSDate *)expiresOn
+                    extendedExpiresOn:(nullable NSDate *)extendedExpiresOn
                                secret:(nullable NSString *)secret
                              familyId:(nullable NSString *)familyId
-                               target:(nullable NSString *)target
                            clientInfo:(nullable MSIDClientInfo *)clientInfo
-                                realm:(nullable NSString *)realm
                      additionalFields:(nullable NSDictionary *)additionalFields {
     MSID_TRACE;
-    self.credentialType = credentialType;
-    self.homeAccountId = homeAccountId;
-    self.environment = environment;
-    self.clientId = clientId;
-    self.secret = secret;
-    self.familyId = familyId;
-    self.target = target;
-    self.clientInfo = clientInfo;
-    self.realm = realm;
-    self.additionalFields = additionalFields;
+
+    _credentialType = credentialType;
+    _homeAccountId = homeAccountId;
+    _environment = environment;
+    _realm = realm;
+    _clientId = clientId;
+    _target = target;
+    _cachedAt = cachedAt;
+    _expiresOn = expiresOn;
+    _extendedExpiresOn = extendedExpiresOn;
+    _secret = secret;
+    _familyId = familyId;
+    _clientInfo = clientInfo;
+    _additionalFields = additionalFields;
 
     return self;
 }
@@ -84,19 +91,19 @@
 }
 
 - (BOOL)isEqualToItem:(MSIDCommonCredential *)item {
-    BOOL result = (self.credentialType == item.credentialType)
-        && (self.clientId == item.clientId || [self.clientId isEqualToString:item.clientId])
-        && (self.secret == item.secret || [self.secret isEqualToString:item.secret])
-        && (self.target == item.target || [self.target isEqualToString:item.target])
-        && (self.realm == item.realm || [self.realm isEqualToString:item.realm])
-        && (self.environment == item.environment || [self.environment isEqualToString:item.environment])
-        && (self.expiresOn == item.expiresOn || [self.expiresOn isEqual:item.expiresOn])
-        && (self.cachedAt == item.cachedAt || [self.cachedAt isEqual:item.cachedAt])
-        && (self.familyId == item.familyId || [self.familyId isEqualToString:item.familyId])
-        && (self.homeAccountId == item.homeAccountId || [self.homeAccountId isEqualToString:item.homeAccountId])
-        && (self.clientInfo == item.clientInfo ||
-            [self.clientInfo.rawClientInfo isEqualToString:item.clientInfo.rawClientInfo])
-        && (self.additionalFields == item.additionalFields || [self.additionalFields isEqual:item.additionalFields]);
+    BOOL result = (_credentialType == item.credentialType)
+        && (_clientId == item.clientId || [_clientId isEqualToString:item.clientId])
+        && (_secret == item.secret || [_secret isEqualToString:item.secret])
+        && (_target == item.target || [_target isEqualToString:item.target])
+        && (_realm == item.realm || [_realm isEqualToString:item.realm])
+        && (_environment == item.environment || [_environment isEqualToString:item.environment])
+        && (_expiresOn == item.expiresOn || [_expiresOn isEqual:item.expiresOn])
+        && (_extendedExpiresOn == item.extendedExpiresOn || [_extendedExpiresOn isEqual:item.extendedExpiresOn])
+        && (_cachedAt == item.cachedAt || [_cachedAt isEqual:item.cachedAt])
+        && (_familyId == item.familyId || [_familyId isEqualToString:item.familyId])
+        && (_homeAccountId == item.homeAccountId || [_homeAccountId isEqualToString:item.homeAccountId])
+        && (_clientInfo == item.clientInfo || [_clientInfo.rawClientInfo isEqualToString:item.clientInfo.rawClientInfo])
+        && (_additionalFields == item.additionalFields || [_additionalFields isEqual:item.additionalFields]);
     return result;
 }
 
@@ -104,18 +111,19 @@
 
 - (NSUInteger)hash {
     NSUInteger hash = [super hash];
-    hash = hash * 31 + self.clientId.hash;
-    hash = hash * 31 + self.credentialType;
-    hash = hash * 31 + self.secret.hash;
-    hash = hash * 31 + self.target.hash;
-    hash = hash * 31 + self.realm.hash;
-    hash = hash * 31 + self.environment.hash;
-    hash = hash * 31 + self.expiresOn.hash;
-    hash = hash * 31 + self.cachedAt.hash;
-    hash = hash * 31 + self.familyId.hash;
-    hash = hash * 31 + self.homeAccountId.hash;
-    hash = hash * 31 + self.clientInfo.hash;
-    hash = hash * 31 + self.additionalFields.hash;
+    hash = hash * 31 + _clientId.hash;
+    hash = hash * 31 + _credentialType;
+    hash = hash * 31 + _secret.hash;
+    hash = hash * 31 + _target.hash;
+    hash = hash * 31 + _realm.hash;
+    hash = hash * 31 + _environment.hash;
+    hash = hash * 31 + _expiresOn.hash;
+    hash = hash * 31 + _extendedExpiresOn.hash;
+    hash = hash * 31 + _cachedAt.hash;
+    hash = hash * 31 + _familyId.hash;
+    hash = hash * 31 + _homeAccountId.hash;
+    hash = hash * 31 + _clientInfo.hash;
+    hash = hash * 31 + _additionalFields.hash;
     return hash;
 }
 
@@ -123,24 +131,25 @@
 
 - (nonnull instancetype)copyWithZone:(NSZone *)zone {
     MSIDCommonCredential *item = [[self class] allocWithZone:zone];
-    item.clientId = [self.clientId copyWithZone:zone];
-    item.credentialType = self.credentialType;
-    item.secret = [self.secret copyWithZone:zone];
-    item.target = [self.target copyWithZone:zone];
-    item.realm = [self.realm copyWithZone:zone];
-    item.environment = [self.environment copyWithZone:zone];
-    item.expiresOn = [self.expiresOn copyWithZone:zone];
-    item.cachedAt = [self.cachedAt copyWithZone:zone];
-    item.familyId = [self.familyId copyWithZone:zone];
-    item.homeAccountId = [self.homeAccountId copyWithZone:zone];
-    item.clientInfo = [self.clientInfo copyWithZone:zone];
-    item.additionalFields = [self.additionalFields copyWithZone:zone];
+    item.clientId = [_clientId copyWithZone:zone];
+    item.credentialType = _credentialType;
+    item.secret = [_secret copyWithZone:zone];
+    item.target = [_target copyWithZone:zone];
+    item.realm = [_realm copyWithZone:zone];
+    item.environment = [_environment copyWithZone:zone];
+    item.expiresOn = [_expiresOn copyWithZone:zone];
+    item.extendedExpiresOn = [_extendedExpiresOn copyWithZone:zone];
+    item.cachedAt = [_cachedAt copyWithZone:zone];
+    item.familyId = [_familyId copyWithZone:zone];
+    item.homeAccountId = [_homeAccountId copyWithZone:zone];
+    item.clientInfo = [_clientInfo copyWithZone:zone];
+    item.additionalFields = [_additionalFields copyWithZone:zone];
     return item;
 }
 
 #pragma mark - JSON
 
-- (nullable instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error {
+- (nullable instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error {
     MSID_TRACE;
     if (!(self = [super init])) {
         return nil;
@@ -182,7 +191,6 @@
         _additionalFields = additionalFields;
     }
 
-#pragma unused(error)
     return self;
 }
 
@@ -199,7 +207,7 @@
     }
 
     dictionary[MSID_CLIENT_ID_CACHE_KEY] = _clientId;
-    dictionary[MSID_CREDENTIAL_TYPE_CACHE_KEY] = [MSIDCredentialTypeHelpers credentialTypeAsString:self.credentialType];
+    dictionary[MSID_CREDENTIAL_TYPE_CACHE_KEY] = [MSIDCredentialTypeHelpers credentialTypeAsString:_credentialType];
     dictionary[MSID_TOKEN_CACHE_KEY] = _secret;
     dictionary[MSID_TARGET_CACHE_KEY] = _target;
     dictionary[MSID_REALM_CACHE_KEY] = _realm;

--- a/IdentityCore/tests/MSIDCommonCredentialTests.m
+++ b/IdentityCore/tests/MSIDCommonCredentialTests.m
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDCommonCredential.h"
+#import "NSDate+MSIDExtensions.h"
+#import <XCTest/XCTest.h>
+
+@interface MSIDCommonCredentialTests : XCTestCase
+
+@end
+
+@implementation MSIDCommonCredentialTests
+
+#pragma mark - setUp / tearDown
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each
+    // test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each
+    // test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - MSIDCommonCredential tests
+
+- (void)testcredentialTypeAsString_whenAccessTokenType_shouldReturnAccessTokenString {
+    NSString *result = [MSIDCredentialTypeHelpers credentialTypeAsString:MSIDAccessTokenType];
+    XCTAssertEqualObjects(result, @"AccessToken");
+}
+
+- (void)testcredentialTypeAsString_whenRefreshTokenType_shouldReturnRefreshTokenString {
+    NSString *result = [MSIDCredentialTypeHelpers credentialTypeAsString:MSIDRefreshTokenType];
+    XCTAssertEqualObjects(result, @"RefreshToken");
+}
+
+- (void)testcredentialTypeAsString_whenIDTokenType_shouldReturnIDTokenString {
+    NSString *result = [MSIDCredentialTypeHelpers credentialTypeAsString:MSIDIDTokenType];
+    XCTAssertEqualObjects(result, @"IdToken");
+}
+
+- (void)testcredentialTypeAsString_whenLegacyTokenType_shouldReturnLegacyTokenString {
+    NSString *result = [MSIDCredentialTypeHelpers credentialTypeAsString:MSIDLegacySingleResourceTokenType];
+    XCTAssertEqualObjects(result, @"LegacySingleResourceToken");
+}
+
+- (void)testcredentialTypeAsString_whenOtherTokenType_shouldReturnOtherTokenString {
+    NSString *result = [MSIDCredentialTypeHelpers credentialTypeAsString:MSIDCredentialTypeOther];
+    XCTAssertEqualObjects(result, @"token");
+}
+
+- (void)testTokenTypeFromString_whenAccessTokenString_shouldReturnAccessTokenType {
+    MSIDCredentialType result = [MSIDCredentialTypeHelpers credentialTypeFromString:@"AccessToken"];
+    XCTAssertEqual(result, MSIDAccessTokenType);
+}
+
+- (void)testTokenTypeFromString_whenRefreshTokenString_shouldReturnRefreshTokenType {
+    MSIDCredentialType result = [MSIDCredentialTypeHelpers credentialTypeFromString:@"RefreshToken"];
+    XCTAssertEqual(result, MSIDRefreshTokenType);
+}
+
+- (void)testTokenTypeFromString_whenIDTokenString_shouldReturnIDTokenType {
+    MSIDCredentialType result = [MSIDCredentialTypeHelpers credentialTypeFromString:@"IdToken"];
+    XCTAssertEqual(result, MSIDIDTokenType);
+}
+
+- (void)testTokenTypeFromString_whenLegacyTokenString_shouldReturnLegacyTokenType {
+    MSIDCredentialType result = [MSIDCredentialTypeHelpers credentialTypeFromString:@"LegacySingleResourceToken"];
+    XCTAssertEqual(result, MSIDLegacySingleResourceTokenType);
+}
+
+- (void)testTokenTypeFromString_whenOtherTokenString_shouldReturnOtherTokenType {
+    MSIDCredentialType result = [MSIDCredentialTypeHelpers credentialTypeFromString:@"token"];
+    XCTAssertEqual(result, MSIDCredentialTypeOther);
+}
+
+#pragma mark - IsEqualToItem handling
+
+- (void)testCredentialIsEqualToItemBehavior {
+    NSDictionary *credentialDict1 = @{
+        @"credential_type": @"AccessToken",
+        @"client_id": @"clientid1",
+        @"secret": @"thesecret1",
+        @"target": @"target1",
+        @"realm": @"realm xyz",
+        @"environment": @"environment abc",
+        @"cached_at": @"0",
+        @"expires_on": @"1000",
+        @"extended_expires_on": @"2000",
+        @"home_account_id": @"home account id1"
+    };
+    NSDictionary *credentialDict2 = @{
+        @"credential_type": @"AccessToken",
+        @"client_id": @"clientid2",
+        @"secret": @"thesecret2",
+        @"target": @"target2",
+        @"realm": @"realm xyz",
+        @"environment": @"environment abc",
+        @"cached_at": @"11",
+        @"expires_on": @"1111",
+        @"extended_expires_on": @"2222",
+        @"home_account_id": @"home account id2"
+    };
+    NSError *error = nil;
+    MSIDCommonCredential *item1 = [[MSIDCommonCredential alloc] initWithJSONDictionary:credentialDict1 error:&error];
+    XCTAssertNotNil(item1);
+    XCTAssertNil(error);
+
+    MSIDCommonCredential *item2 = [[MSIDCommonCredential alloc] initWithJSONDictionary:credentialDict2 error:&error];
+    XCTAssertNotNil(item2);
+    XCTAssertNil(error);
+    XCTAssertFalse([item1 isEqualToItem:item2]);
+
+    MSIDCommonCredential *item1copy = [[MSIDCommonCredential alloc] initWithJSONDictionary:credentialDict1
+                                                                                     error:&error];
+    XCTAssertNotNil(item1copy);
+    XCTAssertNil(error);
+    XCTAssertTrue([item1 isEqualToItem:item1copy]);
+
+    item1copy.target = nil;
+    XCTAssertFalse([item1 isEqualToItem:item1copy]);
+    XCTAssertNil(item1copy.target);
+    XCTAssertNotNil(item1.target);
+
+    item1.target = nil;
+    XCTAssertTrue([item1 isEqualToItem:item1copy]);
+}
+
+@end


### PR DESCRIPTION
Creates a class that's basically a subset of MSIDCredentialCacheItem for sharing with microsoft-authentication-library-for-cpp. Not used by microsoft-authentication-library-common-for-objc at this time.