### PR TITLE
Fixed issue when Facebook sends a dummy fragment and MSAL is not able to read the auth code

### DIFF
--- a/IdentityCore/src/webview/response/MSIDWebOAuth2Response.m
+++ b/IdentityCore/src/webview/response/MSIDWebOAuth2Response.m
@@ -111,12 +111,7 @@
 {
     // Check for auth response
     // Try both the URL and the fragment parameters:
-    NSDictionary *parameters = [url msidFragmentParameters];
-    if (parameters.count == 0)
-    {
-        parameters = [url msidQueryParameters];
-    }
-    
+    NSDictionary *parameters = [self msidWebResponseParametersFromURL:url];
     NSString *stateReceived = parameters[MSID_OAUTH2_STATE];
     
     if (!requestState && !stateReceived)

--- a/IdentityCore/src/webview/response/MSIDWebviewResponse.h
+++ b/IdentityCore/src/webview/response/MSIDWebviewResponse.h
@@ -38,4 +38,6 @@
                     context:(id<MSIDRequestContext>)context
                       error:(NSError **)error;
 
++ (NSDictionary *)msidWebResponseParametersFromURL:(NSURL *)url;
+
 @end

--- a/IdentityCore/src/webview/response/MSIDWebviewResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebviewResponse.m
@@ -51,17 +51,29 @@
         _url = url;
         
         // Check for auth response
-        // Try both the URL and the fragment parameters:
-        NSDictionary *parameters = [url msidFragmentParameters];
-        if (parameters.count == 0)
-        {
-            parameters = [url msidQueryParameters];
-        }
-        
-        _parameters = parameters;
+        _parameters = [self.class msidWebResponseParametersFromURL:url];
     }
     
     return self;
+}
+
++ (NSDictionary *)msidWebResponseParametersFromURL:(NSURL *)url
+{
+    NSMutableDictionary *responseParameters = [NSMutableDictionary new];
+    
+    /*
+     Note that here we only really need to look for query parameters, since this SDK operates based on authorization code grant.
+     By default, resulting authorization code will be returned in the query parameters for authorization code grant unless request specifies a different response_mode parameter, which it doesn't in this case.
+     
+     However, the code to check for fragments has been in ADALs since 2014 and this class will be also used by ADALs. There're two possible reasons why this code was necessary:
+     1. Clients sent response_mode=fragment in the extra query parameters and it worked because of ADALs handling.
+     2. Some older ADFS version didn't correctly implement the default response mode.
+     
+     Therefore, the code to read fragment contents will be kept for backward compatibility reasons until determined 100% unnecessary by any clients.
+     */
+    [responseParameters addEntriesFromDictionary:[url msidFragmentParameters]];
+    [responseParameters addEntriesFromDictionary:[url msidQueryParameters]];
+    return responseParameters;
 }
 
 @end

--- a/IdentityCore/tests/MSIDWebAADAuthResponseTests.m
+++ b/IdentityCore/tests/MSIDWebAADAuthResponseTests.m
@@ -100,6 +100,67 @@
     XCTAssertEqualObjects(response.cloudHostName, @"cloudHost");
 }
 
+- (void)testInit_whenURLContainsBothFragmentAndQuery_withCodeInQuery_shouldContainResponseWithAllValues
+{
+    NSString *state = @"state";
+    
+    NSError *error;
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:@"https://contoso.com"];
+    urlComponents.queryItems = @{
+                                 MSID_OAUTH2_CODE : @"code",
+                                 MSID_AUTH_CLOUD_INSTANCE_HOST_NAME : @"cloudHost",
+                                 MSID_OAUTH2_STATE : state.msidBase64UrlEncode
+                                 }.urlQueryItemsArray;
+    urlComponents.fragment = @"_=_";
+    
+    MSIDWebAADAuthResponse *response = [[MSIDWebAADAuthResponse alloc] initWithURL:urlComponents.URL requestState:@"state" ignoreInvalidState:NO context:nil error:&error];
+    XCTAssertNotNil(response);
+    XCTAssertNil(error);
+    
+    XCTAssertEqualObjects(response.authorizationCode, @"code");
+    XCTAssertEqualObjects(response.cloudHostName, @"cloudHost");
+}
+
+- (void)testInit_whenURLContainsBothFragmentAndQuery_withCodeInFragment_shouldContainResponseWithAllValues
+{
+    NSString *state = @"state";
+    
+    NSError *error;
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:@"https://contoso.com"];
+    urlComponents.queryItems = @{
+                                 MSID_AUTH_CLOUD_INSTANCE_HOST_NAME : @"cloudHost",
+                                 MSID_OAUTH2_STATE : state.msidBase64UrlEncode
+                                 }.urlQueryItemsArray;
+    urlComponents.fragment = @"code=fragment_code";
+    
+    MSIDWebAADAuthResponse *response = [[MSIDWebAADAuthResponse alloc] initWithURL:urlComponents.URL requestState:@"state" ignoreInvalidState:NO context:nil error:&error];
+    XCTAssertNotNil(response);
+    XCTAssertNil(error);
+    
+    XCTAssertEqualObjects(response.authorizationCode, @"fragment_code");
+    XCTAssertEqualObjects(response.cloudHostName, @"cloudHost");
+}
+
+- (void)testInit_whenURLContainsBothFragmentAndQuery_withCodeInBoth_shouldUseCodeFromTheQuery
+{
+    NSString *state = @"state";
+    
+    NSError *error;
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:@"https://contoso.com"];
+    urlComponents.queryItems = @{
+                                 MSID_OAUTH2_CODE : @"query_code",
+                                 MSID_AUTH_CLOUD_INSTANCE_HOST_NAME : @"cloudHost",
+                                 MSID_OAUTH2_STATE : state.msidBase64UrlEncode
+                                 }.urlQueryItemsArray;
+    urlComponents.fragment = @"code=fragment_code&_=_";
+    
+    MSIDWebAADAuthResponse *response = [[MSIDWebAADAuthResponse alloc] initWithURL:urlComponents.URL requestState:@"state" ignoreInvalidState:NO context:nil error:&error];
+    XCTAssertNotNil(response);
+    XCTAssertNil(error);
+    
+    XCTAssertEqualObjects(response.authorizationCode, @"query_code");
+    XCTAssertEqualObjects(response.cloudHostName, @"cloudHost");
+}
 
 - (void)testInit_whenNoCloudHostInstanceNameExist_shouldNotContainCloudInstanceHostName
 {


### PR DESCRIPTION
There's an issue with Facebook+B2C, where Facebook sends a dummy fragment for security reasons. Since MSAL had code to check for fragment first and only look for query parameters, when no fragment is present, the dummy fragment from Facebook broke MSALs. 

Normally, fragment should be never returned for authorization code flows, and is rather used for implicit flows. Therefore, it's questionable why ADALs always checked for fragments first. This change allows SDKs to be checking both fragment and query for authorization code with a preference for the query (since fragment shouldn't actually happen in normal scenario). 

This change will be released as MSAL hotfix once tested.