### PR TITLE
Remove deprecated setPersistance for UIPasteboard

### DIFF
--- a/IdentityCore/src/controllers/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/ios/MSIDBrokerInteractiveController.m
@@ -215,7 +215,6 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
 {
     UIPasteboard *appPasteBoard = [UIPasteboard pasteboardWithName:@"WPJ"
                                                             create:YES];
-    appPasteBoard.persistent = YES;
     url = [NSURL URLWithString:[NSString stringWithFormat:@"%@&%@=%@", url.absoluteString, @"sourceApplication", [[NSBundle mainBundle] bundleIdentifier]]];
     [appPasteBoard setURL:url];
 }


### PR DESCRIPTION
msal update for release 0.3.0: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/495
broker update for dev: https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/316
