### PR TITLE
Change order of execution for completion block and session clearing in MSIDWebViewAuthorization

### DIFF
--- a/IdentityCore/src/webview/MSIDWebviewAuthorization.m
+++ b/IdentityCore/src/webview/MSIDWebviewAuthorization.m
@@ -128,8 +128,8 @@ static MSIDWebviewSession *s_currentSession = nil;
                                                                           context:nil
                                                                             error:&responseError];
         
-        completionHandler(response, responseError);
         [MSIDWebviewAuthorization clearCurrentWebAuthSessionAndFactory];
+        completionHandler(response, responseError);
     };
     
     [s_currentSession.webviewController startWithCompletionHandler:startCompletionBlock];


### PR DESCRIPTION
Otherwise, if new session is started from previous session's completionBlock, we might run into multiple interactive requests error