### PR TITLE
Fixed error http response handling to use correct serializer

### DIFF
--- a/IdentityCore/src/network/MSIDHttpRequest.h
+++ b/IdentityCore/src/network/MSIDHttpRequest.h
@@ -53,6 +53,8 @@
 
 @property (nonatomic, nonnull) id<MSIDResponseSerialization> responseSerializer;
 
+@property (nonatomic, nonnull) id<MSIDResponseSerialization> errorResponseSerializer;
+
 @property (nonatomic, nullable) id<MSIDHttpRequestTelemetryHandling> telemetry;
 
 @property (nonatomic, nullable) id<MSIDHttpRequestErrorHandling> errorHandler;

--- a/IdentityCore/src/network/MSIDHttpRequest.m
+++ b/IdentityCore/src/network/MSIDHttpRequest.m
@@ -99,6 +99,7 @@ static NSTimeInterval const s_defaultRetryInterval = 0.5;
                                     httpResponse:httpResponse
                                             data:data
                                      httpRequest:self
+                              responseSerializer:self.responseSerializer
                                          context:self.context
                                  completionBlock:completionBlock];
               }

--- a/IdentityCore/src/network/MSIDHttpRequest.m
+++ b/IdentityCore/src/network/MSIDHttpRequest.m
@@ -95,11 +95,13 @@ static NSTimeInterval const s_defaultRetryInterval = 0.5;
           {
               if (self.errorHandler)
               {
+                  id<MSIDResponseSerialization> responseSerializer = self.errorResponseSerializer ? self.errorResponseSerializer : self.responseSerializer;
+                  
                   [self.errorHandler handleError:error
                                     httpResponse:httpResponse
                                             data:data
                                      httpRequest:self
-                              responseSerializer:self.responseSerializer
+                              responseSerializer:responseSerializer
                                          context:self.context
                                  completionBlock:completionBlock];
               }

--- a/IdentityCore/src/network/error_handler/MSIDHttpRequestErrorHandling.h
+++ b/IdentityCore/src/network/error_handler/MSIDHttpRequestErrorHandling.h
@@ -23,6 +23,7 @@
 
 #import <Foundation/Foundation.h>
 #import "MSIDHttpRequestProtocol.h"
+#import "MSIDResponseSerialization.h"
 
 @protocol MSIDHttpRequestErrorHandling <NSObject>
 
@@ -30,6 +31,7 @@
        httpResponse:(NSHTTPURLResponse *)httpResponse
                data:(NSData *)data
         httpRequest:(id<MSIDHttpRequestProtocol>)httpRequest
+ responseSerializer:(id<MSIDResponseSerialization>)responseSerializer
             context:(id<MSIDRequestContext>)context
     completionBlock:(MSIDHttpRequestDidCompleteBlock)completionBlock;
 

--- a/IdentityCore/src/network/request/MSIDAADAuthorityMetadataResponseSerializer.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorityMetadataResponseSerializer.m
@@ -51,6 +51,24 @@
         return nil;
     }
     
+    if ([jsonObject msidAssertContainsField:@"error" context:context error:nil]
+        && [jsonObject msidAssertType:NSString.class ofField:@"error" context:context errorCode:MSIDErrorServerInvalidResponse error:nil])
+    {
+        NSError *oauthError = MSIDCreateError(MSIDOAuthErrorDomain,
+                                              MSIDErrorAuthorityValidation,
+                                              jsonObject[@"error_description"],
+                                              jsonObject[@"error"],
+                                              nil,
+                                              nil,
+                                              context.correlationId,
+                                              nil);
+        if (error)
+        {
+            *error = oauthError;
+        }
+        return nil;
+    }
+    
     __auto_type reponse = [MSIDAADAuthorityMetadataResponse new];
     reponse.metadata = jsonObject[@"metadata"];
     

--- a/IdentityCore/src/network/request/MSIDAADAuthorityMetadataResponseSerializer.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorityMetadataResponseSerializer.m
@@ -56,8 +56,8 @@
     {
         NSError *oauthError = MSIDCreateError(MSIDOAuthErrorDomain,
                                               MSIDErrorAuthorityValidation,
-                                              jsonObject[@"error_description"],
-                                              jsonObject[@"error"],
+                                              jsonObject[MSID_OAUTH2_ERROR_DESCRIPTION],
+                                              jsonObject[MSID_OAUTH2_ERROR],
                                               nil,
                                               nil,
                                               context.correlationId,

--- a/IdentityCore/tests/integration/MSIDHttpRequestIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDHttpRequestIntegrationTests.m
@@ -59,6 +59,7 @@
 @property (nonatomic) id<MSIDHttpRequestProtocol> passedHttpRequest;
 @property (nonatomic) id<MSIDRequestContext> passedContext;
 @property (nonatomic, copy) MSIDHttpRequestDidCompleteBlock passedBlock;
+@property (nonatomic) id<MSIDResponseSerialization> responseSerializer;
 
 @end
 
@@ -68,6 +69,7 @@
        httpResponse:(NSHTTPURLResponse *)httpResponse
                data:(NSData *)data
         httpRequest:(id<MSIDHttpRequestProtocol>)httpRequest
+ responseSerializer:(id<MSIDResponseSerialization>)responseSerializer
             context:(id<MSIDRequestContext>)context
     completionBlock:(MSIDHttpRequestDidCompleteBlock)completionBlock
 {
@@ -78,6 +80,7 @@
     self.passedHttpRequest = httpRequest;
     self.passedContext = context;
     self.passedBlock = completionBlock;
+    self.responseSerializer = responseSerializer;
 }
 
 @end


### PR DESCRIPTION
Previous logic was wrong, because it was always trying to use AAD token response serializer and return token response (e.g. even for authority validation requests). This caused some issues in broker scenarios, where we didn't return correct error code. 

I changed the logic according to what ADAL has been doing:
1. If 200, parse response
2. If 400 and 401, look for PkeyAuth header. If pkeyauth header is missing, parse response. For response parsing, either use error response serializer if one is provided, or default one. 
3. If 500...599, retry
4. Everything else is unhandled response

I also fixed error case for authority validation response, which was previously working by accident :)