### PR TITLE
Handle error properly for authority validation

### DIFF
--- a/IdentityCore/src/network/request/MSIDAADAuthorityMetadataResponseSerializer.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorityMetadataResponseSerializer.m
@@ -54,7 +54,7 @@
     if ([jsonObject msidAssertContainsField:@"error" context:context error:nil]
         && [jsonObject msidAssertType:NSString.class ofField:@"error" context:context errorCode:MSIDErrorServerInvalidResponse error:nil])
     {
-        NSError *oauthError = MSIDCreateError(MSIDOAuthErrorDomain,
+        NSError *oauthError = MSIDCreateError(MSIDErrorDomain,
                                               MSIDErrorAuthorityValidation,
                                               jsonObject[MSID_OAUTH2_ERROR_DESCRIPTION],
                                               jsonObject[MSID_OAUTH2_ERROR],

--- a/IdentityCore/src/network/request/MSIDAADOpenIdConfigurationInfoResponseSerializer.m
+++ b/IdentityCore/src/network/request/MSIDAADOpenIdConfigurationInfoResponseSerializer.m
@@ -52,6 +52,24 @@ static NSString *s_tenantIdPlaceholder = @"{tenantid}";
         return nil;
     }
     
+    if ([jsonObject msidAssertContainsField:@"error" context:context error:nil]
+        && [jsonObject msidAssertType:NSString.class ofField:@"error" context:context errorCode:MSIDErrorServerInvalidResponse error:nil])
+    {
+        NSError *oauthError = MSIDCreateError(MSIDErrorDomain,
+                                              MSIDErrorAuthorityValidation,
+                                              jsonObject[MSID_OAUTH2_ERROR_DESCRIPTION],
+                                              jsonObject[MSID_OAUTH2_ERROR],
+                                              nil,
+                                              nil,
+                                              context.correlationId,
+                                              nil);
+        if (error)
+        {
+            *error = oauthError;
+        }
+        return nil;
+    }
+    
     __auto_type metadata = [MSIDOpenIdProviderMetadata new];
     
     if (![jsonObject msidAssertContainsField:@"authorization_endpoint" context:context error:error])

--- a/IdentityCore/tests/MSIDAADAuthorityMetadataResponseSerializerTests.m
+++ b/IdentityCore/tests/MSIDAADAuthorityMetadataResponseSerializerTests.m
@@ -97,4 +97,27 @@
     XCTAssertNil(response);
 }
 
+- (void)testResponseObjectForResponse_whenErrorMessage_shouldReturnNilWithError
+{
+    __auto_type responseJson = @{ @"error": @"invalid_instance",
+                                  @"error_description": @"Unknown or invalid instance.",
+                                  @"error_codes": @5049,
+                                  @"timestamp": @"2019-02-22 07:49:38Z",
+                                  @"trace_id": @"d855",
+                                  @"correlation_id": @"6f62"
+                                  };
+    
+    NSData *data = [NSJSONSerialization dataWithJSONObject:responseJson options:0 error:nil];
+    __auto_type responseSerializer = [MSIDAADAuthorityMetadataResponseSerializer new];
+    
+    NSError *error = nil;
+    __auto_type response = (MSIDAADAuthorityMetadataResponse *)[responseSerializer responseObjectForResponse:[NSHTTPURLResponse new] data:data context:nil error:&error];
+    
+    XCTAssertNil(response);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorAuthorityValidation);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Unknown or invalid instance.");
+}
+
 @end

--- a/IdentityCore/tests/MSIDOpenIdConfigurationInfoResponseSerializerTests.m
+++ b/IdentityCore/tests/MSIDOpenIdConfigurationInfoResponseSerializerTests.m
@@ -181,4 +181,27 @@
     XCTAssertNil(response);
 }
 
+- (void)testResponseObjectForResponse_whenErrorMessage_shouldReturnNilWithError
+{
+    __auto_type responseJson = @{ @"error": @"invalid_tenant",
+                                  @"error_description": @"Tenant not found.",
+                                  @"error_codes": @5049,
+                                  @"timestamp": @"2019-02-22 07:49:38Z",
+                                  @"trace_id": @"d855",
+                                  @"correlation_id": @"6f62"
+                                  };
+    
+    NSData *data = [NSJSONSerialization dataWithJSONObject:responseJson options:0 error:nil];
+    __auto_type responseSerializer = [MSIDAADOpenIdConfigurationInfoResponseSerializer new];
+    
+    NSError *error = nil;
+    __auto_type response = (MSIDOpenIdProviderMetadata *)[responseSerializer responseObjectForResponse:[NSHTTPURLResponse new] data:data context:nil error:&error];
+    
+    XCTAssertNil(response);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorAuthorityValidation);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Tenant not found.");
+}
+
 @end


### PR DESCRIPTION
Fix two issues:

1) `MSIDAADOpenIdConfigurationInfoResponseSerializer.m` is lack of code to handle error case

2) Error code `MSIDErrorAuthorityValidation` is mapped to be `AD_ERROR_UNEXPECTED` rather than `AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION`. 
It is because in error converter, we expect authority validation error to be `MSIDErrorDomain`.