### PR TITLE
Add MSIDStorageManager.h + stub impl for Mac.

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -996,6 +996,8 @@
 		04930F941FEDB2E000FC4DCD /* MSIDAuthority.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAuthority.m; sourceTree = "<group>"; };
 		04D32CB01FD6212F000B123E /* MSIDError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDError.h; sourceTree = "<group>"; };
 		04D32CB11FD62141000B123E /* MSIDError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDError.m; sourceTree = "<group>"; };
+		0544CA8B21ED1B5500A723E7 /* MSIDStorageManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MSIDStorageManager.h; path = src/cache/MSIDStorageManager.h; sourceTree = "<group>"; };
+		0544CA8C21ED1B5500A723E7 /* MSIDStorageManagerMac.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MSIDStorageManagerMac.m; path = src/cache/MSIDStorageManagerMac.m; sourceTree = "<group>"; };
 		0570FE7C219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MSIDCredentialCacheItem+MSIDBaseToken.m"; sourceTree = "<group>"; };
 		0570FE7D219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDCredentialCacheItem+MSIDBaseToken.h"; sourceTree = "<group>"; };
 		1E2EDFF8219125400054FAD9 /* MSIDTokenResponse+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDTokenResponse+Internal.h"; sourceTree = "<group>"; };
@@ -2878,6 +2880,8 @@
 		D68FB47E1FBA698A005308BB = {
 			isa = PBXGroup;
 			children = (
+				0544CA8B21ED1B5500A723E7 /* MSIDStorageManager.h */,
+				0544CA8C21ED1B5500A723E7 /* MSIDStorageManagerMac.m */,
 				D6DA89721FBA6A4E004C56C7 /* src */,
 				D6DA89731FBA6A4E004C56C7 /* tests */,
 				D626FF751FBA7A6600EE4487 /* xcconfig */,

--- a/IdentityCore/src/cache/MSIDStorageManager.h
+++ b/IdentityCore/src/cache/MSIDStorageManager.h
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@class MSIDCredentialCacheItem;
+@class MSIDAccountCacheItem;
+
+@interface MSIDStorageManager : NSObject
+
+/**
+ * Gets all credentials which match the parameters. May return a partial list of credentials
+ * if failed to read all of them, in which case the error result may be set.
+ * correlationId: optional
+ * homeAccountId: required
+ * environment: required
+ * realm: optional. Empty string means "match all".
+ * clientId: required
+ * target: optional. Empty string means "match all".
+ * type: required. It's a collection of types. The API should return all types which are present in the set.
+ * error: optional
+ */
+- (nullable NSArray<MSIDCredentialCacheItem *> *)readCredentials:(nullable NSString *)correlationId
+                                                   homeAccountId:(nullable NSString *)homeAccountId
+                                                     environment:(nullable NSString *)environment
+                                                           realm:(nullable NSString *)realm
+                                                        clientId:(nullable NSString *)clientId
+                                                          target:(nullable NSString *)target
+                                                           types:(nullable NSSet<NSNumber *> *)types
+                                                           error:(NSError *_Nullable *_Nullable)error;
+
+/**
+ * Writes all credentials in the list to the storage.
+ * correlationId: optional
+ * credentials: the list of credentials to write. They don't have to fall under the same environment, account, or user.
+ * error: optional
+ */
+- (BOOL)writeCredentials:(nullable NSString *)correlationId
+             credentials:(nullable NSArray<MSIDCredentialCacheItem *> *)credentials
+                   error:(NSError *_Nullable *_Nullable)error;
+
+/** Deletes all matching credentials. Parameters mirror read_credentials. */
+- (BOOL)deleteCredentials:(nullable NSString *)correlationId
+            homeAccountId:(nullable NSString *)homeAccountId
+              environment:(nullable NSString *)environment
+                    realm:(nullable NSString *)realm
+                 clientId:(nullable NSString *)clientId
+                   target:(nullable NSString *)target
+                    types:(nullable NSSet<NSNumber *> *)types
+                    error:(NSError *_Nullable *_Nullable)error;
+
+/**
+ * Reads all accounts present in the cache. May return a partial list of accounts if failed
+ * to read all of them, in which case the error result may be set.
+ * correlationId: optional
+ * error: optional
+ */
+- (nullable NSArray<MSIDAccountCacheItem *> *)readAllAccounts:(nullable NSString *)correlationId
+                                                        error:(NSError *_Nullable *_Nullable)error;
+
+/**
+ * Reads an account object, if present. If account is not present in the cache, error is nil
+ * with "account" being nil.
+ * correlationId: optional
+ * homeAccountId: required
+ * environment: required
+ * realm: required
+ * error: optional
+ */
+- (nullable MSIDAccountCacheItem *)readAccount:(nullable NSString *)correlationId
+                                 homeAccountId:(nullable NSString *)homeAccountId
+                                   environment:(nullable NSString *)environment
+                                         realm:(nullable NSString *)realm
+                                         error:(NSError *_Nullable *_Nullable)error;
+
+/**
+ * Write an account object into cache. A non-nil error means that the account wasn't written.
+ * correlationId: optional
+ * account: required
+ * error: optional
+ */
+- (BOOL)writeAccount:(nullable NSString *)correlationId
+             account:(nullable MSIDAccountCacheItem *)account
+               error:(NSError *_Nullable *_Nullable)error;
+
+/**
+ * Deletes an account and all associated credentials.
+ * Specifically, it removes all associated access tokens and id tokens.
+ * It does not remove any refresh tokens or family refresh tokens, because those are associated with multiple accounts.
+ * correlationId: optional
+ * homeAccountId: required
+ * environment: required
+ * realm: required
+ * error: optional
+ */
+- (BOOL)deleteAccount:(nullable NSString *)correlationId
+        homeAccountId:(nullable NSString *)homeAccountId
+          environment:(nullable NSString *)environment
+                realm:(nullable NSString *)realm
+                error:(NSError *_Nullable *_Nullable)error;
+
+/**
+ * Deletes all information associated with a given homeAccountId and environment.
+ * This includes all accounts, access tokens, id tokens, refresh tokens, and family refresh tokens.
+ * correlationId: optional
+ * homeAccountId: required
+ * environment: optional. Empty string means "match all".
+ * error: optional
+ */
+- (BOOL)deleteAccounts:(nullable NSString *)correlationId
+         homeAccountId:(nullable NSString *)homeAccountId
+           environment:(nullable NSString *)environment
+                 error:(NSError *_Nullable *_Nullable)error;
+
+@end

--- a/IdentityCore/src/cache/MSIDStorageManagerMac.m
+++ b/IdentityCore/src/cache/MSIDStorageManagerMac.m
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDAccountType.h"
+#import "MSIDAccountCacheItem.h"
+#import "MSIDCredentialCacheItem.h"
+#import "MSIDLogger.h"
+#import "MSIDStorageManager.h"
+#import "MSIDCredentialType.h"
+
+@implementation MSIDStorageManager
+
+/** Gets all credentials which match the parameters. */
+- (nullable NSArray<MSIDCredentialCacheItem *> *)readCredentials:(nullable __unused NSString *)correlationId
+                                                   homeAccountId:(nullable __unused NSString *)homeAccountId
+                                                     environment:(nullable __unused NSString *)environment
+                                                           realm:(nullable __unused NSString *)realm
+                                                        clientId:(nullable __unused NSString *)clientId
+                                                          target:(nullable __unused NSString *)target
+                                                           types:(nullable __unused NSSet<NSNumber *> *)types
+                                                           error:(__unused NSError *_Nullable *_Nullable)error {
+    return nil;
+}
+
+/** Writes all credentials in the list to the storage. */
+- (BOOL)writeCredentials:(nullable __unused NSString *)correlationId
+             credentials:(nullable __unused NSArray<MSIDCredentialCacheItem *> *)credentials
+                   error:(NSError __unused *_Nullable *_Nullable)error {
+    return TRUE;
+}
+
+/** Deletes all matching credentials. Parameters mirror read_credentials. */
+- (BOOL)deleteCredentials:(nullable __unused NSString *)correlationId
+            homeAccountId:(nullable __unused NSString *)homeAccountId
+              environment:(nullable __unused NSString *)environment
+                    realm:(nullable __unused NSString *)realm
+                 clientId:(nullable __unused NSString *)clientId
+                   target:(nullable __unused NSString *)target
+                    types:(nullable __unused NSSet<NSNumber *> *)types
+                    error:(__unused NSError *_Nullable *_Nullable)error {
+    return TRUE;
+}
+
+/** Reads all accounts present in the cache. */
+- (nullable NSArray<MSIDAccountCacheItem *> *)readAllAccounts:(nullable __unused NSString *)correlationId
+                                                        error:(__unused NSError *_Nullable *_Nullable)error {
+    return nil;
+}
+
+/** Reads an account object, if present. */
+- (nullable MSIDAccountCacheItem *)readAccount:(nullable __unused NSString *)correlationId
+                                 homeAccountId:(nullable __unused NSString *)homeAccountId
+                                   environment:(nullable __unused NSString *)environment
+                                         realm:(nullable __unused NSString *)realm
+                                         error:(__unused NSError *_Nullable *_Nullable)error {
+    return nil;
+}
+
+/** Write an account object into cache. */
+- (BOOL)writeAccount:(nullable __unused NSString *)correlationId
+             account:(nullable __unused MSIDAccountCacheItem *)account
+               error:(__unused NSError *_Nullable *_Nullable)error {
+    return TRUE;
+}
+
+/** Deletes an account and all associated credentials. */
+- (BOOL)deleteAccount:(nullable __unused NSString *)correlationId
+        homeAccountId:(nullable __unused NSString *)homeAccountId
+          environment:(nullable __unused NSString *)environment
+                realm:(nullable __unused NSString *)realm
+                error:(__unused NSError *_Nullable *_Nullable)error {
+    return TRUE;
+}
+
+/** Deletes all information associated with a given homeAccountId and environment. */
+- (BOOL)deleteAccounts:(nullable __unused NSString *)correlationId
+         homeAccountId:(nullable __unused NSString *)homeAccountId
+           environment:(nullable __unused NSString *)environment
+                 error:(__unused NSError *_Nullable *_Nullable)error {
+    return TRUE;
+}
+
+@end


### PR DESCRIPTION
Shows a proposed low-level storage API, intended to be potentially usable by both MSAL/C++ and MSAL/Obj-C for Mac keychain-based storage. The implementation is just a stub.