### PR TITLE
Support pkeyauth for network request

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 		6035CD8D207EA67300369E69 /* MSIDTelemetryIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6035CD8B207EA67300369E69 /* MSIDTelemetryIntegrationTests.m */; };
 		6057EE9020B5FDF8007976EB /* MSIDAADOAuthEmbeddedWebviewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6057EE8F20B5FDF8007976EB /* MSIDAADOAuthEmbeddedWebviewController.m */; };
 		6057EE9120B5FDF8007976EB /* MSIDAADOAuthEmbeddedWebviewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6057EE8F20B5FDF8007976EB /* MSIDAADOAuthEmbeddedWebviewController.m */; };
+		6065B06822051B0100C66DDF /* MSIDPKeyAuthHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6068303820A33A9000CCA6AB /* MSIDPKeyAuthHandler.m */; };
 		606830062098ACED00CCA6AB /* MSIDNegotiateHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 606830042098ACED00CCA6AB /* MSIDNegotiateHandler.m */; };
 		6068300A2098C9D300CCA6AB /* MSIDCredentialCollectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 606830092098C9D300CCA6AB /* MSIDCredentialCollectionController.m */; };
 		606830102098E94100CCA6AB /* MSIDCertificateChooser.m in Sources */ = {isa = PBXBuildFile; fileRef = 6068300F2098E94100CCA6AB /* MSIDCertificateChooser.m */; };
@@ -3926,6 +3927,7 @@
 				B251CC3D2041058D005E0179 /* MSIDAccessToken.m in Sources */,
 				B297E1E820A12BDE00F370EC /* MSIDDefaultAccountCacheKey.m in Sources */,
 				B251CC4D204105A7005E0179 /* MSIDIdToken.m in Sources */,
+				6065B06822051B0100C66DDF /* MSIDPKeyAuthHandler.m in Sources */,
 				B2893CB11FCF6A8C00E348E9 /* NSMutableDictionary+MSIDExtensions.m in Sources */,
 				B2AF1D30218BCEDE0080C1A0 /* MSIDInteractiveTokenRequest.m in Sources */,
 				04930F961FEDB2E100FC4DCD /* MSIDAuthority.m in Sources */,

--- a/IdentityCore/src/network/MSIDHttpRequestProtocol.h
+++ b/IdentityCore/src/network/MSIDHttpRequestProtocol.h
@@ -29,6 +29,7 @@ typedef void (^MSIDHttpRequestDidCompleteBlock)(id response, NSError *error);
 
 @property (nonatomic) NSInteger retryCounter;
 @property (nonatomic) NSTimeInterval retryInterval;
+@property (nonatomic) NSURLRequest *urlRequest;
 
 - (void)sendWithBlock:(MSIDHttpRequestDidCompleteBlock)completionBlock;
 

--- a/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
+++ b/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
@@ -26,10 +26,12 @@
 #import "MSIDHttpResponseSerializer.h"
 #import "MSIDAADJsonResponsePreprocessor.h"
 #import "MSIDAADTokenResponse.h"
+#import "MSIDWorkPlaceJoinConstants.h"
+#import "MSIDPKeyAuthHandler.h"
 
 @implementation MSIDAADRequestErrorHandler
 
-- (void)handleError:(NSError * )error
+- (void)handleError:(NSError *)error
        httpResponse:(NSHTTPURLResponse *)httpResponse
                data:(NSData *)data
         httpRequest:(id<MSIDHttpRequestProtocol>)httpRequest
@@ -58,6 +60,37 @@
         });
         
         return;
+    }
+    
+    // pkeyauth challenge
+    if (httpResponse.statusCode == 400 || httpResponse.statusCode == 401)
+    {
+        NSString *wwwAuthValue = [httpResponse.allHeaderFields valueForKey:kMSIDWwwAuthenticateHeader];
+        
+        if (![NSString msidIsStringNilOrBlank:wwwAuthValue] && [wwwAuthValue containsString:kMSIDPKeyAuthName])
+        {
+            [MSIDPKeyAuthHandler handleWwwAuthenticateHeader:wwwAuthValue
+                                                  requestUrl:httpRequest.urlRequest.URL
+                                                     context:context
+                                           completionHandler:^void (NSString *authHeader, NSError *error){
+                                               if (![NSString msidIsStringNilOrBlank:authHeader])
+                                               {
+                                                   // append auth header
+                                                   NSMutableURLRequest *newRequest = [httpRequest.urlRequest mutableCopy];
+                                                   [newRequest setValue:authHeader forHTTPHeaderField:@"Authorization"];
+                                                   httpRequest.urlRequest = newRequest;
+                                                   
+                                                   // resend the request
+                                                   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                                                       [httpRequest sendWithBlock:completionBlock];
+                                                   });
+                                                   return;
+                                               }
+                                               
+                                               if (completionBlock) { completionBlock(nil, error); }
+                                           }];
+            return;
+        }
     }
 
     __auto_type responseSerializer = [MSIDHttpResponseSerializer new];

--- a/IdentityCore/src/network/request_configurator/MSIDAADRequestConfigurator.m
+++ b/IdentityCore/src/network/request_configurator/MSIDAADRequestConfigurator.m
@@ -77,7 +77,9 @@ static NSTimeInterval const s_defaultTimeoutInterval = 300;
     mutableUrlRequest.URL = requestUrl;
     mutableUrlRequest.timeoutInterval = self.timeoutInterval;
     mutableUrlRequest.cachePolicy = NSURLRequestReloadIgnoringCacheData;
+#if TARGET_OS_IPHONE
     [mutableUrlRequest setValue:kMSIDPKeyAuthHeaderVersion forHTTPHeaderField:kMSIDPKeyAuthHeader];
+#endif
     [mutableUrlRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
     
     NSMutableDictionary *headers = [mutableUrlRequest.allHTTPHeaderFields mutableCopy];

--- a/IdentityCore/src/network/request_configurator/MSIDAADRequestConfigurator.m
+++ b/IdentityCore/src/network/request_configurator/MSIDAADRequestConfigurator.m
@@ -33,6 +33,7 @@
 #import "MSIDAuthority.h"
 #import "MSIDConstants.h"
 #import "MSIDAADJsonResponsePreprocessor.h"
+#import "MSIDWorkPlaceJoinConstants.h"
 
 static NSTimeInterval const s_defaultTimeoutInterval = 300;
 
@@ -76,6 +77,7 @@ static NSTimeInterval const s_defaultTimeoutInterval = 300;
     mutableUrlRequest.URL = requestUrl;
     mutableUrlRequest.timeoutInterval = self.timeoutInterval;
     mutableUrlRequest.cachePolicy = NSURLRequestReloadIgnoringCacheData;
+    [mutableUrlRequest setValue:kMSIDPKeyAuthHeaderVersion forHTTPHeaderField:kMSIDPKeyAuthHeader];
     [mutableUrlRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
     
     NSMutableDictionary *headers = [mutableUrlRequest.allHTTPHeaderFields mutableCopy];

--- a/IdentityCore/src/network/response_serializer/MSIDResponseSerialization.h
+++ b/IdentityCore/src/network/response_serializer/MSIDResponseSerialization.h
@@ -32,8 +32,8 @@
  Result could be any type, it depens on specific implementation in a subclass.
  */
 - (nullable id)responseObjectForResponse:(nullable NSHTTPURLResponse *)httpResponse
-                           data:(nullable NSData *)data
-                        context:(nullable id <MSIDRequestContext>)context
-                          error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+                                    data:(nullable NSData *)data
+                                 context:(nullable id <MSIDRequestContext>)context
+                                   error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.h
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.h
@@ -30,4 +30,9 @@
                 context:(id<MSIDRequestContext>)context
       completionHandler:(void (^)(NSURLRequest *challengeResponse, NSError *error))completionHandler;
 
++ (void)handleWwwAuthenticateHeader:(NSString *)wwwAuthHeaderValue
+                         requestUrl:(NSURL *)requestUrl
+                            context:(id<MSIDRequestContext>)context
+                  completionHandler:(void (^)(NSString *authHeader, NSError *error))completionHandler;
+
 @end

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -86,4 +86,166 @@
     return YES;
 }
 
++ (void)handleWwwAuthenticateHeader:(NSString *)wwwAuthHeaderValue
+                         requestUrl:(NSURL *)requestUrl
+                            context:(id<MSIDRequestContext>)context
+                  completionHandler:(void (^)(NSString *authHeader, NSError *error))completionHandler
+{
+    //pkeyauth word length=8 + 1 whitespace
+    wwwAuthHeaderValue = [wwwAuthHeaderValue substringFromIndex:[kMSIDPKeyAuthName length] + 1];
+    
+    NSDictionary *authHeaderParams = [self parseAuthHeader:wwwAuthHeaderValue];
+    
+    if (!authHeaderParams)
+    {
+        MSID_LOG_ERROR(context, @"Unparseable wwwAuthHeader received");
+        MSID_LOG_ERROR_PII(context, @"Unparseable wwwAuthHeader received %@", wwwAuthHeaderValue);
+    }
+    
+    NSError *error = nil;
+    NSString *authHeader = [MSIDPkeyAuthHelper createDeviceAuthResponse:requestUrl.absoluteString
+                                                          challengeData:authHeaderParams
+                                                                context:context
+                                                                  error:&error];
+    
+    if (completionHandler)
+    {
+        completionHandler(authHeader, error);
+    }
+}
+
+// Decodes the parameters that come in the Authorization header. We expect them in the following
+// format:
+//
+// <key>="<value>", key="<value>", key="<value>"
+// i.e. version="1.0",CertAuthorities="OU=MyOrganization,CN=MyThingy,DN=windows,DN=net",Context="context!"
+//
+// This parser is lenient on whitespace, and on the presence of enclosing quotation marks. It also
+// will allow commented out quotation marks
++ (NSDictionary *)parseAuthHeader:(NSString *)authHeader
+{
+    if (!authHeader)
+    {
+        return nil;
+    }
+    
+    NSMutableDictionary *params = [NSMutableDictionary new];
+    NSUInteger strLength = [authHeader length];
+    NSRange currentRange = NSMakeRange(0, strLength);
+    NSCharacterSet *whiteChars = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+    NSCharacterSet *alphaNum = [NSCharacterSet alphanumericCharacterSet];
+    
+    while (currentRange.location < strLength)
+    {
+        // Eat up any whitepace at the beginning
+        while (currentRange.location < strLength && [whiteChars characterIsMember:[authHeader characterAtIndex:currentRange.location]])
+        {
+            ++currentRange.location;
+            --currentRange.length;
+        }
+        
+        if (currentRange.location == strLength)
+        {
+            return params;
+        }
+        
+        if (![alphaNum characterIsMember:[authHeader characterAtIndex:currentRange.location]])
+        {
+            // malformed string
+            return nil;
+        }
+        
+        // Find the key
+        NSUInteger found = [authHeader rangeOfString:@"=" options:0 range:currentRange].location;
+        // If there are no keys left then exit out
+        if (found == NSNotFound)
+        {
+            // If there still is string left that means it's malformed
+            if (currentRange.length > 0)
+            {
+                return nil;
+            }
+            
+            // Otherwise we're at the end, return params
+            return params;
+        }
+        NSUInteger length = found - currentRange.location;
+        NSString *key = [authHeader substringWithRange:NSMakeRange(currentRange.location, length)];
+        
+        // don't want the '='
+        ++length;
+        currentRange.location += length;
+        currentRange.length -= length;
+        
+        NSString *value = nil;
+        
+        
+        if ([authHeader characterAtIndex:currentRange.location] == '"')
+        {
+            ++currentRange.location;
+            --currentRange.length;
+            
+            found = currentRange.location;
+            
+            do {
+                NSRange range = NSMakeRange(found, strLength - found);
+                found = [authHeader rangeOfString:@"\"" options:0 range:range].location;
+            } while (found != NSNotFound && [authHeader characterAtIndex:found-1] == '\\');
+            
+            // If we couldn't find a matching closing quote then we have a malformed string and return NULL
+            if (found == NSNotFound)
+            {
+                return nil;
+            }
+            
+            length = found - currentRange.location;
+            value = [authHeader substringWithRange:NSMakeRange(currentRange.location, length)];
+            
+            ++length;
+            currentRange.location += length;
+            currentRange.length -= length;
+            
+            // find the next comma
+            found = [authHeader rangeOfString:@"," options:0 range:currentRange].location;
+            if (found != NSNotFound)
+            {
+                length = found - currentRange.location;
+            }
+            
+        }
+        else
+        {
+            found = [authHeader rangeOfString:@"," options:0 range:currentRange].location;
+            // If we didn't find the comma that means we're at the end of the list
+            if (found == NSNotFound)
+            {
+                length = currentRange.length;
+            }
+            else
+            {
+                length = found - currentRange.location;
+            }
+            
+            value = [authHeader substringWithRange:NSMakeRange(currentRange.location, length)];
+        }
+        
+        NSString *existingValue = [params valueForKey:key];
+        if (existingValue)
+        {
+            [params setValue:[existingValue stringByAppendingFormat:@".%@", value] forKey:key];
+        }
+        else
+        {
+            [params setValue:value forKey:key];
+        }
+        
+        ++length;
+        currentRange.location += length;
+        currentRange.length -= length;
+    }
+    
+    
+    return params;
+}
+
 @end

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinConstants.h
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinConstants.h
@@ -30,3 +30,5 @@ extern NSString *const kMSIDProtectionSpaceDistinguishedName;
 extern NSString *const kMSIDPKeyAuthUrn;
 extern NSString *const kMSIDPKeyAuthHeader;
 extern NSString *const kMSIDPKeyAuthHeaderVersion;
+extern NSString *const kMSIDWwwAuthenticateHeader;
+extern NSString *const kMSIDPKeyAuthName;

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinConstants.m
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinConstants.m
@@ -28,3 +28,5 @@ NSString *const kMSIDProtectionSpaceDistinguishedName   = @"MS-Organization-Acce
 NSString *const kMSIDPKeyAuthUrn                        = @"urn:http-auth:PKeyAuth?";
 NSString *const kMSIDPKeyAuthHeader                     = @"x-ms-PkeyAuth";
 NSString *const kMSIDPKeyAuthHeaderVersion              = @"1.0";
+NSString* const kMSIDWwwAuthenticateHeader              = @"WWW-Authenticate";
+NSString* const kMSIDPKeyAuthName                       = @"PKeyAuth";

--- a/IdentityCore/tests/MSIDAADRequestConfiguratorTests.m
+++ b/IdentityCore/tests/MSIDAADRequestConfiguratorTests.m
@@ -84,6 +84,7 @@
     XCTAssertNotNil(headers[@"x-client-OS"]);
     XCTAssertNotNil(headers[@"x-client-SKU"]);
     XCTAssertNotNil(headers[@"x-client-Ver"]);
+    XCTAssertNotNil(headers[@"x-ms-PkeyAuth"]);
 #if TARGET_OS_IPHONE
     XCTAssertNotNil(headers[@"x-client-DM"]);
 #endif

--- a/IdentityCore/tests/MSIDAADRequestConfiguratorTests.m
+++ b/IdentityCore/tests/MSIDAADRequestConfiguratorTests.m
@@ -84,8 +84,8 @@
     XCTAssertNotNil(headers[@"x-client-OS"]);
     XCTAssertNotNil(headers[@"x-client-SKU"]);
     XCTAssertNotNil(headers[@"x-client-Ver"]);
-    XCTAssertNotNil(headers[@"x-ms-PkeyAuth"]);
 #if TARGET_OS_IPHONE
+    XCTAssertNotNil(headers[@"x-ms-PkeyAuth"]);
     XCTAssertNotNil(headers[@"x-client-DM"]);
 #endif
 }

--- a/IdentityCore/tests/MSIDAADRequestErrorHandlerTests.m
+++ b/IdentityCore/tests/MSIDAADRequestErrorHandlerTests.m
@@ -32,6 +32,7 @@
 
 @property (nonatomic) NSInteger retryCounter;
 @property (nonatomic) NSTimeInterval retryInterval;
+@property (nonatomic) NSURLRequest *urlRequest;
 
 @end
 

--- a/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
@@ -81,6 +81,7 @@
     [response setResponseJSON:responseJson];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:response];
     
@@ -130,6 +131,7 @@
                                                          respondWithError:[NSError new]];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     responseWithError->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:responseWithError];
     
@@ -241,6 +243,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : @"https://login.microsoftonline.com/common/.well-known/openid-configuration",
@@ -279,6 +282,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : @"https://example.com/common/.well-known/openid-configuration",
@@ -318,6 +322,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : @"https://login.microsoftonline.com/common/.well-known/openid-configuration",
@@ -369,6 +374,7 @@
                                                          respondWithError:error];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     responseWithError->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:responseWithError];
 
@@ -426,6 +432,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"error" : @"invalid_instance"};
     [response setResponseJSON:responseJson];
@@ -455,6 +462,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"error" : @"invalid_instance"};
     [response setResponseJSON:responseJson];
@@ -499,6 +507,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : @"https://login.microsoftonline.com/common/.well-known/openid-configuration",
@@ -562,6 +571,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"IdentityProviderService" : @{@"PassiveAuthEndpoint" : @"https://example.com/adfs/ls"}};
     [response setResponseJSON:responseJson];
@@ -603,6 +613,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"IdentityProviderService" : @{@"PassiveAuthEndpoint" : @"https://example.com/adfs/ls"}};
     [response setResponseJSON:responseJson];
@@ -643,6 +654,7 @@
                                                          respondWithError:error];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     responseWithError->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:responseWithError];
 
@@ -691,6 +703,7 @@
                                                          respondWithError:error];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     responseWithError->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:responseWithError];
 
@@ -747,6 +760,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"IdentityProviderService" : @{@"PassiveAuthEndpoint" : @"https://example.com/adfs/ls"}};
     [response setResponseJSON:responseJson];
@@ -802,6 +816,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"IdentityProviderService" : @{@"PassiveAuthEndpoint" : @"https://example.com/adfs/ls"}};
     [response setResponseJSON:responseJson];
@@ -876,6 +891,7 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+    headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : openIdConfigurationEndpoint.absoluteString,

--- a/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
@@ -81,7 +81,9 @@
     [response setResponseJSON:responseJson];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:response];
     
@@ -131,7 +133,9 @@
                                                          respondWithError:[NSError new]];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     responseWithError->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:responseWithError];
     
@@ -243,7 +247,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : @"https://login.microsoftonline.com/common/.well-known/openid-configuration",
@@ -282,7 +288,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : @"https://example.com/common/.well-known/openid-configuration",
@@ -322,7 +330,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : @"https://login.microsoftonline.com/common/.well-known/openid-configuration",
@@ -374,7 +384,9 @@
                                                          respondWithError:error];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     responseWithError->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:responseWithError];
 
@@ -432,7 +444,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"error" : @"invalid_instance"};
     [response setResponseJSON:responseJson];
@@ -462,7 +476,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"error" : @"invalid_instance"};
     [response setResponseJSON:responseJson];
@@ -507,7 +523,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : @"https://login.microsoftonline.com/common/.well-known/openid-configuration",
@@ -571,7 +589,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"IdentityProviderService" : @{@"PassiveAuthEndpoint" : @"https://example.com/adfs/ls"}};
     [response setResponseJSON:responseJson];
@@ -613,7 +633,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"IdentityProviderService" : @{@"PassiveAuthEndpoint" : @"https://example.com/adfs/ls"}};
     [response setResponseJSON:responseJson];
@@ -654,7 +676,9 @@
                                                          respondWithError:error];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     responseWithError->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:responseWithError];
 
@@ -703,7 +727,9 @@
                                                          respondWithError:error];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     responseWithError->_requestHeaders = headers;
     [MSIDTestURLSession addResponse:responseWithError];
 
@@ -760,7 +786,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"IdentityProviderService" : @{@"PassiveAuthEndpoint" : @"https://example.com/adfs/ls"}};
     [response setResponseJSON:responseJson];
@@ -816,7 +844,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{@"IdentityProviderService" : @{@"PassiveAuthEndpoint" : @"https://example.com/adfs/ls"}};
     [response setResponseJSON:responseJson];
@@ -891,7 +921,9 @@
                                                          reponse:httpResponse];
     NSMutableDictionary *headers = [[MSIDDeviceId deviceId] mutableCopy];
     headers[@"Accept"] = @"application/json";
+#if TARGET_OS_IPHONE
     headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
     response->_requestHeaders = headers;
     __auto_type responseJson = @{
                                  @"tenant_discovery_endpoint" : openIdConfigurationEndpoint.absoluteString,

--- a/IdentityCore/tests/util/MSIDTestURLResponse+Util.m
+++ b/IdentityCore/tests/util/MSIDTestURLResponse+Util.m
@@ -42,6 +42,7 @@
         headers[@"Accept"] = @"application/json";
         headers[@"x-app-name"] = @"MSIDTestsHostApp";
         headers[@"x-app-ver"] = @"1.0";
+        headers[@"x-ms-PkeyAuth"] = @"1.0";
 
         s_msidHeaders = [headers copy];
     });


### PR DESCRIPTION
Added PKeyAuth support for network request.

Question:
1) Currently B2C network request will also have `x-ms-PkeyAuth=1.0` in header, will that be an issue?
2) Does Mac needs PKeyAuth support for token endpoint? If not, needs to change not to send `x-ms-PkeyAuth=1.0` for Mac.

Manual testing has been done to verify the flow for broker.

TODO:
Some unit testing might be needed for `MSIDPKeyAuthHandler.m`, which I don't have time to finish today :P