### PR TITLE
 Change order of execution for completion block and session clearing

### DIFF
--- a/IdentityCore/src/webview/MSIDWebviewAuthorization.m
+++ b/IdentityCore/src/webview/MSIDWebviewAuthorization.m
@@ -115,8 +115,8 @@ static MSIDWebviewSession *s_currentSession = nil;
     
     void (^startCompletionBlock)(NSURL *, NSError *) = ^void(NSURL *callbackURL, NSError *error) {
         if (error) {
-            completionHandler(nil, error);
             [MSIDWebviewAuthorization clearCurrentWebAuthSessionAndFactory];
+            completionHandler(nil, error);
             return;
         }
         

--- a/IdentityCore/src/webview/MSIDWebviewAuthorization.m
+++ b/IdentityCore/src/webview/MSIDWebviewAuthorization.m
@@ -128,8 +128,8 @@ static MSIDWebviewSession *s_currentSession = nil;
                                                                           context:nil
                                                                             error:&responseError];
         
-        completionHandler(response, responseError);
         [MSIDWebviewAuthorization clearCurrentWebAuthSessionAndFactory];
+        completionHandler(response, responseError);
     };
     
     [s_currentSession.webviewController startWithCompletionHandler:startCompletionBlock];


### PR DESCRIPTION
Otherwise, if you start another interactive from completion block, you'd get multiple interactive sessions error (happens in some cases for broker auth)