### PR TITLE
add conditional check for kerberos challenge.

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNegotiateHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNegotiateHandler.m
@@ -40,19 +40,19 @@
       completionHandler:(ChallengeCompletionHandler)completionHandler
 {
 #pragma unused(challenge)
-    
+
+#ifndef DISABLE_KERBEROS
     if ([self hasValidKBRCredential:context])
     {
         // This means we have an unexpired credential, let system handle it
         MSID_LOG_INFO(context, @"Perform default system handling for Negotiate");
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+        return YES;
     }
-    else
-    {
-        // This challenge is rejected and the next authentication protection space should be tried by OS
-        MSID_LOG_INFO(context, @"Reject protection space, so the next one can be tried");
-        completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
-    }
+#endif
+    // This challenge is rejected and the next authentication protection space should be tried by OS
+    MSID_LOG_INFO(context, @"Reject protection space, so the next one can be tried");
+    completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
     
     return YES;
 }


### PR DESCRIPTION
Skb for mac has a Kerberos issue, and currently, out of options on fixing kerberos cert issue from the customer side.
So, mitigation for now is to have ADAL support "disabling" kerberos challenge.
This PR address that.