### PR TITLE
Authority factory revisited

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -52,8 +52,6 @@
     NSArray *_otherAccessors;
 }
 
-@property (nonatomic) MSIDAuthorityFactory *authorityFactory;
-
 @end
 
 @implementation MSIDLegacyTokenCacheAccessor
@@ -72,7 +70,6 @@
         _serializer = [[MSIDKeyedArchiverSerializer alloc] init];
         _otherAccessors = otherAccessors;
         _factory = factory;
-        _authorityFactory = [MSIDAuthorityFactory new];
     }
 
     return self;
@@ -108,8 +105,8 @@
 {
     MSID_LOG_VERBOSE(context, @"(Legacy accessor) Saving broker response, only save SSO state %d", saveSSOStateOnly);
 
-    __auto_type authority = [self.authorityFactory authorityFromUrl:[NSURL URLWithString:response.authority]
-                                                            context:context error:error];
+    __auto_type authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:response.authority]
+                                                           context:context error:error];
     
     if (!authority) return NO;
     
@@ -273,7 +270,7 @@
         account.accountIdentifier = refreshToken.accountIdentifier;
         account.username = refreshToken.accountIdentifier.legacyAccountId;
         NSURL *rtAuthority = [refreshToken.authority.url msidURLForPreferredHost:authority.environment context:context error:error];
-        account.authority = [self.authorityFactory authorityFromUrl:rtAuthority rawTenant:refreshToken.realm context:context error:nil];
+        account.authority = [MSIDAuthorityFactory authorityFromUrl:rtAuthority rawTenant:refreshToken.realm context:context error:nil];
         account.accountType = MSIDAccountTypeMSSTS;
         [resultAccounts addObject:account];
     }
@@ -301,7 +298,7 @@
         MSIDAccount *account = [MSIDAccount new];
         account.accountIdentifier = refreshToken.accountIdentifier;
         // TODO: Should we create account if authority is nil?
-        __auto_type authority = [_authorityFactory authorityFromUrl:refreshToken.authority.url rawTenant:refreshToken.realm context:context error:nil];
+        __auto_type authority = [MSIDAuthorityFactory authorityFromUrl:refreshToken.authority.url rawTenant:refreshToken.realm context:context error:nil];
         account.authority = authority;
         account.accountType = MSIDAccountTypeMSSTS;
         return account;

--- a/IdentityCore/src/network/request_configurator/MSIDAADRequestConfigurator.m
+++ b/IdentityCore/src/network/request_configurator/MSIDAADRequestConfigurator.m
@@ -60,8 +60,7 @@ static NSTimeInterval const s_defaultTimeoutInterval = 300;
     
     __auto_type requestUrl = request.urlRequest.URL;
     
-    __auto_type authorityFactory = [MSIDAuthorityFactory new];
-    __auto_type authority = [authorityFactory authorityFromUrl:request.urlRequest.URL context:request.context error:nil];
+    __auto_type authority = [MSIDAuthorityFactory authorityFromUrl:request.urlRequest.URL context:request.context error:nil];
     // If url is authority, then we are trying to get network url of it. Otherwise we use provided url.
     __auto_type authorityUrl = [authority networkUrlWithContext:request.context];
     

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.h
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.h
@@ -33,8 +33,6 @@
 
 @interface MSIDAADOauth2Factory : MSIDOauth2Factory
 
-@property (nonatomic, readonly) MSIDAuthorityFactory *authorityFactory;
-
 - (MSIDTokenResponse *)tokenResponseFromJSON:(NSDictionary *)json
                                 refreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)token
                                      context:(id<MSIDRequestContext>)context

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
@@ -46,16 +46,6 @@
 
 @implementation MSIDAADOauth2Factory
 
-- (instancetype)init
-{
-    self = [super init];
-    if (self)
-    {
-        _authorityFactory = [MSIDAuthorityFactory new];
-    }
-    return self;
-}
-
 #pragma mark - Helpers
 
 - (BOOL)checkResponseClass:(MSIDTokenResponse *)response

--- a/IdentityCore/src/oauth2/aad_v1/MSIDAADV1Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v1/MSIDAADV1Oauth2Factory.m
@@ -192,7 +192,7 @@
         return NO;
     }
     
-    __auto_type authority = [self.authorityFactory authorityFromUrl:account.authority.url rawTenant:response.idTokenObj.realm context:nil error:nil];
+    __auto_type authority = [MSIDAuthorityFactory authorityFromUrl:account.authority.url rawTenant:response.idTokenObj.realm context:nil error:nil];
     
     account.authority = authority;
     return YES;
@@ -207,7 +207,7 @@
         return NO;
     }
     
-    __auto_type authority = [self.authorityFactory authorityFromUrl:token.authority.url rawTenant:response.idTokenObj.realm context:nil error:nil];
+    __auto_type authority = [MSIDAuthorityFactory authorityFromUrl:token.authority.url rawTenant:response.idTokenObj.realm context:nil error:nil];
 
     token.authority = authority;
     return YES;

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -185,7 +185,7 @@
                       tokenResponse:(MSIDTokenResponse *)response
                               error:(NSError **)error
 {
-    return [self.authorityFactory authorityFromUrl:url
+    return [MSIDAuthorityFactory authorityFromUrl:url
                                          rawTenant:response.idTokenObj.realm
                                            context:nil
                                              error:error];

--- a/IdentityCore/src/oauth2/account/MSIDAccount.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccount.m
@@ -138,8 +138,7 @@
         NSString *tenant = cacheItem.realm;
         
         __auto_type authorityUrl = [NSURL msidURLWithEnvironment:environment tenant:tenant];
-        __auto_type authorityFactory = [MSIDAuthorityFactory new];
-        _authority = [authorityFactory authorityFromUrl:authorityUrl context:nil error:nil];
+        _authority = [MSIDAuthorityFactory authorityFromUrl:authorityUrl context:nil error:nil];
     }
     
     return self;

--- a/IdentityCore/src/oauth2/b2c/MSIDB2COauth2Factory.m
+++ b/IdentityCore/src/oauth2/b2c/MSIDB2COauth2Factory.m
@@ -127,7 +127,7 @@
         tenantId = response.clientInfo.utid;
     }
 
-    return [self.authorityFactory authorityFromUrl:url rawTenant:tenantId context:nil error:nil];
+    return [MSIDAuthorityFactory authorityFromUrl:url rawTenant:tenantId context:nil error:nil];
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDBaseToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDBaseToken.m
@@ -127,8 +127,7 @@
         NSString *tenant = tokenCacheItem.realm;
 
         __auto_type authorityUrl = [NSURL msidURLWithEnvironment:environment tenant:tenant];
-        __auto_type authorityFactory = [MSIDAuthorityFactory new];
-        _authority = [authorityFactory authorityFromUrl:authorityUrl rawTenant:tenant context:nil error:nil];
+        _authority = [MSIDAuthorityFactory authorityFromUrl:authorityUrl rawTenant:tenant context:nil error:nil];
         
         if (!_authority)
         {

--- a/IdentityCore/src/oauth2/token/MSIDLegacyAccessToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDLegacyAccessToken.m
@@ -95,8 +95,7 @@
 
     if (self)
     {
-        __auto_type authorityFactory = [MSIDAuthorityFactory new];
-        __auto_type authority = [authorityFactory authorityFromUrl:tokenCacheItem.authority context:nil error:nil];
+        __auto_type authority = [MSIDAuthorityFactory authorityFromUrl:tokenCacheItem.authority context:nil error:nil];
         
         _accessToken = tokenCacheItem.accessToken;
         _idToken = tokenCacheItem.idToken;

--- a/IdentityCore/src/oauth2/token/MSIDLegacyRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDLegacyRefreshToken.m
@@ -94,8 +94,7 @@
 
     if (self)
     {
-        __auto_type authorityFactory = [MSIDAuthorityFactory new];
-        __auto_type authority = [authorityFactory authorityFromUrl:tokenCacheItem.authority context:nil error:nil];
+        __auto_type authority = [MSIDAuthorityFactory authorityFromUrl:tokenCacheItem.authority context:nil error:nil];
         
         _idToken = tokenCacheItem.idToken;
         _authority = authority;

--- a/IdentityCore/src/validation/MSIDAADAuthority.m
+++ b/IdentityCore/src/validation/MSIDAADAuthority.m
@@ -84,7 +84,7 @@
 - (NSURL *)cacheUrlWithContext:(id<MSIDRequestContext>)context
 {
     __auto_type universalAuthorityURL = [self universalAuthorityURL];
-    __auto_type authority = (MSIDAADAuthority *)[self.authorityFactory authorityFromUrl:universalAuthorityURL context:context error:nil];
+    __auto_type authority = (MSIDAADAuthority *)[MSIDAuthorityFactory authorityFromUrl:universalAuthorityURL context:context error:nil];
     if (authority) NSParameterAssert([authority isKindOfClass:MSIDAADAuthority.class]);
     
     return [self.authorityCache cacheUrlForAuthority:authority context:context];
@@ -93,7 +93,7 @@
 - (NSArray<NSURL *> *)legacyAccessTokenLookupAuthorities
 {
     __auto_type universalAuthorityURL = [self universalAuthorityURL];
-    __auto_type authority = (MSIDAADAuthority *)[self.authorityFactory authorityFromUrl:universalAuthorityURL context:nil error:nil];
+    __auto_type authority = (MSIDAADAuthority *)[MSIDAuthorityFactory authorityFromUrl:universalAuthorityURL context:nil error:nil];
     if (authority) NSParameterAssert([authority isKindOfClass:MSIDAADAuthority.class]);
     
     return [self.authorityCache cacheAliasesForAuthority:authority];

--- a/IdentityCore/src/validation/MSIDAADAuthority.m
+++ b/IdentityCore/src/validation/MSIDAADAuthority.m
@@ -27,6 +27,7 @@
 #import "MSIDAADTenant.h"
 #import "MSIDAuthorityFactory.h"
 #import "MSIDTelemetryEventStrings.h"
+#import "MSIDAuthority+Internal.h"
 
 @interface MSIDAADAuthority()
 

--- a/IdentityCore/src/validation/MSIDADFSAuthority.m
+++ b/IdentityCore/src/validation/MSIDADFSAuthority.m
@@ -24,6 +24,7 @@
 #import "MSIDADFSAuthority.h"
 #import "MSIDAdfsAuthorityResolver.h"
 #import "MSIDTelemetryEventStrings.h"
+#import "MSIDAuthority+Internal.h"
 
 @implementation MSIDADFSAuthority
 

--- a/IdentityCore/src/validation/MSIDAuthority+Internal.h
+++ b/IdentityCore/src/validation/MSIDAuthority+Internal.h
@@ -27,6 +27,8 @@
 
 #import "MSIDAuthority.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MSIDAuthority()
 
 @property (atomic) MSIDOpenIdProviderMetadata *metadata;
@@ -34,4 +36,9 @@
 
 - (id<MSIDAuthorityResolving>)resolver;
 
+- (instancetype)initWithURL:(NSURL *)url
+                    context:(nullable id<MSIDRequestContext>)context
+                      error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+NS_ASSUME_NONNULL_END
 @end

--- a/IdentityCore/src/validation/MSIDAuthority.h
+++ b/IdentityCore/src/validation/MSIDAuthority.h
@@ -52,10 +52,6 @@ typedef void(^MSIDOpenIdConfigurationInfoBlock)(MSIDOpenIdProviderMetadata * _Nu
 - (instancetype _Nullable )init NS_UNAVAILABLE;
 + (instancetype _Nullable )new NS_UNAVAILABLE;
 
-- (nullable instancetype)initWithURL:(nonnull NSURL *)url
-                             context:(nullable id<MSIDRequestContext>)context
-                               error:(NSError * _Nullable __autoreleasing * _Nullable)error NS_DESIGNATED_INITIALIZER;
-
 - (void)resolveAndValidate:(BOOL)validate
          userPrincipalName:(nullable NSString *)upn
                    context:(nullable id<MSIDRequestContext>)context

--- a/IdentityCore/src/validation/MSIDAuthorityFactory.h
+++ b/IdentityCore/src/validation/MSIDAuthorityFactory.h
@@ -28,11 +28,11 @@
 
 @interface MSIDAuthorityFactory : NSObject
 
-- (nullable MSIDAuthority *)authorityFromUrl:(nonnull NSURL *)url
-                                        context:(nullable id<MSIDRequestContext>)context
-                                          error:(NSError * _Nullable __autoreleasing * _Nullable)error;
++ (nullable MSIDAuthority *)authorityFromUrl:(nonnull NSURL *)url
+                                     context:(nullable id<MSIDRequestContext>)context
+                                       error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
-- (nullable MSIDAuthority *)authorityFromUrl:(nonnull NSURL *)url
++ (nullable MSIDAuthority *)authorityFromUrl:(nonnull NSURL *)url
                                    rawTenant:(nullable NSString *)rawTenant
                                      context:(nullable id<MSIDRequestContext>)context
                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error;

--- a/IdentityCore/src/validation/MSIDAuthorityFactory.m
+++ b/IdentityCore/src/validation/MSIDAuthorityFactory.m
@@ -25,6 +25,7 @@
 #import "MSIDAADAuthority.h"
 #import "MSIDADFSAuthority.h"
 #import "MSIDB2CAuthority.h"
+#import "MSIDAuthority+Internal.h"
 
 @implementation MSIDAuthorityFactory
 

--- a/IdentityCore/src/validation/MSIDAuthorityFactory.m
+++ b/IdentityCore/src/validation/MSIDAuthorityFactory.m
@@ -29,14 +29,14 @@
 
 @implementation MSIDAuthorityFactory
 
-- (MSIDAuthority *)authorityFromUrl:(NSURL *)url
++ (MSIDAuthority *)authorityFromUrl:(NSURL *)url
                                context:(id<MSIDRequestContext>)context
                                  error:(NSError **)error
 {
     return [self authorityFromUrl:url rawTenant:nil context:context error:error];
 }
 
-- (MSIDAuthority *)authorityFromUrl:(NSURL *)url
++ (MSIDAuthority *)authorityFromUrl:(NSURL *)url
                           rawTenant:(NSString *)rawTenant
                             context:(id<MSIDRequestContext>)context
                               error:(NSError **)error

--- a/IdentityCore/src/validation/MSIDB2CAuthority.m
+++ b/IdentityCore/src/validation/MSIDB2CAuthority.m
@@ -24,6 +24,7 @@
 #import "MSIDB2CAuthority.h"
 #import "MSIDB2CAuthorityResolver.h"
 #import "MSIDTelemetryEventStrings.h"
+#import "MSIDAuthority+Internal.h"
 
 @implementation MSIDB2CAuthority
 

--- a/IdentityCore/tests/MSIDAadAuthorityCacheTests.m
+++ b/IdentityCore/tests/MSIDAadAuthorityCacheTests.m
@@ -26,6 +26,7 @@
 #import "MSIDAadAuthorityCacheRecord.h"
 #import "MSIDAADAuthority.h"
 #import "MSIDAuthorityFactory.h"
+#import "MSIDAuthority+Internal.h"
 
 @interface MSIDAadAuthorityCache ()
 

--- a/IdentityCore/tests/MSIDIntuneMAMResourcesCacheTests.m
+++ b/IdentityCore/tests/MSIDIntuneMAMResourcesCacheTests.m
@@ -26,6 +26,7 @@
 #import "MSIDIntuneInMemoryCacheDataSource.h"
 #import "NSString+MSIDTestUtil.h"
 #import "MSIDAuthorityMock.h"
+#import "MSIDAuthority+Internal.h"
 
 @interface MSIDIntuneMAMResourcesCacheTests : XCTestCase
 

--- a/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
@@ -35,6 +35,7 @@
 #import "MSIDAADAuthority.h"
 #import "MSIDADFSAuthority.h"
 #import "NSString+MSIDTestUtil.h"
+#import "MSIDAuthority+Internal.h"
 
 @interface MSIDAuthorityIntegrationTests : XCTestCase
 

--- a/IdentityCore/tests/integration/MSIDCacheSchemaValidationTests.m
+++ b/IdentityCore/tests/integration/MSIDCacheSchemaValidationTests.m
@@ -61,9 +61,8 @@
 
 - (MSIDConfiguration *)aadTestConfiguration
 {
-    MSIDAuthorityFactory *authorityFactory = [MSIDAuthorityFactory new];
     NSURL *authorityURL = [NSURL URLWithString:@"https://login.microsoftonline.com/common"];
-    MSIDAuthority *authority = [authorityFactory authorityFromUrl:authorityURL context:nil error:nil];
+    MSIDAuthority *authority = [MSIDAuthorityFactory authorityFromUrl:authorityURL context:nil error:nil];
 
     MSIDConfiguration *configuration = [[MSIDConfiguration alloc] initWithAuthority:authority
                                                                         redirectUri:@"msalb6c69a37-df96-4db0-9088-2ab96e1d8215://auth"
@@ -470,9 +469,8 @@
 
 - (MSIDConfiguration *)b2cTestConfiguration
 {
-    MSIDAuthorityFactory *authorityFactory = [MSIDAuthorityFactory new];
     NSURL *authorityURL = [NSURL URLWithString:@"https://login.microsoftonline.com/tfp/iosmsalb2c.onmicrosoft.com/b2c_1_signin"];
-    MSIDAuthority *authority = [authorityFactory authorityFromUrl:authorityURL context:nil error:nil];
+    MSIDAuthority *authority = [MSIDAuthorityFactory authorityFromUrl:authorityURL context:nil error:nil];
 
     MSIDConfiguration *configuration = [[MSIDConfiguration alloc] initWithAuthority:authority
                                                                         redirectUri:@"msal0a7f52dd-260e-432f-94de-b47828c3f372://auth"

--- a/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
@@ -50,6 +50,7 @@
 #import "MSIDAADAuthority.h"
 #import "MSIDAadAuthorityCacheRecord.h"
 #import "MSIDAppMetadataCacheItem.h"
+#import "MSIDAuthority+Internal.h"
 
 @interface MSIDDefaultAccessorSSOIntegrationTests : XCTestCase
 {

--- a/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
@@ -43,6 +43,7 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDAADAuthority.h"
 #import "MSIDAppMetadataCacheItem.h"
+#import "MSIDAuthority+Internal.h"
 
 @interface MSIDLegacyAccessorSSOIntegrationTests : XCTestCase
 {

--- a/IdentityCore/tests/integration/ios/MSIDWipeDataTelemetryTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDWipeDataTelemetryTests.m
@@ -42,6 +42,7 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDAADV2Oauth2Factory.h"
 #import "MSIDAADAuthority.h"
+#import "MSIDAuthority+Internal.h"
 
 @interface MSIDTestRequestContext : NSObject <MSIDRequestContext>
 

--- a/IdentityCore/tests/util/NSString+MSIDTestUtil.m
+++ b/IdentityCore/tests/util/NSString+MSIDTestUtil.m
@@ -27,9 +27,8 @@
 
 - (MSIDAuthority *)authority
 {
-    __auto_type authorityFactory = [MSIDAuthorityFactory new];
     __auto_type authorityUrl = [[NSURL alloc] initWithString:self];
-    __auto_type authority = [authorityFactory authorityFromUrl:authorityUrl context:nil error:nil];
+    __auto_type authority = [MSIDAuthorityFactory authorityFromUrl:authorityUrl context:nil error:nil];
     
     return authority;
 }


### PR DESCRIPTION
- move MSIDAuthority initializer to internal class to prevent external SDKs from calling MSIDAuthority initializers directly

- change instance methods of MSIDAuthorityFactory to class methods. There seems no good reason to have this as instance methods. Furthermore, there doesn't seem a need to have multiple factory classes of this kind.