### PR TITLE
NSError + OAuth 

### DIFF
--- a/IdentityCore/src/MSIDDefaultErrorConverter.m
+++ b/IdentityCore/src/MSIDDefaultErrorConverter.m
@@ -42,8 +42,8 @@
 
     NSMutableDictionary *userInfo = [NSMutableDictionary new];
     userInfo[MSIDErrorDescriptionKey] = errorDescription;
-    userInfo[MSIDOAuthErrorKey] = oauthError;
-    userInfo[MSIDOAuthSubErrorKey] = subError;
+    userInfo[self.oauthErrorKey] = oauthError;
+    userInfo[self.subErrorKey] = subError;
     userInfo[NSUnderlyingErrorKey]  = underlyingError;
     userInfo[MSIDCorrelationIdKey] = [correlationId UUIDString];
     if (additionalUserInfo)
@@ -52,6 +52,16 @@
     }
 
     return [NSError errorWithDomain:domain code:code userInfo:userInfo];
+}
+
+- (NSString *)oauthErrorKey
+{
+    return MSIDOAuthErrorKey;
+}
+
+- (nonnull NSString *)subErrorKey
+{
+    return MSIDOAuthSubErrorKey;
 }
 
 @end

--- a/IdentityCore/src/MSIDErrorConverting.h
+++ b/IdentityCore/src/MSIDErrorConverting.h
@@ -35,4 +35,8 @@
                         correlationId:(nullable NSUUID *)correlationId
                              userInfo:(nullable NSDictionary *)userInfo;
 
+- (nonnull NSString *)oauthErrorKey;
+
+- (nonnull NSString *)subErrorKey;
+
 @end

--- a/IdentityCore/src/util/NSError+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSError+MSIDExtensions.h
@@ -38,4 +38,8 @@ typedef NS_OPTIONS(NSUInteger, MSIDErrorFilteringOptions)
  */
 - (nonnull NSError *)msidErrorWithFilteringOptions:(MSIDErrorFilteringOptions)option;
 
+- (nullable NSString *)msidOauthError;
+
+- (nullable NSString *)msidSubError;
+
 @end

--- a/IdentityCore/src/util/NSError+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSError+MSIDExtensions.m
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import "NSError+MSIDExtensions.h"
+#import "MSIDErrorConverter.h"
 
 @implementation NSError (MSIDExtensions)
 
@@ -51,6 +52,16 @@
     __auto_type error = [[NSError alloc] initWithDomain:self.domain code:self.code userInfo:errorUserInfo];
     
     return error;
+}
+
+- (nullable NSString *)msidOauthError
+{
+    return self.userInfo[MSIDErrorConverter.errorConverter.oauthErrorKey];
+}
+
+- (nullable NSString *)msidSubError
+{
+    return self.userInfo[MSIDErrorConverter.errorConverter.subErrorKey];
 }
 
 @end

--- a/IdentityCore/tests/MSIDErrorTests.m
+++ b/IdentityCore/tests/MSIDErrorTests.m
@@ -46,13 +46,23 @@
 
     NSMutableDictionary *customUserInfo = [userInfo mutableCopy];
     customUserInfo[@"custom_description"] = errorDescription;
-    customUserInfo[@"custom_oautherror"] = oauthError;
-    customUserInfo[@"custom_suberror"] = subError;
+    customUserInfo[self.oauthErrorKey] = oauthError;
+    customUserInfo[self.subErrorKey] = subError;
     customUserInfo[@"custom_underlyingerror"] = underlyingError;
     customUserInfo[@"custom_correlationid"] = [correlationId UUIDString];
 
     NSError *resultError = [NSError errorWithDomain:newDomain code:errorCode userInfo:customUserInfo];
     return resultError;
+}
+
+- (NSString *)oauthErrorKey
+{
+    return @"custom_oautherror";
+}
+
+- (nonnull NSString *)subErrorKey
+{
+    return @"custom_suberror";
 }
 
 @end


### PR DESCRIPTION
Allows getting OAuth errors without knowing under which string key they are stored in `userInfo` dictionary.