### PR TITLE
 Modifying extra query params logic to differentiate between authorize and token request extra query parameters

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -568,6 +568,8 @@
 		B26A0B942072B824006BD95A /* MSIDAADOauth2FactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B26A0B922072B824006BD95A /* MSIDAADOauth2FactoryTests.m */; };
 		B26A0B972072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B26A0B952072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m */; };
 		B26A0B9A2072BABE006BD95A /* MSIDAADV2Oauth2FactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B26A0B982072BABD006BD95A /* MSIDAADV2Oauth2FactoryTests.m */; };
+		B274DEC721FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */; };
+		B274DEC821FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */; };
 		B27551C22081705300AA7A38 /* MSIDJWTHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7590C207EE9A400C1FE74 /* MSIDJWTHelper.m */; };
 		B27551C32081705300AA7A38 /* MSIDJWTHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7590C207EE9A400C1FE74 /* MSIDJWTHelper.m */; };
 		B27551DE20817A5E00AA7A38 /* MSIDClientCredentialHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = B2C75907207EE5C900C1FE74 /* MSIDClientCredentialHelper.h */; };
@@ -1444,6 +1446,7 @@
 		B26A0B922072B824006BD95A /* MSIDAADOauth2FactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADOauth2FactoryTests.m; sourceTree = "<group>"; };
 		B26A0B952072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV1Oauth2FactoryTests.m; sourceTree = "<group>"; };
 		B26A0B982072BABD006BD95A /* MSIDAADV2Oauth2FactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV2Oauth2FactoryTests.m; sourceTree = "<group>"; };
+		B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDInteractiveRequestParametersTests.m; sourceTree = "<group>"; };
 		B27551AF20816B4800AA7A38 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		B27551C8208179EE00AA7A38 /* libIdentityAutomation iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIdentityAutomation iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B27551D520817A1E00AA7A38 /* libIdentityAutomation Mac.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "libIdentityAutomation Mac.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3079,6 +3082,7 @@
 				B2BE923321A0F80000F5AB8C /* MSIDLegacyTokenRequestProviderTests.m */,
 				B25D496321B4BE2A00502BE5 /* MSIDRequestParametersTests.m */,
 				23D204A421D5A745009B5975 /* MSIDDefaultTokenResponseValidatorTests.m */,
+				B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -3648,6 +3652,7 @@
 				B279835A20D33A0A0051167F /* MSIDIdTokenClaimsTests.m in Sources */,
 				B2BE926121A25A8600F5AB8C /* MSIDInteractiveControllerIntegrationTests.m in Sources */,
 				B2544EEB21684B2B00B4C108 /* MSIDCacheSchemaValidationTests.m in Sources */,
+				B274DEC721FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */,
 				B2936F4F20AA908F0050C585 /* MSIDCredentialCacheItemTests.m in Sources */,
 				606B108B20D084B600B34224 /* MSIDAADV1WebviewFactoryTests.m in Sources */,
 				B2936F7520ABF4940050C585 /* MSIDIdTokenTests.m in Sources */,
@@ -4045,6 +4050,7 @@
 				2361DE8C2048B6F8005FD48A /* MSIDAccountTests.m in Sources */,
 				B2DD5BA5204761720084313F /* MSIDRefreshTokenTests.m in Sources */,
 				23AE9DBC2148574F00B285F3 /* MSIDErrorExtensionsTests.m in Sources */,
+				B274DEC821FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */,
 				9686C72E21192C65001FFF51 /* MSIDWebOpenBrowserResponseTests.m in Sources */,
 				B280800B204CD81400944D89 /* MSIDLegacyCacheKeyTests.m in Sources */,
 				B210F44F1FDDF5D2005A8F76 /* MSIDClientInfoTests.m in Sources */,

--- a/IdentityCore/src/configuration/webview/MSIDWebviewConfiguration.h
+++ b/IdentityCore/src/configuration/webview/MSIDWebviewConfiguration.h
@@ -44,7 +44,6 @@
 @property (readwrite) NSUUID *correlationId;
 
 @property (readwrite) NSDictionary<NSString *, NSString *> *extraQueryParameters;
-@property (readwrite) NSDictionary<NSString *, NSString *> *sliceParameters;
 @property (readwrite) NSString *promptBehavior;
 @property (readwrite) NSString *claims;
 

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.h
@@ -38,6 +38,7 @@
                                        code:(nonnull NSString *)code
                                      claims:(nullable NSString *)claims
                                codeVerifier:(nullable NSString *)codeVerifier
+                            extraParameters:(nullable NSDictionary *)extraParameters
                                     context:(nullable id<MSIDRequestContext>)context;
 
 @end

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
@@ -34,6 +34,7 @@
                             code:(NSString *)code
                           claims:(NSString *)claims
                     codeVerifier:(NSString *)codeVerifier
+                 extraParameters:(NSDictionary *)extraParameters
                          context:(nullable id<MSIDRequestContext>)context
 {
     self = [super initWithEndpoint:endpoint
@@ -43,6 +44,7 @@
                               code:code
                             claims:claims
                       codeVerifier:codeVerifier
+                   extraParameters:extraParameters
                            context:context];
     if (self)
     {

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
@@ -36,6 +36,7 @@
                                      scope:(nullable NSString *)scope
                               refreshToken:(nonnull NSString *)refreshToken
                                     claims:(nullable NSString *)claims
+                           extraParameters:(nullable NSDictionary *)extraParameters
                                    context:(nullable id<MSIDRequestContext>)context;
 
 @end

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
@@ -32,9 +32,10 @@
                            scope:(NSString *)scope
                     refreshToken:(NSString *)refreshToken
                           claims:(NSString *)claims
+                 extraParameters:(NSDictionary *)extraParameters
                          context:(nullable id<MSIDRequestContext>)context
 {
-    self = [super initWithEndpoint:endpoint clientId:clientId scope:scope refreshToken:refreshToken context:context];
+    self = [super initWithEndpoint:endpoint clientId:clientId scope:scope refreshToken:refreshToken extraParameters:extraParameters context:context];
     if (self)
     {
         __auto_type requestConfigurator = [MSIDAADRequestConfigurator new];

--- a/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.h
@@ -31,6 +31,7 @@
                                       scope:(nullable NSString *)scope
                                refreshToken:(nonnull NSString *)refreshToken
                                    resource:(nonnull NSString *)resource
+                            extraParameters:(nullable NSDictionary *)extraParameters
                                     context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable )initWithEndpoint:(nonnull NSURL *)endpoint

--- a/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.m
@@ -30,9 +30,10 @@
                            scope:(NSString *)scope
                     refreshToken:(NSString *)refreshToken
                         resource:(NSString *)resource
+                 extraParameters:(NSDictionary *)extraParameters
                          context:(nullable id<MSIDRequestContext>)context
 {
-    self = [super initWithEndpoint:endpoint clientId:clientId scope:scope refreshToken:refreshToken context:context];
+    self = [super initWithEndpoint:endpoint clientId:clientId scope:scope refreshToken:refreshToken extraParameters:extraParameters context:context];
     if (self)
     {
         NSParameterAssert(resource);

--- a/IdentityCore/src/network/request/MSIDAuthorizationCodeGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAuthorizationCodeGrantRequest.h
@@ -32,6 +32,7 @@
                                        code:(nonnull NSString *)code
                                      claims:(nullable NSString *)claims
                                codeVerifier:(nullable NSString *)codeVerifier
+                            extraParameters:(nullable NSDictionary *)extraParameters
                                     context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable )initWithEndpoint:(nonnull NSURL *)endpoint

--- a/IdentityCore/src/network/request/MSIDAuthorizationCodeGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAuthorizationCodeGrantRequest.m
@@ -32,6 +32,7 @@
                             code:(NSString *)code
                           claims:(NSString *)claims
                     codeVerifier:(NSString *)codeVerifier
+                 extraParameters:(NSDictionary *)extraParameters
                          context:(nullable id<MSIDRequestContext>)context
 {
     self = [super initWithEndpoint:endpoint clientId:clientId scope:scope context:context];
@@ -46,6 +47,12 @@
         parameters[MSID_OAUTH2_CODE] = code;
         parameters[MSID_OAUTH2_CODE_VERIFIER] = codeVerifier;
         parameters[MSID_OAUTH2_CLAIMS] = claims;
+        
+        if (extraParameters)
+        {
+            [parameters addEntriesFromDictionary:extraParameters];
+        }
+        
         _parameters = parameters;
     }
     

--- a/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.h
@@ -29,6 +29,7 @@
                                   clientId:(nonnull NSString *)clientId
                                      scope:(nullable NSString *)scope
                               refreshToken:(nonnull NSString *)refreshToken
+                           extraParameters:(nullable NSDictionary *)extraParameters
                                    context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable)initWithEndpoint:(nonnull NSURL *)endpoint

--- a/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.m
@@ -25,11 +25,12 @@
 
 @implementation MSIDRefreshTokenGrantRequest
 
-- (instancetype)initWithEndpoint:(NSURL *)endpoint
-                        clientId:(NSString *)clientId
-                           scope:(NSString *)scope
-                    refreshToken:(NSString *)refreshToken
-                         context:(nullable id<MSIDRequestContext>)context
+- (instancetype _Nullable)initWithEndpoint:(nonnull NSURL *)endpoint
+                                  clientId:(nonnull NSString *)clientId
+                                     scope:(nullable NSString *)scope
+                              refreshToken:(nonnull NSString *)refreshToken
+                           extraParameters:(nullable NSDictionary *)extraParameters
+                                   context:(nullable id<MSIDRequestContext>)context
 {
     self = [super initWithEndpoint:endpoint clientId:clientId scope:scope context:context];
     if (self)
@@ -39,6 +40,12 @@
         NSMutableDictionary *parameters = [_parameters mutableCopy];
         parameters[MSID_OAUTH2_GRANT_TYPE] = MSID_OAUTH2_REFRESH_TOKEN;
         parameters[MSID_OAUTH2_REFRESH_TOKEN] = refreshToken;
+        
+        if (extraParameters)
+        {
+            [parameters addEntriesFromDictionary:extraParameters];
+        }
+        
         _parameters = parameters;
     }
     

--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.m
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.m
@@ -405,6 +405,7 @@
                                                                                                              code:authCode
                                                                                                            claims:claims
                                                                                                      codeVerifier:pkceCodeVerifier
+                                                                                                  extraParameters:parameters.extraTokenRequestParameters
                                                                                                           context:parameters];
     tokenRequest.responseSerializer = [[MSIDTokenResponseSerializer alloc] initWithOauth2Factory:self];
     

--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.m
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.m
@@ -420,9 +420,8 @@
                                                                                                clientId:parameters.clientId
                                                                                                   scope:allScopes
                                                                                            refreshToken:refreshToken
-                                                                                        extraParameters:parameters.additionalRequestParameters
+                                                                                        extraParameters:parameters.extraTokenRequestParameters
                                                                                                 context:parameters];
-    // TODO: add extra query parameters here
     tokenRequest.responseSerializer = [[MSIDTokenResponseSerializer alloc] initWithOauth2Factory:self];
     
     return tokenRequest;

--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.m
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.m
@@ -420,7 +420,9 @@
                                                                                                clientId:parameters.clientId
                                                                                                   scope:allScopes
                                                                                            refreshToken:refreshToken
+                                                                                        extraParameters:parameters.additionalRequestParameters
                                                                                                 context:parameters];
+    // TODO: add extra query parameters here
     tokenRequest.responseSerializer = [[MSIDTokenResponseSerializer alloc] initWithOauth2Factory:self];
     
     return tokenRequest;

--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.m
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.m
@@ -186,8 +186,7 @@
     NSString *promptParam = MSIDPromptParamFromType(parameters.promptType);
     configuration.promptBehavior = promptParam;
     configuration.loginHint = parameters.accountIdentifier.displayableId ?: parameters.loginHint;
-    configuration.extraQueryParameters = parameters.extraQueryParameters;
-    configuration.sliceParameters = parameters.sliceParameters;
+    configuration.extraQueryParameters = parameters.allAuthorizeRequestExtraParameters;
     configuration.customHeaders = parameters.customWebviewHeaders;
 #if TARGET_OS_IPHONE
     configuration.parentController = parameters.parentViewController;

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
@@ -55,11 +55,6 @@
            }];
     }
     
-    if (configuration.sliceParameters)
-    {
-        [parameters addEntriesFromDictionary:configuration.sliceParameters];
-    }
-    
     parameters[@"haschrome"] = @"1";
     parameters[MSID_OAUTH2_CLAIMS] = configuration.claims;
     [parameters addEntriesFromDictionary:MSIDDeviceId.deviceId];

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -258,7 +258,7 @@
                                                                                                         scope:allScopes
                                                                                                  refreshToken:refreshToken
                                                                                                        claims:claims
-                                                                                              extraParameters:parameters.additionalRequestParameters
+                                                                                              extraParameters:parameters.extraTokenRequestParameters
                                                                                                       context:parameters];
     tokenRequest.responseSerializer = [[MSIDAADTokenResponseSerializer alloc] initWithOauth2Factory:self];
 

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -234,6 +234,7 @@
                                                                                                                    code:authCode
                                                                                                                  claims:claims
                                                                                                            codeVerifier:pkceCodeVerifier
+                                                                                                        extraParameters:parameters.extraTokenRequestParameters
                                                                                                                 context:parameters];
     tokenRequest.responseSerializer = [[MSIDAADTokenResponseSerializer alloc] initWithOauth2Factory:self];
 

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -258,6 +258,7 @@
                                                                                                         scope:allScopes
                                                                                                  refreshToken:refreshToken
                                                                                                        claims:claims
+                                                                                              extraParameters:parameters.additionalRequestParameters
                                                                                                       context:parameters];
     tokenRequest.responseSerializer = [[MSIDAADTokenResponseSerializer alloc] initWithOauth2Factory:self];
 

--- a/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.h
@@ -42,8 +42,8 @@
 #endif
 @property (nonatomic) NSString *extraScopesToConsent;
 @property (nonatomic) MSIDPromptType promptType;
-// Additional request parameters that will only be appended to authorize requests in addition to additionalParameters from parent class
-@property (nonatomic) NSDictionary *authorizeEndpointParameters;
+// Additional request parameters that will only be appended to authorize requests in addition to extraURLQueryParameters from parent class
+@property (nonatomic) NSDictionary *extraAuthorizeURLQueryParameters;
 @property (nonatomic) NSString *telemetryWebviewType;
 @property (nonatomic) NSString *supportedBrokerProtocolScheme;
 @property (nonatomic) BOOL enablePkce;

--- a/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.h
@@ -42,12 +42,14 @@
 #endif
 @property (nonatomic) NSString *extraScopesToConsent;
 @property (nonatomic) MSIDPromptType promptType;
-@property (nonatomic) NSDictionary *extraQueryParameters;
+// Additional request parameters that will only be appended to authorize requests in addition to additionalParameters from parent class
+@property (nonatomic) NSDictionary *authorizeEndpointParameters;
 @property (nonatomic) NSString *telemetryWebviewType;
 @property (nonatomic) NSString *supportedBrokerProtocolScheme;
 @property (nonatomic) BOOL enablePkce;
 
 - (NSOrderedSet *)allAuthorizeRequestScopes;
+- (NSDictionary *)allAuthorizeRequestExtraParameters;
 
 // Initialize parameters with extra scopes, and interactive request type
 - (instancetype)initWithAuthority:(MSIDAuthority *)authority

--- a/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.m
@@ -72,6 +72,11 @@
 
 - (NSDictionary *)allAuthorizeRequestExtraParameters
 {
+    if (!self.authorizeEndpointParameters && !self.additionalRequestParameters)
+    {
+        return nil;
+    }
+    
     NSMutableDictionary *authorizeParams = [[NSMutableDictionary alloc] initWithDictionary:self.authorizeEndpointParameters];
     [authorizeParams addEntriesFromDictionary:self.additionalRequestParameters];
     return authorizeParams;

--- a/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.m
@@ -72,13 +72,13 @@
 
 - (NSDictionary *)allAuthorizeRequestExtraParameters
 {
-    if (!self.authorizeEndpointParameters && !self.additionalRequestParameters)
+    if (!self.extraAuthorizeURLQueryParameters && !self.extraURLQueryParameters)
     {
         return nil;
     }
     
-    NSMutableDictionary *authorizeParams = [[NSMutableDictionary alloc] initWithDictionary:self.authorizeEndpointParameters];
-    [authorizeParams addEntriesFromDictionary:self.additionalRequestParameters];
+    NSMutableDictionary *authorizeParams = [[NSMutableDictionary alloc] initWithDictionary:self.extraAuthorizeURLQueryParameters];
+    [authorizeParams addEntriesFromDictionary:self.extraURLQueryParameters];
     return authorizeParams;
 }
 
@@ -91,7 +91,7 @@
         return NO;
     }
 
-    if ([self.claims count] && self.authorizeEndpointParameters[MSID_OAUTH2_CLAIMS])
+    if ([self.claims count] && self.allAuthorizeRequestExtraParameters[MSID_OAUTH2_CLAIMS])
     {
         MSIDFillAndLogError(error, MSIDErrorInvalidDeveloperParameter, @"Duplicate claims parameter is found in extraQueryParameters. Please remove it.", nil);
         return NO;

--- a/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.m
@@ -70,6 +70,13 @@
     return requestScopes;
 }
 
+- (NSDictionary *)allAuthorizeRequestExtraParameters
+{
+    NSMutableDictionary *authorizeParams = [[NSMutableDictionary alloc] initWithDictionary:self.authorizeEndpointParameters];
+    [authorizeParams addEntriesFromDictionary:self.additionalRequestParameters];
+    return authorizeParams;
+}
+
 - (BOOL)validateParametersWithError:(NSError **)error
 {
     BOOL result = [super validateParametersWithError:error];
@@ -79,7 +86,7 @@
         return NO;
     }
 
-    if ([self.claims count] && self.extraQueryParameters[MSID_OAUTH2_CLAIMS])
+    if ([self.claims count] && self.authorizeEndpointParameters[MSID_OAUTH2_CLAIMS])
     {
         MSIDFillAndLogError(error, MSIDErrorInvalidDeveloperParameter, @"Duplicate claims parameter is found in extraQueryParameters. Please remove it.", nil);
         return NO;

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -41,7 +41,8 @@
 @property (nonatomic) NSString *oidcScope;
 @property (nonatomic) MSIDAccountIdentifier *accountIdentifier;
 @property (nonatomic) BOOL validateAuthority;
-@property (nonatomic) NSDictionary *sliceParameters;
+// Additional query parameters that will be appended for both token and authorize requests
+@property (nonatomic) NSDictionary *additionalRequestParameters;
 @property (nonatomic) NSUInteger tokenExpirationBuffer;
 @property (nonatomic) BOOL extendedLifetimeEnabled;
 

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -41,8 +41,10 @@
 @property (nonatomic) NSString *oidcScope;
 @property (nonatomic) MSIDAccountIdentifier *accountIdentifier;
 @property (nonatomic) BOOL validateAuthority;
-// Additional query parameters that will be appended for both token and authorize requests
-@property (nonatomic) NSDictionary *additionalRequestParameters;
+// Additional body parameters that will be appended to all token requests
+@property (nonatomic) NSDictionary *extraTokenRequestParameters;
+// Additional URL query parameters that will be added to both token and authorize requests
+@property (nonatomic) NSDictionary *extraURLQueryParameters;
 @property (nonatomic) NSUInteger tokenExpirationBuffer;
 @property (nonatomic) BOOL extendedLifetimeEnabled;
 

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -131,9 +131,9 @@
         endpointQPs = [NSMutableDictionary dictionary];
     }
 
-    if (self.sliceParameters)
+    if (self.additionalRequestParameters)
     {
-        [endpointQPs addEntriesFromDictionary:self.sliceParameters];
+        [endpointQPs addEntriesFromDictionary:self.additionalRequestParameters];
     }
 
     tokenEndpoint.query = [endpointQPs msidWWWFormURLEncode];

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -131,9 +131,9 @@
         endpointQPs = [NSMutableDictionary dictionary];
     }
 
-    if (self.additionalRequestParameters)
+    if (self.extraURLQueryParameters)
     {
-        [endpointQPs addEntriesFromDictionary:self.additionalRequestParameters];
+        [endpointQPs addEntriesFromDictionary:self.extraURLQueryParameters];
     }
 
     tokenEndpoint.query = [endpointQPs msidWWWFormURLEncode];

--- a/IdentityCore/src/requests/MSIDBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDBrokerTokenRequest.m
@@ -146,7 +146,7 @@
     NSString *claimsString = [self claimsParameter];
     NSString *clientAppName = clientMetadata[MSID_APP_NAME_KEY];
     NSString *clientAppVersion = clientMetadata[MSID_APP_VER_KEY];
-    NSString *extraQueryParameters = [self.requestParameters.extraQueryParameters count] ? [self.requestParameters.extraQueryParameters msidWWWFormURLEncode] : @"";
+    NSString *extraQueryParameters = [self.requestParameters.authorizeEndpointParameters count] ? [self.requestParameters.authorizeEndpointParameters msidWWWFormURLEncode] : @"";
 
     NSMutableDictionary *queryDictionary = [NSMutableDictionary new];
     [queryDictionary msidSetNonEmptyString:self.requestParameters.authority.url.absoluteString forKey:@"authority"];

--- a/IdentityCore/src/requests/MSIDBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDBrokerTokenRequest.m
@@ -146,7 +146,7 @@
     NSString *claimsString = [self claimsParameter];
     NSString *clientAppName = clientMetadata[MSID_APP_NAME_KEY];
     NSString *clientAppVersion = clientMetadata[MSID_APP_VER_KEY];
-    NSString *extraQueryParameters = [self.requestParameters.authorizeEndpointParameters count] ? [self.requestParameters.authorizeEndpointParameters msidWWWFormURLEncode] : @"";
+    NSString *extraQueryParameters = [self.requestParameters.extraAuthorizeURLQueryParameters count] ? [self.requestParameters.extraAuthorizeURLQueryParameters msidWWWFormURLEncode] : @"";
 
     NSMutableDictionary *queryDictionary = [NSMutableDictionary new];
     [queryDictionary msidSetNonEmptyString:self.requestParameters.authority.url.absoluteString forKey:@"authority"];

--- a/IdentityCore/tests/MSIDAADV1WebviewFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADV1WebviewFactoryTests.m
@@ -65,7 +65,6 @@
     config.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     config.promptBehavior = @"login";
     config.claims = @"claims";
-    config.sliceParameters = DEFAULT_TEST_SLICE_PARAMS_DICT;
     config.loginHint = @"fakeuser@contoso.com";
     
     NSString *requestState = @"state";
@@ -92,7 +91,6 @@
                                           }];
     
     [expectedQPs addEntriesFromDictionary:[MSIDDeviceId deviceId]];
-    [expectedQPs addEntriesFromDictionary:DEFAULT_TEST_SLICE_PARAMS_DICT];
     
     XCTAssertTrue([expectedQPs compareAndPrintDiff:params]);
 }
@@ -112,7 +110,6 @@
     config.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     config.promptBehavior = @"login";
     config.claims = @"claims";
-    config.sliceParameters = DEFAULT_TEST_SLICE_PARAMS_DICT;
     config.loginHint = @"fakeuser@contoso.com";
     
     NSString *requestState = @"state";
@@ -140,7 +137,6 @@
                                           }];
     
     [expectedQPs addEntriesFromDictionary:[MSIDDeviceId deviceId]];
-    [expectedQPs addEntriesFromDictionary:DEFAULT_TEST_SLICE_PARAMS_DICT];
     
     XCTAssertTrue([expectedQPs compareAndPrintDiff:params]);
 }

--- a/IdentityCore/tests/MSIDAADV2WebviewFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADV2WebviewFactoryTests.m
@@ -67,7 +67,6 @@
     config.claims = @"claims";
     config.utid = DEFAULT_TEST_UTID;
     config.uid = DEFAULT_TEST_UID;
-    config.sliceParameters = DEFAULT_TEST_SLICE_PARAMS_DICT;
     config.loginHint = @"fakeuser@contoso.com";
     
     NSString *requestState = @"state";
@@ -99,7 +98,6 @@
                                           }];
     
     [expectedQPs addEntriesFromDictionary:[MSIDDeviceId deviceId]];
-    [expectedQPs addEntriesFromDictionary:DEFAULT_TEST_SLICE_PARAMS_DICT];
     
     XCTAssertTrue([expectedQPs compareAndPrintDiff:params]);
 }

--- a/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
@@ -69,7 +69,6 @@
     config.loginHint = @"fakeuser@contoso.com";
     config.claims = @"claims";
     config.promptBehavior = @"login";
-    config.sliceParameters = DEFAULT_TEST_SLICE_PARAMS_DICT;
     
     NSString *requestState = @"state";
     
@@ -88,13 +87,11 @@
                                           @"login_hint" : @"fakeuser@contoso.com",
                                           @"state" : requestState.msidBase64UrlEncode,
                                           @"prompt" : @"login",
-                                          @"slice": @"myslice",
                                           @"haschrome" : @"1",
                                           @"scope" : @"scope1"
                                           
                                           }];
     [expectedQPs addEntriesFromDictionary:[MSIDDeviceId deviceId]];
-    [expectedQPs addEntriesFromDictionary:DEFAULT_TEST_SLICE_PARAMS_DICT];
     
     XCTAssertTrue([expectedQPs compareAndPrintDiff:params]);
 }

--- a/IdentityCore/tests/MSIDInteractiveRequestParametersTests.m
+++ b/IdentityCore/tests/MSIDInteractiveRequestParametersTests.m
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDInteractiveRequestParameters.h"
+#import "MSIDAuthorityFactory.h"
+
+@interface MSIDInteractiveRequestParametersTests : XCTestCase
+
+@end
+
+@implementation MSIDInteractiveRequestParametersTests
+
+- (void)testInitWithAllSupportedParameters_shouldInitialize_returnNilError
+{
+    MSIDAuthority *authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
+    NSUUID *correlationID = [NSUUID UUID];
+    
+    NSError *error = nil;
+    
+    MSIDInteractiveRequestParameters *parameters = [[MSIDInteractiveRequestParameters alloc] initWithAuthority:authority
+                                                                                                   redirectUri:@"redirect"
+                                                                                                      clientId:@"clientid"
+                                                                                                        scopes:[@"scope scope2" msidScopeSet]
+                                                                                                    oidcScopes:[@"openid openid2" msidScopeSet]
+                                                                                          extraScopesToConsent:[@"extra extra2" msidScopeSet]
+                                                                                                 correlationId:correlationID
+                                                                                                telemetryApiId:@"100"
+                                                                                       supportedBrokerProtocol:@"2"
+                                                                                                   requestType:MSIDInteractiveRequestBrokeredType
+                                                                                                         error:&error];
+    
+    XCTAssertNotNil(parameters);
+    XCTAssertEqualObjects(parameters.authority, authority);
+    XCTAssertEqualObjects(parameters.redirectUri, @"redirect");
+    XCTAssertEqualObjects(parameters.clientId, @"clientid");
+    XCTAssertEqualObjects(parameters.target, @"scope scope2");
+    XCTAssertEqualObjects(parameters.oidcScope, @"openid openid2");
+    XCTAssertEqualObjects(parameters.extraScopesToConsent, @"extra extra2");
+    XCTAssertEqualObjects(parameters.correlationId, correlationID);
+    XCTAssertEqualObjects(parameters.telemetryApiId, @"100");
+    XCTAssertEqualObjects(parameters.supportedBrokerProtocolScheme, @"2");
+    XCTAssertEqual(parameters.requestType, MSIDInteractiveRequestBrokeredType);
+    
+    XCTAssertNil(error);
+}
+
+- (void)testAllAuthorizeRequestScopes_whenOnlyResourceScopesProvided_shouldReturnResourceScopesOnly
+{
+    MSIDAuthority *authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
+    MSIDInteractiveRequestParameters *parameters = [[MSIDInteractiveRequestParameters alloc] initWithAuthority:authority
+                                                                                                   redirectUri:@"redirect"
+                                                                                                      clientId:@"clientid"
+                                                                                                        scopes:[@"scope scope2" msidScopeSet]
+                                                                                                    oidcScopes:nil
+                                                                                          extraScopesToConsent:nil
+                                                                                                 correlationId:nil
+                                                                                                telemetryApiId:@"100"
+                                                                                       supportedBrokerProtocol:@"2"
+                                                                                                   requestType:MSIDInteractiveRequestBrokeredType
+                                                                                                         error:nil];
+    
+    NSOrderedSet *allScopes = [parameters allAuthorizeRequestScopes];
+    XCTAssertEqualObjects([@"scope scope2 openid" msidScopeSet], allScopes);
+    
+}
+
+- (void)testAllAuthorizeRequestScopes_whenBothResourceAndOIDCScopesProvided_shouldReturnAllScopesCombined
+{
+    MSIDAuthority *authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
+    MSIDInteractiveRequestParameters *parameters = [[MSIDInteractiveRequestParameters alloc] initWithAuthority:authority
+                                                                                                   redirectUri:@"redirect"
+                                                                                                      clientId:@"clientid"
+                                                                                                        scopes:[@"scope scope2" msidScopeSet]
+                                                                                                    oidcScopes:[@"openid openid2" msidScopeSet]
+                                                                                          extraScopesToConsent:nil
+                                                                                                 correlationId:nil
+                                                                                                telemetryApiId:@"100"
+                                                                                       supportedBrokerProtocol:@"2"
+                                                                                                   requestType:MSIDInteractiveRequestBrokeredType
+                                                                                                         error:nil];
+    
+    NSOrderedSet *allScopes = [parameters allAuthorizeRequestScopes];
+    XCTAssertEqualObjects([@"scope scope2 openid openid2" msidScopeSet], allScopes);
+}
+
+- (void)testAllAuthorizeRequestScopes_whenResource_AndOIDCS_AndExtraScopesProvided_shouldReturnAllScopesCombined
+{
+    MSIDAuthority *authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
+    MSIDInteractiveRequestParameters *parameters = [[MSIDInteractiveRequestParameters alloc] initWithAuthority:authority
+                                                                                                   redirectUri:@"redirect"
+                                                                                                      clientId:@"clientid"
+                                                                                                        scopes:[@"scope scope2" msidScopeSet]
+                                                                                                    oidcScopes:[@"openid openid2" msidScopeSet]
+                                                                                          extraScopesToConsent:[@"extra1 extra5" msidScopeSet]
+                                                                                                 correlationId:nil
+                                                                                                telemetryApiId:@"100"
+                                                                                       supportedBrokerProtocol:@"2"
+                                                                                                   requestType:MSIDInteractiveRequestBrokeredType
+                                                                                                         error:nil];
+    
+    NSOrderedSet *allScopes = [parameters allAuthorizeRequestScopes];
+    XCTAssertEqualObjects([@"scope scope2 openid openid2 extra1 extra5" msidScopeSet], allScopes);
+}
+
+- (void)testAllAuthorizeRequestParameters_whenNoExtraParameters_shouldReturnNilResult
+{
+    MSIDInteractiveRequestParameters *parameters = [MSIDInteractiveRequestParameters new];
+    
+    NSDictionary *eqp = [parameters allAuthorizeRequestExtraParameters];
+    XCTAssertNil(eqp);
+}
+
+- (void)testAllAuthorizeRequestParameters_whenOnlyAuthorizeParameters_shouldReturnAuthorizeParameters
+{
+    MSIDInteractiveRequestParameters *parameters = [MSIDInteractiveRequestParameters new];
+    NSDictionary *authorizeEndpointParameters = @{@"eqp1": @"val1", @"eqp2": @"val2"};
+    parameters.authorizeEndpointParameters = authorizeEndpointParameters;
+    
+    NSDictionary *eqp = [parameters allAuthorizeRequestExtraParameters];
+    XCTAssertNotNil(eqp);
+    XCTAssertEqualObjects(eqp, authorizeEndpointParameters);
+}
+
+- (void)testAllAuthorizeRequestParameters_whenOnlyTokenParameters_shouldReturnTokenParameters
+{
+    MSIDInteractiveRequestParameters *parameters = [MSIDInteractiveRequestParameters new];
+    NSDictionary *additionalParams = @{@"eqp1": @"val1", @"eqp2": @"val2"};
+    parameters.additionalRequestParameters = additionalParams;
+    
+    NSDictionary *eqp = [parameters allAuthorizeRequestExtraParameters];
+    XCTAssertNotNil(eqp);
+    XCTAssertEqualObjects(eqp, additionalParams);
+}
+
+- (void)testAllAuthorizeRequestParameters_whenBothAuthorizeAndTokenParameters_shouldReturnAllParametersCombined
+{
+    MSIDInteractiveRequestParameters *parameters = [MSIDInteractiveRequestParameters new];
+    NSDictionary *authorizeEndpointParameters = @{@"eqp1": @"val1", @"eqp2": @"val2"};
+    parameters.authorizeEndpointParameters = authorizeEndpointParameters;
+    parameters.additionalRequestParameters = @{@"add1": @"val1", @"add2": @"val2"};
+    
+    NSDictionary *eqp = [parameters allAuthorizeRequestExtraParameters];
+    XCTAssertNotNil(eqp);
+    NSDictionary *expectedParams = @{@"eqp1": @"val1", @"eqp2": @"val2", @"add1": @"val1", @"add2": @"val2"};
+    XCTAssertEqualObjects(eqp, expectedParams);
+}
+
+@end

--- a/IdentityCore/tests/MSIDInteractiveRequestParametersTests.m
+++ b/IdentityCore/tests/MSIDInteractiveRequestParametersTests.m
@@ -135,7 +135,7 @@
 {
     MSIDInteractiveRequestParameters *parameters = [MSIDInteractiveRequestParameters new];
     NSDictionary *authorizeEndpointParameters = @{@"eqp1": @"val1", @"eqp2": @"val2"};
-    parameters.authorizeEndpointParameters = authorizeEndpointParameters;
+    parameters.extraAuthorizeURLQueryParameters = authorizeEndpointParameters;
     
     NSDictionary *eqp = [parameters allAuthorizeRequestExtraParameters];
     XCTAssertNotNil(eqp);
@@ -146,7 +146,7 @@
 {
     MSIDInteractiveRequestParameters *parameters = [MSIDInteractiveRequestParameters new];
     NSDictionary *additionalParams = @{@"eqp1": @"val1", @"eqp2": @"val2"};
-    parameters.additionalRequestParameters = additionalParams;
+    parameters.extraURLQueryParameters = additionalParams;
     
     NSDictionary *eqp = [parameters allAuthorizeRequestExtraParameters];
     XCTAssertNotNil(eqp);
@@ -157,8 +157,8 @@
 {
     MSIDInteractiveRequestParameters *parameters = [MSIDInteractiveRequestParameters new];
     NSDictionary *authorizeEndpointParameters = @{@"eqp1": @"val1", @"eqp2": @"val2"};
-    parameters.authorizeEndpointParameters = authorizeEndpointParameters;
-    parameters.additionalRequestParameters = @{@"add1": @"val1", @"add2": @"val2"};
+    parameters.extraAuthorizeURLQueryParameters = authorizeEndpointParameters;
+    parameters.extraURLQueryParameters = @{@"add1": @"val1", @"add2": @"val2"};
     
     NSDictionary *eqp = [parameters allAuthorizeRequestExtraParameters];
     XCTAssertNotNil(eqp);

--- a/IdentityCore/tests/integration/ios/MSIDBrokerTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerTokenRequestTests.m
@@ -161,7 +161,7 @@
 - (void)testInitBrokerRequest_whenParametersWithOptionalParameters_shouldReturnValidPayload
 {
     MSIDInteractiveRequestParameters *parameters = [self defaultTestParameters];
-    parameters.authorizeEndpointParameters = @{@"my_eqp1, ,": @"my_eqp2", @"my_eqp3": @"my_eqp4"};
+    parameters.extraAuthorizeURLQueryParameters = @{@"my_eqp1, ,": @"my_eqp2", @"my_eqp3": @"my_eqp4"};
     parameters.claims = @{@"access_token":@{@"polids":@{@"values":@[@"5ce770ea-8690-4747-aa73-c5b3cd509cd4"], @"essential":@YES}}};
     parameters.clientCapabilities = @[@"cp1", @"cp2"];
 

--- a/IdentityCore/tests/integration/ios/MSIDBrokerTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerTokenRequestTests.m
@@ -161,7 +161,7 @@
 - (void)testInitBrokerRequest_whenParametersWithOptionalParameters_shouldReturnValidPayload
 {
     MSIDInteractiveRequestParameters *parameters = [self defaultTestParameters];
-    parameters.extraQueryParameters = @{@"my_eqp1, ,": @"my_eqp2", @"my_eqp3": @"my_eqp4"};
+    parameters.authorizeEndpointParameters = @{@"my_eqp1, ,": @"my_eqp2", @"my_eqp3": @"my_eqp4"};
     parameters.claims = @{@"access_token":@{@"polids":@{@"values":@[@"5ce770ea-8690-4747-aa73-c5b3cd509cd4"], @"essential":@YES}}};
     parameters.clientCapabilities = @[@"cp1", @"cp2"];
 

--- a/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
@@ -90,7 +90,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -188,7 +188,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2", @"instance_aware" : @"true" };
+    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2", @"instance_aware" : @"true" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -287,7 +287,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -378,7 +378,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -470,7 +470,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -559,7 +559,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -622,7 +622,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -681,7 +681,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;

--- a/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
@@ -90,7 +90,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.extraAuthorizeURLQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -188,7 +188,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2", @"instance_aware" : @"true" };
+    parameters.extraAuthorizeURLQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2", @"instance_aware" : @"true" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -287,7 +287,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.extraAuthorizeURLQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -378,7 +378,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.extraAuthorizeURLQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -470,7 +470,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.extraAuthorizeURLQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -559,7 +559,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.extraAuthorizeURLQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -622,7 +622,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.extraAuthorizeURLQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;
@@ -681,7 +681,7 @@
     parameters.authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:@"https://login.microsoftonline.com/common"] context:nil error:nil];
     parameters.redirectUri = @"x-msauth-test://com.microsoft.testapp";
     parameters.clientId = @"my_client_id";
-    parameters.authorizeEndpointParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
+    parameters.extraAuthorizeURLQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSIDWebviewTypeWKWebView;


### PR DESCRIPTION
There’re multiple extra parameters we might need to send to authorize and token endpoints. 

Authorize endpoint:
Extra query parameters are always sent as URL query parameters and there’re parameters that we want to send to both authorize and token endpoint (e.g. slice parameters) or just to authorize endpoint (e.g. domain_hint=XXX).

Token endpoint:
Most of extra parameters need to be sent as part of POST body. Those parameters shouldn’t be sent to authorize endpoint (e.g. itver=1)

However, some extra parameters will only work when sent as part of URL query (e.g. slice=testslice)

Since we need all 3 categories of extra parameters, this PR introduces 3 categories of parameters:

1. MSIDRequestParamaters.extraURLQueryParameters - those parameters will be sent to both authorize and token endpoints as URL query (e.g. slice=testslice)
2. MSIDRequestParameters.extraTokenRequestParameters - those parameters will be sent only to the token endpoint as part of POST body (e.g. itver=1).
3. MSIDInteractiveRequestParameters.extraAuthorizeURLQueryParameters - those parameters are additional parameters that need to be sent only to authorize endpoint (e.g. domain_hint=XX)

MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/446
