### PR TITLE
Change configuration to support AppCenter SDK

### DIFF
--- a/IdentityCore/xcconfig/identitycore__idlib__ios.xcconfig
+++ b/IdentityCore/xcconfig/identitycore__idlib__ios.xcconfig
@@ -1,2 +1,11 @@
 #include "identitycore__lib__common__ios.xcconfig"
 #include "identitycore__idlib__common.xcconfig"
+
+// Force the linker to resolve symbols.
+GENERATE_MASTER_OBJECT_FILE = YES
+
+// Add armv7s and arm64e to standard ARCHs.
+ARCHS = $(ARCHS_STANDARD) armv7s arm64e
+
+// Activate full bitcode on release configuration for real devices.
+OTHER_CFLAGS[config=Release][sdk=iphoneos*] = $(OTHER_CFLAGS) -fembed-bitcode


### PR DESCRIPTION
- GENERATE_MASTER_OBJECT_FILE is activated to include category symbols into static library.
- armv7s and arm64e are added to ARCH.
- bitcode marker flag is added to support full bitcode on release configuration for real devices.
