### PR TITLE
Forward-declare MSIDRequestContext in MSIDAccountCredentialCache.h

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
@@ -25,15 +25,16 @@
 #import "MSIDCredentialType.h"
 #import "MSIDAccountType.h"
 
-@class MSIDCredentialCacheItem;
 @class MSIDAccountCacheItem;
-@class MSIDDefaultCredentialCacheKey;
-@protocol MSIDTokenCacheDataSource;
-@class MSIDDefaultCredentialCacheQuery;
-@class MSIDDefaultAccountCacheQuery;
-@class MSIDDefaultAccountCacheKey;
 @class MSIDAppMetadataCacheItem;
 @class MSIDAppMetadataCacheQuery;
+@class MSIDCredentialCacheItem;
+@class MSIDDefaultAccountCacheKey;
+@class MSIDDefaultAccountCacheQuery;
+@class MSIDDefaultCredentialCacheKey;
+@class MSIDDefaultCredentialCacheQuery;
+@protocol MSIDRequestContext;
+@protocol MSIDTokenCacheDataSource;
 
 @interface MSIDAccountCredentialCache : NSObject
 


### PR DESCRIPTION
This protocol was neither forward-declared nor included by this header,
making it dependenant on its position in the include order of other files.

This change also sorts the forward-declared classes and symbols in this
file.