### PR TITLE
Update architectures for iOS simulator

### DIFF
--- a/IdentityCore/xcconfig/identitycore__common__ios.xcconfig
+++ b/IdentityCore/xcconfig/identitycore__common__ios.xcconfig
@@ -5,4 +5,4 @@ LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path
 TARGETED_DEVICE_FAMILY = 1,2
 ENABLE_BITCODE = YES
 SKIP_INSTALL = YES
-ARCHS = $(ARCHS_STANDARD) armv7s arm64e
+ARCHS[sdk=iphoneos*] = $(ARCHS_STANDARD) armv7s arm64e


### PR DESCRIPTION
I noticed that Xcode was printing a warning whenever building for simulator due to additional armv7s architecture. I updated config to only have custom architectures when building for iOS, to avoid this warning. 