### PR TITLE
 ID token factory now also checks upn and unique_name claim to determine version

### DIFF
--- a/IdentityCore/src/oauth2/aad_base/MSIDAADIdTokenClaimsFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADIdTokenClaimsFactory.m
@@ -52,14 +52,16 @@
         }
     }
 
-    // If no version claim is returned, or it's unsupported version, check if UPN claim is present
-    // If UPN is present, return AAD v1 id token.
+    // If no version claim is returned, or it's unsupported version, check if UPN or unique_name claims are present
+    // If UPN/unique_name is present, return AAD v1 id token.
     // Return base OIDC token in all other cases
     // Note, that we shouldn't be checking for upn claim only and deciding v1 vs v2, because if v2 adds upn claim one day, this logic will break
-    // However, AAD cannot stop returning ver 2.0 claim for AAD v2 or upn for AAD v1 because that would be a breaking change, so we can rely on those
+    // However, AAD cannot stop returning ver 2.0 claim for AAD v2 or upn/unique_name for AAD v1 because that would be a breaking change, so we can rely on those
     NSString *idTokenUPNClaim = allClaims[@"upn"];
+    NSString *idTokenUniqueNameClaim = allClaims[@"unique_name"];
 
-    if (![NSString msidIsStringNilOrBlank:idTokenUPNClaim])
+    if (![NSString msidIsStringNilOrBlank:idTokenUPNClaim]
+        || ![NSString msidIsStringNilOrBlank:idTokenUniqueNameClaim])
     {
         return [[MSIDAADV1IdTokenClaims alloc] initWithJSONDictionary:allClaims error:error];
     }

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADIdTokenClaimsFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADIdTokenClaimsFactory.m
@@ -55,6 +55,8 @@
     // If no version claim is returned, or it's unsupported version, check if UPN claim is present
     // If UPN is present, return AAD v1 id token.
     // Return base OIDC token in all other cases
+    // Note, that we shouldn't be checking for upn claim only and deciding v1 vs v2, because if v2 adds upn claim one day, this logic will break
+    // However, AAD cannot stop returning ver 2.0 claim for AAD v2 or upn for AAD v1 because that would be a breaking change, so we can rely on those
     NSString *idTokenUPNClaim = allClaims[@"upn"];
 
     if (![NSString msidIsStringNilOrBlank:idTokenUPNClaim])

--- a/IdentityCore/tests/MSIDAADIdTokenClaimsFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADIdTokenClaimsFactoryTests.m
@@ -31,6 +31,7 @@
 #import "MSIDAADV2IdTokenClaims.h"
 #import "MSIDAADV1IdTokenClaims.h"
 #import "MSIDIdTokenClaims.h"
+#import "NSDictionary+MSIDTestUtil.h"
 
 @interface MSIDAADIdTokenClaimsFactoryTests : XCTestCase
 
@@ -55,6 +56,41 @@
     NSError *error = nil;
     MSIDIdTokenClaims *claims = [MSIDAADIdTokenClaimsFactory claimsFromRawIdToken:idToken error:&error];
     XCTAssertTrue([claims isKindOfClass:[MSIDAADV1IdTokenClaims class]]);
+    XCTAssertNil(error);
+}
+
+- (void)testClaimsForRawIDToken_whenAADV1IDToken_withoutVerClaim_withUPNClaim_shouldReturnAADV1Claims
+{
+    NSString *idTokenp1 = [@{ @"typ": @"JWT", @"alg": @"RS256", @"kid": @"_kid_value"} msidBase64UrlJson];
+    NSString *idTokenp2 = [@{ @"iss" : @"issuer",
+                              @"preferred_username" : @"username",
+                              @"sub" : @"sub",
+                              @"tid": @"tenantId",
+                              @"upn": @"upn"
+                              } msidBase64UrlJson];
+    NSString *idToken = [NSString stringWithFormat:@"%@.%@.%@", idTokenp1, idTokenp2, idTokenp1];
+
+    NSError *error = nil;
+    MSIDIdTokenClaims *claims = [MSIDAADIdTokenClaimsFactory claimsFromRawIdToken:idToken error:&error];
+    XCTAssertTrue([claims isKindOfClass:[MSIDAADV1IdTokenClaims class]]);
+    XCTAssertNil(error);
+}
+
+- (void)testClaimsForRawIDToken_whenAADV2IDToken_withUPNClaim_shouldReturnAADV2Claims
+{
+    NSString *idTokenp1 = [@{ @"typ": @"JWT", @"alg": @"RS256", @"kid": @"_kid_value"} msidBase64UrlJson];
+    NSString *idTokenp2 = [@{ @"iss" : @"issuer",
+                              @"preferred_username" : @"username",
+                              @"sub" : @"sub",
+                              @"ver": @"2.0",
+                              @"tid": @"tenantId",
+                              @"upn": @"upn"
+                              } msidBase64UrlJson];
+    NSString *idToken = [NSString stringWithFormat:@"%@.%@.%@", idTokenp1, idTokenp2, idTokenp1];
+
+    NSError *error = nil;
+    MSIDIdTokenClaims *claims = [MSIDAADIdTokenClaimsFactory claimsFromRawIdToken:idToken error:&error];
+    XCTAssertTrue([claims isKindOfClass:[MSIDAADV2IdTokenClaims class]]);
     XCTAssertNil(error);
 }
 

--- a/IdentityCore/tests/MSIDAADIdTokenClaimsFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADIdTokenClaimsFactoryTests.m
@@ -76,6 +76,23 @@
     XCTAssertNil(error);
 }
 
+- (void)testClaimsForRawIDToken_whenAADV1IDToken_withoutVerClaim_withUniqueNameClaim_shouldReturnAADV1Claims
+{
+    NSString *idTokenp1 = [@{ @"typ": @"JWT", @"alg": @"RS256", @"kid": @"_kid_value"} msidBase64UrlJson];
+    NSString *idTokenp2 = [@{ @"iss" : @"issuer",
+                              @"preferred_username" : @"username",
+                              @"sub" : @"sub",
+                              @"tid": @"tenantId",
+                              @"unique_name": @"unique name"
+                              } msidBase64UrlJson];
+    NSString *idToken = [NSString stringWithFormat:@"%@.%@.%@", idTokenp1, idTokenp2, idTokenp1];
+
+    NSError *error = nil;
+    MSIDIdTokenClaims *claims = [MSIDAADIdTokenClaimsFactory claimsFromRawIdToken:idToken error:&error];
+    XCTAssertTrue([claims isKindOfClass:[MSIDAADV1IdTokenClaims class]]);
+    XCTAssertNil(error);
+}
+
 - (void)testClaimsForRawIDToken_whenAADV2IDToken_withUPNClaim_shouldReturnAADV2Claims
 {
     NSString *idTokenp1 = [@{ @"typ": @"JWT", @"alg": @"RS256", @"kid": @"_kid_value"} msidBase64UrlJson];


### PR DESCRIPTION
ADAL PR: https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/1357