### PR TITLE
[On hold] Updates to allow MSIDAccountCacheItem reuse in msalcpp

### DIFF
--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem.h
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem.h
@@ -20,6 +20,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+#ifndef MSIDAccountCacheItem_H
+#define MSIDAccountCacheItem_H
 
 #import "MSIDAccountType.h"
 #import "MSIDJsonSerializable.h"
@@ -49,4 +51,10 @@
                      environment:(nullable NSString *)environment
               environmentAliases:(nullable NSArray<NSString *> *)environmentAliases;
 
++ (nullable instancetype)accountWithJSONDictionary:(nullable NSDictionary *)jsonDictionary
+                                             error:(__unused NSError *__nullable *__nullable)error;
+
+- (void)setRawClientInfo:(nullable NSString *)base64String error:(NSError *__nullable *__nullable)error;
 @end
+
+#endif // MSIDAccountCacheItem_H

--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem.m
@@ -109,6 +109,11 @@
 
 #pragma mark - JSON
 
++ (instancetype)accountWithJSONDictionary:(nullable NSDictionary *)jsonDictionary
+                                    error:(__unused NSError *__nullable *__nullable)error {
+    return [[MSIDAccountCacheItem alloc] initWithJSONDictionary:jsonDictionary error:error];
+}
+
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
 {
     MSID_TRACE;
@@ -209,6 +214,11 @@
     }
 
     return YES;
+}
+
+- (void)setRawClientInfo:(NSString *)base64String error:(NSError**)error
+{
+    _clientInfo = [[MSIDClientInfo alloc] initWithRawClientInfo:base64String error:error];
 }
 
 @end

--- a/IdentityCore/src/oauth2/account/MSIDAccountType.h
+++ b/IdentityCore/src/oauth2/account/MSIDAccountType.h
@@ -20,6 +20,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+#ifndef MSIDAccountType_H
+#define MSIDAccountType_H
 
 #import <Foundation/Foundation.h>
 
@@ -37,3 +39,5 @@ typedef NS_ENUM(NSInteger, MSIDAccountType)
 + (MSIDAccountType)accountTypeFromString:(NSString *)type;
 
 @end
+
+#endif // MSIDAccountType_H

--- a/IdentityCore/tests/MSIDAccountCacheItemTests.m
+++ b/IdentityCore/tests/MSIDAccountCacheItemTests.m
@@ -87,8 +87,8 @@
                                      };
     
     NSError *error = nil;
-    MSIDAccountCacheItem *cacheItem = [[MSIDAccountCacheItem alloc] initWithJSONDictionary:jsonDictionary error:&error];
-    
+    MSIDAccountCacheItem *cacheItem = [MSIDAccountCacheItem accountWithJSONDictionary:jsonDictionary error:&error];
+
     XCTAssertNotNil(cacheItem);
     XCTAssertEqualObjects(cacheItem.environment, DEFAULT_TEST_ENVIRONMENT);
     XCTAssertEqualObjects(cacheItem.realm, @"contoso.com");
@@ -144,9 +144,7 @@
     firstAccount.name = @"test user";
     firstAccount.realm = @"contoso.com";
     NSString *base64String = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
-    NSError *error = nil;
-    MSIDClientInfo *clientInfo = [[MSIDClientInfo alloc] initWithRawClientInfo:base64String error:&error];
-    firstAccount.clientInfo = clientInfo;
+    [firstAccount setRawClientInfo:base64String error:nil];
     firstAccount.alternativeAccountId = @"alternative_clientID";
     firstAccount.additionalAccountFields = @{@"test": @"test2",
                                              @"test3": @"test4"};

--- a/IdentityCore/tests/MSIDAccountCacheItemTests.m
+++ b/IdentityCore/tests/MSIDAccountCacheItemTests.m
@@ -70,7 +70,7 @@
 
 #pragma mark - JSON deserialization
 
-- (void)testInitWithJSONDictionary_whenAccount_andAllFieldsSet_shouldAccountCacheItem
+- (void)testAccountWithJSONDictionary_whenAccount_andAllFieldsSet_shouldAccountCacheItem
 {
     NSDictionary *jsonDictionary = @{@"authority_type": @"AAD",
                                      @"environment": DEFAULT_TEST_ENVIRONMENT,


### PR DESCRIPTION
These updates allow MSIDAccountCacheItem reuse in msalcpp:
- Adds `setRawClientInfo` to accommodate a difference in the clientInfo property type.
- Adds `accountWithJSONDictionary` to accommodate initialization differences.
- Adds header `#ifdnef` protection in a couple of places to support overriding a few select headers with msalcpp-based customizations. Even with a custom include path the non-msalcpp headers get `#imported` in some cases and these prevent this problem.
- Updates the unit tests in `MSIDAccountCacheItemTests.m` to use the above changes. With the updates, these unit tests build and pass when part of an msalcpp build, and continue to pass when part of a msalobjc build.

