### PR TITLE
Add aadoverride check to the .pch

### DIFF
--- a/IdentityCore/src/IdentityCore.pch
+++ b/IdentityCore/src/IdentityCore.pch
@@ -36,6 +36,9 @@
 #import <AppKit/AppKit.h>
 #endif
 
+// Broker SDK relies on having ADAL_BROKER defined to 1.
+// This is defined in the ADAuthenticationBroker/Frameworks/aad_overrides.h file.
+// Without this, the build for Broker will not include this definition.
 #if __has_include("../../../../../aad_overrides.h")
 #include "../../../../../aad_overrides.h"
 #endif

--- a/IdentityCore/src/IdentityCore.pch
+++ b/IdentityCore/src/IdentityCore.pch
@@ -36,4 +36,8 @@
 #import <AppKit/AppKit.h>
 #endif
 
+#if __has_include("../../../../../aad_overrides.h")
+#include "../../../../../aad_overrides.h"
+#endif
+
 #endif /* IdentityCore_pch */


### PR DESCRIPTION
Allows broker to use msid with the right define "AD_BROKER 1"