### PR TITLE
Make validateTokenResult public method

### DIFF
--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
@@ -50,4 +50,10 @@
                                       correlationID:(nonnull NSUUID *)correlationID
                                               error:(NSError * _Nullable * _Nullable)error;
 
+- (BOOL)validateTokenResult:(nonnull MSIDTokenResult *)tokenResult
+              configuration:(nonnull MSIDConfiguration *)configuration
+             requestAccount:(nullable MSIDAccountIdentifier *)accountIdentifier
+              correlationID:(nonnull NSUUID *)correlationID
+                      error:(NSError * _Nullable * _Nullable)error;
+
 @end

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
@@ -78,7 +78,6 @@
 }
 
 - (BOOL)validateTokenResult:(MSIDTokenResult *)tokenResult
-               oauthFactory:(MSIDOauth2Factory *)factory
               configuration:(MSIDConfiguration *)configuration
              requestAccount:(MSIDAccountIdentifier *)accountIdentifier
               correlationID:(NSUUID *)correlationID
@@ -137,7 +136,6 @@
     }
 
     BOOL resultValid = [self validateTokenResult:tokenResult
-                                    oauthFactory:factory
                                    configuration:configuration
                                   requestAccount:nil
                                    correlationID:correlationID
@@ -207,7 +205,6 @@
     }
 
     BOOL resultValid = [self validateTokenResult:tokenResult
-                                    oauthFactory:factory
                                    configuration:parameters.msidConfiguration
                                   requestAccount:parameters.accountIdentifier
                                    correlationID:parameters.correlationId

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
@@ -29,7 +29,6 @@
 @implementation MSIDLegacyTokenResponseValidator
 
 - (BOOL)validateTokenResult:(MSIDTokenResult *)tokenResult
-               oauthFactory:(MSIDOauth2Factory *)factory
               configuration:(MSIDConfiguration *)configuration
              requestAccount:(MSIDAccountIdentifier *)accountIdentifier
               correlationID:(NSUUID *)correlationID

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
@@ -33,7 +33,6 @@
 @implementation MSIDDefaultTokenResponseValidator
 
 - (BOOL)validateTokenResult:(MSIDTokenResult *)tokenResult
-               oauthFactory:(MSIDOauth2Factory *)factory
               configuration:(MSIDConfiguration *)configuration
              requestAccount:(MSIDAccountIdentifier *)accountIdentifier
               correlationID:(NSUUID *)correlationID


### PR DESCRIPTION
We will need it in the broker, so we can validate MSIDTokenResult before returning back to the calling app.