### PR TITLE
apply hotfix 2.7.9-wpj

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
@@ -81,9 +81,8 @@
                    context:(id<MSIDRequestContext>)context
          completionHandler:(ChallengeCompletionHandler)completionHandler
 {
-    NSError *error = nil;
-    MSIDRegistrationInformation *info = [MSIDWorkPlaceJoinUtil getRegistrationInformation:context urlChallenge:challenge error:&error];
-    if (!info || error)
+    MSIDRegistrationInformation *info = [MSIDWorkPlaceJoinUtil getRegistrationInformation:context urlChallenge:challenge];
+    if (!info)
     {
         MSID_LOG_INFO(context, @"Device is not workplace joined");
         MSID_LOG_INFO_PII(context, @"Device is not workplace joined. host: %@", challenge.protectionSpace.host);

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
@@ -67,7 +67,7 @@
     
     for (NSData *distinguishedName in distinguishedNames)
     {
-        NSString *distinguishedNameString = [[[NSString alloc] initWithData:distinguishedName encoding:NSISOLatin1StringEncoding] lowercaseString];
+        NSString *distinguishedNameString = [[[NSString alloc] initWithData:distinguishedName encoding:NSASCIIStringEncoding] lowercaseString];
         if ([distinguishedNameString containsString:[kMSIDProtectionSpaceDistinguishedName lowercaseString]])
         {
             return YES;
@@ -81,8 +81,9 @@
                    context:(id<MSIDRequestContext>)context
          completionHandler:(ChallengeCompletionHandler)completionHandler
 {
-    MSIDRegistrationInformation *info = [MSIDWorkPlaceJoinUtil getRegistrationInformation:context error:nil];
-    if (!info || ![info isWorkPlaceJoined])
+    NSError *error = nil;
+    MSIDRegistrationInformation *info = [MSIDWorkPlaceJoinUtil getRegistrationInformation:context urlChallenge:challenge error:&error];
+    if (!info || error)
     {
         MSID_LOG_INFO(context, @"Device is not workplace joined");
         MSID_LOG_INFO_PII(context, @"Device is not workplace joined. host: %@", challenge.protectionSpace.host);

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -57,16 +57,9 @@
     NSArray *authorityParts = [submitUrl componentsSeparatedByString:@"?"];
     NSString *authority = [authorityParts objectAtIndex:0];
     
-    error = nil;
     NSString *authHeader = [MSIDPkeyAuthHelper createDeviceAuthResponse:authority
                                                           challengeData:queryParamsMap
-                                                                context:context
-                                                                  error:&error];
-    if (!authHeader)
-    {
-        completionHandler(nil, error);
-        return YES;
-    }
+                                                                context:context];
     
     // Attach client version to response url
     NSURLComponents *responseUrlComp = [[NSURLComponents alloc] initWithURL:[NSURL URLWithString:submitUrl] resolvingAgainstBaseURL:NO];

--- a/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.h
+++ b/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.h
@@ -28,8 +28,7 @@
 
 + (nullable NSString *)createDeviceAuthResponse:(nonnull NSString *)authorizationServer
                                   challengeData:(nullable NSDictionary *)challengeData
-                                        context:(nullable id<MSIDRequestContext>)context
-                                          error:(NSError * _Nullable * _Nullable)error;
+                                        context:(nullable id<MSIDRequestContext>)context;
 
 + (nonnull NSString *)computeThumbprint:(nonnull NSData *)data
                                  isSha2:(BOOL)isSha2;

--- a/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
+++ b/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
@@ -73,8 +73,7 @@
 {
     NSError *localError = nil;
     MSIDRegistrationInformation *info =
-    [MSIDWorkPlaceJoinUtil getRegistrationInformation:context
-                                                error:&localError];
+    [MSIDWorkPlaceJoinUtil getRegistrationInformation:context urlChallenge:nil error:&localError];
     
     if (!info && localError)
     {

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
@@ -28,6 +28,7 @@
 @interface MSIDWorkPlaceJoinUtil : NSObject
 
 + (MSIDRegistrationInformation *)getRegistrationInformation:(id<MSIDRequestContext>)context
+                                               urlChallenge:(NSURLAuthenticationChallenge *)challenge
                                                       error:(NSError **)error;
 
 @end

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
@@ -28,7 +28,6 @@
 @interface MSIDWorkPlaceJoinUtil : NSObject
 
 + (MSIDRegistrationInformation *)getRegistrationInformation:(id<MSIDRequestContext>)context
-                                               urlChallenge:(NSURLAuthenticationChallenge *)challenge
-                                                      error:(NSError **)error;
+                                               urlChallenge:(NSURLAuthenticationChallenge *)challenge;
 
 @end

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -49,6 +49,7 @@ goto _error; \
 
 
 + (MSIDRegistrationInformation *)getRegistrationInformation:(id<MSIDRequestContext>)context
+                                               urlChallenge:(NSURLAuthenticationChallenge *)challenge
                                                       error:(NSError **)error
 {
     NSString *teamId = [MSIDKeychainUtil teamId];

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -29,24 +29,8 @@
 
 @implementation MSIDWorkPlaceJoinUtil
 
-// Convenience macro for checking keychain status codes while looking up the WPJ
-// information. We don't send errors for errSecItemNotFound (because not having
-// WPJ information is an expected case) or errSecNoAccessForItem (because non-
-// Microsoft apps will not be able to access the workplace join information).
-#define CHECK_KEYCHAIN_STATUS(_operation) \
-{ \
-if (status != noErr) \
-{ \
-if (!(status == errSecItemNotFound || status == -25243)) \
-{ \
-NSError *localError = \
-MSIDCreateError(MSIDKeychainErrorDomain, status, _operation, nil, nil, nil, context.correlationId, nil); \
-if (error) { *error = localError; } \
-} \
-goto _error; \
-} \
-}
-
+// Convenience macro to release CF objects
+#define CFReleaseNull(CF) { CFTypeRef _cf = (CF); if (_cf) CFRelease(_cf); CF = NULL; }
 
 + (MSIDRegistrationInformation *)getRegistrationInformation:(id<MSIDRequestContext>)context
                                                urlChallenge:(NSURLAuthenticationChallenge *)challenge
@@ -54,116 +38,99 @@ goto _error; \
 {
     NSString *teamId = [MSIDKeychainUtil teamId];
     
-#if TARGET_OS_SIMULATOR
-    NSString *sharedAccessGroup = nil;
+    if (!teamId) return nil;
     
-    // Only in the simulator if we don't have a shared access group we want the rest of the code to
-    // at least attempt to work.
-    if (teamId)
-    {
-        sharedAccessGroup = [NSString stringWithFormat:@"%@.com.microsoft.workplacejoin", teamId];
-    }
-#else
-    if (!teamId)
-    {
-        return nil;
-    }
     NSString *sharedAccessGroup = [NSString stringWithFormat:@"%@.com.microsoft.workplacejoin", teamId];
-#endif
-    
-    MSID_LOG_VERBOSE(nil, @"Attempting to get registration information - shared access Group");
-    MSID_LOG_VERBOSE_PII(nil, @"Attempting to get registration information - %@ shared access Group", sharedAccessGroup);
-    
+
+    MSIDRegistrationInformation *info = nil;
     SecIdentityRef identity = NULL;
     SecCertificateRef certificate = NULL;
     SecKeyRef privateKey = NULL;
     NSString *certificateSubject = nil;
     NSData *certificateData = nil;
     NSString *certificateIssuer = nil;
-    NSData *issuer = nil;
-    NSDictionary *cerDict = nil;
-    
-    NSMutableDictionary *identityAttr = [[NSMutableDictionary alloc] init];
-    [identityAttr setObject:(__bridge id)kSecClassIdentity forKey:(__bridge id)kSecClass];
-    [identityAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id<NSCopying>)(kSecReturnRef)];
-    [identityAttr setObject:(__bridge id) kSecAttrKeyClassPrivate forKey:(__bridge id)kSecAttrKeyClass];
-    [identityAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id<NSCopying>)(kSecReturnAttributes)];
-#if TARGET_OS_SIMULATOR
-    if (sharedAccessGroup)
-#endif
-        [identityAttr setObject:sharedAccessGroup forKey:(__bridge id)kSecAttrAccessGroup];
-    
-    CFDictionaryRef result = NULL;
     OSStatus status = noErr;
-    //get the issuer information
-    status = SecItemCopyMatching((__bridge CFDictionaryRef)identityAttr, (CFTypeRef *)&result);
-    CHECK_KEYCHAIN_STATUS(@"retrieve wpj identity attr");
     
-    cerDict = (__bridge NSDictionary *) result;
-    assert([cerDict isKindOfClass:[NSDictionary class]]);
-    issuer = [cerDict objectForKey:(__bridge id)kSecAttrIssuer];
-    certificateIssuer = [[NSString alloc] initWithData:issuer encoding:NSISOLatin1StringEncoding];
-    CFRelease(result);
-    result = NULL;
+    MSID_LOG_VERBOSE(nil, @"Attempting to get registration information - shared access Group");
+    MSID_LOG_VERBOSE_PII(nil, @"Attempting to get registration information - %@ shared access Group", sharedAccessGroup);
     
-    // now get the identity out and use it.
-    [identityAttr removeObjectForKey:(__bridge id<NSCopying>)(kSecReturnAttributes)];
-    status = SecItemCopyMatching((__bridge CFDictionaryRef)identityAttr, (CFTypeRef*)&identity);
-    CHECK_KEYCHAIN_STATUS(@"retrieve wpj identity ref");;
-    if (CFGetTypeID(identity) != SecIdentityGetTypeID())
+    identity = [self copyWPJIdentity:context sharedAccessGroup:sharedAccessGroup certificateIssuer:&certificateIssuer];
+    if (!identity || CFGetTypeID(identity) != SecIdentityGetTypeID())
     {
-        CFRelease(identity);
-        
-        if (error)
-        {
-            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Wrong object type returned from identity query", nil, nil, nil, context.correlationId, nil);
-        }
+        MSID_LOG_VERBOSE(context, @"Failed to retrieve WPJ identity.");
+        CFReleaseNull(identity);
         return nil;
     }
-    //Get the certificate and data
-    status = SecIdentityCopyCertificate(identity, &certificate);
-    CHECK_KEYCHAIN_STATUS(@"copy identity certificate");
     
+    // Get the wpj certificate
+    MSID_LOG_VERBOSE(context, @"Retrieving WPJ certificate reference.");
+    status = SecIdentityCopyCertificate(identity, &certificate);
+    
+    // Get the private key
+    MSID_LOG_VERBOSE(context, @"Retrieving WPJ private key reference.");
     status = SecIdentityCopyPrivateKey(identity, &privateKey);
-    CHECK_KEYCHAIN_STATUS(@"copy identity private key");
     
     certificateSubject = (NSString *)CFBridgingRelease(SecCertificateCopySubjectSummary(certificate));
     certificateData = (NSData *)CFBridgingRelease(SecCertificateCopyData(certificate));
     
-    if(!(identity && certificate && certificateSubject && certificateData && privateKey && certificateIssuer))
+    if(!(certificate && certificateSubject && certificateData && privateKey && certificateIssuer))
     {
         // We never should hit this error anyways, as any of this stuff being missing will cause failures farther up.
         if (error)
         {
-            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Missing some piece of WPJ data", nil, nil, nil, context.correlationId, nil);
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Missing some pieces of WPJ data", nil, nil, nil, context.correlationId, nil);
         }
         
         return nil;
     }
+    else
+    {
+        info = [[MSIDRegistrationInformation alloc] initWithSecurityIdentity:identity
+                                                           certificateIssuer:certificateIssuer
+                                                                 certificate:certificate
+                                                          certificateSubject:certificateSubject
+                                                             certificateData:certificateData
+                                                                  privateKey:privateKey];
+        
+    }
     
+    CFReleaseNull(identity);
+    CFReleaseNull(certificate);
+    CFReleaseNull(privateKey);
+    
+    return info;
+}
+
++ (SecIdentityRef)copyWPJIdentity:(id<MSIDRequestContext>)context
+                sharedAccessGroup:(NSString *)accessGroup
+                certificateIssuer:(NSString **)issuer
+
+{
+    NSMutableDictionary *identityDict = [[NSMutableDictionary alloc] init];
+    [identityDict setObject:(__bridge id)kSecClassIdentity forKey:(__bridge id)kSecClass];
+    [identityDict setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id)kSecReturnRef];
+    [identityDict setObject:(__bridge id) kSecAttrKeyClassPrivate forKey:(__bridge id)kSecAttrKeyClass];
+    [identityDict setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id)kSecReturnAttributes];
+    [identityDict setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+    
+    CFDictionaryRef result = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)identityDict, (CFTypeRef *)&result);
+    
+    if (status != errSecSuccess)
     {
-        MSIDRegistrationInformation *info = [[MSIDRegistrationInformation alloc] initWithSecurityIdentity:identity
-                                                                                        certificateIssuer:certificateIssuer
-                                                                                              certificate:certificate
-                                                                                       certificateSubject:certificateSubject
-                                                                                          certificateData:certificateData
-                                                                                               privateKey:privateKey];
-        return info;
+        return NULL;
     }
-_error:
-    if (identity)
+    
+    NSDictionary *resultDict = (__bridge_transfer NSDictionary *)result;
+    NSData *certIsuuer = [resultDict objectForKey:(__bridge NSString*)kSecAttrIssuer];
+    
+    if (issuer)
     {
-        CFRelease(identity);
+        *issuer = [[NSString alloc] initWithData:certIsuuer encoding:NSASCIIStringEncoding];
     }
-    if (certificate)
-    {
-        CFRelease(certificate);
-    }
-    if (privateKey)
-    {
-        CFRelease(privateKey);
-    }
-    return nil;
+    
+    SecIdentityRef identityRef = (__bridge_retained SecIdentityRef)[resultDict objectForKey:(__bridge NSString*)kSecValueRef];
+    return identityRef;
 }
 
 @end

--- a/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
@@ -60,12 +60,12 @@
     MSID_LOG_VERBOSE(context, @"Retrieving WPJ certificate reference.");
     status = SecIdentityCopyCertificate(identity, &certificate);
     
-    certificateSubject = (__bridge_transfer NSString*)(SecCertificateCopySubjectSummary(certificate));
-    certificateData = (__bridge_transfer NSData*)(SecCertificateCopyData(certificate));
-    
     // Get the private key
     MSID_LOG_VERBOSE(context, @"Retrieving WPJ private key reference.");
     status = SecIdentityCopyPrivateKey(identity, &privateKey);
+    
+    certificateSubject = (__bridge_transfer NSString*)(SecCertificateCopySubjectSummary(certificate));
+    certificateData = (__bridge_transfer NSData*)(SecCertificateCopyData(certificate));
     
     if (!certificate || !certificateIssuer || !certificateSubject || !certificateData || !privateKey)
     {

--- a/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
@@ -38,11 +38,10 @@ goto _error; \
 } \
 }
 
-static const UInt8 certificateIdentifier[] = "WorkPlaceJoin-Access\0";
-
 @implementation MSIDWorkPlaceJoinUtil
 
 + (MSIDRegistrationInformation *)getRegistrationInformation:(id<MSIDRequestContext>)context
+                                               urlChallenge:(NSURLAuthenticationChallenge *)challenge
                                                       error:(NSError **)error
 {
     MSIDRegistrationInformation *info = nil;
@@ -52,57 +51,40 @@ static const UInt8 certificateIdentifier[] = "WorkPlaceJoin-Access\0";
     NSString *certificateSubject = nil;
     NSData *certificateData = nil;
     NSString *certificateIssuer  = nil;
-    NSError *localError = nil;
-    
-    if (error)
-    {
-        *error = nil;
-    }
+    OSStatus status = noErr;
     
     MSID_LOG_VERBOSE(context, @"Attempting to get WPJ registration information");
+    identity = [self copyWPJIdentity:context issuer:&certificateIssuer certificateAuthorities:challenge.protectionSpace.distinguishedNames];
     
-    [self copyCertificate:&certificate identity:&identity issuer:&certificateIssuer context:context error:&localError];
-    if (localError)
+    // If there's no identity in the keychain, return nil. adError won't be set if the
+    // identity can't be found since this isn't considered an error condition.
+    if (!identity || CFGetTypeID(identity) != SecIdentityGetTypeID())
     {
-        if (error)
-        {
-            *error = localError;
-        }
-        MSID_LOG_ERROR(context, @"Failed to retrieve WPJ certificate. Error code: %ld", (long)localError.code);
+        MSID_LOG_VERBOSE(context, @"Failed to retrieve WPJ identity.");
         goto _error;
     }
     
-    // If there's no certificate in the keychain, return nil. adError won't be set if the
-    // cert can't be found since this isn't considered an error condition.
-    if (!certificate)
-    {
-        return nil;
-    }
+    // Get the wpj certificate
+    MSID_LOG_VERBOSE(context, @"Retrieving WPJ certificate reference.");
+    status = SecIdentityCopyCertificate(identity, &certificate);
+    CHECK_KEYCHAIN_STATUS(@"Failed to read WPJ certificate.");
     
     certificateSubject = (__bridge_transfer NSString*)(SecCertificateCopySubjectSummary(certificate));
     certificateData = (__bridge_transfer NSData*)(SecCertificateCopyData(certificate));
     
     // Get the private key
     MSID_LOG_VERBOSE(context, @"Retrieving WPJ private key reference.");
+    status = SecIdentityCopyPrivateKey(identity, &privateKey);
+    CHECK_KEYCHAIN_STATUS(@"Failed to read WPJ private key for identifier.");
     
-    privateKey = [self copyPrivateKeyRefForIdentifier:kMSIDPrivateKeyIdentifier context:context error:&localError];
-    if (localError)
+    if (!certificate || !certificateIssuer || !certificateSubject || !certificateData || !privateKey)
     {
         if (error)
         {
-            *error = localError;
-        }
-        MSID_LOG_ERROR(context, @"Failed to retrieve WPJ private key reference. Error code %ld", (long)localError.code);
-        goto _error;
-    }
-    
-    if (!identity || !certificateIssuer || !certificateSubject || !certificateData || !privateKey)
-    {
-        // The code above will catch missing security items, but not missing item attributes. These are caught here.
-        if (error)
-        {
+            // The code above will catch missing security items, but not missing item attributes. These are caught here.
             *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Missing some piece of WPJ data", nil, nil, nil, context.correlationId, nil);
         }
+        
         goto _error;
     }
     
@@ -121,162 +103,88 @@ _error:
     if (identity)
     {
         CFRelease(identity);
+        identity = NULL;
     }
     if (certificate)
     {
         CFRelease(certificate);
+        certificate = NULL;
     }
     if (privateKey)
     {
         CFRelease(privateKey);
+        privateKey = NULL;
     }
     
     return info;
 }
 
++ (SecIdentityRef)copyWPJIdentity:(id<MSIDRequestContext>)context
+                           issuer:(NSString **)issuer
+           certificateAuthorities:(NSArray<NSData *> *)authorities
 
-+ (BOOL)copyCertificate:(SecCertificateRef __nullable * __nonnull)certificate
-               identity:(SecIdentityRef __nullable * __nonnull)identity
-                 issuer:(NSString * __nullable * __nonnull)issuer
-                context:(id<MSIDRequestContext>)context
-                  error:(NSError **)error
 {
-    OSStatus status = noErr;
-    NSError *localError = nil;
-    NSData *issuerData = nil;
-    NSDictionary *identityQuery = nil;
-    CFDictionaryRef result = NULL;
-    
-    *identity = nil;
-    *certificate = nil;
-    if (error)
-    {
-        *error = nil;
-    }
-    
-    *certificate = [self copyWPJCertificateRef:context error:&localError];
-    
-    if (localError)
-    {
-        if (error)
-        {
-            *error = localError;
-        }
-        
-        MSID_LOG_ERROR(context, @"Failed to retrieve WPJ client certificate from keychain. Error code: %ld", (long)localError.code);
-        goto _error;
-    }
-    
-    // If there's no certificate in the keychain, adError won't be set since this isn't an error condition.
-    if (!*certificate)
-    {
-        return NO;
-    }
-    
-    // In OS X the shared access group cannot be set, so the search needs to be more
-    // specific. The code below searches the identity by passing the WPJ cert as reference.
-    identityQuery = @{ (__bridge id)kSecClass : (__bridge id)kSecClassIdentity,
-                       (__bridge id)kSecReturnRef : (__bridge id)kCFBooleanTrue,
-                       (__bridge id)kSecReturnAttributes : (__bridge id)kCFBooleanTrue,
-                       (__bridge id)kSecAttrKeyClass : (__bridge id)kSecAttrKeyClassPrivate,
-                       (__bridge id)kSecValueRef : (__bridge id)*certificate
-                       };
-    
-    status = SecItemCopyMatching((__bridge CFDictionaryRef)identityQuery, (CFTypeRef*)&result);
-    CHECK_KEYCHAIN_STATUS(@"Failed to retrieve WPJ identity from keychain.");
-    
-    issuerData = [(__bridge NSDictionary*)result objectForKey:(__bridge id)kSecAttrIssuer];
-    if (issuerData)
-    {
-        *issuer = [[NSString alloc] initWithData:issuerData encoding:NSISOLatin1StringEncoding];
-    }
-    
-    *identity = (__bridge SecIdentityRef)([(__bridge NSDictionary*)result objectForKey:(__bridge id)kSecValueRef]);
-    if (*identity)
-    {
-        CFRetain(*identity);
-    }
-    
-    CFRelease(result);
-    
-    return YES;
-    
-_error:
-    
-    if (*identity)
-    {
-        CFRelease(*identity);
-    }
-    *identity = nil;
-    
-    if (*certificate)
-    {
-        CFRelease(*certificate);
-    }
-    *certificate = nil;
-    
-    *issuer = nil;
-    
-    return NO;
-}
-
-
-+ (SecCertificateRef)copyWPJCertificateRef:(id<MSIDRequestContext>)context
-                                     error:(NSError **)error
-{
-    OSStatus status= noErr;
-    SecCertificateRef certRef = NULL;
-    NSData *issuerTag = [self wpjCertIssuerTag];
-    
-    // Set the private key query dictionary.
-    NSDictionary *queryCert = @{ (__bridge id)kSecClass : (__bridge id)kSecClassCertificate,
-                                 (__bridge id)kSecAttrLabel : issuerTag
-                                 };
-    
-    // Get the certificate. If the certificate is not found, this is not considered an error.
-    status = SecItemCopyMatching((__bridge CFDictionaryRef)queryCert, (CFTypeRef*)&certRef);
-    if (status == errSecItemNotFound)
+    if (![authorities count])
     {
         return NULL;
     }
     
-    CHECK_KEYCHAIN_STATUS(@"Failed to read WPJ certificate.");
+    NSDictionary *query = @{ (__bridge id)kSecClass : (__bridge id)kSecClassIdentity,
+                             (__bridge id)kSecReturnAttributes:(__bridge id)kCFBooleanTrue,
+                             (__bridge id)kSecReturnRef :  (__bridge id)kCFBooleanTrue,
+                             (__bridge id)kSecMatchLimit : (__bridge id)kSecMatchLimitAll,
+                             (__bridge id)kSecMatchIssuers : authorities
+                             };
     
-    return certRef;
+    CFArrayRef identityList = NULL;
+    SecIdentityRef identityRef = NULL;
+    NSDictionary *identityDict = nil;
+    NSData *currentIssuer = nil;
+    NSString *currentIssuerName = nil;
     
-_error:
-    return NULL;
-}
-
-+ (NSData *)wpjCertIssuerTag
-{
-    return [NSData dataWithBytes:certificateIdentifier length:strlen((const char *)certificateIdentifier)];
-}
-
-+ (SecKeyRef)copyPrivateKeyRefForIdentifier:(NSString *)identifier
-                                    context:(id<MSIDRequestContext>)context
-                                      error:(NSError **)error
-{
-    OSStatus status= noErr;
-    SecKeyRef privateKeyReference = NULL;
+    OSStatus status = SecItemCopyMatching((CFDictionaryRef)query, (CFTypeRef *)&identityList);
     
-    NSData *privateKeyTag = [NSData dataWithBytes:[identifier UTF8String] length:identifier.length];
+    if (status != errSecSuccess)
+    {
+        return NULL;
+    }
     
-    // Set the private key query dictionary.
-    NSDictionary *privateKeyQuery = @{ (__bridge id)kSecClass : (__bridge id)kSecClassKey,
-                                       (__bridge id)kSecAttrApplicationTag : privateKeyTag,
-                                       (__bridge id)kSecAttrKeyType : (__bridge id)kSecAttrKeyTypeRSA,
-                                       (__bridge id)kSecReturnRef : (__bridge id)kCFBooleanTrue
-                                       };
+    CFIndex identityCount = CFArrayGetCount(identityList);
+    NSString *challengeIssuerName = [[NSString alloc] initWithData:authorities[0] encoding:NSASCIIStringEncoding];
     
-    // Get the key.
-    status = SecItemCopyMatching((__bridge CFDictionaryRef)privateKeyQuery, (CFTypeRef*)&privateKeyReference);
-    CHECK_KEYCHAIN_STATUS(@"Failed to read WPJ private key for identifier.");
+    for (int resultIndex = 0; resultIndex < identityCount; resultIndex++)
+    {
+        identityDict = (NSDictionary *)CFArrayGetValueAtIndex(identityList, resultIndex);
+        
+        if ([identityDict isKindOfClass:[NSDictionary class]])
+        {
+            currentIssuer = [identityDict objectForKey:(__bridge NSString*)kSecAttrIssuer];
+            currentIssuerName = [[NSString alloc] initWithData:currentIssuer encoding:NSASCIIStringEncoding];
+            
+            /* The issuer name returned from the certificate in keychain is capitalized but the issuer name returned from the TLS challenge is not.
+             Hence we need to do a caseInsenstitive compare to match the issuer.
+             */
+            if ([challengeIssuerName caseInsensitiveCompare:currentIssuerName] == NSOrderedSame)
+            {
+                identityRef = (__bridge_retained SecIdentityRef)[identityDict objectForKey:(__bridge NSString*)kSecValueRef];
+                
+                if (issuer)
+                {
+                    *issuer = currentIssuerName;
+                }
+                
+                break;
+            }
+        }
+    }
     
-    return privateKeyReference;
+    if (identityList)
+    {
+        CFRelease(identityList);
+        identityList = NULL;
+    }
     
-_error:
-    return nil;
+    return identityRef; //Caller must call CFRelease
 }
 
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,3 @@
+Version 1.0.11
+------------
+* Apply hotfix 2.7.9 for Mac OS to query WPJ cert using issuers from authentication challenge


### PR DESCRIPTION
* Apply hotfix 2.7.9 for wpj cert fix for Mac OS.
* Update ios pkayAuth challenge code to create a pKeyAuth request with empty header incase we do not retrieve a WPJ identity from keychain or if the retrieved identity is corrupt which allows the server to show an Enroll page allowing the developer to register their device.
Previous implementation would fail with error in case the parts of the WPJ identity like the certificate or issuer were missing leaving the developer in an unrecoverable state.