### PR TITLE
MSID logging fixes

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -729,7 +729,7 @@
     if (![NSString msidIsStringNilOrBlank:refreshToken.familyId])
     {
         MSID_LOG_VERBOSE(context, @"(Default accessor) Saving family refresh token %@", _PII_NULLIFY(refreshToken.refreshToken));
-        MSID_LOG_VERBOSE_PII(context, @"(Default accessor) Saving family refresh token %@", refreshToken.refreshToken);
+        MSID_LOG_VERBOSE_PII(context, @"(Default accessor) Saving family refresh token %@", refreshToken);
 
         if (![self saveToken:refreshToken context:context error:error])
         {

--- a/IdentityCore/src/oauth2/token/MSIDAccessToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDAccessToken.m
@@ -212,7 +212,7 @@ static NSUInteger s_expirationBuffer = 300;
 - (NSString *)description
 {
     NSString *baseDescription = [super description];
-    return [baseDescription stringByAppendingFormat:@"(access token=%@, expiresOn=%@, target=%@)", _PII_NULLIFY(_accessToken), _expiresOn, _target];
+    return [baseDescription stringByAppendingFormat:@"(access token=%@, expiresOn=%@, target=%@)", [_accessToken msidSecretLoggingHash], _expiresOn, _target];
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDIdToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDIdToken.m
@@ -113,7 +113,7 @@
 - (NSString *)description
 {
     NSString *baseDescription = [super description];
-    return [baseDescription stringByAppendingFormat:@"(id token=%@)", _PII_NULLIFY(_rawIdToken)];
+    return [baseDescription stringByAppendingFormat:@"(id token=%@)", [_rawIdToken msidSecretLoggingHash]];
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDLegacyAccessToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDLegacyAccessToken.m
@@ -141,7 +141,7 @@
 - (NSString *)description
 {
     NSString *baseDescription = [super description];
-    return [baseDescription stringByAppendingFormat:@"(id token=%@, access token=%@)", _PII_NULLIFY(_idToken), _PII_NULLIFY(_accessToken)];
+    return [baseDescription stringByAppendingFormat:@"(id token=%@, access token=%@)", [_idToken msidSecretLoggingHash], [_accessToken msidSecretLoggingHash]];
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDLegacyRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDLegacyRefreshToken.m
@@ -137,7 +137,7 @@
 - (NSString *)description
 {
     NSString *baseDescription = [super description];
-    return [baseDescription stringByAppendingFormat:@"(id token=%@, legacy user ID=%@)", _PII_NULLIFY(_idToken), _accountIdentifier.displayableId];
+    return [baseDescription stringByAppendingFormat:@"(id token=%@, legacy user ID=%@)", [_idToken msidSecretLoggingHash], _accountIdentifier.displayableId];
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDLegacySingleResourceToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDLegacySingleResourceToken.m
@@ -139,7 +139,7 @@
 - (NSString *)description
 {
     NSString *baseDescription = [super description];
-    return [baseDescription stringByAppendingFormat:@"(refresh token=%@, family id=%@)", _PII_NULLIFY(_refreshToken), _familyId];
+    return [baseDescription stringByAppendingFormat:@"(refresh token=%@, family id=%@)", [_refreshToken msidSecretLoggingHash], _familyId];
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
@@ -150,7 +150,7 @@
 - (NSString *)description
 {
     NSString *baseDescription = [super description];
-    return [baseDescription stringByAppendingFormat:@"(primary refresh token=%@)", _PII_NULLIFY(_refreshToken)];
+    return [baseDescription stringByAppendingFormat:@"(primary refresh token=%@)", [_refreshToken msidSecretLoggingHash]];
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDRefreshToken.m
@@ -118,7 +118,7 @@
 - (NSString *)description
 {
     NSString *baseDescription = [super description];
-    return [baseDescription stringByAppendingFormat:@"(refresh token=%@, family ID=%@)", _PII_NULLIFY(_refreshToken), _familyId];
+    return [baseDescription stringByAppendingFormat:@"(refresh token=%@, family ID=%@)", [_refreshToken msidSecretLoggingHash], _familyId];
 }
 
 @end

--- a/IdentityCore/src/util/NSURL+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSURL+MSIDExtensions.h
@@ -56,4 +56,6 @@
 - (NSURL *)msidURLForPreferredHost:(NSString *)preferredHost context:(id<MSIDRequestContext>)context error:(NSError * __autoreleasing *)error;
 - (NSURL *)msidURLWithQueryParameters:(NSDictionary *)queryParameters;
 
+- (NSURL *)msidPIINullifiedURL;
+
 @end

--- a/IdentityCore/src/util/NSURL+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSURL+MSIDExtensions.m
@@ -298,4 +298,25 @@ const unichar queryStringSeparator = '?';
     return [components URL];
 }
 
+- (NSURL *)msidPIINullifiedURL
+{
+    NSURLComponents *components = [[NSURLComponents alloc] initWithURL:self resolvingAgainstBaseURL:NO];
+    
+    NSMutableArray *piiQueryItems = [NSMutableArray new];
+    
+    for (NSURLQueryItem *queryItem in components.queryItems)
+    {
+        NSString *piiValue = [NSString msidIsStringNilOrBlank:queryItem.value] ? @"(null)" : @"(not-null)";
+        NSURLQueryItem *piiQueryItem = [[NSURLQueryItem alloc] initWithName:queryItem.name value:piiValue];
+        [piiQueryItems addObject:piiQueryItem];
+    }
+    
+    if ([piiQueryItems count])
+    {
+        components.queryItems = piiQueryItems;
+    }
+    
+    return components.URL;
+}
+
 @end

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -303,7 +303,6 @@
 {
     __auto_type isKnown = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:endURL.host];
     MSID_LOG_VERBOSE(self.context, @"-completeWebAuthWithURL: %@", isKnown ? endURL.host : @"unknown host");
-    // TODO: remove me!
     MSID_LOG_VERBOSE_PII(self.context, @"-completeWebAuthWithURL: %@", [endURL msidPIINullifiedURL]);
     
     [self endWebAuthWithURL:endURL error:nil];

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -303,7 +303,8 @@
 {
     __auto_type isKnown = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:endURL.host];
     MSID_LOG_VERBOSE(self.context, @"-completeWebAuthWithURL: %@", isKnown ? endURL.host : @"unknown host");
-    MSID_LOG_VERBOSE_PII(self.context, @"-completeWebAuthWithURL: %@", endURL);
+    // TODO: remove me!
+    MSID_LOG_VERBOSE_PII(self.context, @"-completeWebAuthWithURL: %@", [endURL msidPIINullifiedURL]);
     
     [self endWebAuthWithURL:endURL error:nil];
 }

--- a/IdentityCore/tests/MSIDURLExtensionsTests.m
+++ b/IdentityCore/tests/MSIDURLExtensionsTests.m
@@ -367,6 +367,28 @@
 
     XCTAssertEqualObjects(resultURL, expectedResultURL);
 }
-    
+
+- (void)testMsidPIINullifiedURL_whenNoQueryParameters_shouldReturnURL
+{
+    NSURL *inputURL = [NSURL URLWithString:@"https://login.microsoftonline.com/path/path2/path3"];
+    NSURL *resultURL = [inputURL msidPIINullifiedURL];
+    XCTAssertEqualObjects(inputURL, resultURL);
+}
+
+- (void)testMsidPIINullifiedURL_whenQueryParametersWithValue_shouldReturnURLWithNullifiedQueryParams
+{
+    NSURL *inputURL = [NSURL URLWithString:@"https://login.microsoftonline.com/path/path2/path3?query1=value1&query2=value2"];
+    NSURL *expectedResultURL = [NSURL URLWithString:@"https://login.microsoftonline.com/path/path2/path3?query1=(not-null)&query2=(not-null)"];
+    NSURL *resultURL = [inputURL msidPIINullifiedURL];
+    XCTAssertEqualObjects(expectedResultURL, resultURL);
+}
+
+- (void)testMsidPIINullifiedURL_whenQueryParametersWithoutValue_shouldReturnURLWithNillifiedQueryParams
+{
+    NSURL *inputURL = [NSURL URLWithString:@"https://login.microsoftonline.com/path/path2/path3?query1=&query2="];
+    NSURL *expectedResultURL = [NSURL URLWithString:@"https://login.microsoftonline.com/path/path2/path3?query1=(null)&query2=(null)"];
+    NSURL *resultURL = [inputURL msidPIINullifiedURL];
+    XCTAssertEqualObjects(expectedResultURL, resultURL);
+}
 
 @end


### PR DESCRIPTION
Fixed logging refresh token in one place
Fixed logging endURL, which might contain authorization code
Log token hash instead of null-notnull