### PR TITLE
Enable reusing most of MSIDAccountCacheItem in msalcpp

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -16,6 +16,13 @@
 		0570FE7F219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 0570FE7C219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.m */; };
 		0570FE80219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 0570FE7D219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.h */; };
 		0570FE81219E33FB00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 0570FE7C219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.m */; };
+		057B75C121BF430B00BE9DFD /* MSIDAccountCacheItem+Util.h in Headers */ = {isa = PBXBuildFile; fileRef = 057B75BF21BF430B00BE9DFD /* MSIDAccountCacheItem+Util.h */; };
+		057B75C221BF430B00BE9DFD /* MSIDAccountCacheItem+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 057B75C021BF430B00BE9DFD /* MSIDAccountCacheItem+Util.m */; };
+		057B75C321BF430B00BE9DFD /* MSIDAccountCacheItem+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 057B75C021BF430B00BE9DFD /* MSIDAccountCacheItem+Util.m */; };
+		057B75C621C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 057B75C421C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.h */; };
+		057B75C721C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 057B75C521C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.m */; };
+		057B75C821C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 057B75C521C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.m */; };
+		057B75CC21C08CEF00BE9DFD /* MSIDAccountCacheItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 057B75CB21C08CEE00BE9DFD /* MSIDAccountCacheItem.h */; };
 		1E2EDFF9219125400054FAD9 /* MSIDTokenResponse+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2EDFF8219125400054FAD9 /* MSIDTokenResponse+Internal.h */; };
 		1E33F49E21711BE700919E9C /* MSIDAppMetadataCacheKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3590B8216D210E003D43BE /* MSIDAppMetadataCacheKey.m */; };
 		1E33F49F21711BF400919E9C /* MSIDAppMetadataCacheKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E3590B7216D210E003D43BE /* MSIDAppMetadataCacheKey.h */; };
@@ -727,7 +734,6 @@
 		B2AF1D4C218BD12E0080C1A0 /* MSIDInteractiveRequestParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = B2AF1D49218BD12D0080C1A0 /* MSIDInteractiveRequestParameters.m */; };
 		B2B1D56D20425DA600DD81F0 /* MSIDCredentialItemSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = B2B1D56C20425DA600DD81F0 /* MSIDCredentialItemSerializer.h */; };
 		B2B1D56F20425DBF00DD81F0 /* MSIDAccountItemSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = B2B1D56E20425DBF00DD81F0 /* MSIDAccountItemSerializer.h */; };
-		B2B1D57220425DFD00DD81F0 /* MSIDAccountCacheItem.h in Headers */ = {isa = PBXBuildFile; fileRef = B2B1D57020425DFD00DD81F0 /* MSIDAccountCacheItem.h */; };
 		B2B1D57320425DFD00DD81F0 /* MSIDAccountCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B1D57120425DFD00DD81F0 /* MSIDAccountCacheItem.m */; };
 		B2B1D57420425DFD00DD81F0 /* MSIDAccountCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B1D57120425DFD00DD81F0 /* MSIDAccountCacheItem.m */; };
 		B2B1D578204369D600DD81F0 /* MSIDAccountType.h in Headers */ = {isa = PBXBuildFile; fileRef = B2B1D576204369D600DD81F0 /* MSIDAccountType.h */; };
@@ -994,6 +1000,11 @@
 		04D32CB11FD62141000B123E /* MSIDError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDError.m; sourceTree = "<group>"; };
 		0570FE7C219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MSIDCredentialCacheItem+MSIDBaseToken.m"; sourceTree = "<group>"; };
 		0570FE7D219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDCredentialCacheItem+MSIDBaseToken.h"; sourceTree = "<group>"; };
+		057B75BF21BF430B00BE9DFD /* MSIDAccountCacheItem+Util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDAccountCacheItem+Util.h"; sourceTree = "<group>"; };
+		057B75C021BF430B00BE9DFD /* MSIDAccountCacheItem+Util.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MSIDAccountCacheItem+Util.m"; sourceTree = "<group>"; };
+		057B75C421C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDAccountCacheItem+ClientInfoUtil.h"; sourceTree = "<group>"; };
+		057B75C521C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MSIDAccountCacheItem+ClientInfoUtil.m"; sourceTree = "<group>"; };
+		057B75CB21C08CEE00BE9DFD /* MSIDAccountCacheItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDAccountCacheItem.h; sourceTree = "<group>"; };
 		1E2EDFF8219125400054FAD9 /* MSIDTokenResponse+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDTokenResponse+Internal.h"; sourceTree = "<group>"; };
 		1E3590B3216C3702003D43BE /* MSIDAppMetadataCacheItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAppMetadataCacheItem.h; sourceTree = "<group>"; };
 		1E3590B4216C3702003D43BE /* MSIDAppMetadataCacheItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAppMetadataCacheItem.m; sourceTree = "<group>"; };
@@ -1549,7 +1560,6 @@
 		B2AF1D49218BD12D0080C1A0 /* MSIDInteractiveRequestParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDInteractiveRequestParameters.m; sourceTree = "<group>"; };
 		B2B1D56C20425DA600DD81F0 /* MSIDCredentialItemSerializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCredentialItemSerializer.h; sourceTree = "<group>"; };
 		B2B1D56E20425DBF00DD81F0 /* MSIDAccountItemSerializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountItemSerializer.h; sourceTree = "<group>"; };
-		B2B1D57020425DFD00DD81F0 /* MSIDAccountCacheItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountCacheItem.h; sourceTree = "<group>"; };
 		B2B1D57120425DFD00DD81F0 /* MSIDAccountCacheItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountCacheItem.m; sourceTree = "<group>"; };
 		B2B1D576204369D600DD81F0 /* MSIDAccountType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountType.h; sourceTree = "<group>"; };
 		B2B1D577204369D600DD81F0 /* MSIDAccountType.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountType.m; sourceTree = "<group>"; };
@@ -1819,6 +1829,14 @@
 				23DADC0F20B8BF4F005D7389 /* MSIDAadAuthorityCacheRecord.m */,
 			);
 			path = validation;
+			sourceTree = "<group>";
+		};
+		057B75BC21BF400500BE9DFD /* include */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = include;
+			path = "New Group";
 			sourceTree = "<group>";
 		};
 		1E4D74A8216E7A1C0091426A /* appmetadata */ = {
@@ -2459,13 +2477,18 @@
 		B226D85B1FFB07840012BF8B /* token */ = {
 			isa = PBXGroup;
 			children = (
+				057B75CB21C08CEE00BE9DFD /* MSIDAccountCacheItem.h */,
+				057B75C421C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.h */,
+				057B75C521C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.m */,
+				057B75BF21BF430B00BE9DFD /* MSIDAccountCacheItem+Util.h */,
+				057B75C021BF430B00BE9DFD /* MSIDAccountCacheItem+Util.m */,
+				057B75BC21BF400500BE9DFD /* include */,
 				0570FE7D219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.h */,
 				0570FE7C219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.m */,
 				B251CC53204109A4005E0179 /* MSIDCredentialCacheItem.h */,
 				B251CC54204109A4005E0179 /* MSIDCredentialCacheItem.m */,
 				B297E1EE20A25F0C00F370EC /* MSIDLegacyTokenCacheItem.h */,
 				B297E1EF20A25F0C00F370EC /* MSIDLegacyTokenCacheItem.m */,
-				B2B1D57020425DFD00DD81F0 /* MSIDAccountCacheItem.h */,
 				B2B1D57120425DFD00DD81F0 /* MSIDAccountCacheItem.m */,
 				1E3590B3216C3702003D43BE /* MSIDAppMetadataCacheItem.h */,
 				1E3590B4216C3702003D43BE /* MSIDAppMetadataCacheItem.m */,
@@ -3195,6 +3218,7 @@
 				9686480420C7711400EF7E73 /* MSIDAADV1WebviewFactory.h in Headers */,
 				B20657A61FC91C9A00412B7D /* MSIDTelemetryEventInterface.h in Headers */,
 				B28D90BF218FEA0700E230D6 /* MSIDTokenResult.h in Headers */,
+				057B75CC21C08CEF00BE9DFD /* MSIDAccountCacheItem.h in Headers */,
 				B2D5625820CCD50E00FFF59C /* MSIDTelemetry+Cache.h in Headers */,
 				23B4CC6F2181680600DBDBCE /* MSIDIntuneEnrollmentIdsCache.h in Headers */,
 				238E19E12086FE28004DF483 /* MSIDAuthorizationCodeGrantRequest.h in Headers */,
@@ -3235,9 +3259,9 @@
 				B2C707F32192524700D917B8 /* MSIDDefaultTokenRequestProvider.h in Headers */,
 				B251CC3E2041058D005E0179 /* MSIDAccessToken.h in Headers */,
 				23AE9DB72148529A00B285F3 /* NSError+MSIDExtensions.h in Headers */,
+				057B75C621C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.h in Headers */,
 				238EF042208FE88C0035ABE6 /* MSIDAADAuthorizationCodeGrantRequest.h in Headers */,
 				B210F4311FDDE7EB005A8F76 /* MSIDTokenResponse.h in Headers */,
-				B2B1D57220425DFD00DD81F0 /* MSIDAccountCacheItem.h in Headers */,
 				1E33F4A021711C1100919E9C /* MSIDAppMetadataCacheItem.h in Headers */,
 				B2C708B3219A620B00D917B8 /* MSIDBrokerKeyProvider.h in Headers */,
 				23B39ABC209BD47D000AA905 /* MSIDB2CAuthorityResolver.h in Headers */,
@@ -3280,6 +3304,7 @@
 				1E33F49F21711BF400919E9C /* MSIDAppMetadataCacheKey.h in Headers */,
 				2308476B207D6D500024CE7C /* NSData+MSIDExtensions.h in Headers */,
 				B210F44D1FDDF5AA005A8F76 /* MSIDClientInfo.h in Headers */,
+				057B75C121BF430B00BE9DFD /* MSIDAccountCacheItem+Util.h in Headers */,
 				B20657DF1FCA208C00412B7D /* NSDate+MSIDExtensions.h in Headers */,
 				96090D9820E59B2000E42B37 /* MSIDNotifications.h in Headers */,
 				96F94A3320817C1A0034676C /* MSIDNTLMHandler.h in Headers */,
@@ -3910,6 +3935,7 @@
 				96F94A3B208184790034676C /* MSIDOAuth2EmbeddedWebviewController.m in Sources */,
 				23B39AC3209BD901000AA905 /* MSIDAdfsAuthorityResolver.m in Sources */,
 				232C657C2137684E002A41FE /* MSIDDRSDiscoveryResponseSerializer.m in Sources */,
+				057B75C821C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.m in Sources */,
 				B28D90C1218FEA0700E230D6 /* MSIDTokenResult.m in Sources */,
 				B251CC3D2041058D005E0179 /* MSIDAccessToken.m in Sources */,
 				B297E1E820A12BDE00F370EC /* MSIDDefaultAccountCacheKey.m in Sources */,
@@ -3946,6 +3972,7 @@
 				B20657C31FC9262700412B7D /* NSString+MSIDTelemetryExtensions.m in Sources */,
 				2306D2B420AD05A700F875A3 /* MSIDURLSessionDelegate.m in Sources */,
 				600D19B320964CE70004CD43 /* MSIDPkeyAuthHelper.m in Sources */,
+				057B75C321BF430B00BE9DFD /* MSIDAccountCacheItem+Util.m in Sources */,
 				1E3C0ED7217FE2BF0022D61D /* MSIDAppMetadataCacheQuery.m in Sources */,
 				23B3A4532187AFD3009070B2 /* MSIDJsonSerializer.m in Sources */,
 				B20657AC1FC91FB100412B7D /* MSIDTelemetryPiiOiiRules.m in Sources */,
@@ -4297,6 +4324,7 @@
 				600D19BC20964D8C0004CD43 /* MSIDWorkPlaceJoinUtil.m in Sources */,
 				B251CC3C2041058D005E0179 /* MSIDAccessToken.m in Sources */,
 				B2DD4B2220A7D2F90047A66E /* MSIDLegacyAccessToken.m in Sources */,
+				057B75C221BF430B00BE9DFD /* MSIDAccountCacheItem+Util.m in Sources */,
 				23B3A44D21868766009070B2 /* MSIDCacheItemJsonSerializer.m in Sources */,
 				607123C1210FCAAD00B91068 /* MSIDAADAuthorityValidationRequest.m in Sources */,
 				B251CC4C204105A7005E0179 /* MSIDIdToken.m in Sources */,
@@ -4328,6 +4356,7 @@
 				B20657AD1FC91FB100412B7D /* MSIDTelemetryPiiOiiRules.m in Sources */,
 				B2C708842198DE0100D917B8 /* MSIDBrokerKeyProvider.m in Sources */,
 				23B39AB8209BC705000AA905 /* MSIDOpenIdProviderMetadata.m in Sources */,
+				057B75C721C04B4B00BE9DFD /* MSIDAccountCacheItem+ClientInfoUtil.m in Sources */,
 				960F915820CB4ABC0055A162 /* MSIDAADWebviewFactory.m in Sources */,
 				04930F851FEC8E6800FC4DCD /* MSIDAadAuthorityCache.m in Sources */,
 				B2AF1D39218BCF140080C1A0 /* MSIDRequestControllerFactory.m in Sources */,

--- a/IdentityCore/src/MSIDJsonSerializer.m
+++ b/IdentityCore/src/MSIDJsonSerializer.m
@@ -26,6 +26,7 @@
 #import "MSIDCredentialCacheItem.h"
 #import "MSIDCredentialCacheItem+MSIDBaseToken.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDAppMetadataCacheItem.h"
 
 @implementation MSIDJsonSerializer

--- a/IdentityCore/src/cache/MSIDMacTokenCache.m
+++ b/IdentityCore/src/cache/MSIDMacTokenCache.m
@@ -27,6 +27,7 @@
 #import "MSIDCredentialItemSerializer.h"
 #import "MSIDAccountItemSerializer.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDUserInformation.h"
 
 #define CURRENT_WRAPPER_CACHE_VERSION 1.0

--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
@@ -25,6 +25,7 @@
 #import "MSIDCredentialCacheItem.h"
 #import "MSIDCredentialCacheItem+MSIDBaseToken.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDDefaultCredentialCacheKey.h"
 #import "MSIDCacheItemJsonSerializer.h"
 #import "MSIDTokenCacheDataSource.h"

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -27,6 +27,7 @@
 #import "MSIDRefreshToken.h"
 #import "MSIDIdToken.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDAccountCredentialCache.h"
 #import "MSIDConfiguration.h"
 #import "MSIDOauth2Factory.h"

--- a/IdentityCore/src/cache/serializers/MSIDCacheItemJsonSerializer.m
+++ b/IdentityCore/src/cache/serializers/MSIDCacheItemJsonSerializer.m
@@ -27,6 +27,7 @@
 #import "MSIDCredentialCacheItem.h"
 #import "MSIDCredentialCacheItem+MSIDBaseToken.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDAppMetadataCacheItem.h"
 
 @interface MSIDCacheItemJsonSerializer()

--- a/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
+++ b/IdentityCore/src/cache/serializers/MSIDKeyedArchiverSerializer.m
@@ -26,6 +26,7 @@
 #import "MSIDCredentialCacheItem.h"
 #import "MSIDCredentialCacheItem+MSIDBaseToken.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDLegacyTokenCacheItem.h"
 #import "MSIDAppMetadataCacheItem.h"
 

--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem+ClientInfoUtil.h
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem+ClientInfoUtil.h
@@ -21,14 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "MSIDAccountCacheItem.h"
-#import "MSIDAccountCacheItem+Util.h"
-#import "MSIDAccountCacheItem+ClientInfoUtil.h"
-#import "MSIDClientInfo.h"
+@interface MSIDAccountCacheItem (ClientInfoUtil)
 
-@implementation MSIDAccountCacheItem
-
-// See MSIDAccountCacheItem+Util and MSIDAccountCacheItem+ClientInfoUtil
-// (Implementaiton moved to categories in order to facilitate integration with msalcpp.)
+-(void)setRawClientInfo:(nullable NSString*)rawClientInfo;
+-(nullable NSString *)rawClientInfo;
 
 @end

--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem+ClientInfoUtil.m
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem+ClientInfoUtil.m
@@ -22,13 +22,18 @@
 // THE SOFTWARE.
 
 #import "MSIDAccountCacheItem.h"
-#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDAccountCacheItem+ClientInfoUtil.h"
 #import "MSIDClientInfo.h"
 
-@implementation MSIDAccountCacheItem
+@implementation MSIDAccountCacheItem (ClientInfoUtil)
 
-// See MSIDAccountCacheItem+Util and MSIDAccountCacheItem+ClientInfoUtil
-// (Implementaiton moved to categories in order to facilitate integration with msalcpp.)
+-(void)setRawClientInfo:(NSString*)rawClientInfo
+{
+    self.clientInfo = [[MSIDClientInfo alloc] initWithRawClientInfo:rawClientInfo error:nil];
+}
 
+-(NSString *)rawClientInfo
+{
+    return self.clientInfo.rawClientInfo;
+}
 @end

--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem+Util.h
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem+Util.h
@@ -21,14 +21,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "MSIDAccountCacheItem.h"
-#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDAccountCacheItem+ClientInfoUtil.h"
-#import "MSIDClientInfo.h"
 
-@implementation MSIDAccountCacheItem
+@interface MSIDAccountCacheItem (Util) <NSCopying, MSIDJsonSerializable>
 
-// See MSIDAccountCacheItem+Util and MSIDAccountCacheItem+ClientInfoUtil
-// (Implementaiton moved to categories in order to facilitate integration with msalcpp.)
+- (BOOL)isEqual:(nullable id)object;
+
+- (BOOL)isEqualToItem:(nullable MSIDAccountCacheItem *)item;
+
+- (NSUInteger)hash;
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone;
+
+- (nonnull instancetype)initWithJSONDictionary:(nullable NSDictionary *)json error:(__unused NSError * __nullable * __nullable)error;
+
+- (nullable NSDictionary *)jsonDictionary;
+
+- (void)updateFieldsFromAccount:(nullable MSIDAccountCacheItem *)account;
+
+- (BOOL)matchesWithHomeAccountId:(nullable NSString *)homeAccountId
+                     environment:(nullable NSString *)environment
+              environmentAliases:(nullable NSArray<NSString *> *)environmentAliases;
 
 @end

--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem+Util.m
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem+Util.m
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDJsonSerializable.h"
+#import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
+#import "MSIDClientInfo.h"
+
+@implementation MSIDAccountCacheItem (Util)
+
+#pragma mark - Equal
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+    {
+        return YES;
+    }
+    
+    if (![object isKindOfClass:self.class])
+    {
+        return NO;
+    }
+    
+    return [self isEqualToItem:(MSIDAccountCacheItem *)object];
+}
+
+- (BOOL)isEqualToItem:(MSIDAccountCacheItem *)item
+{
+    BOOL result = YES;
+    result &= self.accountType == item.accountType;
+    result &= (!self.homeAccountId && !item.homeAccountId) || [self.homeAccountId isEqualToString:item.homeAccountId];
+    result &= (!self.localAccountId && !item.localAccountId) || [self.localAccountId isEqualToString:item.localAccountId];
+    result &= (!self.username && !item.username) || [self.username isEqualToString:item.username];
+    result &= (!self.givenName && !item.givenName) || [self.givenName isEqualToString:item.givenName];
+    result &= (!self.middleName && !item.middleName) || [self.middleName isEqualToString:item.middleName];
+    result &= (!self.familyName && !item.familyName) || [self.familyName isEqualToString:item.familyName];
+    result &= (!self.name && !item.name) || [self.name isEqualToString:item.name];
+    result &= (!self.realm && !item.realm) || [self.realm isEqualToString:item.realm];
+    result &= (!self.rawClientInfo && !item.rawClientInfo) || [self.rawClientInfo isEqualToString:item.rawClientInfo];
+    result &= (!self.environment && !item.environment) || [self.environment isEqualToString:item.environment];
+    result &= (!self.alternativeAccountId && !item.alternativeAccountId) || [self.alternativeAccountId isEqualToString:item.alternativeAccountId];
+    return result;
+}
+
+#pragma mark - NSObject
+
+- (NSUInteger)hash
+{
+    NSUInteger hash = [super hash];
+    hash = hash * 31 + self.accountType;
+    hash = hash * 31 + self.homeAccountId.hash;
+    hash = hash * 31 + self.localAccountId.hash;
+    hash = hash * 31 + self.username.hash;
+    hash = hash * 31 + self.givenName.hash;
+    hash = hash * 31 + self.middleName.hash;
+    hash = hash * 31 + self.familyName.hash;
+    hash = hash * 31 + self.name.hash;
+    hash = hash * 31 + self.realm.hash;
+    hash = hash * 31 + self.rawClientInfo.hash;
+    hash = hash * 31 + self.environment.hash;
+    hash = hash * 31 + self.alternativeAccountId.hash;
+    return hash;
+}
+
+#pragma mark - NSCopying
+
+- (nonnull id)copyWithZone:(NSZone *)zone
+{
+    MSIDAccountCacheItem *item = [[self class] allocWithZone:zone];
+    item.accountType = self.accountType;
+    item.homeAccountId = [self.homeAccountId copyWithZone:zone];
+    item.localAccountId = [self.localAccountId copyWithZone:zone];
+    item.username = [self.username copyWithZone:zone];
+    item.givenName = [self.givenName copyWithZone:zone];
+    item.middleName = [self.middleName copyWithZone:zone];
+    item.familyName = [self.familyName copyWithZone:zone];
+    item.name = [self.name copyWithZone:zone];
+    item.realm = [self.realm copyWithZone:zone];
+    item.rawClientInfo = [self.rawClientInfo copyWithZone:zone];
+    item.environment = [self.environment copyWithZone:zone];
+    item.alternativeAccountId = [self.alternativeAccountId copyWithZone:zone];
+    return item;
+}
+
+#pragma mark - JSON
+
+- (nonnull instancetype)initWithJSONDictionary:(nullable NSDictionary *)json error:(__unused NSError * __nullable * __nullable)error
+{
+    MSID_TRACE;
+    if (!(self = [super init]))
+    {
+        return nil;
+    }
+    
+    if (!json)
+    {
+        MSID_LOG_WARN(nil, @"Tried to decode an account cache item from nil json");
+        return nil;
+    }
+    
+    self.json = json;
+    
+    self.accountType = [MSIDAccountTypeHelpers accountTypeFromString:json[MSID_AUTHORITY_TYPE_CACHE_KEY]];
+    
+    if (!self.accountType)
+    {
+        MSID_LOG_WARN(nil, @"No account type present in the JSON for credential");
+        return nil;
+    }
+    
+    self.localAccountId = json[MSID_LOCAL_ACCOUNT_ID_CACHE_KEY];
+    self.homeAccountId = json[MSID_HOME_ACCOUNT_ID_CACHE_KEY];
+    self.username = json[MSID_USERNAME_CACHE_KEY];
+    self.givenName = json[MSID_GIVEN_NAME_CACHE_KEY];
+    self.middleName = json[MSID_MIDDLE_NAME_CACHE_KEY];
+    self.familyName = json[MSID_FAMILY_NAME_CACHE_KEY];
+    self.name = json[MSID_NAME_CACHE_KEY];
+    self.realm = json[MSID_REALM_CACHE_KEY];
+    self.rawClientInfo = json[MSID_CLIENT_INFO_CACHE_KEY];
+    self.environment = json[MSID_ENVIRONMENT_CACHE_KEY];
+    self.alternativeAccountId = json[MSID_ALTERNATIVE_ACCOUNT_ID_KEY];
+    return self;
+}
+
+- (nullable NSDictionary *)jsonDictionary
+{
+    MSID_TRACE;
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    
+    if (self.json)
+    {
+        [dictionary addEntriesFromDictionary:self.json];
+    }
+    
+    NSDictionary* additionalAccountFields = self.additionalAccountFields;
+    if (additionalAccountFields)
+    {
+        [dictionary addEntriesFromDictionary:additionalAccountFields];
+    }
+    
+    dictionary[MSID_AUTHORITY_TYPE_CACHE_KEY] = [MSIDAccountTypeHelpers accountTypeAsString:self.accountType];
+    dictionary[MSID_HOME_ACCOUNT_ID_CACHE_KEY] = self.homeAccountId;
+    dictionary[MSID_LOCAL_ACCOUNT_ID_CACHE_KEY] = self.localAccountId;
+    dictionary[MSID_USERNAME_CACHE_KEY] = self.username;
+    dictionary[MSID_GIVEN_NAME_CACHE_KEY] = self.givenName;
+    dictionary[MSID_MIDDLE_NAME_CACHE_KEY] = self.middleName;
+    dictionary[MSID_FAMILY_NAME_CACHE_KEY] = self.familyName;
+    dictionary[MSID_NAME_CACHE_KEY] = self.name;
+    dictionary[MSID_ENVIRONMENT_CACHE_KEY] = self.environment;
+    dictionary[MSID_REALM_CACHE_KEY] = self.realm;
+    dictionary[MSID_CLIENT_INFO_CACHE_KEY] = self.rawClientInfo;
+    dictionary[MSID_ALTERNATIVE_ACCOUNT_ID_KEY] = self.alternativeAccountId;
+    return dictionary;
+}
+
+#pragma mark - Update
+
+- (void)updateFieldsFromAccount:(nullable MSIDAccountCacheItem *)account
+{
+    NSMutableDictionary *allAdditionalFields = [NSMutableDictionary dictionary];
+    [allAdditionalFields addEntriesFromDictionary:account.additionalAccountFields];
+    [allAdditionalFields addEntriesFromDictionary:self.additionalAccountFields];
+    self.additionalAccountFields = allAdditionalFields;
+}
+
+#pragma mark - Query
+
+- (BOOL)matchesWithHomeAccountId:(nullable NSString *)homeAccountId
+                     environment:(nullable NSString *)environment
+              environmentAliases:(nullable NSArray<NSString *> *)environmentAliases
+{
+    if (homeAccountId && ![self.homeAccountId isEqualToString:homeAccountId])
+    {
+        return NO;
+    }
+    
+    if (environment && ![self.environment isEqualToString:environment])
+    {
+        return NO;
+    }
+    
+    if ([environmentAliases count] && ![self.environment msidIsEquivalentWithAnyAlias:environmentAliases])
+    {
+        return NO;
+    }
+    
+    return YES;
+}
+@end

--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem.h
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem.h
@@ -20,13 +20,15 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+#ifndef MSIDAccountCacheItem_H
+#define MSIDAccountCacheItem_H
 
 #import "MSIDAccountType.h"
 #import "MSIDJsonSerializable.h"
 
 @class MSIDClientInfo;
 
-@interface MSIDAccountCacheItem : NSObject <NSCopying, MSIDJsonSerializable>
+@interface MSIDAccountCacheItem : NSObject
 
 @property (readwrite) MSIDAccountType accountType;
 @property (readwrite, nonnull) NSString *homeAccountId;
@@ -43,10 +45,8 @@
 
 @property (readwrite, nullable) NSDictionary *additionalAccountFields;
 
-- (void)updateFieldsFromAccount:(nonnull MSIDAccountCacheItem *)account;
-
-- (BOOL)matchesWithHomeAccountId:(nullable NSString *)homeAccountId
-                     environment:(nullable NSString *)environment
-              environmentAliases:(nullable NSArray<NSString *> *)environmentAliases;
+@property (readwrite, nullable) NSDictionary *json;
 
 @end
+
+#endif // MSIDAccountCacheItem_H

--- a/IdentityCore/src/oauth2/account/MSIDAccount.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccount.m
@@ -26,6 +26,7 @@
 #import "MSIDAADTokenResponse.h"
 #import "MSIDIdTokenClaims.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDTokenResponse.h"
 #import "MSIDClientInfo.h"
 #import "MSIDClientInfo.h"

--- a/IdentityCore/tests/MSIDAccountCacheItemTests.m
+++ b/IdentityCore/tests/MSIDAccountCacheItemTests.m
@@ -23,6 +23,7 @@
 
 #import <XCTest/XCTest.h>
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDTestIdentifiers.h"
 #import "NSDictionary+MSIDTestUtil.h"
 #import "MSIDClientInfo.h"

--- a/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
+++ b/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
@@ -32,6 +32,7 @@
 #import "MSIDCredentialCacheItem.h"
 #import "MSIDTestIdTokenUtil.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDDefaultAccountCacheQuery.h"
 #import "MSIDTestCacheDataSource.h"
 #import "MSIDAppMetadataCacheItem.h"

--- a/IdentityCore/tests/MSIDAccountTests.m
+++ b/IdentityCore/tests/MSIDAccountTests.m
@@ -25,6 +25,7 @@
 #import "MSIDTestIdentifiers.h"
 #import "MSIDAccount.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "NSDictionary+MSIDTestUtil.h"
 #import "MSIDConfiguration.h"
 #import "MSIDTokenResponse.h"

--- a/IdentityCore/tests/MSIDCacheItemJsonSerializerTests.m
+++ b/IdentityCore/tests/MSIDCacheItemJsonSerializerTests.m
@@ -27,6 +27,7 @@
 #import "NSDictionary+MSIDTestUtil.h"
 #import "MSIDRefreshToken.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDAppMetadataCacheItem.h"
 
 @interface MSIDCacheItemJsonSerializerTests : XCTestCase

--- a/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
+++ b/IdentityCore/tests/MSIDKeyedArchiverSerializerTests.m
@@ -26,6 +26,7 @@
 #import "NSDictionary+MSIDTestUtil.h"
 #import "MSIDCredentialCacheItem.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDLegacyTokenCacheItem.h"
 #import "MSIDClientInfo.h"
 

--- a/IdentityCore/tests/integration/MSIDCacheSchemaValidationTests.m
+++ b/IdentityCore/tests/integration/MSIDCacheSchemaValidationTests.m
@@ -31,6 +31,7 @@
 #import "MSIDDefaultCredentialCacheKey.h"
 #import "MSIDDefaultAccountCacheKey.h"
 #import "MSIDAccountCacheItem.h"
+#import "MSIDAccountCacheItem+Util.h"
 #import "MSIDB2CTokenResponse.h"
 #import "MSIDB2COauth2Factory.h"
 #import "MSIDAppMetadataCacheItem.h"


### PR DESCRIPTION
These changes allow msalcpp to almost entirely reuse MSIDAccountCacheItem by moving it's methods into a category that can be shared. The clientInfo property is handled very differently between the two codebases, so it was moved into it's own category, which allows msalcpp to provide a different implementation of it's getter & setter.