### PR TITLE
Access Token look up cache fix.

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -677,7 +677,7 @@
     // Delete access tokens with intersecting scopes
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
     query.homeAccountId = accessToken.accountIdentifier.homeAccountId;
-    query.environment = accessToken.authority.environment;
+    query.environment = [[accessToken.authority cacheUrlWithContext:context] msidHostWithPortIfNecessary];
     query.realm = accessToken.authority.url.msidTenant;
     query.clientId = accessToken.clientId;
     query.target = [accessToken.scopes msidToString];


### PR DESCRIPTION
*Access token look up was not passing preferred host as the environment and was unable to delete access tokens with intersecting scopes.