### PR TITLE
Account validation revisit

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -4838,6 +4838,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4E961FC3626A00CD70C5 /* identitycore__tests__ios.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MSIDTestsHostApp.app/MSIDTestsHostApp";
@@ -4848,6 +4849,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4E961FC3626A00CD70C5 /* identitycore__tests__ios.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MSIDTestsHostApp.app/MSIDTestsHostApp";
 			};

--- a/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
@@ -247,12 +247,13 @@
         }
 
         NSError *validationError = nil;
+        
         MSIDTokenResult *tokenResult = [self.tokenResponseValidator validateAndSaveTokenResponse:tokenResponse
                                                                                     oauthFactory:self.oauthFactory
                                                                                       tokenCache:self.tokenCache
                                                                                requestParameters:self.requestParameters
                                                                                            error:&validationError];
-
+        
         if (!tokenResult)
         {
             // Special case - need to return homeAccountId in case of Intune policies required.
@@ -274,7 +275,18 @@
             completionBlock(nil, validationError, nil);
             return;
         }
-
+        
+        BOOL accountChecked = [self.tokenResponseValidator validateAccount:self.requestParameters.accountIdentifier
+                                                               tokenResult:tokenResult
+                                                             correlationID:self.requestParameters.correlationId
+                                                                     error:&validationError];
+        
+        if (!accountChecked)
+        {
+            completionBlock(nil, validationError, nil);
+            return;
+        }
+        
         completionBlock(tokenResult, nil, nil);
     }];
 }

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
@@ -51,10 +51,14 @@
                                       correlationID:(nonnull NSUUID *)correlationID
                                               error:(NSError * _Nullable * _Nullable)error;
 
+- (BOOL)validateAccount:(nonnull MSIDAccountIdentifier *)accountIdentifier
+            tokenResult:(nonnull MSIDTokenResult *)tokenResult
+          correlationID:(nonnull NSUUID *)correlationID
+                  error:(NSError * _Nullable * _Nullable)error;
+
 - (BOOL)validateTokenResult:(nonnull MSIDTokenResult *)tokenResult
               configuration:(nonnull MSIDConfiguration *)configuration
                   oidcScope:(nullable NSString *)oidcScope
-             requestAccount:(nullable MSIDAccountIdentifier *)accountIdentifier
               correlationID:(nonnull NSUUID *)correlationID
                       error:(NSError * _Nullable * _Nullable)error;
 

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
@@ -82,11 +82,18 @@
 - (BOOL)validateTokenResult:(__unused MSIDTokenResult *)tokenResult
               configuration:(__unused MSIDConfiguration *)configuration
                   oidcScope:(__unused NSString *)oidcScope
-             requestAccount:(__unused MSIDAccountIdentifier *)accountIdentifier
               correlationID:(__unused NSUUID *)correlationID
                       error:(__unused NSError **)error
 {
     // Post saving validation
+    return YES;
+}
+
+- (BOOL)validateAccount:(__unused MSIDAccountIdentifier *)accountIdentifier
+            tokenResult:(__unused MSIDTokenResult *)tokenResult
+          correlationID:(__unused NSUUID *)correlationID
+                  error:(__unused NSError *__autoreleasing  _Nullable *)error
+{
     return YES;
 }
 
@@ -168,7 +175,6 @@
     BOOL resultValid = [self validateTokenResult:tokenResult
                                    configuration:configuration
                                        oidcScope:oidcScope
-                                  requestAccount:nil
                                    correlationID:correlationID
                                            error:error];
 
@@ -220,7 +226,6 @@
     BOOL resultValid = [self validateTokenResult:tokenResult
                                    configuration:parameters.msidConfiguration
                                        oidcScope:parameters.oidcScope
-                                  requestAccount:parameters.accountIdentifier
                                    correlationID:parameters.correlationId
                                            error:error];
 

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
@@ -61,22 +61,22 @@
     {
         case MSIDLegacyIdentifierTypeRequiredDisplayableId:
         {
-            if (!accountIdentifier.displayableId)
+            if (!accountIdentifier.displayableId
+                || [accountIdentifier.displayableId.lowercaseString isEqualToString:tokenResult.account.accountIdentifier.displayableId.lowercaseString])
             {
                 return YES;
             }
-            
-            return [accountIdentifier.displayableId.lowercaseString isEqualToString:tokenResult.account.accountIdentifier.displayableId.lowercaseString];
+            break;
         }
             
         case MSIDLegacyIdentifierTypeUniqueNonDisplayableId:
         {
-            if (!accountIdentifier.localAccountId)
+            if (!accountIdentifier.localAccountId
+                || [accountIdentifier.localAccountId.lowercaseString isEqualToString:tokenResult.account.localAccountId.lowercaseString])
             {
                 return YES;
             }
-            
-            return [accountIdentifier.localAccountId.lowercaseString isEqualToString:tokenResult.account.localAccountId.lowercaseString];
+            break;
         }
         case MSIDLegacyIdentifierTypeOptionalDisplayableId:
         {
@@ -84,15 +84,16 @@
         }
             
         default:
-        {
-            if (error)
-            {
-                *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorMismatchedAccount, @"Different user was returned by the server then specified in the acquireToken call. If this is a new sign in use and ADUserIdentifier is of OptionalDisplayableId type, pass in the userId returned on the initial authentication flow in all future acquireToken calls.", nil, nil, nil, correlationID, nil);
-            }
-            
-            return NO;
-        }
+            break;
+        
     }
+    
+    if (error)
+    {
+        *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorMismatchedAccount, @"Different user was returned by the server then specified in the acquireToken call. If this is a new sign in use and ADUserIdentifier is of OptionalDisplayableId type, pass in the userId returned on the initial authentication flow in all future acquireToken calls.", nil, nil, nil, correlationID, nil);
+    }
+    
+    return NO;
 }
 
 @end

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
@@ -35,7 +35,6 @@
 - (BOOL)validateTokenResult:(MSIDTokenResult *)tokenResult
               configuration:(MSIDConfiguration *)configuration
                   oidcScope:(NSString *)oidcScope
-             requestAccount:(MSIDAccountIdentifier *)accountIdentifier
               correlationID:(NSUUID *)correlationID
                       error:(NSError **)error
 {
@@ -74,6 +73,14 @@
         return NO;
     }
 
+    return YES;
+}
+
+- (BOOL)validateAccount:(MSIDAccountIdentifier *)accountIdentifier
+            tokenResult:(MSIDTokenResult *)tokenResult
+              correlationID:(NSUUID *)correlationID
+                      error:(NSError **)error
+{
     if (accountIdentifier.uid != nil
         && ![accountIdentifier.uid isEqualToString:tokenResult.accessToken.accountIdentifier.uid])
     {
@@ -82,10 +89,10 @@
             NSDictionary *userInfo = @{MSIDInvalidTokenResultKey : tokenResult};
             *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorMismatchedAccount, @"Different account was returned from the server", nil, nil, nil, correlationID, userInfo);
         }
-
+        
         return NO;
     }
-
+    
     return YES;
 }
 

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
@@ -74,8 +74,8 @@
         return NO;
     }
 
-    if (accountIdentifier.homeAccountId != nil
-        && ![accountIdentifier.homeAccountId isEqualToString:tokenResult.accessToken.accountIdentifier.homeAccountId])
+    if (accountIdentifier.uid != nil
+        && ![accountIdentifier.uid isEqualToString:tokenResult.accessToken.accountIdentifier.uid])
     {
         if (error)
         {

--- a/IdentityCore/tests/MSIDLegacyTokenResponseValidatorTests.m
+++ b/IdentityCore/tests/MSIDLegacyTokenResponseValidatorTests.m
@@ -49,7 +49,7 @@
 
 #pragma mark - Tests
 
-- (void)testValidateTokenResult_whenAccountTypeIsRequiredDisplayableId_andAccountMismatch_shouldReturnError
+- (void)testValidateAccount_whenAccountTypeIsRequiredDisplayableId_andAccountMismatch_shouldReturnError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
     MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
@@ -57,12 +57,10 @@
     testAccount.displayableId = @"user2@contoso.com";
     
     NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
+    BOOL result = [self.validator validateAccount:testAccount
+                                      tokenResult:testResult
+                                    correlationID:[NSUUID new]
+                                            error:&error];
     
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
@@ -70,25 +68,23 @@
     XCTAssertEqual(error.code, MSIDErrorMismatchedAccount);
 }
 
-- (void)testValidateTokenResult_whenAccountTypeIsRequiredDisplayableId_andNoAccountProvided_shouldReturnNoError
+- (void)testValidateAccount_whenAccountTypeIsRequiredDisplayableId_andNoAccountProvided_shouldReturnNoError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
     MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
     testAccount.legacyAccountIdentifierType = MSIDLegacyIdentifierTypeRequiredDisplayableId;
     
     NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
+    BOOL result = [self.validator validateAccount:testAccount
+                                      tokenResult:testResult
+                                    correlationID:[NSUUID new]
+                                            error:&error];
     
     XCTAssertTrue(result);
     XCTAssertNil(error);
 }
 
-- (void)testValidateTokenResult_whenAccountTypeIsRequiredDisplayableId_andAccountMatches_shouldReturnNoError
+- (void)testValidateAccount_whenAccountTypeIsRequiredDisplayableId_andAccountMatches_shouldReturnNoError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
     MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
@@ -96,12 +92,10 @@
     testAccount.displayableId = @"user@contoso.com";
     
     NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
+    BOOL result = [self.validator validateAccount:testAccount
+                                      tokenResult:testResult
+                                    correlationID:[NSUUID new]
+                                            error:&error];
     
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
@@ -109,7 +103,7 @@
     XCTAssertEqual(error.code, MSIDErrorMismatchedAccount);
 }
 
-- (void)testValidateTokenResult_whenAccountTypeIsOptionalDisplayableId_andAccountMatches_shouldReturnNoError
+- (void)testValidateAccount_whenAccountTypeIsOptionalDisplayableId_andAccountMatches_shouldReturnNoError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
     MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
@@ -117,36 +111,32 @@
     testAccount.displayableId = @"user@contoso.com";
     
     NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
+    BOOL result = [self.validator validateAccount:testAccount
+                                      tokenResult:testResult
+                                    correlationID:[NSUUID new]
+                                            error:&error];
     
     XCTAssertTrue(result);
     XCTAssertNil(error);
 }
 
-- (void)testValidateTokenResult_whenAccountTypeIsOptionalDisplayableId_andNoInputAccount_shouldReturnNoError
+- (void)testValidateAccount_whenAccountTypeIsOptionalDisplayableId_andNoInputAccount_shouldReturnNoError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
     MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
     testAccount.legacyAccountIdentifierType = MSIDLegacyIdentifierTypeOptionalDisplayableId;
     
     NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
+    BOOL result = [self.validator validateAccount:testAccount
+                                      tokenResult:testResult
+                                    correlationID:[NSUUID new]
+                                            error:&error];
     
     XCTAssertTrue(result);
     XCTAssertNil(error);
 }
 
-- (void)testValidateTokenResult_whenAccountTypeIsOptionalDisplayableId_andAccountMismatch_shouldReturnNoError
+- (void)testValidateAccount_whenAccountTypeIsOptionalDisplayableId_andAccountMismatch_shouldReturnNoError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
     MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
@@ -154,18 +144,16 @@
     testAccount.displayableId = @"user2@contoso.com";
     
     NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
+    BOOL result = [self.validator validateAccount:testAccount
+                                      tokenResult:testResult
+                                    correlationID:[NSUUID new]
+                                            error:&error];
     
     XCTAssertTrue(result);
     XCTAssertNil(error);
 }
 
-- (void)testValidateTokenResult_whenAccountTypeIsUniqueId_andAccountMismatch_shouldReturnError
+- (void)testValidateAccount_whenAccountTypeIsUniqueId_andAccountMismatch_shouldReturnError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
     MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
@@ -173,12 +161,10 @@
     testAccount.localAccountId = @"oid2";
     
     NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
+    BOOL result = [self.validator validateAccount:testAccount
+                                      tokenResult:testResult
+                                    correlationID:[NSUUID new]
+                                            error:&error];
     
     XCTAssertFalse(result);
     XCTAssertNotNil(error);
@@ -186,25 +172,23 @@
     XCTAssertEqual(error.code, MSIDErrorMismatchedAccount);
 }
 
-- (void)testValidateTokenResult_whenAccountTypeIsUniqueId_andNoInputAccount_shouldReturnNoError
+- (void)testValidateAccount_whenAccountTypeIsUniqueId_andNoInputAccount_shouldReturnNoError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
     MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
     testAccount.legacyAccountIdentifierType = MSIDLegacyIdentifierTypeUniqueNonDisplayableId;
     
     NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
+    BOOL result = [self.validator validateAccount:testAccount
+                                      tokenResult:testResult
+                                    correlationID:[NSUUID new]
+                                            error:&error];
     
     XCTAssertTrue(result);
     XCTAssertNil(error);
 }
 
-- (void)testValidateTokenResult_whenAccountTypeIsUniqueId_andAccountMatches_shouldReturnNoError
+- (void)testValidateAccount_whenAccountTypeIsUniqueId_andAccountMatches_shouldReturnNoError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
     MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
@@ -212,55 +196,28 @@
     testAccount.localAccountId = @"unique_oid";
     
     NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
+    BOOL result = [self.validator validateAccount:testAccount
+                                      tokenResult:testResult
+                                    correlationID:[NSUUID new]
+                                            error:&error];
     
     XCTAssertTrue(result);
     XCTAssertNil(error);
 }
 
-- (void)testValidateTokenResult_whenNoAccountProvided_shouldReturnNoError
+- (void)testValidateTokenResult_whenResultContainsAccount_shouldReturnNoError
 {
     MSIDTokenResult *testResult = [self testTokenResult];
-    MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
     
     NSError *error = nil;
     BOOL result = [self.validator validateTokenResult:testResult
                                         configuration:[MSIDConfiguration new]
                                             oidcScope:nil
-                                       requestAccount:testAccount
                                         correlationID:[NSUUID new]
                                                 error:&error];
     
     XCTAssertTrue(result);
     XCTAssertNil(error);
-}
-
-- (void)testValidateTokenResult_whenNoAccountInResult_shouldReturnError
-{
-    MSIDTokenResult *testResult = [self testTokenResult];
-    MSIDAccount *resultAccount = nil;
-    testResult.account = resultAccount;
-    MSIDAccountIdentifier *testAccount = [MSIDAccountIdentifier new];
-    testAccount.legacyAccountIdentifierType = MSIDLegacyIdentifierTypeUniqueNonDisplayableId;
-    testAccount.localAccountId = @"unique_oid";
-    
-    NSError *error = nil;
-    BOOL result = [self.validator validateTokenResult:testResult
-                                        configuration:[MSIDConfiguration new]
-                                            oidcScope:nil
-                                       requestAccount:testAccount
-                                        correlationID:[NSUUID new]
-                                                error:&error];
-    
-    XCTAssertFalse(result);
-    XCTAssertNotNil(error);
-    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
-    XCTAssertEqual(error.code, MSIDErrorInternal);
 }
 
 #pragma mark - Helpers

--- a/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
@@ -716,7 +716,7 @@
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
-- (void)testAcquireTokenSilent_whenExpiredAccessTokenInCache_andDifferentAccountReturn_shouldReturnError
+- (void)testAcquireTokenSilent_whenExpiredAccessTokenInCache_andDifferentAccountReturn_shouldReturnValidResult
 {
     MSIDRequestParameters *silentParameters = [self silentRequestParameters];
     MSIDDefaultTokenCacheAccessor *tokenCache = self.tokenCache;
@@ -758,9 +758,8 @@
 
     [silentRequest executeRequestWithCompletion:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
 
-        XCTAssertNotNil(error);
-        XCTAssertNil(result);
-        XCTAssertEqual(error.code, MSIDErrorMismatchedAccount);
+        XCTAssertNil(error);
+        XCTAssertNotNil(result);
         [expectation fulfill];
     }];
 


### PR DESCRIPTION
Decouple account validation, as it should really be done only on interactive requests.
