### PR TITLE
Send enrollmentID in acquireToken requests

### DIFF
--- a/IdentityCore/src/MSIDOAuth2Constants.h
+++ b/IdentityCore/src/MSIDOAuth2Constants.h
@@ -66,6 +66,7 @@ extern NSString *const MSID_OAUTH2_EXPIRES_ON;
 extern NSString *const MSID_OAUTH2_EXT_EXPIRES_IN;
 extern NSString *const MSID_FAMILY_ID;
 extern NSString *const MSID_AUTH_CLOUD_INSTANCE_HOST_NAME;
+extern NSString *const MSID_ENROLLMENT_ID;
 
 // Used for PKCE support
 extern NSString *const MSID_OAUTH2_CODE_CHALLENGE;

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -68,6 +68,7 @@ NSString *const MSID_OAUTH2_PROMPT_NONE         = @"none";
 NSString *const MSID_OAUTH2_EXPIRES_ON          = @"expires_on";
 NSString *const MSID_OAUTH2_EXT_EXPIRES_IN      = @"ext_expires_in";
 NSString *const MSID_FAMILY_ID                  = @"foci";
+NSString *const MSID_ENROLLMENT_ID              = @"microsoft_enrollment_id";
 
 NSString *const MSID_OAUTH2_CODE_CHALLENGE               = @"code_challenge";
 NSString *const MSID_OAUTH2_CODE_CHALLENGE_METHOD        = @"code_challenge_method";

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.h
@@ -32,7 +32,7 @@
 
 - (instancetype _Nullable )initWithEndpoint:(nonnull NSURL *)endpoint
                                    clientId:(nonnull NSString *)clientId
-                              homeAccountId:(nullable NSString *)homeAccountId
+                               enrollmentId:(nullable NSString *)enrollmentId
                                       scope:(nullable NSString *)scope
                                 redirectUri:(nonnull NSString *)redirectUri
                                        code:(nonnull NSString *)code

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.h
@@ -32,6 +32,7 @@
 
 - (instancetype _Nullable )initWithEndpoint:(nonnull NSURL *)endpoint
                                    clientId:(nonnull NSString *)clientId
+                              homeAccountId:(nullable NSString *)homeAccountId
                                       scope:(nullable NSString *)scope
                                 redirectUri:(nonnull NSString *)redirectUri
                                        code:(nonnull NSString *)code

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
@@ -45,10 +45,7 @@
         NSMutableDictionary *parameters = [_parameters mutableCopy];
         parameters[MSID_OAUTH2_CLIENT_INFO] = @YES;
         parameters[MSID_OAUTH2_CLAIMS] = claims;
-        if (enrollmentId != nil)
-        {
-            parameters[MSID_ENROLLMENT_ID] = enrollmentId;
-        }
+        parameters[MSID_ENROLLMENT_ID] = enrollmentId;
         
         _parameters = parameters;
     }

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
@@ -23,11 +23,14 @@
 
 #import "MSIDAADAuthorizationCodeGrantRequest.h"
 #import "MSIDAADRequestConfigurator.h"
+#import "MSIDADFSAuthority.h"
+#import "MSIDIntuneEnrollmentIdsCache.h"
 
 @implementation MSIDAADAuthorizationCodeGrantRequest
 
 - (instancetype)initWithEndpoint:(NSURL *)endpoint
                         clientId:(NSString *)clientId
+                   homeAccountId:(NSString *)homeAccountId
                            scope:(NSString *)scope
                      redirectUri:(NSString *)redirectUri
                             code:(NSString *)code
@@ -44,6 +47,17 @@
         NSMutableDictionary *parameters = [_parameters mutableCopy];
         parameters[MSID_OAUTH2_CLIENT_INFO] = @YES;
         parameters[MSID_OAUTH2_CLAIMS] = claims;
+        
+        if (homeAccountId != nil
+            && ![MSIDADFSAuthority isAuthorityFormatValid:_urlRequest.URL context:nil error:nil])
+        {
+            NSString* enrollmentId = [[MSIDIntuneEnrollmentIdsCache sharedCache] enrollmentIdForHomeAccountId:homeAccountId context:nil error:nil];
+            if (enrollmentId != nil)
+            {
+                parameters[MSID_ENROLLMENT_ID] = enrollmentId;
+            }
+        }
+        
         _parameters = parameters;
     }
     

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
@@ -23,14 +23,12 @@
 
 #import "MSIDAADAuthorizationCodeGrantRequest.h"
 #import "MSIDAADRequestConfigurator.h"
-#import "MSIDADFSAuthority.h"
-#import "MSIDIntuneEnrollmentIdsCache.h"
 
 @implementation MSIDAADAuthorizationCodeGrantRequest
 
 - (instancetype)initWithEndpoint:(NSURL *)endpoint
                         clientId:(NSString *)clientId
-                   homeAccountId:(NSString *)homeAccountId
+                    enrollmentId:(NSString *)enrollmentId
                            scope:(NSString *)scope
                      redirectUri:(NSString *)redirectUri
                             code:(NSString *)code
@@ -47,15 +45,9 @@
         NSMutableDictionary *parameters = [_parameters mutableCopy];
         parameters[MSID_OAUTH2_CLIENT_INFO] = @YES;
         parameters[MSID_OAUTH2_CLAIMS] = claims;
-        
-        if (homeAccountId != nil
-            && ![MSIDADFSAuthority isAuthorityFormatValid:_urlRequest.URL context:nil error:nil])
+        if (enrollmentId != nil)
         {
-            NSString* enrollmentId = [[MSIDIntuneEnrollmentIdsCache sharedCache] enrollmentIdForHomeAccountId:homeAccountId context:nil error:nil];
-            if (enrollmentId != nil)
-            {
-                parameters[MSID_ENROLLMENT_ID] = enrollmentId;
-            }
+            parameters[MSID_ENROLLMENT_ID] = enrollmentId;
         }
         
         _parameters = parameters;

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
@@ -32,7 +32,7 @@
 
 - (instancetype _Nullable)initWithEndpoint:(nonnull NSURL *)endpoint
                                   clientId:(nonnull NSString *)clientId
-                             homeAccountId:(nullable NSString *)homeAccountId
+                              enrollmentId:(nullable NSString *)enrollmentId
                                      scope:(nullable NSString *)scope
                               refreshToken:(nonnull NSString *)refreshToken
                                     claims:(nullable NSString *)claims

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
@@ -32,6 +32,7 @@
 
 - (instancetype _Nullable)initWithEndpoint:(nonnull NSURL *)endpoint
                                   clientId:(nonnull NSString *)clientId
+                             homeAccountId:(nullable NSString *)homeAccountId
                                      scope:(nullable NSString *)scope
                               refreshToken:(nonnull NSString *)refreshToken
                                     claims:(nullable NSString *)claims

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
@@ -23,11 +23,14 @@
 
 #import "MSIDAADRefreshTokenGrantRequest.h"
 #import "MSIDAADRequestConfigurator.h"
+#import "MSIDADFSAuthority.h"
+#import "MSIDIntuneEnrollmentIdsCache.h"
 
 @implementation MSIDAADRefreshTokenGrantRequest
 
 - (instancetype)initWithEndpoint:(NSURL *)endpoint
                         clientId:(NSString *)clientId
+                   homeAccountId:(NSString *)homeAccountId
                            scope:(NSString *)scope
                     refreshToken:(NSString *)refreshToken
                           claims:(NSString *)claims
@@ -42,6 +45,17 @@
         NSMutableDictionary *parameters = [_parameters mutableCopy];
         parameters[MSID_OAUTH2_CLIENT_INFO] = @YES;
         parameters[MSID_OAUTH2_CLAIMS] = claims;
+        
+        if (homeAccountId != nil
+            && ![MSIDADFSAuthority isAuthorityFormatValid:_urlRequest.URL context:nil error:nil])
+        {
+            NSString* enrollmentId = [[MSIDIntuneEnrollmentIdsCache sharedCache] enrollmentIdForHomeAccountId:homeAccountId context:nil error:nil];
+            if (enrollmentId != nil)
+            {
+                parameters[MSID_ENROLLMENT_ID] = enrollmentId;
+            }
+        }
+        
         _parameters = parameters;
     }
     

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
@@ -23,14 +23,12 @@
 
 #import "MSIDAADRefreshTokenGrantRequest.h"
 #import "MSIDAADRequestConfigurator.h"
-#import "MSIDADFSAuthority.h"
-#import "MSIDIntuneEnrollmentIdsCache.h"
 
 @implementation MSIDAADRefreshTokenGrantRequest
 
 - (instancetype)initWithEndpoint:(NSURL *)endpoint
                         clientId:(NSString *)clientId
-                   homeAccountId:(NSString *)homeAccountId
+                    enrollmentId:(NSString *)enrollmentId
                            scope:(NSString *)scope
                     refreshToken:(NSString *)refreshToken
                           claims:(NSString *)claims
@@ -45,15 +43,9 @@
         NSMutableDictionary *parameters = [_parameters mutableCopy];
         parameters[MSID_OAUTH2_CLIENT_INFO] = @YES;
         parameters[MSID_OAUTH2_CLAIMS] = claims;
-        
-        if (homeAccountId != nil
-            && ![MSIDADFSAuthority isAuthorityFormatValid:_urlRequest.URL context:nil error:nil])
+        if (enrollmentId != nil)
         {
-            NSString* enrollmentId = [[MSIDIntuneEnrollmentIdsCache sharedCache] enrollmentIdForHomeAccountId:homeAccountId context:nil error:nil];
-            if (enrollmentId != nil)
-            {
-                parameters[MSID_ENROLLMENT_ID] = enrollmentId;
-            }
+            parameters[MSID_ENROLLMENT_ID] = enrollmentId;
         }
         
         _parameters = parameters;

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
@@ -43,10 +43,7 @@
         NSMutableDictionary *parameters = [_parameters mutableCopy];
         parameters[MSID_OAUTH2_CLIENT_INFO] = @YES;
         parameters[MSID_OAUTH2_CLAIMS] = claims;
-        if (enrollmentId != nil)
-        {
-            parameters[MSID_ENROLLMENT_ID] = enrollmentId;
-        }
+        parameters[MSID_ENROLLMENT_ID] = enrollmentId;
         
         _parameters = parameters;
     }


### PR DESCRIPTION
Include enrollmentID in token request by refresh token or by auth code, if the authority is not ADFS