### PR TITLE
Added local account id into account identifier

### DIFF
--- a/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.h
+++ b/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(NSInteger, MSIDLegacyAccountIdentifierType)
 
 @property (nonatomic, readwrite) NSString *homeAccountId;
 @property (nonatomic, readwrite) NSString *legacyAccountId;
+@property (nonatomic, readwrite) NSString *localAccountId;
 @property (nonatomic, readwrite) MSIDLegacyAccountIdentifierType legacyAccountIdentifierType;
 @property (nonatomic, readwrite) NSString *uid;
 @property (nonatomic, readwrite) NSString *utid;

--- a/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.m
@@ -81,6 +81,7 @@
     account.legacyAccountId = [_legacyAccountId copyWithZone:zone];
     account.homeAccountId = [_homeAccountId copyWithZone:zone];
     account.legacyAccountIdentifierType = _legacyAccountIdentifierType;
+    account.localAccountId = [_localAccountId copyWithZone:zone];
     return account;
 }
 
@@ -106,6 +107,7 @@
     NSUInteger hash = 0;
     hash = hash * 31 + self.homeAccountId.hash;
     hash = hash * 31 + self.legacyAccountId.hash;
+    hash = hash * 31 + self.localAccountId.hash;
     hash = hash * 31 + self.legacyAccountIdentifierType;
     return hash;
 }
@@ -120,6 +122,7 @@
     BOOL result = YES;
     result &= (!self.homeAccountId && !account.homeAccountId) || [self.homeAccountId isEqualToString:account.homeAccountId];
     result &= (!self.legacyAccountId && !account.legacyAccountId) || [self.legacyAccountId isEqualToString:account.legacyAccountId];
+    result &= (!self.localAccountId && !account.localAccountId) || [self.localAccountId isEqualToString:account.localAccountId];
     result &= self.legacyAccountIdentifierType == account.legacyAccountIdentifierType;
     return result;
 }

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
@@ -81,7 +81,7 @@
 
         case MSIDLegacyIdentifierTypeUniqueNonDisplayableId:
         {
-            return [accountIdentifier.displayableId.lowercaseString isEqualToString:tokenResult.account.localAccountId.lowercaseString];
+            return [accountIdentifier.localAccountId.lowercaseString isEqualToString:tokenResult.account.localAccountId.lowercaseString];
         }
         case MSIDLegacyIdentifierTypeOptionalDisplayableId:
         {

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
@@ -81,7 +81,7 @@
 
         case MSIDLegacyIdentifierTypeUniqueNonDisplayableId:
         {
-            return [accountIdentifier.legacyAccountId.lowercaseString isEqualToString:tokenResult.account.localAccountId.lowercaseString];
+            return [accountIdentifier.localAccountId.lowercaseString isEqualToString:tokenResult.account.localAccountId.lowercaseString];
         }
         case MSIDLegacyIdentifierTypeOptionalDisplayableId:
         {


### PR DESCRIPTION
This is necessary to handle MSIDLegacyIdentifierTypeUniqueNonDisplayableId correctly for ADAL and broker. For MSIDLegacyIdentifierTypeUniqueNonDisplayableId cases, we should verify the result against this unique ID, but not use it for cache lookups. This, it makes sense to add a separate property for it.