### PR TITLE
Add missing CPU architectures

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -4055,6 +4055,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4E981FC3626A00CD70C5 /* identitycore__idlib__ios.xcconfig */;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					arm64e,
+					armv7s,
+				);
 				GCC_OPTIMIZATION_LEVEL = 0;
 			};
 			name = Debug;
@@ -4063,6 +4068,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4E981FC3626A00CD70C5 /* identitycore__idlib__ios.xcconfig */;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					arm64e,
+					armv7s,
+				);
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The common authentication library is missing `armv7s` and `arm64e` CPU architectures. This PR adds those libraries to unblock https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/443 which does the same thing for the MSAL library.

Let me know if you need more context and don't hesitate to get in touch.

Cheers!
Benjamin