### PR TITLE
MSAL API updates bug fixes

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -649,6 +649,11 @@
 		B2808005204CB2A700944D89 /* MSIDAADV1TokenResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2808003204CB2A700944D89 /* MSIDAADV1TokenResponseTests.m */; };
 		B280800B204CD81400944D89 /* MSIDLegacyCacheKeyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2808009204CD81400944D89 /* MSIDLegacyCacheKeyTests.m */; };
 		B280800E204CD82100944D89 /* MSIDDefaultCredentialCacheKeyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B280800C204CD82100944D89 /* MSIDDefaultCredentialCacheKeyTests.m */; };
+		B281B334226BB83C009619AB /* MSIDOAuthRequestConfigurator.h in Headers */ = {isa = PBXBuildFile; fileRef = B281B332226BB83C009619AB /* MSIDOAuthRequestConfigurator.h */; };
+		B281B335226BB83C009619AB /* MSIDOAuthRequestConfigurator.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B333226BB83C009619AB /* MSIDOAuthRequestConfigurator.m */; };
+		B281B336226BB83C009619AB /* MSIDOAuthRequestConfigurator.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B333226BB83C009619AB /* MSIDOAuthRequestConfigurator.m */; };
+		B281B338226BBB1C009619AB /* MSIDOAuthRequestConfiguratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B337226BBB1C009619AB /* MSIDOAuthRequestConfiguratorTests.m */; };
+		B281B339226BBB1C009619AB /* MSIDOAuthRequestConfiguratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B337226BBB1C009619AB /* MSIDOAuthRequestConfiguratorTests.m */; };
 		B2893CB11FCF6A8C00E348E9 /* NSMutableDictionary+MSIDExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BDA66D1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m */; };
 		B28AC66421A0BB9D00A1FC4A /* MSIDTestBrokerResponseHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = B28AC66221A0BB9D00A1FC4A /* MSIDTestBrokerResponseHelper.h */; };
 		B28AC66521A0BB9D00A1FC4A /* MSIDTestBrokerResponseHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B28AC66321A0BB9D00A1FC4A /* MSIDTestBrokerResponseHelper.m */; };
@@ -1631,6 +1636,9 @@
 		B2808003204CB2A700944D89 /* MSIDAADV1TokenResponseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV1TokenResponseTests.m; sourceTree = "<group>"; };
 		B2808009204CD81400944D89 /* MSIDLegacyCacheKeyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLegacyCacheKeyTests.m; sourceTree = "<group>"; };
 		B280800C204CD82100944D89 /* MSIDDefaultCredentialCacheKeyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDDefaultCredentialCacheKeyTests.m; sourceTree = "<group>"; };
+		B281B332226BB83C009619AB /* MSIDOAuthRequestConfigurator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDOAuthRequestConfigurator.h; sourceTree = "<group>"; };
+		B281B333226BB83C009619AB /* MSIDOAuthRequestConfigurator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOAuthRequestConfigurator.m; sourceTree = "<group>"; };
+		B281B337226BBB1C009619AB /* MSIDOAuthRequestConfiguratorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOAuthRequestConfiguratorTests.m; sourceTree = "<group>"; };
 		B2893CAE1FCF68B200E348E9 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		B28AC66221A0BB9D00A1FC4A /* MSIDTestBrokerResponseHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTestBrokerResponseHelper.h; sourceTree = "<group>"; };
 		B28AC66321A0BB9D00A1FC4A /* MSIDTestBrokerResponseHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTestBrokerResponseHelper.m; sourceTree = "<group>"; };
@@ -2263,6 +2271,8 @@
 				238EF02B208FD0200035ABE6 /* MSIDHttpRequestConfiguratorProtocol.h */,
 				238EF02C208FD0200035ABE6 /* MSIDAADRequestConfigurator.h */,
 				238EF02A208FD0200035ABE6 /* MSIDAADRequestConfigurator.m */,
+				B281B332226BB83C009619AB /* MSIDOAuthRequestConfigurator.h */,
+				B281B333226BB83C009619AB /* MSIDOAuthRequestConfigurator.m */,
 			);
 			path = request_configurator;
 			sourceTree = "<group>";
@@ -3449,6 +3459,7 @@
 				23CA0C5E220A68D400768729 /* MSIDPkeyAuthHelperTests.m */,
 				23FB5C1F225516FA002BF1EB /* MSIDClaimsRequestTests.m */,
 				05566D142204BCF9002DBA40 /* MSIDMacKeychainTokenCacheTests.m */,
+				B281B337226BBB1C009619AB /* MSIDOAuthRequestConfiguratorTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -3665,6 +3676,7 @@
 				B29A36BF20B1289D00427B63 /* MSIDAccountIdentifier.h in Headers */,
 				96891A962190F15E00D7F437 /* MSIDWPJChallengeHandler.h in Headers */,
 				B20657A51FC91C1600412B7D /* MSIDTelemetryDispatcher.h in Headers */,
+				B281B334226BB83C009619AB /* MSIDOAuthRequestConfigurator.h in Headers */,
 				238E19CB2086FC87004DF483 /* MSIDUrlRequestSerializer.h in Headers */,
 				96F21B1A20A65187002B87C3 /* MSIDWebviewInteracting.h in Headers */,
 				B251CC3F2041058D005E0179 /* MSIDLegacySingleResourceToken.h in Headers */,
@@ -4248,6 +4260,7 @@
 				B29A36BB20AFAB0200427B63 /* MSIDDefaultAccessorSSOIntegrationTests.m in Sources */,
 				B2DD4B3820A922170047A66E /* MSIDDefaultAccountCacheQueryTests.m in Sources */,
 				B2936F4A20AA8E1F0050C585 /* MSIDCacheItemJsonSerializerTests.m in Sources */,
+				B281B338226BBB1C009619AB /* MSIDOAuthRequestConfiguratorTests.m in Sources */,
 				238AB2A920BF473F00CD8675 /* MSIDURLSessionDelegateTests.m in Sources */,
 				B2808001204CB29900944D89 /* MSIDAADTokenResponseTests.m in Sources */,
 				B28BBD3F221267B200F51723 /* MSIDLegacyTokenResponseValidatorTests.m in Sources */,
@@ -4321,6 +4334,7 @@
 				23D2046421CF1F60009B5975 /* MSIDAADTokenResponseSerializer.m in Sources */,
 				B2AF1D35218BCEEB0080C1A0 /* MSIDSilentTokenRequest.m in Sources */,
 				606830102098E94100CCA6AB /* MSIDCertificateChooser.m in Sources */,
+				B281B336226BB83C009619AB /* MSIDOAuthRequestConfigurator.m in Sources */,
 				B2AF1D23218BCD870080C1A0 /* MSIDSilentController.m in Sources */,
 				60B3856020A96E2700D546D0 /* MSIDWebviewUIController.m in Sources */,
 				B251CC412041058D005E0179 /* MSIDRefreshToken.m in Sources */,
@@ -4541,6 +4555,7 @@
 				606B108C20D084B600B34224 /* MSIDAADV1WebviewFactoryTests.m in Sources */,
 				96CD652A20C885E2004813EE /* MSIDWebviewFactoryTests.m in Sources */,
 				239DF9C220E04BC9002D428B /* MSIDB2CAuthorityTests.m in Sources */,
+				B281B339226BBB1C009619AB /* MSIDOAuthRequestConfiguratorTests.m in Sources */,
 				B2808005204CB2A700944D89 /* MSIDAADV1TokenResponseTests.m in Sources */,
 				D6D9A4BD1FBE712900EFA430 /* MSIDURLExtensionsTests.m in Sources */,
 				960F918B20CBECAE0055A162 /* MSIDAADWebviewFactoryTests.m in Sources */,
@@ -4812,6 +4827,7 @@
 				B251CC1C2040F6B5005E0179 /* MSIDLegacyTokenCacheKey.m in Sources */,
 				B2EF143C1FF2F228005DC1C0 /* MSIDAADV2TokenResponse.m in Sources */,
 				B297E1DD20A0F5D600F370EC /* MSIDDefaultCredentialCacheQuery.m in Sources */,
+				B281B335226BB83C009619AB /* MSIDOAuthRequestConfigurator.m in Sources */,
 				B2115828202BD5F3005CE586 /* MSIDCacheKey.m in Sources */,
 				B28BDAC0221F7F230055FFE6 /* MSIDCBAWebAADAuthResponse.m in Sources */,
 				B297E1F120A25F0C00F370EC /* MSIDLegacyTokenCacheItem.m in Sources */,

--- a/IdentityCore/src/network/MSIDHttpRequest.h
+++ b/IdentityCore/src/network/MSIDHttpRequest.h
@@ -63,8 +63,10 @@
 
 @property (nonatomic) NSInteger retryCounter;
 @property (nonatomic) NSTimeInterval retryInterval;
+@property (nonatomic) NSTimeInterval requestTimeoutInterval;
 
 @property (class, nonatomic, readwrite) NSInteger retryCountSetting;
 @property (class, nonatomic, readwrite) NSTimeInterval retryIntervalSetting;
+@property (class, nonatomic, readwrite) NSTimeInterval requestTimeoutInterval;
 
 @end

--- a/IdentityCore/src/network/MSIDHttpRequest.m
+++ b/IdentityCore/src/network/MSIDHttpRequest.m
@@ -30,9 +30,11 @@
 #import "MSIDHttpRequestTelemetry.h"
 #import "MSIDURLSessionManager.h"
 #import "MSIDJsonResponsePreprocessor.h"
+#import "MSIDOAuthRequestConfigurator.h"
 
 static NSInteger s_retryCount = 1;
 static NSTimeInterval s_retryInterval = 0.5;
+static NSTimeInterval s_requestTimeoutInterval = 300;
 
 @implementation MSIDHttpRequest
 
@@ -50,6 +52,7 @@ static NSTimeInterval s_retryInterval = 0.5;
         _telemetry = [MSIDHttpRequestTelemetry new];
         _retryCounter = s_retryCount;
         _retryInterval = s_retryInterval;
+        _requestTimeoutInterval = s_requestTimeoutInterval;
     }
     
     return self;
@@ -58,6 +61,10 @@ static NSTimeInterval s_retryInterval = 0.5;
 - (void)sendWithBlock:(MSIDHttpRequestDidCompleteBlock)completionBlock
 {
     NSParameterAssert(self.urlRequest);
+    
+    __auto_type requestConfigurator = [MSIDOAuthRequestConfigurator new];
+    requestConfigurator.timeoutInterval = _requestTimeoutInterval;
+    [requestConfigurator configure:self];
     
     self.urlRequest = [self.requestSerializer serializeWithRequest:self.urlRequest parameters:self.parameters];
     
@@ -119,5 +126,7 @@ static NSTimeInterval s_retryInterval = 0.5;
 
 + (NSTimeInterval)retryIntervalSetting { return s_retryInterval; }
 + (void)setRetryIntervalSetting:(NSTimeInterval)retryIntervalSetting { s_retryInterval = retryIntervalSetting; }
++ (void)setRequestTimeoutInterval:(NSTimeInterval)requestTimeoutInterval { s_requestTimeoutInterval = requestTimeoutInterval; }
++ (NSTimeInterval)requestTimeoutInterval { return s_requestTimeoutInterval; }
 
 @end

--- a/IdentityCore/src/network/MSIDURLSessionManager.m
+++ b/IdentityCore/src/network/MSIDURLSessionManager.m
@@ -82,24 +82,4 @@ static MSIDURLSessionManager *s_defaultManager = nil;
     s_defaultManager = defaultManager;
 }
 
-- (void)setTimeoutIntervalForRequest:(NSTimeInterval)timeoutIntervalForRequest
-{
-    s_defaultManager.configuration.timeoutIntervalForRequest = timeoutIntervalForRequest;
-}
-
-- (void)setTimeoutIntervalForResource:(NSTimeInterval)timeoutIntervalForResource
-{
-    s_defaultManager.configuration.timeoutIntervalForResource = timeoutIntervalForResource;
-}
-
-- (NSTimeInterval)timeoutIntervalForResource
-{
-    return s_defaultManager.configuration.timeoutIntervalForResource;
-}
-
-- (NSTimeInterval)timeoutIntervalForRequest
-{
-    return s_defaultManager.configuration.timeoutIntervalForRequest;
-}
-
 @end

--- a/IdentityCore/src/network/request_configurator/MSIDAADRequestConfigurator.m
+++ b/IdentityCore/src/network/request_configurator/MSIDAADRequestConfigurator.m
@@ -35,22 +35,10 @@
 #import "MSIDAADJsonResponsePreprocessor.h"
 #import "MSIDWorkPlaceJoinConstants.h"
 
-static NSTimeInterval const s_defaultTimeoutInterval = 300;
-
 @interface MSIDAADRequestConfigurator()
 @end
 
 @implementation MSIDAADRequestConfigurator
-
-- (instancetype)init
-{
-    self = [super init];
-    if (self)
-    {
-        _timeoutInterval = s_defaultTimeoutInterval;
-    }
-    return self;
-}
 
 - (void)configure:(MSIDHttpRequest *)request
 {
@@ -75,8 +63,6 @@ static NSTimeInterval const s_defaultTimeoutInterval = 300;
     
     NSMutableURLRequest *mutableUrlRequest = [request.urlRequest mutableCopy];
     mutableUrlRequest.URL = requestUrl;
-    mutableUrlRequest.timeoutInterval = self.timeoutInterval;
-    mutableUrlRequest.cachePolicy = NSURLRequestReloadIgnoringCacheData;
 #if TARGET_OS_IPHONE
     [mutableUrlRequest setValue:kMSIDPKeyAuthHeaderVersion forHTTPHeaderField:kMSIDPKeyAuthHeader];
 #endif

--- a/IdentityCore/src/network/request_configurator/MSIDOAuthRequestConfigurator.h
+++ b/IdentityCore/src/network/request_configurator/MSIDOAuthRequestConfigurator.h
@@ -24,6 +24,12 @@
 #import <Foundation/Foundation.h>
 #import "MSIDHttpRequestConfiguratorProtocol.h"
 
-@interface MSIDAADRequestConfigurator : NSObject <MSIDHttpRequestConfiguratorProtocol>
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDOAuthRequestConfigurator : NSObject <MSIDHttpRequestConfiguratorProtocol>
+
+@property (nonatomic) NSTimeInterval timeoutInterval;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/network/request_configurator/MSIDOAuthRequestConfigurator.m
+++ b/IdentityCore/src/network/request_configurator/MSIDOAuthRequestConfigurator.m
@@ -21,9 +21,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import "MSIDHttpRequestConfiguratorProtocol.h"
+#import "MSIDOAuthRequestConfigurator.h"
+#import "MSIDHttpRequest.h"
 
-@interface MSIDAADRequestConfigurator : NSObject <MSIDHttpRequestConfiguratorProtocol>
+@implementation MSIDOAuthRequestConfigurator
+
+- (void)configure:(MSIDHttpRequest *)request
+{
+    NSParameterAssert(request.urlRequest);
+    NSParameterAssert(request.urlRequest.URL);
+    
+    NSMutableURLRequest *mutableUrlRequest = [request.urlRequest mutableCopy];
+    mutableUrlRequest.timeoutInterval = self.timeoutInterval;
+    mutableUrlRequest.cachePolicy = NSURLRequestReloadIgnoringCacheData;
+    request.urlRequest = mutableUrlRequest;
+}
 
 @end

--- a/IdentityCore/src/validation/MSIDAuthority+Internal.h
+++ b/IdentityCore/src/validation/MSIDAuthority+Internal.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (atomic) MSIDOpenIdProviderMetadata *metadata;
 @property (atomic) NSURL *openIdConfigurationEndpoint;
+@property (atomic) NSURL *url;
 
 - (id<MSIDAuthorityResolving>)resolver;
 

--- a/IdentityCore/src/validation/MSIDAuthority.m
+++ b/IdentityCore/src/validation/MSIDAuthority.m
@@ -288,9 +288,9 @@ static MSIDCache <NSString *, MSIDOpenIdProviderMetadata *> *s_openIdConfigurati
 - (id)copyWithZone:(NSZone *)zone
 {
     MSIDAuthority *authority = [[self.class allocWithZone:zone] initWithURL:_url context:nil error:nil];
-    authority->_openIdConfigurationEndpoint = [_openIdConfigurationEndpoint copyWithZone:zone];
-    authority->_metadata = _metadata;
-    authority->_url = [_url copyWithZone:zone];
+    authority.openIdConfigurationEndpoint = [_openIdConfigurationEndpoint copyWithZone:zone];
+    authority.metadata = _metadata;
+    authority.url = [_url copyWithZone:zone];
     
     return authority;
 }

--- a/IdentityCore/tests/MSIDAADRequestConfiguratorTests.m
+++ b/IdentityCore/tests/MSIDAADRequestConfiguratorTests.m
@@ -49,11 +49,6 @@
     [super tearDown];
 }
 
-- (void)testRequestConfigurator_byDefaultIntervalIs300Seconds
-{
-    XCTAssertEqual(self.requestConfigurator.timeoutInterval, 300);
-}
-
 - (void)testConfigure_shouldConfigureAADRequest
 {
     __auto_type baseUrl = [[NSURL alloc] initWithString:@"https://fake.url"];
@@ -62,7 +57,6 @@
     context.correlationId = [[NSUUID alloc] initWithUUIDString:@"E621E1F8-C36C-495A-93FC-0C247A3E6E5F"];
     httpRequest.context = context;
     httpRequest.urlRequest = [[NSURLRequest alloc] initWithURL:baseUrl];
-    self.requestConfigurator.timeoutInterval = 60;
     
     [self.requestConfigurator configure:httpRequest];
     
@@ -74,8 +68,6 @@
     }
     XCTAssertTrue([httpRequest.errorHandler isKindOfClass:MSIDAADRequestErrorHandler.class]);
     XCTAssertEqualObjects(httpRequest.urlRequest.allHTTPHeaderFields[@"Accept"], @"application/json");
-    XCTAssertEqual(httpRequest.urlRequest.timeoutInterval, 60);
-    XCTAssertEqual(httpRequest.urlRequest.cachePolicy, NSURLRequestReloadIgnoringCacheData);
     XCTAssertEqualObjects(httpRequest.urlRequest.URL.absoluteString, @"https://fake.url");
     __auto_type headers = httpRequest.urlRequest.allHTTPHeaderFields;
     XCTAssertEqualObjects(headers[MSID_OAUTH2_CORRELATION_ID_REQUEST], @"true");

--- a/IdentityCore/tests/MSIDOAuthRequestConfiguratorTests.m
+++ b/IdentityCore/tests/MSIDOAuthRequestConfiguratorTests.m
@@ -21,9 +21,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import "MSIDHttpRequestConfiguratorProtocol.h"
+#import <XCTest/XCTest.h>
+#import "MSIDOAuthRequestConfigurator.h"
+#import "MSIDHttpRequest.h"
+#import "MSIDTestContext.h"
 
-@interface MSIDAADRequestConfigurator : NSObject <MSIDHttpRequestConfiguratorProtocol>
+@interface MSIDOAuthRequestConfiguratorTests : XCTestCase
+
+@end
+
+@implementation MSIDOAuthRequestConfiguratorTests
+
+- (void)testConfigure_shouldConfigureBaseOAuthRequest
+{
+    __auto_type baseUrl = [[NSURL alloc] initWithString:@"https://fake.url"];
+    __auto_type httpRequest = [MSIDHttpRequest new];
+    __auto_type context = [MSIDTestContext new];
+    context.correlationId = [[NSUUID alloc] initWithUUIDString:@"E621E1F8-C36C-495A-93FC-0C247A3E6E5F"];
+    httpRequest.context = context;
+    httpRequest.urlRequest = [[NSURLRequest alloc] initWithURL:baseUrl];
+    
+    MSIDOAuthRequestConfigurator *requestConfigurator = [MSIDOAuthRequestConfigurator new];
+    requestConfigurator.timeoutInterval = 3333;
+    
+    [requestConfigurator configure:httpRequest];
+    XCTAssertEqual(httpRequest.urlRequest.timeoutInterval, 3333);
+    XCTAssertEqual(httpRequest.urlRequest.cachePolicy, NSURLRequestReloadIgnoringCacheData);
+    XCTAssertEqualObjects(httpRequest.urlRequest.URL.absoluteString, @"https://fake.url");
+}
 
 @end


### PR DESCRIPTION
Fixes for following issues:
1. Translate programmatic cancel error to user cancel for MSAL (otherwise developer using passed in web view would need to look for internal error)
2. Don’t let configuration be editable after Public client is created, so copy it (follows the logic of NSURLSessionConfiguration)
3. Deprecate validateAuthority flag in public client application (Android already removed the flag, so might be a good idea to deprecate it)
4. Removes validateAuthority flag from public client conf (since we’re trying to get rid of the flag, no need to add new place for it)
5. Added known authorities logic for acquire token silent
6. Fixed known authorities logic: previously it was always comparing MSALAuthority with MSIDAuthority which failed
7. Added an exception for AAD authority: even if it’s a known authority, validate it
8. Fixed customWebView being not picked up from public client application
9. Fixed setting timeout interval in MSALHttpConfig: the problem here is that after session is created, modifying config doesn’t have any effect. Recreating session in the middle of something is not a good idea either. Therefore, I removed second timeout setting and only left per request timeout, as a short term fix. We can add second timeout in future separately once we figure out how to modify session settings.