### PR TITLE
Fix on B2C validation copyWithZone

### DIFF
--- a/IdentityCore/src/validation/MSIDB2CAuthority.m
+++ b/IdentityCore/src/validation/MSIDB2CAuthority.m
@@ -170,6 +170,11 @@
 - (id)copyWithZone:(NSZone *)zone
 {
     MSIDB2CAuthority *authority = [[self.class allocWithZone:zone] initWithURL:_url validateFormat:NO context:nil error:nil];
+    
+    authority.openIdConfigurationEndpoint = [_openIdConfigurationEndpoint copyWithZone:zone];
+    authority.metadata = self.metadata;
+    authority.url = [_url copyWithZone:zone];
+    
     return authority;
 }
 

--- a/IdentityCore/src/validation/MSIDB2CAuthority.m
+++ b/IdentityCore/src/validation/MSIDB2CAuthority.m
@@ -169,8 +169,8 @@
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    MSIDB2CAuthority *authority = [[self.class allocWithZone:zone] initWithURL:_url validateFormat:NO context:nil error:nil];
-    
+    MSIDB2CAuthority *authority = [[self.class allocWithZone:zone] initWithURL:[_url copyWithZone:zone]
+                                                                validateFormat:NO context:nil error:nil];
     authority.openIdConfigurationEndpoint = [_openIdConfigurationEndpoint copyWithZone:zone];
     authority.metadata = self.metadata;
     

--- a/IdentityCore/src/validation/MSIDB2CAuthority.m
+++ b/IdentityCore/src/validation/MSIDB2CAuthority.m
@@ -165,4 +165,12 @@
     return [NSURL URLWithString:normalizedAuthorityUrl];
 }
 
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MSIDB2CAuthority *authority = [[self.class allocWithZone:zone] initWithURL:_url validateFormat:NO context:nil error:nil];
+    return authority;
+}
+
 @end

--- a/IdentityCore/src/validation/MSIDB2CAuthority.m
+++ b/IdentityCore/src/validation/MSIDB2CAuthority.m
@@ -173,7 +173,6 @@
     
     authority.openIdConfigurationEndpoint = [_openIdConfigurationEndpoint copyWithZone:zone];
     authority.metadata = self.metadata;
-    authority.url = [_url copyWithZone:zone];
     
     return authority;
 }

--- a/IdentityCore/tests/MSIDB2CAuthorityTests.m
+++ b/IdentityCore/tests/MSIDB2CAuthorityTests.m
@@ -31,6 +31,7 @@
 #import "NSString+MSIDTestUtil.h"
 #import "MSIDOpenIdProviderMetadata.h"
 #import "MSIDAuthority+Internal.h"
+#import "MSIDB2CAuthority.h"
 
 @interface MSIDB2CAuthorityTests : XCTestCase
 
@@ -283,6 +284,17 @@
     rhs.metadata = [MSIDOpenIdProviderMetadata new];
     
     XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testCopyWithZone_whenFormatNotValidated_shouldCopy
+{
+    NSURL *authorityUrl = [[NSURL alloc] initWithString:@"https://login.microsoft.com/nonstandard/b2c"];
+    MSIDB2CAuthority *authority = [[MSIDB2CAuthority alloc] initWithURL:authorityUrl validateFormat:NO context:nil error:nil];
+    
+    MSIDB2CAuthority *copiedAuthority = [authority copy];
+    
+    XCTAssertNotNil(copiedAuthority);
+    XCTAssertEqualObjects(copiedAuthority.url, authorityUrl);
 }
 
 @end

--- a/IdentityCore/tests/MSIDB2CAuthorityTests.m
+++ b/IdentityCore/tests/MSIDB2CAuthorityTests.m
@@ -295,6 +295,8 @@
     
     XCTAssertNotNil(copiedAuthority);
     XCTAssertEqualObjects(copiedAuthority.url, authorityUrl);
+    XCTAssertEqualObjects(copiedAuthority.metadata, authority.metadata);
+    XCTAssertEqualObjects(copiedAuthority.openIdConfigurationEndpoint, authority.openIdConfigurationEndpoint);
 }
 
 @end


### PR DESCRIPTION
implement copyWithZone separately for B2C authority, without format validation.