### PR TITLE
Fixed navigation delegate clear for passed in webview

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -95,7 +95,11 @@
 
 -(void)dealloc
 {
-    [self.webView setNavigationDelegate:nil];
+    if ([self.webView.navigationDelegate isEqual:self])
+    {
+        [self.webView setNavigationDelegate:nil];
+    }
+    
     self.webView = nil;
 }
 


### PR DESCRIPTION
In case we use passed in webview, we might run into a race condition between previous controller clearing out navigation delegate and new controller setting it. What happens in most cases is that new controller already started loading some requests, but the previous controller gets its dealloc method called and clears out navigation delegate of the shared webview. This results in passed in webview getting "stuck", since nobody is handling its redirects anymore. 

This is the cause of some broker PRT operations getting "stuck", since it often has a chain of different interactive operations, which all are reusing same WKWebView. 