### PR TITLE
Revise double PII logging when PII is enabled

### DIFF
--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -159,6 +159,6 @@ void MSIDFillAndLogError(NSError **error, MSIDErrorCode errorCode, NSString *err
         *error = MSIDCreateError(MSIDErrorDomain, errorCode, errorDescription, nil, nil, nil, correlationID, nil);
     }
 
-    MSID_LOG_ERROR_CORR(correlationID, @"Encountered error with code %ld", (long)errorCode);
-    MSID_LOG_ERROR_CORR_PII(correlationID, @"Encountered error with code %ld, description %@", (long)errorCode, errorDescription);
+    MSID_LOG_NO_PII(MSIDLogLevelError, correlationID, nil, @"Encountered error with code %ld", (long)errorCode);
+    MSID_LOG_PII(MSIDLogLevelError, correlationID, nil, @"Encountered error with code %ld, description %@", (long)errorCode, errorDescription);
 }

--- a/IdentityCore/src/MSIDJsonSerializer.m
+++ b/IdentityCore/src/MSIDJsonSerializer.m
@@ -48,8 +48,8 @@
                                                      error:&internalError];
     if (internalError)
     {
-        MSID_LOG_ERROR(context, @"Failed to serialize to json data.");
-        MSID_LOG_ERROR_PII(context, @"Failed to serialize to json data, error: %@", internalError);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, context, @"Failed to serialize to json data.");
+        MSID_LOG_PII(MSIDLogLevelError, nil, context, @"Failed to serialize to json data, error: %@", internalError);
         
         if (error) *error = internalError;
         return nil;
@@ -71,8 +71,8 @@
     
     if (internalError)
     {
-        MSID_LOG_ERROR(context, @"Failed to deserialize json object.");
-        MSID_LOG_ERROR_PII(context, @"Failed to deserialize json object, error: %@", internalError);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, context, @"Failed to deserialize json object.");
+        MSID_LOG_PII(MSIDLogLevelError, nil, context, @"Failed to deserialize json object, error: %@", internalError);
         
         if (error) *error = internalError;
         return nil;

--- a/IdentityCore/src/cache/MSIDMacTokenCache.m
+++ b/IdentityCore/src/cache/MSIDMacTokenCache.m
@@ -466,8 +466,9 @@ return NO; \
     assert(key);
     
     MSID_LOG_INFO(context, @"Set item, key info (account: %@ service: %@)", _PII_NULLIFY(key.account), _PII_NULLIFY(key.service));
-    MSID_LOG_INFO_PII(context, @"Set item, key info (account: %@ service: %@)", key.account, key.service);
-    MSID_LOG_INFO_PII(context, @"Item info %@", item);
+    
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Set item, key info (account: %@ service: %@)", key.account, key.service);
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Item info %@", item);
     
     if (!key)
     {
@@ -529,8 +530,8 @@ return NO; \
                                             context:(id<MSIDRequestContext>)context
                                               error:(__unused NSError **)error
 {
-    MSID_LOG_INFO(context, @"Get items, key info (account: %@ service: %@)", _PII_NULLIFY(key.account), _PII_NULLIFY(key.service));
-    MSID_LOG_INFO_PII(context, @"Get items, key info (account: %@ service: %@)", key.account, key.service);
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Get items, key info (account: %@ service: %@)", _PII_NULLIFY(key.account), _PII_NULLIFY(key.service));
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Get items, key info (account: %@ service: %@)", key.account, key.service);
 
     if (!self.cache)
     {

--- a/IdentityCore/src/cache/MSIDUserInformation.m
+++ b/IdentityCore/src/cache/MSIDUserInformation.m
@@ -65,8 +65,8 @@
 
     if (error)
     {
-        MSID_LOG_WARN(nil, @"Invalid ID token");
-        MSID_LOG_WARN_PII(nil, @"Invalid ID token, error %@", error.localizedDescription);
+        MSID_LOG_NO_PII(MSIDLogLevelWarning, nil, nil, @"Invalid ID token");
+        MSID_LOG_PII(MSIDLogLevelWarning, nil, nil, @"Invalid ID token, error %@", error.localizedDescription);
     }
 
     return idTokenClaims;

--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
@@ -126,8 +126,8 @@
 {
     assert(key);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Get credential for key %@", key.logDescription);
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Get credential for key %@", key.piiLogDescription);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get credential for key %@", key.logDescription);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get credential for key %@", key.piiLogDescription);
 
     return [_dataSource tokenWithKey:key serializer:_serializer context:context error:error];
 }
@@ -136,7 +136,7 @@
                                                               context:(nullable id<MSIDRequestContext>)context
                                                                 error:(NSError * _Nullable * _Nullable)error
 {
-    MSID_LOG_VERBOSE(context, @"(Default cache) Get all credentials with type %@", [MSIDCredentialTypeHelpers credentialTypeAsString:type]);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get all credentials with type %@", [MSIDCredentialTypeHelpers credentialTypeAsString:type]);
 
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
     query.credentialType = type;
@@ -151,8 +151,8 @@
 {
     assert(cacheQuery);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Get accounts with environment %@", cacheQuery.environment);
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Get accounts with environment %@, unique user id %@", cacheQuery.environment, cacheQuery.homeAccountId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get accounts with environment %@", cacheQuery.environment);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get accounts with environment %@, unique user id %@", cacheQuery.environment, cacheQuery.homeAccountId);
 
     NSArray<MSIDAccountCacheItem *> *cacheItems = [_dataSource accountsWithKey:cacheQuery serializer:_serializer context:context error:error];
 
@@ -187,8 +187,8 @@
 {
     assert(key);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Get account for key %@", key.logDescription);
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Get account for key %@", key.piiLogDescription);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get account for key %@", key.logDescription);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get account for key %@", key.piiLogDescription);
 
     return [_dataSource accountWithKey:key serializer:_serializer context:context error:error];
 }
@@ -197,7 +197,7 @@
                                                              context:(nullable id<MSIDRequestContext>)context
                                                                error:(NSError * _Nullable * _Nullable)error
 {
-    MSID_LOG_VERBOSE(context, @"(Default cache) Get all accounts with type %@", [MSIDAccountTypeHelpers accountTypeAsString:type]);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get all accounts with type %@", [MSIDAccountTypeHelpers accountTypeAsString:type]);
 
     MSIDDefaultAccountCacheQuery *query = [MSIDDefaultAccountCacheQuery new];
     query.accountType = MSIDAccountTypeMSSTS;
@@ -208,7 +208,7 @@
 - (nullable NSArray<MSIDCredentialCacheItem *> *)getAllItemsWithContext:(nullable id<MSIDRequestContext>)context
                                                              error:(NSError * _Nullable * _Nullable)error
 {
-    MSID_LOG_VERBOSE(context, @"(Default cache) Get all items from cache");
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get all items from cache");
 
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
     query.matchAnyCredentialType = YES;
@@ -222,8 +222,8 @@
 {
     assert(credential);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Saving token %@ with environment %@, realm %@, clientID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credential.credentialType], credential.environment, credential.realm, credential.clientId);
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Saving token %@ for userID %@ with environment %@, realm %@, clientID %@,", credential, credential.homeAccountId, credential.environment, credential.environment, credential.clientId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Saving token %@ with environment %@, realm %@, clientID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credential.credentialType], credential.environment, credential.realm, credential.clientId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Saving token %@ for userID %@ with environment %@, realm %@, clientID %@,", credential, credential.homeAccountId, credential.environment, credential.environment, credential.clientId);
     
     MSIDDefaultCredentialCacheKey *key = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:credential.homeAccountId
                                                                                           environment:credential.environment
@@ -249,8 +249,8 @@
 {
     assert(account);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Saving account with environment %@", account.environment);
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Saving account %@", account);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Saving account with environment %@", account.environment);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Saving account %@", account);
 
     MSIDDefaultAccountCacheKey *key = [[MSIDDefaultAccountCacheKey alloc] initWithHomeAccountId:account.homeAccountId
                                                                                     environment:account.environment
@@ -282,8 +282,8 @@
 {
     assert(cacheQuery);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Removing credentials with type %@, environment %@, realm %@, clientID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:cacheQuery.credentialType], cacheQuery.environment, cacheQuery.realm, cacheQuery.clientId);
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Removing credentials with type %@, environment %@, realm %@, clientID %@, unique user ID %@, target %@", [MSIDCredentialTypeHelpers credentialTypeAsString:cacheQuery.credentialType], cacheQuery.environment, cacheQuery.realm, cacheQuery.clientId, cacheQuery.homeAccountId, cacheQuery.target);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing credentials with type %@, environment %@, realm %@, clientID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:cacheQuery.credentialType], cacheQuery.environment, cacheQuery.realm, cacheQuery.clientId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing credentials with type %@, environment %@, realm %@, clientID %@, unique user ID %@, target %@", [MSIDCredentialTypeHelpers credentialTypeAsString:cacheQuery.credentialType], cacheQuery.environment, cacheQuery.realm, cacheQuery.clientId, cacheQuery.homeAccountId, cacheQuery.target);
 
     if (cacheQuery.exactMatch)
     {
@@ -303,8 +303,8 @@
 {
     assert(credential);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Removing credential %@ with environment %@, realm %@, clientID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credential.credentialType], credential.environment, credential.realm, credential.clientId);
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Removing credential %@ for userID %@ with environment %@, realm %@, clientID %@,", credential, credential.homeAccountId, credential.environment, credential.realm, credential.clientId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing credential %@ with environment %@, realm %@, clientID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credential.credentialType], credential.environment, credential.realm, credential.clientId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing credential %@ for userID %@ with environment %@, realm %@, clientID %@,", credential, credential.homeAccountId, credential.environment, credential.realm, credential.clientId);
 
     MSIDDefaultCredentialCacheKey *key = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:credential.homeAccountId
                                                                                          environment:credential.environment
@@ -334,8 +334,8 @@
 {
     assert(cacheQuery);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Removing accounts with environment %@, realm %@", cacheQuery.environment, cacheQuery.realm);
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Removing accounts with environment %@, realm %@, unique user id %@", cacheQuery.environment, cacheQuery.realm, cacheQuery.homeAccountId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing accounts with environment %@, realm %@", cacheQuery.environment, cacheQuery.realm);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing accounts with environment %@, realm %@, unique user id %@", cacheQuery.environment, cacheQuery.realm, cacheQuery.homeAccountId);
 
     if (cacheQuery.exactMatch)
     {
@@ -353,8 +353,8 @@
 {
     assert(account);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Removing account with environment %@", account.environment);
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Removing account with environment %@, user ID %@, username %@", account.environment, account.homeAccountId, account.username);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing account with environment %@", account.environment);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing account with environment %@, user ID %@, username %@", account.environment, account.homeAccountId, account.username);
 
     MSIDDefaultAccountCacheKey *key = [[MSIDDefaultAccountCacheKey alloc] initWithHomeAccountId:account.homeAccountId
                                                                                    environment:account.environment
@@ -378,7 +378,7 @@
 {
     assert(credentials);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Removing multiple credentials");
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing multiple credentials");
 
     BOOL result = YES;
 
@@ -396,7 +396,7 @@
 {
     assert(accounts);
 
-    MSID_LOG_VERBOSE(context, @"(Default cache) Removing multiple accounts");
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing multiple accounts");
 
     BOOL result = YES;
 
@@ -427,8 +427,8 @@
 {
     assert(metadata);
     
-    MSID_LOG_VERBOSE(context, @"Saving app's metadata with clientId %@", metadata.clientId);
-    MSID_LOG_VERBOSE_PII(context, @"Saving app's metadata %@", metadata);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Saving app's metadata with clientId %@", metadata.clientId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Saving app's metadata %@", metadata);
     
     MSIDAppMetadataCacheKey *key = [[MSIDAppMetadataCacheKey alloc] initWithClientId:metadata.clientId
                                                                          environment:metadata.environment
@@ -448,7 +448,7 @@
 {
     assert(appMetadata);
     
-    MSID_LOG_VERBOSE(context, @"(Default cache) Removing app metadata with clientId %@, environment %@", appMetadata.clientId, appMetadata.environment);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Removing app metadata with clientId %@, environment %@", appMetadata.clientId, appMetadata.environment);
     
     MSIDAppMetadataCacheKey *key = [[MSIDAppMetadataCacheKey alloc] initWithClientId:appMetadata.clientId
                                                                          environment:appMetadata.environment
@@ -464,7 +464,7 @@
 {
     assert(cacheQuery);
     
-    MSID_LOG_VERBOSE_PII(context, @"(Default cache) Get app metadata entries with clientId %@, environment %@", cacheQuery.clientId, cacheQuery.environment);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default cache) Get app metadata entries with clientId %@, environment %@", cacheQuery.clientId, cacheQuery.environment);
     
     NSArray<MSIDAppMetadataCacheItem *> *cacheItems = [_dataSource appMetadataEntriesWithKey:cacheQuery serializer:_serializer context:context error:error];
     

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -80,7 +80,7 @@
                             context:(id<MSIDRequestContext>)context
                               error:(NSError *__autoreleasing *)error
 {
-    MSID_LOG_VERBOSE(context, @"(Default accessor) Saving multi resource refresh token");
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Saving multi resource refresh token");
 
     // Save access token
     BOOL result = [self saveAccessTokenWithConfiguration:configuration response:response factory:factory context:context error:error];
@@ -108,7 +108,7 @@
         return NO;
     }
 
-    MSID_LOG_VERBOSE(context, @"(Legacy accessor) Saving SSO state");
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Saving SSO state");
 
     BOOL result = [self saveRefreshTokenWithConfiguration:configuration response:response factory:factory context:context error:error];
 
@@ -149,7 +149,7 @@
         
         if (refreshToken)
         {
-            MSID_LOG_VERBOSE(context, @"(Default accessor) Found refresh token in a different accessor %@", [accessor class]);
+            MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Found refresh token in a different accessor %@", [accessor class]);
             return refreshToken;
         }
     }
@@ -182,7 +182,7 @@
         
         if (prt)
         {
-            MSID_LOG_VERBOSE(context, @"(Default accessor) Found primary refresh token in a different accessor %@", [accessor class]);
+            MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Found primary refresh token in a different accessor %@", [accessor class]);
             return prt;
         }
     }
@@ -201,8 +201,8 @@
     
     if (![NSString msidIsStringNilOrBlank:accountIdentifier.homeAccountId])
     {
-        MSID_LOG_VERBOSE(context, @"(Default accessor) Finding token with user ID, clientId %@, familyID %@, authority %@", configuration.clientId, familyId, configuration.authority);
-        MSID_LOG_VERBOSE_PII(context, @"(Default accessor) Finding token with user ID %@, clientId %@, familyID %@, authority %@", accountIdentifier.homeAccountId, configuration.clientId, familyId, configuration.authority);
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Finding token with user ID, clientId %@, familyID %@, authority %@", configuration.clientId, familyId, configuration.authority);
+        MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Finding token with user ID %@, clientId %@, familyID %@, authority %@", accountIdentifier.homeAccountId, configuration.clientId, familyId, configuration.authority);
 
         MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
         query.homeAccountId = accountIdentifier.homeAccountId;
@@ -218,15 +218,15 @@
 
         if (refreshToken)
         {
-            MSID_LOG_VERBOSE(context, @"(Default accessor) Found %@refresh token by home account id", credentialType == MSIDPrimaryRefreshTokenType ? @"primary " : @"");
+            MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Found %@refresh token by home account id", credentialType == MSIDPrimaryRefreshTokenType ? @"primary " : @"");
             return refreshToken;
         }
     }
 
     if (![NSString msidIsStringNilOrBlank:accountIdentifier.displayableId])
     {
-        MSID_LOG_VERBOSE(context, @"(Default accessor) Finding refresh token with legacy user ID, clientId %@, authority %@", configuration.clientId, configuration.authority);
-        MSID_LOG_VERBOSE_PII(context, @"(Default accessor) Finding refresh token with legacy user ID %@, clientId %@, authority %@", accountIdentifier.displayableId, configuration.clientId, configuration.authority);
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Finding refresh token with legacy user ID, clientId %@, authority %@", configuration.clientId, configuration.authority);
+        MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Finding refresh token with legacy user ID %@, clientId %@, authority %@", accountIdentifier.displayableId, configuration.clientId, configuration.authority);
         
         MSIDRefreshToken *refreshToken = (MSIDRefreshToken *) [self getRefreshableTokenByDisplayableId:accountIdentifier.displayableId
                                                                                              authority:configuration.authority
@@ -238,7 +238,7 @@
 
         if (refreshToken)
         {
-            MSID_LOG_VERBOSE(context, @"(Default accessor) Found %@refresh token by legacy account id", credentialType == MSIDPrimaryRefreshTokenType ? @"primary " : @"");
+            MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Found %@refresh token by legacy account id", credentialType == MSIDPrimaryRefreshTokenType ? @"primary " : @"");
             return refreshToken;
         }
     }
@@ -298,8 +298,9 @@
     if (accessToken)
     {
         NSTimeInterval expiresIn = [accessToken.expiresOn timeIntervalSinceNow];
-        MSID_LOG_INFO(context, @"Found access token for account %@ which expires in %f", _PII_NULLIFY(accountIdentifier), expiresIn);
-        MSID_LOG_INFO_PII(context, @"Found access token for account %@ which expires in %f", accountIdentifier, expiresIn);
+        
+        MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Found access token for account %@ which expires in %f", _PII_NULLIFY(accountIdentifier), expiresIn);
+        MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Found access token for account %@ which expires in %f", accountIdentifier, expiresIn);
     }
     else
     {
@@ -340,8 +341,8 @@
     
     if (idToken)
     {
-        MSID_LOG_INFO(context, @"Found id token for account %@.", _PII_NULLIFY(accountIdentifier));
-        MSID_LOG_INFO_PII(context, @"Found id token %@ for account %@.", [idToken.rawIdToken msidSecretLoggingHash], accountIdentifier);
+        MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Found id token for account %@.", _PII_NULLIFY(accountIdentifier));
+        MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Found id token %@ for account %@.", [idToken.rawIdToken msidSecretLoggingHash], accountIdentifier);
     }
     else
     {
@@ -370,8 +371,8 @@
                                             error:(NSError **)error
 {
     MSID_LOG_INFO(context, @"(Default accessor) Get accounts.");
-    MSID_LOG_VERBOSE(context, @"(Default accessor) Get accounts with environment %@, clientId %@, familyId %@", authority.environment, clientId, familyId);
-    MSID_LOG_VERBOSE_PII(context, @"(Default accessor) Get accounts with environment %@, clientId %@, familyId %@, account %@, username %@", authority.environment, clientId, familyId, accountIdentifier.homeAccountId, accountIdentifier.displayableId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Get accounts with environment %@, clientId %@, familyId %@", authority.environment, clientId, familyId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Get accounts with environment %@, clientId %@, familyId %@, account %@, username %@", authority.environment, clientId, familyId, accountIdentifier.homeAccountId, accountIdentifier.displayableId);
 
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP context:context];
 
@@ -433,8 +434,8 @@
 
     if ([filteredAccountsSet count])
     {
-        MSID_LOG_INFO(context, @"(Default accessor) Found %lu accounts in default accessor.", (unsigned long)[filteredAccountsSet count]);
-        MSID_LOG_INFO_PII(context, @"(Default accessor) Found the following accounts in default accessor: %@", [filteredAccountsSet allObjects]);
+        MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"(Default accessor) Found %lu accounts in default accessor.", (unsigned long)[filteredAccountsSet count]);
+        MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"(Default accessor) Found the following accounts in default accessor: %@", [filteredAccountsSet allObjects]);
         
         [MSIDTelemetry stopCacheEvent:event withItem:nil success:YES context:context];
     }
@@ -457,8 +458,8 @@
     
     if ([filteredAccountsSet count])
     {
-        MSID_LOG_INFO(context, @"(Default accessor) Found %lu accounts in other accessors.", (unsigned long)[filteredAccountsSet count]);
-        MSID_LOG_INFO_PII(context, @"(Default accessor) Found the following accounts in other accessors: %@", [filteredAccountsSet allObjects]);
+        MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"(Default accessor) Found %lu accounts in other accessors.", (unsigned long)[filteredAccountsSet count]);
+        MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"(Default accessor) Found the following accounts in other accessors: %@", [filteredAccountsSet allObjects]);
     }
     else
     {
@@ -473,8 +474,8 @@
                                  context:(id<MSIDRequestContext>)context
                                    error:(NSError **)error
 {
-    MSID_LOG_VERBOSE(context, @"(Default accessor) Looking for account with authority %@", authority.url);
-    MSID_LOG_VERBOSE_PII(context, @"(Default accessor) Looking for account with authority %@, legacy user ID %@, home account ID %@", authority.url, accountIdentifier.displayableId, accountIdentifier.homeAccountId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Looking for account with authority %@", authority.url);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Looking for account with authority %@, legacy user ID %@, home account ID %@", authority.url, accountIdentifier.displayableId, accountIdentifier.homeAccountId);
 
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP context:context];
 
@@ -519,8 +520,8 @@
         return NO;
     }
 
-    MSID_LOG_VERBOSE(context, @"(Default accessor) Clearing cache for environment: %@, client ID %@, family ID %@", authority.environment, clientId, familyId);
-    MSID_LOG_VERBOSE(context, @"(Default accessor) Clearing cache for environment: %@, client ID %@, family ID %@, account %@", authority.environment, clientId, familyId, accountIdentifier.homeAccountId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Clearing cache for environment: %@, client ID %@, family ID %@", authority.environment, clientId, familyId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Clearing cache for environment: %@, client ID %@, family ID %@, account %@", authority.environment, clientId, familyId, accountIdentifier.homeAccountId);
 
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_DELETE context:context];
 
@@ -530,8 +531,8 @@
         && ![NSString msidIsStringNilOrBlank:accountIdentifier.displayableId])
     {
         homeAccountId = [self homeAccountIdForLegacyId:accountIdentifier.displayableId authority:authority context:context error:error];
-        MSID_LOG_VERBOSE(context, @"(Default accessor) Resolving home account ID from legacy account ID");
-        MSID_LOG_VERBOSE(context, @"(Default accessor) Resolving home account ID from legacy account ID, legacy account %@, resolved account %@", accountIdentifier.displayableId, homeAccountId);
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Resolving home account ID from legacy account ID");
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Resolving home account ID from legacy account ID, legacy account %@, resolved account %@", accountIdentifier.displayableId, homeAccountId);
     }
 
     if (homeAccountId)
@@ -604,8 +605,8 @@
         return NO;
     }
 
-    MSID_LOG_VERBOSE(context, @"Removing refresh token with clientID %@, authority %@", token.clientId, token.authority);
-    MSID_LOG_VERBOSE_PII(context, @"Removing refresh token with clientID %@, authority %@, userId %@, token %@", token.clientId, token.authority, token.accountIdentifier.homeAccountId, _PII_NULLIFY(token.refreshToken));
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Removing refresh token with clientID %@, authority %@", token.clientId, token.authority);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Removing refresh token with clientID %@, authority %@, userId %@, token %@", token.clientId, token.authority, token.accountIdentifier.homeAccountId, _PII_NULLIFY(token.refreshToken));
 
     NSURL *authority = token.storageAuthority.url ? token.storageAuthority.url : token.authority.url;
 
@@ -623,8 +624,8 @@
 
     if (tokenInCache && [tokenInCache.refreshToken isEqualToString:token.refreshToken])
     {
-        MSID_LOG_VERBOSE(context, @"Found refresh token in cache and it's the latest version, removing token");
-        MSID_LOG_VERBOSE_PII(context, @"Found refresh token in cache and it's the latest version, removing token %@", token);
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Found refresh token in cache and it's the latest version, removing token");
+        MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Found refresh token in cache and it's the latest version, removing token %@", token);
 
         return [self removeToken:tokenInCache context:context error:error];
     }
@@ -640,8 +641,8 @@
 {
     if (!accountIdentifier)
     {
-        MSID_LOG_ERROR(context, @"(Default accessor) User identifier is expected for default accessor, but not provided");
-        MSID_LOG_ERROR_PII(context, @"(Default accessor) User identifier is expected for default accessor, but not provided");
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, context, @"(Default accessor) User identifier is expected for default accessor, but not provided");
+        MSID_LOG_PII(MSIDLogLevelError, nil, context, @"(Default accessor) User identifier is expected for default accessor, but not provided");
         
         if (error)
         {
@@ -728,8 +729,8 @@
 
     if (![NSString msidIsStringNilOrBlank:refreshToken.familyId])
     {
-        MSID_LOG_VERBOSE(context, @"(Default accessor) Saving family refresh token %@", _PII_NULLIFY(refreshToken.refreshToken));
-        MSID_LOG_VERBOSE_PII(context, @"(Default accessor) Saving family refresh token %@", refreshToken);
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Saving family refresh token %@", _PII_NULLIFY(refreshToken.refreshToken));
+        MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Saving family refresh token %@", refreshToken);
 
         if (![self saveToken:refreshToken context:context error:error])
         {
@@ -817,7 +818,7 @@
 {
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP context:context];
 
-    MSID_LOG_VERBOSE(context, @"(Default accessor) Looking for token with aliases %@, tenant %@, clientId %@, scopes %@", cacheQuery.environmentAliases, cacheQuery.realm, cacheQuery.clientId, cacheQuery.target);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Looking for token with aliases %@, tenant %@, clientId %@, scopes %@", cacheQuery.environmentAliases, cacheQuery.realm, cacheQuery.clientId, cacheQuery.target);
 
     NSError *cacheError = nil;
 
@@ -836,7 +837,7 @@
 
         if (resultToken)
         {
-            MSID_LOG_VERBOSE(context, @"(Default accessor) Found %lu tokens", (unsigned long)[cacheItems count]);
+            MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Found %lu tokens", (unsigned long)[cacheItems count]);
             resultToken.storageAuthority = resultToken.authority;
             resultToken.authority = authority;
             [MSIDTelemetry stopCacheEvent:event withItem:resultToken success:YES context:context];
@@ -863,8 +864,8 @@
                                               context:(id<MSIDRequestContext>)context
                                                 error:(NSError **)error
 {
-    MSID_LOG_VERBOSE(context, @"(Default accessor) Looking for token with authority %@, clientId %@", authority, clientId);
-    MSID_LOG_VERBOSE_PII(context, @"(Default accessor) Looking for token with authority %@, clientId %@, legacy userId %@", authority, clientId, legacyUserId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Looking for token with authority %@, clientId %@", authority, clientId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Looking for token with authority %@, clientId %@, legacy userId %@", authority, clientId, legacyUserId);
 
     NSString *homeAccountId = [self homeAccountIdForLegacyId:legacyUserId
                                                    authority:authority
@@ -873,12 +874,12 @@
 
     if ([NSString msidIsStringNilOrBlank:homeAccountId])
     {
-        MSID_LOG_VERBOSE(context, @"(Default accessor) Didn't find a matching home account id for username");
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor) Didn't find a matching home account id for username");
         return nil;
     }
 
-    MSID_LOG_VERBOSE(context, @"(Default accessor] Found Match with environment %@", authority.environment);
-    MSID_LOG_VERBOSE_PII(context, @"(Default accessor] Found Match with environment %@, home account ID %@", authority.environment, homeAccountId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor] Found Match with environment %@", authority.environment);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Default accessor] Found Match with environment %@, home account ID %@", authority.environment, homeAccountId);
 
     MSIDDefaultCredentialCacheQuery *rtQuery = [MSIDDefaultCredentialCacheQuery new];
     rtQuery.homeAccountId = homeAccountId;

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -82,7 +82,7 @@
 {
     if (response.isMultiResource)
     {
-        MSID_LOG_VERBOSE(context, @"(Legacy accessor) Saving multi resource refresh token");
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Saving multi resource refresh token");
         BOOL result = [self saveAccessTokenWithConfiguration:configuration response:response factory:factory context:context error:error];
 
         if (!result) return NO;
@@ -91,7 +91,7 @@
     }
     else
     {
-        MSID_LOG_VERBOSE(context, @"(Legacy accessor) Saving single resource refresh token");
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Saving single resource refresh token");
         return [self saveLegacySingleResourceTokenWithConfiguration:configuration response:response factory:factory context:context error:error];
     }
 }
@@ -108,7 +108,7 @@
         return NO;
     }
 
-    MSID_LOG_VERBOSE(context, @"(Legacy accessor) Saving SSO state");
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Saving SSO state");
 
     BOOL result = [self saveRefreshTokenWithConfiguration:configuration
                                                  response:response
@@ -166,7 +166,7 @@
         
         if (refreshToken)
         {
-            MSID_LOG_VERBOSE(context, @"(Legacy accessor) Found refresh token in a different accessor %@", [accessor class]);
+            MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Found refresh token in a different accessor %@", [accessor class]);
             return refreshToken;
         }
     }
@@ -202,7 +202,7 @@
         
         if (prt)
         {
-            MSID_LOG_VERBOSE(context, @"(Legacy accessor) Found primary refresh token in a different accessor %@", [accessor class]);
+            MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Found primary refresh token in a different accessor %@", [accessor class]);
             return prt;
         }
     }
@@ -217,8 +217,8 @@
                                              context:(id<MSIDRequestContext>)context
                                                error:(NSError **)error
 {
-    MSID_LOG_VERBOSE(context, @"(Legacy accessor) Get token %@ with authority %@, clientId %@, familyID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType], configuration.authority, configuration.clientId, familyId);
-    MSID_LOG_VERBOSE_PII(context, @"(Legacy accessor) Get token %@ with authority %@, clientId %@, familyID %@, account %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType], configuration.authority, configuration.clientId, familyId, accountIdentifier.homeAccountId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Get token %@ with authority %@, clientId %@, familyID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType], configuration.authority, configuration.clientId, familyId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Get token %@ with authority %@, clientId %@, familyID %@, account %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType], configuration.authority, configuration.clientId, familyId, accountIdentifier.homeAccountId);
     
     if (credentialType!=MSIDRefreshTokenType && credentialType!=MSIDPrimaryRefreshTokenType) return nil;
 
@@ -250,8 +250,8 @@
                                           context:(id<MSIDRequestContext>)context
                                             error:(NSError **)error
 {
-    MSID_LOG_VERBOSE(context, @"(Legacy accessor) Get accounts with environment %@, clientId %@, familyId %@", authority.environment, clientId, familyId);
-    MSID_LOG_VERBOSE(context, @"(Legacy accessor) Get accounts with environment %@, clientId %@, familyId %@, account identifier %@, legacy identifier %@", authority.environment, clientId, familyId, accountIdentifier.homeAccountId, accountIdentifier.displayableId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Get accounts with environment %@, clientId %@, familyId %@", authority.environment, clientId, familyId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Get accounts with environment %@, clientId %@, familyId %@, account identifier %@, legacy identifier %@", authority.environment, clientId, familyId, accountIdentifier.homeAccountId, accountIdentifier.displayableId);
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP context:context];
 
     MSIDLegacyTokenCacheQuery *query = [MSIDLegacyTokenCacheQuery new];
@@ -309,12 +309,12 @@
 
     if ([allRefreshTokens count] == 0)
     {
-        MSID_LOG_VERBOSE(context, @"(Legacy accessor) Found no refresh tokens");
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Found no refresh tokens");
         [MSIDTelemetry stopFailedCacheEvent:event wipeData:[_dataSource wipeInfo:context error:error] context:context];
     }
     else
     {
-        MSID_LOG_VERBOSE(context, @"(Legacy accessor) Found %lu refresh tokens", (unsigned long)[allRefreshTokens count]);
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Found %lu refresh tokens", (unsigned long)[allRefreshTokens count]);
         [MSIDTelemetry stopCacheEvent:event withItem:nil success:YES context:context];
     }
 
@@ -403,8 +403,8 @@
         return NO;
     }
 
-    MSID_LOG_VERBOSE(context, @"Removing refresh token with clientID %@, authority %@", token.clientId, token.authority);
-    MSID_LOG_VERBOSE_PII(context, @"Removing refresh token with clientID %@, authority %@, userId %@, token %@", token.clientId, token.authority, token.accountIdentifier.homeAccountId, _PII_NULLIFY(token.refreshToken));
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Removing refresh token with clientID %@, authority %@", token.clientId, token.authority);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Removing refresh token with clientID %@, authority %@, userId %@, token %@", token.clientId, token.authority, token.accountIdentifier.homeAccountId, _PII_NULLIFY(token.refreshToken));
 
     MSIDCredentialCacheItem *cacheItem = [token tokenCacheItem];
 
@@ -422,8 +422,8 @@
 
     if (tokenInCache && [tokenInCache.refreshToken isEqualToString:token.refreshToken])
     {
-        MSID_LOG_VERBOSE(context, @"Found refresh token in cache and it's the latest version, removing token");
-        MSID_LOG_VERBOSE_PII(context, @"Found refresh token in cache and it's the latest version, removing token %@", token);
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Found refresh token in cache and it's the latest version, removing token");
+        MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Found refresh token in cache and it's the latest version, removing token %@", token);
 
         return [self removeTokenWithAuthority:storageAuthority.url
                                      clientId:cacheItem.clientId
@@ -465,8 +465,8 @@
         return NO;
     }
 
-    MSID_LOG_VERBOSE(context, @"(Legacy accessor) Clearing cache with account and client id %@", clientId);
-    MSID_LOG_VERBOSE_PII(context, @"(Legacy accessor) Clearing cache with account %@ and client id %@", accountIdentifier.displayableId, clientId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Clearing cache with account and client id %@", clientId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Clearing cache with account %@ and client id %@", accountIdentifier.displayableId, clientId);
 
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_DELETE context:context];
 
@@ -545,8 +545,8 @@
     NSString *clientId = familyId ? [MSIDCacheKey familyClientId:familyId] : configuration.clientId;
     NSArray<NSURL *> *aliases = [configuration.authority legacyRefreshTokenLookupAliases] ?: @[];
 
-    MSID_LOG_VERBOSE(context, @"(Legacy accessor) Finding token %@ with legacy user ID, clientId %@, authority %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType], clientId, aliases);
-    MSID_LOG_VERBOSE_PII(context, @"(Legacy accessor) Finding token %@ with legacy user ID %@, clientId %@, authority %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType], accountIdentifier.displayableId, clientId, aliases);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Finding token %@ with legacy user ID, clientId %@, authority %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType], clientId, aliases);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Finding token %@ with legacy user ID %@, clientId %@, authority %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType], accountIdentifier.displayableId, clientId, aliases);
 
     return (MSIDLegacyRefreshToken *)[self getTokenByLegacyUserId:accountIdentifier.displayableId
                                                              type:credentialType
@@ -571,9 +571,9 @@
         MSIDFillAndLogError(error, MSIDErrorInternal, @"Tried to save access token, but no access token returned", context.correlationId);
         return NO;
     }
-
-    MSID_LOG_INFO(context, @"(Legacy accessor) Saving access token in legacy accessor");
-    MSID_LOG_INFO_PII(context, @"(Legacy accessor) Saving access token in legacy accessor %@", accessToken);
+    
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"(Legacy accessor) Saving access token in legacy accessor");
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"(Legacy accessor) Saving access token in legacy accessor %@", accessToken);
 
     return [self saveToken:accessToken
                  cacheItem:accessToken.legacyTokenCacheItem
@@ -595,9 +595,9 @@
         MSID_LOG_INFO(context, @"No refresh token returned in the token response, not updating cache");
         return YES;
     }
-
-    MSID_LOG_INFO(context, @"(Legacy accessor) Saving multi resource refresh token in legacy accessor");
-    MSID_LOG_INFO_PII(context, @"(Legacy accessor) Saving multi resource refresh token in legacy accessor %@", refreshToken);
+    
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"(Legacy accessor) Saving multi resource refresh token in legacy accessor");
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"(Legacy accessor) Saving multi resource refresh token in legacy accessor %@", refreshToken);
 
     BOOL result = [self saveToken:refreshToken
                         cacheItem:refreshToken.legacyTokenCacheItem
@@ -611,8 +611,8 @@
         return result;
     }
 
-    MSID_LOG_VERBOSE(context, @"Saving family refresh token in all caches");
-    MSID_LOG_VERBOSE_PII(context, @"Saving family refresh token in all caches %@", _PII_NULLIFY(refreshToken.refreshToken));
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"Saving family refresh token in all caches");
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Saving family refresh token in all caches %@", _PII_NULLIFY(refreshToken.refreshToken));
 
     // If it's an FRT, save it separately and update the clientId of the token item
     MSIDLegacyRefreshToken *familyRefreshToken = [refreshToken copy];
@@ -638,9 +638,9 @@
         MSIDFillAndLogError(error, MSIDErrorInternal, @"Tried to save single resource token, but no access token returned", context.correlationId);
         return NO;
     }
-
-    MSID_LOG_INFO(context, @"(Legacy accessor) Saving single resource tokens in legacy accessor");
-    MSID_LOG_INFO_PII(context, @"(Legacy accessor) Saving single resource tokens in legacy accessor %@", legacyToken);
+    
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"(Legacy accessor) Saving single resource tokens in legacy accessor");
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"(Legacy accessor) Saving single resource tokens in legacy accessor %@", legacyToken);
 
     // Save token for legacy single resource token
     return [self saveToken:legacyToken
@@ -659,8 +659,8 @@
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_WRITE context:context];
 
     NSURL *alias = [token.authority cacheUrlWithContext:context];;
-    MSID_LOG_VERBOSE(context, @"(Legacy accessor) Saving token %@ with authority %@, clientID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:tokenCacheItem.credentialType], alias, tokenCacheItem.clientId);
-    MSID_LOG_VERBOSE_PII(context, @"(Legacy accessor) Saving token %@ for account %@ with authority %@, clientID %@", tokenCacheItem, userId, alias, tokenCacheItem.clientId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Saving token %@ with authority %@, clientID %@", [MSIDCredentialTypeHelpers credentialTypeAsString:tokenCacheItem.credentialType], alias, tokenCacheItem.clientId);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Saving token %@ for account %@ with authority %@, clientID %@", tokenCacheItem, userId, alias, tokenCacheItem.clientId);
 
     // The authority used to retrieve the item over the network can differ from the preferred authority used to
     // cache the item. As it would be awkward to cache an item using an authority other then the one we store
@@ -681,7 +681,7 @@
     if (!result)
     {
         [MSIDTelemetry stopCacheEvent:event withItem:token success:NO context:context];
-        MSID_LOG_VERBOSE(context, @"Failed to save token with alias: %@", alias);
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"Failed to save token with alias: %@", alias);
         return NO;
     }
 
@@ -732,8 +732,8 @@
         return NO;
     }
 
-    MSID_LOG_VERBOSE(context, @"(Legacy accessor) Removing token with clientId %@, authority %@", clientId, authority);
-    MSID_LOG_VERBOSE_PII(context, @"(Legacy accessor) Removing token with clientId %@, authority %@, target %@, account %@", clientId, authority, target, userId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Removing token with clientId %@, authority %@", clientId, authority);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Removing token with clientId %@, authority %@, target %@, account %@", clientId, authority, target, userId);
 
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_DELETE context:context];
 
@@ -769,8 +769,8 @@
 
     for (NSURL *alias in aliases)
     {
-        MSID_LOG_VERBOSE(context, @"(Legacy accessor) Looking for token with alias %@, clientId %@, resource %@", alias, clientId, resource);
-        MSID_LOG_VERBOSE_PII(context, @"(Legacy accessor) Looking for token with alias %@, clientId %@, resource %@, legacy userId %@", alias, clientId, resource, legacyUserId);
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Looking for token with alias %@, clientId %@, resource %@", alias, clientId, resource);
+        MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"(Legacy accessor) Looking for token with alias %@, clientId %@, resource %@, legacy userId %@", alias, clientId, resource, legacyUserId);
 
         MSIDLegacyTokenCacheKey *key = [[MSIDLegacyTokenCacheKey alloc] initWithAuthority:alias
                                                                                  clientId:clientId
@@ -794,7 +794,7 @@
 
         if (cacheItem)
         {
-            MSID_LOG_VERBOSE(context, @"(Legacy accessor) Found token");
+            MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context,@"(Legacy accessor) Found token");
             MSIDBaseToken *token = [cacheItem tokenWithType:type];
             token.storageAuthority = token.authority;
             token.authority = authority;

--- a/IdentityCore/src/cache/ios/MSIDKeychainTokenCache.m
+++ b/IdentityCore/src/cache/ios/MSIDKeychainTokenCache.m
@@ -61,8 +61,8 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
         @throw @"Attempting to change the keychain group once AuthenticationContexts have been created or the default keychain cache has been retrieved is invalid. The default keychain group should only be set once for the lifetime of an application.";
     }
     
-    MSID_LOG_INFO(nil, @"Setting default keychain group.");
-    MSID_LOG_INFO_PII(nil, @"Setting default keychain group to %@", defaultKeychainGroup);
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, nil, @"Setting default keychain group.");
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, nil, @"Setting default keychain group to %@", defaultKeychainGroup);
     
     if ([defaultKeychainGroup isEqualToString:s_defaultKeychainGroup])
     {
@@ -128,8 +128,8 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
                               (id)kSecAttrAccessGroup : self.keychainGroup,
                               (id)kSecAttrAccount : @"TokenWipe"};
     
-    MSID_LOG_INFO(nil, @"Init MSIDKeychainTokenCache with keychainGroup: %@", [self keychainGroupLoggingName]);
-    MSID_LOG_INFO_PII(nil, @"Init MSIDKeychainTokenCache with keychainGroup: %@", _keychainGroup);
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, nil, @"Init MSIDKeychainTokenCache with keychainGroup: %@", [self keychainGroupLoggingName]);
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, nil, @"Init MSIDKeychainTokenCache with keychainGroup: %@", _keychainGroup);
     
     return self;
 }
@@ -410,8 +410,8 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
                    context:(id<MSIDRequestContext>)context
                      error:(NSError **)error
 {
-    MSID_LOG_VERBOSE(context, @"Remove keychain items, key info (account: %@ service: %@, keychainGroup: %@)", _PII_NULLIFY(key.account), _PII_NULLIFY(key.service), [self keychainGroupLoggingName]);
-    MSID_LOG_VERBOSE_PII(context, @"Remove keychain items, key info (account: %@ service: %@, keychainGroup: %@)", key.account, key.service, self.keychainGroup);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Remove keychain items, key info (account: %@ service: %@, keychainGroup: %@)", _PII_NULLIFY(key.account), _PII_NULLIFY(key.service), [self keychainGroupLoggingName]);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Remove keychain items, key info (account: %@ service: %@, keychainGroup: %@)", key.account, key.service, self.keychainGroup);
     
     if (!key)
     {
@@ -471,8 +471,10 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
     MSID_LOG_INFO_PII(context, @"Full wipe info: %@", wipeInfo);
     
     NSData *wipeData = [NSKeyedArchiver archivedDataWithRootObject:wipeInfo];
-    MSID_LOG_VERBOSE(context, @"Trying to update wipe info...");
-    MSID_LOG_VERBOSE_PII(context, @"Wipe query: %@", self.defaultWipeQuery);
+    
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Trying to update wipe info...");
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context,@"Wipe query: %@", self.defaultWipeQuery);
+    
     OSStatus status = SecItemUpdate((CFDictionaryRef)self.defaultWipeQuery, (CFDictionaryRef)@{ (id)kSecValueData:wipeData});
     MSID_LOG_VERBOSE(context, @"Update wipe info status: %d", (int)status);
     if (status == errSecItemNotFound)
@@ -507,8 +509,9 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
     [query removeObjectForKey:(id)kSecAttrService];
     
     CFTypeRef data = nil;
-    MSID_LOG_VERBOSE(context, @"Trying to get wipe info...");
-    MSID_LOG_VERBOSE_PII(context, @"Wipe query: %@", self.defaultWipeQuery);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Trying to get wipe info...");
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Wipe query: %@", self.defaultWipeQuery);
+    
     OSStatus status = SecItemCopyMatching((CFDictionaryRef)query, &data);
     MSID_LOG_VERBOSE(context, @"Get wipe info status: %d", (int)status);
     
@@ -612,8 +615,8 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
                   context:(id<MSIDRequestContext>)context
                     error:(NSError **)error
 {
-    MSID_LOG_VERBOSE(context, @"Get keychain items, key info (account: %@ service: %@ generic: %@ type: %@, keychainGroup: %@)", _PII_NULLIFY(key.account), key.service, _PII_NULLIFY(key.generic), key.type, [self keychainGroupLoggingName]);
-    MSID_LOG_VERBOSE_PII(context, @"Get keychain items, key info (account: %@ service: %@ generic: %@ type: %@, keychainGroup: %@)", key.account, key.service, key.generic, key.type, self.keychainGroup);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Get keychain items, key info (account: %@ service: %@ generic: %@ type: %@, keychainGroup: %@)", _PII_NULLIFY(key.account), key.service, _PII_NULLIFY(key.generic), key.type, [self keychainGroupLoggingName]);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Get keychain items, key info (account: %@ service: %@ generic: %@ type: %@, keychainGroup: %@)", key.account, key.service, key.generic, key.type, self.keychainGroup);
     
     NSMutableDictionary *query = [self.defaultKeychainQuery mutableCopy];
     if (key.service)
@@ -667,8 +670,8 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 {
     assert(key);
     
-    MSID_LOG_VERBOSE(context, @"Set keychain item, key info (account: %@ service: %@, keychainGroup: %@)", _PII_NULLIFY(key.account), _PII_NULLIFY(key.service), [self keychainGroupLoggingName]);
-    MSID_LOG_VERBOSE_PII(context, @"Set keychain item, key info (account: %@ service: %@, keychainGroup: %@)", key.account, key.service, self.keychainGroup);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Set keychain item, key info (account: %@ service: %@, keychainGroup: %@)", _PII_NULLIFY(key.account), _PII_NULLIFY(key.service), [self keychainGroupLoggingName]);
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Set keychain item, key info (account: %@ service: %@, keychainGroup: %@)", key.account, key.service, self.keychainGroup);
     
     if (!key.service)
     {

--- a/IdentityCore/src/cache/token/MSIDLegacyTokenCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDLegacyTokenCacheItem.m
@@ -207,8 +207,8 @@
 
     if (error)
     {
-        MSID_LOG_WARN(nil, @"Invalid ID token");
-        MSID_LOG_WARN_PII(nil, @"Invalid ID token, error %@", error.localizedDescription);
+        MSID_LOG_NO_PII(MSIDLogLevelWarning, nil, nil, @"Invalid ID token");
+        MSID_LOG_PII(MSIDLogLevelWarning, nil, nil,  @"Invalid ID token, error %@", error.localizedDescription);
     }
 
     return _idTokenClaims;

--- a/IdentityCore/src/controllers/MSIDBaseRequestController.m
+++ b/IdentityCore/src/controllers/MSIDBaseRequestController.m
@@ -52,8 +52,8 @@
 
         if (![_requestParameters validateParametersWithError:&parametersError])
         {
-            MSID_LOG_ERROR(self.requestParameters, @"Request parameters error %ld, %@", (long)parametersError.code, parametersError.domain);
-            MSID_LOG_ERROR_PII(self.requestParameters, @"Request parameters error %@", parametersError);
+            MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Request parameters error %ld, %@", (long)parametersError.code, parametersError.domain);
+            MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters,  @"Request parameters error %@", parametersError);
 
             if (error)
             {

--- a/IdentityCore/src/controllers/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/ios/MSIDBrokerInteractiveController.m
@@ -120,8 +120,8 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
 
     if (!brokerKey)
     {
-        MSID_LOG_ERROR(self.requestParameters, @"Failed to retrieve broker key with error %ld, %@", (long)brokerError.code, brokerError.domain);
-        MSID_LOG_ERROR_PII(self.requestParameters, @"Failed to retrieve broker key with error %@", brokerError);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to retrieve broker key with error %ld, %@", (long)brokerError.code, brokerError.domain);
+        MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to retrieve broker key with error %@", brokerError);
 
         [self stopTelemetryEvent:[self telemetryAPIEvent] error:brokerError];
         completionBlockWrapper(nil, brokerError);

--- a/IdentityCore/src/logger/MSIDLogger.m
+++ b/IdentityCore/src/logger/MSIDLogger.m
@@ -97,16 +97,20 @@ static NSDateFormatter *s_dateFormatter = nil;
     [s_dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
 }
 
-- (void)logLevel:(MSIDLogLevel)level
-         context:(id<MSIDRequestContext>)context
-   correlationId:(NSUUID *)correlationId
-           isPII:(BOOL)isPii
-          format:(NSString *)format, ...
+- (void)logWithLevel:(MSIDLogLevel)level
+             context:(id<MSIDRequestContext>)context
+       correlationId:(NSUUID *)correlationId
+               isPII:(BOOL)isPii
+  ignoreIfPIIEnabled:(BOOL)ignoreIfPIIEnabled
+              format:(NSString *)format, ...
 {
     if (!format) return;
     if (isPii && !self.PiiLoggingEnabled) return;
     if (level > self.level) return;
     if (!self.callback && !self.NSLoggingEnabled) return;
+    // If this is not PII and PII is enabled
+    // we want to avoid logging double lines, so we pass an extra flag to tell logger to ignore this line
+    if (ignoreIfPIIEnabled && self.PiiLoggingEnabled && !isPii) return;
     
     va_list args;
     va_start(args, format);

--- a/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
+++ b/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
@@ -108,8 +108,8 @@
     NSString *message = [NSString stringWithFormat:@"Http error raised: Http Code: %ld \n", (long)httpResponse.statusCode];
     NSString *messagePII = [NSString stringWithFormat:@"Http error raised: Http Code: %ld \n%@", (long)httpResponse.statusCode, errorDescription];
     
-    MSID_LOG_WARN(context, @"%@", message);
-    MSID_LOG_VERBOSE_PII(context, @"%@", messagePII);
+    MSID_LOG_NO_PII(MSIDLogLevelWarning, nil, context, @"%@", message);
+    MSID_LOG_PII(MSIDLogLevelWarning, nil, context, @"%@", messagePII);
     
     NSMutableDictionary *additionalInfo = [NSMutableDictionary new];
     [additionalInfo setValue:httpResponse.allHeaderFields

--- a/IdentityCore/src/network/session_delegate/MSIDURLSessionDelegate.m
+++ b/IdentityCore/src/network/session_delegate/MSIDURLSessionDelegate.m
@@ -72,8 +72,8 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
         newRequest:(NSURLRequest *)request
  completionHandler:(void (^)(NSURLRequest *))completionHandler
 {
-    MSID_LOG_INFO(nil, @"Redirecting to %@", _PII_NULLIFY(request.URL.absoluteString));
-    MSID_LOG_INFO_PII(nil, @"Redirecting to %@", request.URL.absoluteString);
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, nil, @"Redirecting to %@", _PII_NULLIFY(request.URL.absoluteString));
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, nil, @"Redirecting to %@", request.URL.absoluteString);
     
     if (self.taskWillPerformHTTPRedirectionBlock)
     {

--- a/IdentityCore/src/oauth2/MSIDIdTokenClaims.m
+++ b/IdentityCore/src/oauth2/MSIDIdTokenClaims.m
@@ -91,9 +91,9 @@ MSID_JSON_ACCESSOR(ID_TOKEN_EMAIL, email)
             NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:decoded options:0 error:&jsonError];
 
             if (jsonError)
-            {
-                MSID_LOG_WARN(nil, @"Failed to deserialize part of the id_token");
-                MSID_LOG_WARN_PII(nil, @"Failed to deserialize part of the id_token %@", jsonError);
+            { 
+                MSID_LOG_NO_PII(MSIDLogLevelWarning, nil, nil, @"Failed to deserialize part of the id_token");
+                MSID_LOG_PII(MSIDLogLevelWarning, nil, nil, @"Failed to deserialize part of the id_token %@", jsonError);
 
                 if (error) *error = jsonError;
                 return nil;

--- a/IdentityCore/src/oauth2/MSIDTokenResponse.m
+++ b/IdentityCore/src/oauth2/MSIDTokenResponse.m
@@ -143,4 +143,9 @@ MSID_JSON_RW(MSID_OAUTH2_ID_TOKEN, idToken, setIdToken)
     return [_json dictionaryByRemovingFields:knownFields];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"Token response: access token %@, refresh token %@, scope %@, state %@, id token %@, error %@, error description %@", _PII_NULLIFY(self.accessToken), _PII_NULLIFY(self.refreshToken), self.scope, self.state, _PII_NULLIFY(self.idToken), self.error, self.errorDescription];
+}
+
 @end

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
@@ -164,4 +164,10 @@ MSID_JSON_ACCESSOR(@"adi", additionalUserId)
     return [additionalInfo dictionaryByRemovingFields:knownFields];
 }
 
+- (NSString *)description
+{
+    NSString *descr = [super description];
+    return [NSString stringWithFormat:@"%@, familyID %@, suberror %@, additional user ID %@, clientInfo %@", descr, self.familyId, self.suberror, self.additionalUserId, self.clientInfo.rawClientInfo];
+}
+
 @end

--- a/IdentityCore/src/oauth2/aad_v1/MSIDAADV1Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v1/MSIDAADV1Oauth2Factory.m
@@ -132,8 +132,8 @@
 
     if (!response.clientInfo)
     {
-        MSID_LOG_WARN(context, @"Client info was not returned in the server response");
-        MSID_LOG_WARN_PII(context, @"Client info was not returned in the server response");
+        MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, context, @"Client info was not returned in the server response");
+        MSID_LOG_PII(MSIDLogLevelVerbose, nil, context, @"Client info was not returned in the server response");
     }
 
     return YES;

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -102,8 +102,9 @@
 
     if (!response.clientInfo)
     {
-        MSID_LOG_ERROR(context, @"Client info was not returned in the server response");
-        MSID_LOG_ERROR_PII(context, @"Client info was not returned in the server response");
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, context, @"Client info was not returned in the server response");
+        MSID_LOG_PII(MSIDLogLevelError, nil, context, @"Client info was not returned in the server response");
+        
         if (error)
         {
             *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Client info was not returned in the server response", nil, nil, nil, context.correlationId, nil);

--- a/IdentityCore/src/requests/MSIDBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDBrokerTokenRequest.m
@@ -231,8 +231,8 @@
 
     if (cacheError)
     {
-        MSID_LOG_ERROR(self.requestParameters, @"Failed to retrieve valid intune enrollment IDs with error %ld, %@", (long)cacheError.code, cacheError.domain);
-        MSID_LOG_ERROR_PII(self.requestParameters, @"Failed to retrieve valid intune enrollment IDs with error %@", cacheError);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to retrieve valid intune enrollment IDs with error %ld, %@", (long)cacheError.code, cacheError.domain);
+        MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to retrieve valid intune enrollment IDs with error %@", cacheError);
         if (error) *error = cacheError;
         return nil;
     }
@@ -250,8 +250,8 @@
 
     if (cacheError)
     {
-        MSID_LOG_ERROR(self.requestParameters, @"Failed to retrieve valid intune MAM resource with error %ld, %@", (long)cacheError.code, cacheError.domain);
-        MSID_LOG_ERROR_PII(self.requestParameters, @"Failed to retrieve valid intune MAM resource with error %@", cacheError);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to retrieve valid intune MAM resource with error %ld, %@", (long)cacheError.code, cacheError.domain);
+        MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to retrieve valid intune MAM resource with error %@", cacheError);
         if (error) *error = cacheError;
         return nil;
     }

--- a/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
@@ -158,8 +158,8 @@
 #if TARGET_OS_IPHONE
             if (![MSIDAppExtensionUtil isExecutingInAppExtension])
             {
-                MSID_LOG_INFO(nil, @"Opening a browser");
-                MSID_LOG_INFO_PII(nil, @"Opening a browser - %@", browserURL);
+                MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, nil, @"Opening a browser");
+                MSID_LOG_PII(MSIDLogLevelInfo, nil, nil, @"Opening a browser - %@", browserURL);
                 [MSIDAppExtensionUtil sharedApplicationOpenURL:browserURL];
             }
             else

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -118,8 +118,8 @@
             
             if (!refreshableToken)
             {
-                MSID_LOG_WARN(self.requestParameters, @"Didn't find family refresh token with error: %ld, %@", (long)rtError.code, rtError.domain);
-                MSID_LOG_WARN_PII(self.requestParameters, @"Didn't find family refresh token with error: %@", rtError);
+                MSID_LOG_NO_PII(MSIDLogLevelWarning, nil, self.requestParameters, @"Didn't find family refresh token with error: %ld, %@", (long)rtError.code, rtError.domain);
+                MSID_LOG_PII(MSIDLogLevelWarning, nil, self.requestParameters, @"Didn't find family refresh token with error: %@", rtError);
             }
             else
             {
@@ -134,8 +134,8 @@
                 
                 if (!refreshableToken)
                 {
-                    MSID_LOG_WARN(self.requestParameters, @"Didn't find app refresh token with error: %ld, %@", (long)rtError.code, rtError.domain);
-                    MSID_LOG_WARN_PII(self.requestParameters, @"Didn't find app refresh token with error: %@", rtError);
+                    MSID_LOG_NO_PII(MSIDLogLevelWarning, nil, self.requestParameters, @"Didn't find app refresh token with error: %ld, %@", (long)rtError.code, rtError.domain);
+                    MSID_LOG_PII(MSIDLogLevelWarning, nil, self.requestParameters, @"Didn't find app refresh token with error: %@", rtError);
                 }
                 else
                 {
@@ -185,8 +185,8 @@
 
     if (frtCacheError)
     {
-        MSID_LOG_ERROR(self.requestParameters, @"Failed to read family refresh token with error %ld, %@", (long)frtCacheError.code, frtCacheError.domain);
-        MSID_LOG_ERROR_PII(self.requestParameters, @"Failed to read family refresh token with error %@", frtCacheError);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to read family refresh token with error %ld, %@", (long)frtCacheError.code, frtCacheError.domain);
+        MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to read family refresh token with error %@", frtCacheError);
         completionBlock(nil, frtCacheError);
         return;
     }
@@ -204,8 +204,8 @@
 
         if (appRTCacheError)
         {
-            MSID_LOG_ERROR(self.requestParameters, @"Failed to read app spefici refresh token with error %ld, %@", (long)appRTCacheError.code, appRTCacheError.domain);
-            MSID_LOG_ERROR_PII(self.requestParameters, @"Failed to read app specific refresh token with error %@", appRTCacheError);
+            MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to read app spefici refresh token with error %ld, %@", (long)appRTCacheError.code, appRTCacheError.domain);
+            MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to read app specific refresh token with error %@", appRTCacheError);
             completionBlock(nil, appRTCacheError);
             return;
         }
@@ -233,16 +233,16 @@
 
                          if (msidError)
                          {
-                             MSID_LOG_ERROR(self.requestParameters, @"Failed to update familyID cache status with error %ld, %@", (long)error.code, error.domain);
-                             MSID_LOG_ERROR_PII(self.requestParameters, @"Failed to update familyID cache status with error %@", error);
+                             MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to update familyID cache status with error %ld, %@", (long)error.code, error.domain);
+                             MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to update familyID cache status with error %@", error);
                          }
 
                          MSIDBaseToken<MSIDRefreshableToken> *appRefreshToken = [self appRefreshTokenWithError:&msidError];
 
                          if (msidError)
                          {
-                             MSID_LOG_ERROR(self.requestParameters, @"Failed to retrieve multi resource refresh token with error %ld, %@", (long)error.code, error.domain);
-                             MSID_LOG_ERROR_PII(self.requestParameters, @"Failed to retrieve multi resource refresh token with error %@", error);
+                             MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to retrieve multi resource refresh token with error %ld, %@", (long)error.code, error.domain);
+                             MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed to retrieve multi resource refresh token with error %@", error);
                              completionBlock(nil, msidError);
                              return;
                          }
@@ -405,8 +405,8 @@
 
             if (!result)
             {
-                MSID_LOG_WARN(self.requestParameters, @"Failed to remove invalid refresh token with error %ld, %@", (long)removalError.code, removalError.domain);
-                MSID_LOG_WARN_PII(self.requestParameters, @"Failed to remove invalid refresh token with error %@", removalError);
+                MSID_LOG_NO_PII(MSIDLogLevelWarning, nil, self.requestParameters, @"Failed to remove invalid refresh token with error %ld, %@", (long)removalError.code, removalError.domain);
+                MSID_LOG_PII(MSIDLogLevelWarning, nil, self.requestParameters, @"Failed to remove invalid refresh token with error %@", removalError);
             }
         }
 

--- a/IdentityCore/src/requests/result/MSIDTokenResult.m
+++ b/IdentityCore/src/requests/result/MSIDTokenResult.m
@@ -53,4 +53,9 @@
     return self;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"MSIDTokenResult: access token %@, refresh token %@, raw ID token %@, authority %@, correlationID %@, token response %@, account %@", _PII_NULLIFY(_accessToken), _PII_NULLIFY(_refreshToken), _PII_NULLIFY(_rawIdToken), _authority, _correlationId, _PII_NULLIFY(_tokenResponse), _account];
+}
+
 @end

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
@@ -57,8 +57,8 @@
             *error = verificationError;
         }
 
-        MSID_LOG_WARN(nil, @"Unsuccessful token response, error %ld, %@", (long)verificationError.code, verificationError.domain);
-        MSID_LOG_WARN_CORR_PII(correlationID, @"Unsuccessful token response, error %@", verificationError);
+        MSID_LOG_NO_PII(MSIDLogLevelWarning, correlationID, nil, @"Unsuccessful token response, error %ld, %@", (long)verificationError.code, verificationError.domain);
+        MSID_LOG_PII(MSIDLogLevelWarning, correlationID, nil, @"Unsuccessful token response, error %@", verificationError);
 
         return nil;
     }
@@ -163,8 +163,8 @@
 
     if (!isSaved)
     {
-        MSID_LOG_ERROR_CORR(correlationID, @"Failed to save tokens in cache. Error %ld, %@", (long)savingError.code, savingError.domain);
-        MSID_LOG_ERROR_CORR_PII(correlationID, @"Failed to save tokens in cache. Error %@", savingError);
+        MSID_LOG_NO_PII(MSIDLogLevelError, correlationID, nil, @"Failed to save tokens in cache. Error %ld, %@", (long)savingError.code, savingError.domain);
+        MSID_LOG_PII(MSIDLogLevelError, correlationID, nil, @"Failed to save tokens in cache. Error %@", savingError);
     }
     else
     {
@@ -217,7 +217,7 @@
 
     if (!isSaved)
     {
-        MSID_LOG_ERROR(parameters, @"Failed to save tokens in cache. Error %ld, %@", (long)savingError.code, savingError.domain);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, parameters, @"Failed to save tokens in cache. Error %ld, %@", (long)savingError.code, savingError.domain);
         MSID_LOG_ERROR_PII(parameters, @"Failed to save tokens in cache. Error %@", savingError);
     }
     

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyBrokerResponseHandler.m
@@ -105,8 +105,8 @@
 
         if (!intuneResult)
         {
-            MSID_LOG_CORR_WARN(correlationID, @"Unable to save intune token with error %ld, %@", (long)intuneError.code, intuneError.domain);
-            MSID_LOG_WARN_CORR_PII(correlationID, @"Unable to save intune token with error %@", intuneError);
+            MSID_LOG_NO_PII(MSIDLogLevelWarning, correlationID, nil, @"Unable to save intune token with error %ld, %@", (long)intuneError.code, intuneError.domain);
+            MSID_LOG_PII(MSIDLogLevelWarning, correlationID, nil, @"Unable to save intune token with error %@", intuneError);
         }
         else
         {

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
@@ -54,8 +54,8 @@
           correlationID:(NSUUID *)correlationID
                   error:(NSError **)error
 {
-    MSID_LOG_VERBOSE_CORR(correlationID, @"Checking returned account");
-    MSID_LOG_VERBOSE_CORR_PII(correlationID, @"Checking returned account, Input account id %@, returned account ID %@, local account ID %@", accountIdentifier.displayableId, tokenResult.account.accountIdentifier.displayableId, tokenResult.account.localAccountId);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, correlationID, nil, @"Checking returned account");
+    MSID_LOG_PII(MSIDLogLevelVerbose, correlationID, nil, @"Checking returned account, Input account id %@, returned account ID %@, local account ID %@", accountIdentifier.displayableId, tokenResult.account.accountIdentifier.displayableId, tokenResult.account.localAccountId);
     
     switch (accountIdentifier.legacyAccountIdentifierType)
     {

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
@@ -108,8 +108,8 @@
         
         if (!tokenResult)
         {
-            MSID_LOG_CORR_WARN(correlationID, @"Unable to save additional tokens with error %ld, %@", (long)additionalTokensError.code, additionalTokensError.domain);
-            MSID_LOG_WARN_CORR_PII(correlationID, @"Unable to save additional token with error %@", additionalTokensError);
+            MSID_LOG_NO_PII(MSIDLogLevelWarning, correlationID, nil, @"Unable to save additional tokens with error %ld, %@", (long)additionalTokensError.code, additionalTokensError.domain);
+            MSID_LOG_PII(MSIDLogLevelWarning, correlationID, nil, @"Unable to save additional token with error %@", additionalTokensError);
         }
     }
     

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
@@ -83,8 +83,8 @@
             *error = cacheError;
         }
 
-        MSID_LOG_ERROR(self.requestParameters, @"Access token lookup error %ld, %@", (long)cacheError.code, cacheError.domain);
-        MSID_LOG_ERROR_PII(self.requestParameters, @"Access token lookup error %@", cacheError);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Access token lookup error %ld, %@", (long)cacheError.code, cacheError.domain);
+        MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters, @"Access token lookup error %@", cacheError);
         return nil;
     }
 
@@ -226,8 +226,8 @@
             *error = cacheError;
         }
 
-        MSID_LOG_ERROR(self.requestParameters, @"Failed reading app metadata with error %ld, %@", (long)cacheError.code, cacheError.domain);
-        MSID_LOG_ERROR_PII(self.requestParameters, @"Failed reading app metadata with error %@", cacheError);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed reading app metadata with error %ld, %@", (long)cacheError.code, cacheError.domain);
+        MSID_LOG_PII(MSIDLogLevelError, nil, self.requestParameters, @"Failed reading app metadata with error %@", cacheError);
         return nil;
     }
 

--- a/IdentityCore/src/util/MSIDClientCapabilitiesUtil.m
+++ b/IdentityCore/src/util/MSIDClientCapabilitiesUtil.m
@@ -85,8 +85,9 @@ static NSString *kValuesClaim = @"values";
 
     if (!jsonData)
     {
-        MSID_LOG_ERROR(nil, @"Failed to convert capabilities into JSON");
-        MSID_LOG_ERROR_PII(nil, @"Failed to convert capabilities into JSON with error %@", error.description);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, nil, @"Failed to convert capabilities into JSON");
+        MSID_LOG_PII(MSIDLogLevelError, nil, nil, @"Failed to convert capabilities into JSON with error %@", error.description);
+        
         return nil;
     }
 

--- a/IdentityCore/src/util/MSIDJWTHelper.m
+++ b/IdentityCore/src/util/MSIDJWTHelper.m
@@ -92,8 +92,8 @@
                                                          error:&error];
     if (!jsonData)
     {
-        MSID_LOG_ERROR(nil, @"Got an error code: %ld", (long)error.code);
-        MSID_LOG_ERROR_PII(nil, @"Got an error code: %ld error: %@", (long)error.code, error);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, nil, @"Got an error code: %ld", (long)error.code);
+        MSID_LOG_PII(MSIDLogLevelError, nil, nil, @"Got an error code: %ld error: %@", (long)error.code, error);
 
         return nil;
     }

--- a/IdentityCore/src/util/MSIDKeychainUtil.m
+++ b/IdentityCore/src/util/MSIDKeychainUtil.m
@@ -38,8 +38,8 @@
         NSString *bundleSeedID = [components firstObject];
         keychainTeamId = [bundleSeedID length] ? bundleSeedID : nil;
         
-        MSID_LOG_INFO(nil, @"Using \"%@\" Team ID.", _PII_NULLIFY(keychainTeamId));
-        MSID_LOG_INFO_PII(nil, @"Using \"%@\" Team ID.", keychainTeamId);
+        MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, nil, @"Using \"%@\" Team ID.", _PII_NULLIFY(keychainTeamId));
+        MSID_LOG_PII(MSIDLogLevelInfo, nil, nil, @"Using \"%@\" Team ID.", keychainTeamId);
     });
     
     return keychainTeamId;
@@ -86,8 +86,9 @@
         if (status == errSecSuccess)
         {
             appDefaultAccessGroup = [(__bridge NSDictionary *)result objectForKey:(__bridge id)(kSecAttrAccessGroup)];
-            MSID_LOG_INFO(nil, @"Defaul app's acces group: \"%@\".", _PII_NULLIFY(appDefaultAccessGroup));
-            MSID_LOG_INFO_PII(nil, @"Defaul app's acces group: \"%@\".", appDefaultAccessGroup);
+            MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, nil, @"Defaul app's acces group: \"%@\".", _PII_NULLIFY(appDefaultAccessGroup));
+            MSID_LOG_PII(MSIDLogLevelInfo, nil, nil, @"Defaul app's acces group: \"%@\".", appDefaultAccessGroup);
+            
             CFRelease(result);
         }
         else

--- a/IdentityCore/src/util/NSDictionary+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSDictionary+MSIDExtensions.m
@@ -165,8 +165,9 @@
 
     if (!serializedData)
     {
-        MSID_LOG_WARN(context, @"Failed to serialize data with error %ld, %@", (long)serializationError.code, serializationError.domain);
-        MSID_LOG_WARN_PII(context, @"Failed to serialize data with error %@", serializationError);
+        MSID_LOG_NO_PII(MSIDLogLevelWarning, nil, context, @"Failed to serialize data with error %ld, %@", (long)serializationError.code, serializationError.domain);
+        MSID_LOG_PII(MSIDLogLevelWarning, nil, context, @"Failed to serialize data with error %@", serializationError);
+        
         return nil;
     }
 

--- a/IdentityCore/src/validation/MSIDAuthority.m
+++ b/IdentityCore/src/validation/MSIDAuthority.m
@@ -85,8 +85,8 @@ static MSIDCache <NSString *, MSIDOpenIdProviderMetadata *> *s_openIdConfigurati
 
     [[MSIDTelemetry sharedInstance] startEvent:context.telemetryRequestId eventName:MSID_TELEMETRY_EVENT_AUTHORITY_VALIDATION];
     
-    MSID_LOG_INFO(context, @"Resolving authority: %@, upn: %@", [self isKnown] ? self.url : _PII_NULLIFY(self.url), _PII_NULLIFY(upn));
-    MSID_LOG_INFO_PII(context, @"Resolving authority: %@, upn: %@", self.url, upn);
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Resolving authority: %@, upn: %@", [self isKnown] ? self.url : _PII_NULLIFY(self.url), _PII_NULLIFY(upn));
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Resolving authority: %@, upn: %@", self.url, upn);
     
     [resolver resolveAuthority:self
              userPrincipalName:upn

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -236,8 +236,8 @@
     NSURL *requestURL = navigationAction.request.URL;
     __auto_type isKnown = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:requestURL.host];
     
-    MSID_LOG_VERBOSE(self.context, @"-decidePolicyForNavigationAction host: %@", isKnown ? requestURL.host : @"unknown host");
-    MSID_LOG_VERBOSE_PII(self.context, @"-decidePolicyForNavigationAction host: %@", requestURL.host);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, self.context, @"-decidePolicyForNavigationAction host: %@", isKnown ? requestURL.host : @"unknown host");
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, self.context, @"-decidePolicyForNavigationAction host: %@", requestURL.host);
     
     [MSIDNotifications notifyWebAuthDidStartLoad:requestURL];
     
@@ -266,8 +266,9 @@
 {
     NSURL *url = webView.URL;
     __auto_type isKnown = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:url.host];
-    MSID_LOG_VERBOSE(self.context, @"-didFinishNavigation host: %@", isKnown ? url.host : @"unknown host");
-    MSID_LOG_VERBOSE_PII(self.context, @"-didFinishNavigation host: %@", url.host);
+    
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, self.context, @"-didFinishNavigation host: %@", isKnown ? url.host : @"unknown host");
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, self.context, @"-didFinishNavigation host: %@", url.host);
     
     [MSIDNotifications notifyWebAuthDidFinishLoad:url];
     
@@ -302,8 +303,9 @@
 - (void)completeWebAuthWithURL:(NSURL *)endURL
 {
     __auto_type isKnown = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:endURL.host];
-    MSID_LOG_VERBOSE(self.context, @"-completeWebAuthWithURL: %@", isKnown ? endURL.host : @"unknown host");
-    MSID_LOG_VERBOSE_PII(self.context, @"-completeWebAuthWithURL: %@", [endURL msidPIINullifiedURL]);
+    
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, self.context, @"-completeWebAuthWithURL: %@", isKnown ? endURL.host : @"unknown host");
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, self.context, @"-completeWebAuthWithURL: %@", [endURL msidPIINullifiedURL]);
     
     [self endWebAuthWithURL:endURL error:nil];
 }
@@ -332,8 +334,8 @@
         return;
     }
     
-    MSID_LOG_ERROR(self.context, @"-webAuthFailWithError error code %ld", (long)error.code);
-    MSID_LOG_ERROR_PII(self.context, @"-webAuthFailWithError: %@", error);
+    MSID_LOG_NO_PII(MSIDLogLevelError, nil, self.context, @"-webAuthFailWithError error code %ld", (long)error.code);
+    MSID_LOG_PII(MSIDLogLevelError, nil, self.context, @"-webAuthFailWithError: %@", error);
     
     [self endWebAuthWithURL:nil error:error];
 }

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
@@ -42,8 +42,8 @@
 {
     NSString *host = challenge.protectionSpace.host;
     
-    MSID_LOG_INFO(context, @"Attempting to handle client TLS challenge");
-    MSID_LOG_INFO_PII(context, @"Attempting to handle client TLS challenge. host: %@", host);
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Attempting to handle client TLS challenge");
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Attempting to handle client TLS challenge. host: %@", host);
     
     // See if this is a challenge for the WPJ cert.
     if ([MSIDWPJChallengeHandler handleChallenge:challenge

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNTLMHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNTLMHandler.m
@@ -50,15 +50,16 @@
     @synchronized(self)
     {
         // This is the NTLM challenge: use the identity to authenticate:
-        MSID_LOG_INFO(nil, @"Attempting to handle NTLM challenge");
-        MSID_LOG_INFO_PII(nil, @"Attempting to handle NTLM challenge host: %@", challenge.protectionSpace.host);
+        
+        MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Attempting to handle NTLM challenge");
+        MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Attempting to handle NTLM challenge host: %@", challenge.protectionSpace.host);
         
         [MSIDNTLMUIPrompt presentPrompt:^(NSString *username, NSString *password, BOOL cancel)
          {
              if (cancel)
              {
-                 MSID_LOG_INFO(context, @"NTLM challenge cancelled");
-                 MSID_LOG_INFO_PII(context, @"NTLM challenge cancelled - host: %@", challenge.protectionSpace.host);
+                 MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"NTLM challenge cancelled");
+                 MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"NTLM challenge cancelled - host: %@", challenge.protectionSpace.host);
                  
                  completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
              }
@@ -70,8 +71,8 @@
                  
                  completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
                  
-                 MSID_LOG_INFO(context, @"NTLM credentials added");
-                 MSID_LOG_INFO_PII(context, @"NTLM credentials added - host: %@", challenge.protectionSpace.host);
+                 MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"NTLM credentials added");
+                 MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"NTLM credentials added - host: %@", challenge.protectionSpace.host);
              }
          }];
     }//@synchronized

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNegotiateHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNegotiateHandler.m
@@ -89,8 +89,8 @@
                            // Get the lifetime of this credential
                            uint32_t lifeTime = GSSCredentialGetLifetime(credential);
                            
-                           MSID_LOG_INFO(context, @"Found credential for GSS_KRB5_MECHANISM with lifetime %d", lifeTime);
-                           MSID_LOG_INFO_PII(context, @"Found credential for GSS_KRB5_MECHANISM with lifetime %d, displayable name %@", lifeTime, displayableName);
+                           MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Found credential for GSS_KRB5_MECHANISM with lifetime %d", lifeTime);
+                           MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Found credential for GSS_KRB5_MECHANISM with lifetime %d, displayable name %@", lifeTime, displayableName);
                            
                            if (displayableName)
                            {

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -91,8 +91,8 @@
     
     if (!authHeaderParams)
     {
-        MSID_LOG_ERROR(context, @"Unparseable wwwAuthHeader received");
-        MSID_LOG_ERROR_PII(context, @"Unparseable wwwAuthHeader received %@", wwwAuthHeaderValue);
+        MSID_LOG_NO_PII(MSIDLogLevelError, nil, context, @"Unparseable wwwAuthHeader received");
+        MSID_LOG_PII(MSIDLogLevelError, nil, context, @"Unparseable wwwAuthHeader received %@", wwwAuthHeaderValue);
     }
     
     NSError *error = nil;

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDWPJChallengeHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDWPJChallengeHandler.m
@@ -65,8 +65,8 @@
     MSIDRegistrationInformation *info = [MSIDWorkPlaceJoinUtil getRegistrationInformation:context error:nil];
     if (!info || ![info isWorkPlaceJoined])
     {
-        MSID_LOG_INFO(context, @"Device is not workplace joined");
-        MSID_LOG_INFO_PII(context, @"Device is not workplace joined. host: %@", challenge.protectionSpace.host);
+        MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Device is not workplace joined");
+        MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Device is not workplace joined. host: %@", challenge.protectionSpace.host);
         
         // In other cert auth cases we send Cancel to ensure that we continue to get
         // auth challenges, however when we do that with WPJ we don't get the subsequent
@@ -80,8 +80,8 @@
         return YES;
     }
     
-    MSID_LOG_INFO(context, @"Responding to WPJ cert challenge");
-    MSID_LOG_INFO_PII(context, @"Responding to WPJ cert challenge. host: %@", challenge.protectionSpace.host);
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Responding to WPJ cert challenge");
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Responding to WPJ cert challenge. host: %@", challenge.protectionSpace.host);
     
     NSURLCredential *creds = [NSURLCredential credentialWithIdentity:info.securityIdentity
                                                         certificates:@[(__bridge id)info.certificate]

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
@@ -134,8 +134,8 @@ static NSString *s_redirectScheme = nil;
         return NO;
     }
     
-    MSID_LOG_INFO(context, @"Received CertAuthChallenge");
-    MSID_LOG_INFO_PII(context, @"Received CertAuthChallengehost from : %@", challenge.protectionSpace.host);
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, context, @"Received CertAuthChallenge");
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, context, @"Received CertAuthChallengehost from : %@", challenge.protectionSpace.host);
     
     NSURL *requestURL = [currentSession.webviewController startURL];
     

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
@@ -89,6 +89,9 @@ static NSString *s_redirectScheme = nil;
 
 + (BOOL)completeCertAuthChallenge:(NSURL *)endUrl
 {
+    MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, nil, @"Complete cert auth challenge with end URL: %@", endUrl.host);
+    MSID_LOG_PII(MSIDLogLevelInfo, nil, nil, @"Complete cert auth challenge with end URL: %@", [endUrl msidPIINullifiedURL]);
+    
     if (s_certAuthInProgress)
     {
         s_certAuthInProgress = NO;

--- a/IdentityCore/src/webview/response/MSIDWebWPJResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebWPJResponse.m
@@ -59,8 +59,8 @@
         
         if (localError)
         {
-            MSID_LOG_ERROR(context, @"Failed to parse client_info, code %ld, domain %@", (long)localError.code, localError.domain);
-            MSID_LOG_ERROR_PII(context, @"Failed to parse client_info, error: %@", localError);
+            MSID_LOG_NO_PII(MSIDLogLevelError, nil, context, @"Failed to parse client_info, code %ld, domain %@", (long)localError.code, localError.domain);
+            MSID_LOG_PII(MSIDLogLevelError, nil, context, @"Failed to parse client_info, error: %@", localError);
         }
     }
     

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -70,8 +70,8 @@ goto _error; \
     NSString *sharedAccessGroup = [NSString stringWithFormat:@"%@.com.microsoft.workplacejoin", teamId];
 #endif
     
-    MSID_LOG_VERBOSE(nil, @"Attempting to get registration information - shared access Group");
-    MSID_LOG_VERBOSE_PII(nil, @"Attempting to get registration information - %@ shared access Group", sharedAccessGroup);
+    MSID_LOG_NO_PII(MSIDLogLevelVerbose, nil, nil, @"Attempting to get registration information - shared access Group");
+    MSID_LOG_PII(MSIDLogLevelVerbose, nil, nil, @"Attempting to get registration information - %@ shared access Group", sharedAccessGroup);
     
     SecIdentityRef identity = NULL;
     SecCertificateRef certificate = NULL;

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -36,13 +36,18 @@
     [super setUp];
     [[MSIDTestLogger sharedLogger] reset];
     [MSIDTestLogger sharedLogger].callbackInvoked = NO;
+    [MSIDLogger sharedLogger].PiiLoggingEnabled = NO;
 }
 
 #pragma mark - Basic logging
 
 - (void)testLog_whenLogLevelNothingMessageValid_shouldNotThrow
 {
+    [self keyValueObservingExpectationForObject:[MSIDTestLogger sharedLogger] keyPath:@"callbackInvoked" expectedValue:@1];
     XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelNothing context:nil correlationId:nil isPII:NO ignoreIfPIIEnabled:NO format:@"Message"]);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil([MSIDTestLogger sharedLogger].lastMessage);
 }
 
 - (void)testLog_whenLogLevelErrorMessageNil_shouldNotThrow

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -42,12 +42,12 @@
 
 - (void)testLog_whenLogLevelNothingMessageValid_shouldNotThrow
 {
-    XCTAssertNoThrow([[MSIDLogger sharedLogger] logLevel:MSIDLogLevelNothing context:nil correlationId:nil isPII:NO format:@"Message"]);
+    XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelNothing context:nil correlationId:nil isPII:NO ignoreIfPIIEnabled:NO format:@"Message"]);
 }
 
 - (void)testLog_whenLogLevelErrorMessageNil_shouldNotThrow
 {
-    XCTAssertNoThrow([[MSIDLogger sharedLogger] logLevel:MSIDLogLevelError context:nil correlationId:nil isPII:NO format:nil]);
+    XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil isPII:NO ignoreIfPIIEnabled:NO format:nil]);
 }
 
 #pragma mark - PII flag
@@ -58,7 +58,7 @@
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
-    [[MSIDLogger sharedLogger] logLevel:MSIDLogLevelError context:nil correlationId:nil isPII:YES format:@"pii-message"];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil isPII:YES ignoreIfPIIEnabled:NO format:@"pii-message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
@@ -72,12 +72,25 @@
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
-    [[MSIDLogger sharedLogger] logLevel:MSIDLogLevelError context:nil correlationId:nil isPII:NO format:@"non-pii-message"];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil isPII:NO ignoreIfPIIEnabled:NO format:@"non-pii-message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
     XCTAssertEqual(testLogger.lastLevel, MSIDLogLevelError);
     XCTAssertFalse(testLogger.containsPII);
+}
+
+- (void)testLog_whenPiiEnabledNonPiiMessage_andIgnorePiiEnabledYES_shouldNotReturnMessageInCallback
+{
+    [MSIDLogger sharedLogger].PiiLoggingEnabled = YES;
+    MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
+    
+    __auto_type expectation = [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
+    [expectation setInverted:YES];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil isPII:NO ignoreIfPIIEnabled:YES format:@"non-pii-message"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNil(testLogger.lastMessage);
 }
 
 - (void)testLog_whenPiiNotEnabledNonPiiMessage_shouldReturnMessageInCallback
@@ -86,7 +99,7 @@
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
-    [[MSIDLogger sharedLogger] logLevel:MSIDLogLevelError context:nil correlationId:nil isPII:NO format:@"non-pii-message"];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil isPII:NO ignoreIfPIIEnabled:NO format:@"non-pii-message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
@@ -101,7 +114,7 @@
     
     __auto_type expectation = [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
     [expectation setInverted:YES];
-    [[MSIDLogger sharedLogger] logLevel:MSIDLogLevelError context:nil correlationId:nil isPII:YES format:@"pii-message"];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil isPII:YES ignoreIfPIIEnabled:NO format:@"pii-message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNil(testLogger.lastMessage);


### PR DESCRIPTION
Currently, we're not being very consistent about logging double lines (one for PII, another for non PII). Therefore, apps cannot completely ignore non PII lines, but when they don't ignore non PII lines, they end up with duplicate lines (one non PII, second one PII)

This change lets logger to ignore non PII lines, if they're followed by PII lines and PII logging is enabled. 