### PR TITLE
ADAL True MAM CA cache fix

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -3977,6 +3977,7 @@
 					"$(inherited)",
 					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks/Swift",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Debug;
 		};
@@ -3988,6 +3989,7 @@
 					"$(inherited)",
 					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks/Swift",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Release;
 		};
@@ -4028,6 +4030,7 @@
 			baseConfigurationReference = D6CF4E991FC3626A00CD70C5 /* identitycore__testlib__mac.xcconfig */;
 			buildSettings = {
 				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Debug;
 		};
@@ -4035,6 +4038,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4E991FC3626A00CD70C5 /* identitycore__testlib__mac.xcconfig */;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Release;
 		};

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -3999,6 +3999,7 @@
 			buildSettings = {
 				GCC_OPTIMIZATION_LEVEL = 0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Debug;
 		};
@@ -4007,6 +4008,7 @@
 			baseConfigurationReference = D6CF4E9B1FC3626B00CD70C5 /* identitycore__tests__mac.xcconfig */;
 			buildSettings = {
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Release;
 		};

--- a/IdentityCore/src/MSIDOAuth2Constants.h
+++ b/IdentityCore/src/MSIDOAuth2Constants.h
@@ -112,6 +112,8 @@ extern NSString *const MSID_MIDDLE_NAME_CACHE_KEY;
 extern NSString *const MSID_FAMILY_NAME_CACHE_KEY;
 extern NSString *const MSID_NAME_CACHE_KEY;
 extern NSString *const MSID_ALTERNATIVE_ACCOUNT_ID_KEY;
+extern NSString *const MSID_ENROLLMENT_ID_CACHE_KEY;
+extern NSString *const MSID_APPLICATION_IDENTIFIER_CACHE_KEY;
 
 extern NSString *const MSID_ACCESS_TOKEN_CACHE_TYPE;
 extern NSString *const MSID_REFRESH_TOKEN_CACHE_TYPE;

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -114,6 +114,8 @@ NSString *const MSID_MIDDLE_NAME_CACHE_KEY               = @"middle_name";
 NSString *const MSID_FAMILY_NAME_CACHE_KEY               = @"family_name";
 NSString *const MSID_NAME_CACHE_KEY                      = @"name";
 NSString *const MSID_ALTERNATIVE_ACCOUNT_ID_KEY          = @"alternative_account_id";
+NSString *const MSID_ENROLLMENT_ID_CACHE_KEY             = @"enrollment_id";
+NSString *const MSID_APPLICATION_IDENTIFIER_CACHE_KEY    = @"application_cache_identifier";
 
 NSString *const MSID_ACCESS_TOKEN_CACHE_TYPE             = @"AccessToken";
 NSString *const MSID_REFRESH_TOKEN_CACHE_TYPE            = @"RefreshToken";

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -607,7 +607,7 @@
     if (![NSString msidIsStringNilOrBlank:refreshToken.familyId])
     {
         MSID_LOG_VERBOSE(context, @"Saving family refresh token %@", _PII_NULLIFY(refreshToken.refreshToken));
-        MSID_LOG_VERBOSE_PII(context, @"Saving family refresh token %@", refreshToken.refreshToken);
+        MSID_LOG_VERBOSE_PII(context, @"Saving family refresh token %@", _PII_NULLIFY(refreshToken.refreshToken));
 
         if (![self saveToken:refreshToken context:context error:error])
         {

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -628,6 +628,8 @@
                                                                              clientId:tokenCacheItem.clientId
                                                                              resource:tokenCacheItem.target
                                                                          legacyUserId:userId];
+    
+    key.applicationIdentifier = tokenCacheItem.applicationIdentifier;
 
     BOOL result = [_dataSource saveToken:tokenCacheItem
                                      key:key

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -358,7 +358,7 @@
                                                            lookupAliases:aliases
                                                                 clientId:configuration.clientId
                                                                 resource:configuration.target
-                                                           appIdentifier:nil
+                                                           appIdentifier:configuration.applicationIdentifier
                                                                  context:context
                                                                    error:error];
 }
@@ -692,6 +692,8 @@
                                                                              clientId:cacheItem.clientId
                                                                              resource:cacheItem.target
                                                                          legacyUserId:userId];
+    
+    key.applicationIdentifier = cacheItem.applicationIdentifier;
 
     BOOL result = [_dataSource removeItemsWithKey:key context:context error:error];
 

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -340,6 +340,7 @@
                                                    lookupAliases:aliases
                                                         clientId:configuration.clientId
                                                         resource:configuration.target
+                                                   appIdentifier:configuration.applicationIdentifier
                                                          context:context
                                                            error:error];
 }
@@ -357,6 +358,7 @@
                                                            lookupAliases:aliases
                                                                 clientId:configuration.clientId
                                                                 resource:configuration.target
+                                                           appIdentifier:nil
                                                                  context:context
                                                                    error:error];
 }
@@ -385,6 +387,7 @@
                                                                                     lookupAliases:lookupAliases
                                                                                          clientId:cacheItem.clientId
                                                                                          resource:cacheItem.target
+                                                                                    appIdentifier:nil
                                                                                           context:context
                                                                                             error:error];
 
@@ -510,6 +513,7 @@
                                                     lookupAliases:aliases
                                                          clientId:clientId
                                                          resource:nil
+                                                    appIdentifier:nil
                                                           context:context
                                                             error:error];
 }
@@ -706,6 +710,7 @@
                             lookupAliases:(NSArray<NSURL *> *)aliases
                                  clientId:(NSString *)clientId
                                  resource:(NSString *)resource
+                            appIdentifier:(NSString *)appIdentifier
                                   context:(id<MSIDRequestContext>)context
                                     error:(NSError **)error
 {
@@ -725,6 +730,8 @@
         {
             return nil;
         }
+        
+        key.applicationIdentifier = appIdentifier;
         
         NSError *cacheError = nil;
         MSIDLegacyTokenCacheItem *cacheItem = (MSIDLegacyTokenCacheItem *) [_dataSource tokenWithKey:key serializer:_serializer context:context error:&cacheError];

--- a/IdentityCore/src/cache/ios/MSIDKeychainTokenCache.m
+++ b/IdentityCore/src/cache/ios/MSIDKeychainTokenCache.m
@@ -234,7 +234,7 @@ static NSString *s_defaultKeychainGroup = @"com.microsoft.adalcache";
     }
     
     MSID_LOG_INFO(context, @"Found %lu items.", (unsigned long)tokenItems.count);
-    MSID_LOG_INFO_PII(context, @"Items info %@", tokenItems);
+    MSID_LOG_VERBOSE_PII(context, @"Items info %@", tokenItems);
     
     return tokenItems;
 }
@@ -321,7 +321,7 @@ static NSString *s_defaultKeychainGroup = @"com.microsoft.adalcache";
     }
     
     MSID_LOG_INFO(context, @"Found %lu items.", (unsigned long)accountItems.count);
-    MSID_LOG_INFO_PII(context, @"Items info %@", accountItems);
+    MSID_LOG_VERBOSE_PII(context, @"Items info %@", accountItems);
     
     return accountItems;
 }

--- a/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.h
+++ b/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic) NSString *clientId;
 @property (nullable, nonatomic) NSString *resource;
 @property (nullable, nonatomic) NSString *legacyUserId;
+@property (nullable, nonatomic) NSString *applicationIdentifier;
 
 - (instancetype)initWithAuthority:(NSURL *)authority
                          clientId:(NSString *)clientId

--- a/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
+++ b/IdentityCore/src/cache/key/MSIDLegacyTokenCacheKey.m
@@ -53,12 +53,21 @@ static NSString *const s_adalServiceFormat = @"%@|%@|%@|%@";
     NSString *authorityString = authority.absoluteString.msidTrimmedString.lowercaseString;
     resource = resource.msidTrimmedString.lowercaseString;
     clientId = clientId.msidTrimmedString.lowercaseString;
+    
+    NSString *adalCachePrefix = s_adalLibraryString;
+    
+    if (![NSString msidIsStringNilOrBlank:self.applicationIdentifier])
+    {
+        adalCachePrefix = [adalCachePrefix stringByAppendingFormat:@"-%@", self.applicationIdentifier.msidBase64UrlEncode];
+    }
 
-    return [NSString stringWithFormat:s_adalServiceFormat,
-            s_adalLibraryString,
-            authorityString.msidBase64UrlEncode,
-            [self getAttributeName:resource],
-            clientId.msidBase64UrlEncode];
+    NSString *service = [NSString stringWithFormat:s_adalServiceFormat,
+                         adalCachePrefix,
+                         authorityString.msidBase64UrlEncode,
+                         [self getAttributeName:resource],
+                         clientId.msidBase64UrlEncode];
+    
+    return service;
 }
 
 - (instancetype)initWithAccount:(NSString *)account

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.h
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.h
@@ -61,6 +61,12 @@
 // Additional fields
 @property (readwrite, nullable) NSDictionary *additionalInfo;
 
+// Intune enrollment ID
+@property (readwrite, nullable) NSString *enrollmentId;
+
+// Application identifier
+@property (readwrite, nullable) NSString *applicationIdentifier;
+
 - (BOOL)isEqualToItem:(nullable MSIDCredentialCacheItem *)item;
 
 - (nullable MSIDBaseToken *)tokenWithType:(MSIDCredentialType)credentialType;

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -74,6 +74,8 @@
     result &= (!self.familyId || !item.familyId) || [self.familyId isEqualToString:item.familyId];
     result &= (!self.homeAccountId || !item.homeAccountId) || [self.homeAccountId isEqualToString:item.homeAccountId];
     result &= (!self.additionalInfo || !item.additionalInfo) || [self.additionalInfo isEqual:item.additionalInfo];
+    result &= (!self.enrollmentId || !item.enrollmentId) || [self.enrollmentId isEqualToString:item.enrollmentId];
+    result &= (!self.applicationIdentifier || !item.applicationIdentifier) || [self.applicationIdentifier isEqualToString:item.applicationIdentifier];
     return result;
 }
 
@@ -93,6 +95,8 @@
     hash = hash * 31 + self.familyId.hash;
     hash = hash * 31 + self.homeAccountId.hash;
     hash = hash * 31 + self.additionalInfo.hash;
+    hash = hash * 31 + self.enrollmentId.hash;
+    hash = hash * 31 + self.applicationIdentifier.hash;
     return hash;
 }
 
@@ -112,6 +116,8 @@
     item.familyId = [self.familyId copyWithZone:zone];
     item.homeAccountId = [self.homeAccountId copyWithZone:zone];
     item.additionalInfo = [self.additionalInfo copyWithZone:zone];
+    item.enrollmentId = [self.enrollmentId copyWithZone:zone];
+    item.applicationIdentifier = [self.applicationIdentifier copyWithZone:zone];
     return item;
 }
 
@@ -159,6 +165,9 @@
     additionalInfo[MSID_EXTENDED_EXPIRES_ON_CACHE_KEY] = extendedExpiresOn;
     _additionalInfo = additionalInfo;
     
+    _enrollmentId = [json msidStringObjectForKey:MSID_ENROLLMENT_ID_CACHE_KEY];
+    _applicationIdentifier = [json msidStringObjectForKey:MSID_APPLICATION_IDENTIFIER_CACHE_KEY];
+    
     return self;
 }
 
@@ -183,6 +192,8 @@
     dictionary[MSID_HOME_ACCOUNT_ID_CACHE_KEY] = _homeAccountId;
     dictionary[MSID_SPE_INFO_CACHE_KEY] = _additionalInfo[MSID_SPE_INFO_CACHE_KEY];
     dictionary[MSID_EXTENDED_EXPIRES_ON_CACHE_KEY] = [_additionalInfo[MSID_EXTENDED_EXPIRES_ON_CACHE_KEY] msidDateToTimestamp];
+    dictionary[MSID_ENROLLMENT_ID_CACHE_KEY] = _enrollmentId;
+    dictionary[MSID_APPLICATION_IDENTIFIER_CACHE_KEY] = _applicationIdentifier;
     return dictionary;
 }
 

--- a/IdentityCore/src/cache/token/MSIDLegacyTokenCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDLegacyTokenCacheItem.m
@@ -138,7 +138,9 @@
     {
         self.homeAccountId = homeAccountId;
     }
-
+    
+    self.enrollmentId = [coder decodeObjectOfClass:[NSString class] forKey:@"enrollmentId"];
+    self.applicationIdentifier = [coder decodeObjectOfClass:[NSString class] forKey:@"applicationIdentifier"];
     return self;
 }
 
@@ -164,6 +166,8 @@
     [coder encodeObject:[NSMutableDictionary dictionary] forKey:@"additionalClient"];
     [coder encodeObject:self.additionalInfo forKey:@"additionalServer"];
     [coder encodeObject:self.homeAccountId forKey:@"homeAccountId"];
+    [coder encodeObject:self.enrollmentId forKey:@"enrollmentId"];
+    [coder encodeObject:self.applicationIdentifier forKey:@"applicationIdentifier"];
 }
 
 - (MSIDBaseToken *)tokenWithType:(MSIDCredentialType)credentialType

--- a/IdentityCore/src/configuration/MSIDConfiguration.h
+++ b/IdentityCore/src/configuration/MSIDConfiguration.h
@@ -33,6 +33,9 @@
 @property (readwrite) NSString *clientId;
 @property (readwrite) NSString *target;
 
+@property (readwrite) NSString *applicationIdentifier;
+@property (readwrite) NSString *enrollmentId;
+
 @property (readonly) NSString *resource;
 @property (readonly) NSOrderedSet<NSString *> *scopes;
 

--- a/IdentityCore/src/configuration/MSIDConfiguration.m
+++ b/IdentityCore/src/configuration/MSIDConfiguration.m
@@ -35,7 +35,8 @@
     configuration.redirectUri = [_redirectUri copyWithZone:zone];
     configuration.target = [_target copyWithZone:zone];
     configuration.clientId = [_clientId copyWithZone:zone];
-    
+    configuration.enrollmentId = [_enrollmentId copyWithZone:zone];
+    configuration.applicationIdentifier = [_applicationIdentifier copyWithZone:zone];
     return configuration;
 }
 

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
@@ -147,14 +147,15 @@
     {
         return NO;
     }
+    
+    accessToken.enrollmentId = configuration.enrollmentId;
+    accessToken.applicationIdentifier = configuration.applicationIdentifier;
 
     if (!response.extendedExpiresOnDate) return YES;
 
     NSMutableDictionary *additionalServerInfo = [accessToken.additionalServerInfo mutableCopy];
     additionalServerInfo[MSID_EXTENDED_EXPIRES_ON_CACHE_KEY] = response.extendedExpiresOnDate;
     accessToken.additionalServerInfo = additionalServerInfo;
-    accessToken.enrollmentId = configuration.enrollmentId;
-    accessToken.applicationIdentifier = configuration.applicationIdentifier;
 
     return YES;
 }

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
@@ -153,6 +153,8 @@
     NSMutableDictionary *additionalServerInfo = [accessToken.additionalServerInfo mutableCopy];
     additionalServerInfo[MSID_EXTENDED_EXPIRES_ON_CACHE_KEY] = response.extendedExpiresOnDate;
     accessToken.additionalServerInfo = additionalServerInfo;
+    accessToken.enrollmentId = configuration.enrollmentId;
+    accessToken.applicationIdentifier = configuration.applicationIdentifier;
 
     return YES;
 }

--- a/IdentityCore/src/oauth2/token/MSIDAccessToken.h
+++ b/IdentityCore/src/oauth2/token/MSIDAccessToken.h
@@ -39,6 +39,12 @@
 // v2 access tokens are scoped down to resources
 @property (readwrite) NSOrderedSet<NSString *> *scopes;
 
+// Intune Enrollment ID. Application trying to retrieve access token from cache will need to present a valid intune enrollment ID to complete cache lookup.
+@property (readwrite) NSString *enrollmentId;
+
+// Unique app identifier used for cases when access token storage needs to be partitioned per application
+@property (readwrite) NSString *applicationIdentifier;
+
 - (BOOL)isExpired;
 - (BOOL)isExpiredWithExpiryBuffer:(NSUInteger)expiryBuffer;
 - (BOOL)isExtendedLifetimeValid;

--- a/IdentityCore/src/oauth2/token/MSIDAccessToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDAccessToken.m
@@ -49,7 +49,8 @@ static NSUInteger s_expirationBuffer = 300;
     item->_cachedAt = [_cachedAt copyWithZone:zone];
     item->_accessToken = [_accessToken copyWithZone:zone];
     item->_target = [_target copyWithZone:zone];
-
+    item->_enrollmentId = [_enrollmentId copyWithZone:zone];
+    item->_applicationIdentifier = [_applicationIdentifier copyWithZone:zone];
     return item;
 }
 
@@ -77,6 +78,8 @@ static NSUInteger s_expirationBuffer = 300;
     hash = hash * 31 + self.accessToken.hash;
     hash = hash * 31 + self.target.hash;
     hash = hash * 31 + self.cachedAt.hash;
+    hash = hash * 31 + self.enrollmentId.hash;
+    hash = hash * 31 + self.applicationIdentifier.hash;
     return hash;
 }
 
@@ -92,7 +95,9 @@ static NSUInteger s_expirationBuffer = 300;
     result &= (!self.accessToken && !token.accessToken) || [self.accessToken isEqualToString:token.accessToken];
     result &= (!self.target && !token.target) || [self.target isEqualToString:token.target];
     result &= (!self.cachedAt && !token.cachedAt) || [self.cachedAt isEqualToDate:token.cachedAt];
-
+    result &= (!self.enrollmentId && !token.enrollmentId) || [self.enrollmentId isEqualToString:token.enrollmentId];
+    result &= (!self.applicationIdentifier && !token.applicationIdentifier) || [self.applicationIdentifier isEqualToString:token.applicationIdentifier];
+    
     return result;
 }
 
@@ -121,6 +126,9 @@ static NSUInteger s_expirationBuffer = 300;
             MSID_LOG_ERROR(nil, @"Trying to initialize access token when missing target field");
             return nil;
         }
+        
+        _enrollmentId = tokenCacheItem.enrollmentId;
+        _applicationIdentifier = tokenCacheItem.applicationIdentifier;
     }
     
     return self;
@@ -134,6 +142,8 @@ static NSUInteger s_expirationBuffer = 300;
     cacheItem.secret = self.accessToken;
     cacheItem.target = self.target;
     cacheItem.credentialType = MSIDAccessTokenType;
+    cacheItem.enrollmentId = self.enrollmentId;
+    cacheItem.applicationIdentifier = self.applicationIdentifier;
     return cacheItem;
 }
 
@@ -207,7 +217,7 @@ static NSUInteger s_expirationBuffer = 300;
 - (NSString *)description
 {
     NSString *baseDescription = [super description];
-    return [baseDescription stringByAppendingFormat:@"(access token=%@, expiresOn=%@, target=%@)", _PII_NULLIFY(_accessToken), _expiresOn, _target];
+    return [baseDescription stringByAppendingFormat:@"(access token=%@, expiresOn=%@, target=%@, enrollmentId=%@, applicationIdentfier=%@)", _PII_NULLIFY(_accessToken), _expiresOn, _target, _PII_NULLIFY(_enrollmentId), _applicationIdentifier];
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDBaseToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDBaseToken.m
@@ -119,7 +119,7 @@
         
         if (![self supportsCredentialType:tokenCacheItem.credentialType])
         {
-            MSID_LOG_ERROR(nil, @"Trying to initialize with a wrong token type");
+            MSID_LOG_VERBOSE(nil, @"Trying to initialize with a wrong token type");
             return nil;
         }
 

--- a/IdentityCore/src/oauth2/token/MSIDLegacyAccessToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDLegacyAccessToken.m
@@ -127,6 +127,8 @@
     cacheItem.clientId = self.clientId;
     cacheItem.additionalInfo = self.additionalServerInfo;
     cacheItem.homeAccountId = self.accountIdentifier.homeAccountId;
+    cacheItem.applicationIdentifier = self.applicationIdentifier;
+    cacheItem.enrollmentId = self.enrollmentId;
     return cacheItem;
 }
 

--- a/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
@@ -1696,6 +1696,105 @@
     XCTAssertEqualObjects(accessToken.authority.url.absoluteString, @"https://login.windows.net/common");
 }
 
+- (void)testGetAccessTokenForAccount_whenAccessTokenCachePartitionedByAppIdentifier_andTwoTokensInCache_shouldReturnToken
+{
+    // Save first token
+    [self saveResponseWithUPN:@"upn@test.com"
+                     clientId:@"test_client_id"
+                    authority:@"https://login.windows.net/common"
+             responseResource:@"graph"
+                inputResource:@"graph"
+                          uid:@"uid"
+                         utid:@"utid"
+                  accessToken:@"access token"
+                 refreshToken:@"refresh token"
+             additionalFields:nil
+                 enrollmentId:@"myenrollmentid1"
+                appIdentifier:@"myapp1"
+                     accessor:_nonSSOAccessor];
+    
+    // Save second token (same clientId, but different app identifier)
+    [self saveResponseWithUPN:@"upn@test.com"
+                     clientId:@"test_client_id"
+                    authority:@"https://login.windows.net/common"
+             responseResource:@"graph"
+                inputResource:@"graph"
+                          uid:@"uid"
+                         utid:@"utid"
+                  accessToken:@"access token 2"
+                 refreshToken:@"refresh token 2"
+             additionalFields:nil
+                 enrollmentId:@"myenrollmentid2"
+                appIdentifier:@"myapp2"
+                     accessor:_nonSSOAccessor];
+    
+    // Check cache state
+    NSArray *refreshTokens = [self getAllLegacyRefreshTokens];
+    XCTAssertEqual([refreshTokens count], 1);
+    
+    NSArray *accessTokens = [self getAllLegacyAccessTokens];
+    XCTAssertEqual([accessTokens count], 2);
+    
+    // Get token
+    MSIDConfiguration *configuration = [MSIDTestConfiguration configurationWithAuthority:@"https://login.windows.net/common"
+                                                                                clientId:@"test_client_id"
+                                                                             redirectUri:nil
+                                                                                  target:@"graph"];
+    configuration.applicationIdentifier = @"myapp1";
+    configuration.enrollmentId = @"myenrollmentid1";
+    
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithLegacyAccountId:@"upn@test.com" homeAccountId:nil];
+    NSError *error = nil;
+    MSIDLegacyAccessToken *accessToken = [_legacyAccessor getAccessTokenForAccount:account configuration:configuration context:nil error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertNotNil(accessToken);
+    XCTAssertEqualObjects(accessToken.accessToken, @"access token");
+    XCTAssertEqualObjects(accessToken.accountIdentifier.legacyAccountId, @"upn@test.com");
+    XCTAssertEqualObjects(accessToken.clientId, @"test_client_id");
+    XCTAssertEqualObjects(accessToken.authority.url.absoluteString, @"https://login.windows.net/common");
+}
+
+- (void)testGetAccessTokenForAccount_whenAccessTokenCachePartitionedByAppIdentifier_whenDifferentApp_shouldReturnNil
+{
+    // Save first token
+    [self saveResponseWithUPN:@"upn@test.com"
+                     clientId:@"test_client_id"
+                    authority:@"https://login.windows.net/common"
+             responseResource:@"graph"
+                inputResource:@"graph"
+                          uid:@"uid"
+                         utid:@"utid"
+                  accessToken:@"access token"
+                 refreshToken:@"refresh token"
+             additionalFields:nil
+                 enrollmentId:@"myenrollmentid1"
+                appIdentifier:@"myapp1"
+                     accessor:_nonSSOAccessor];
+    
+    // Check cache state
+    NSArray *refreshTokens = [self getAllLegacyRefreshTokens];
+    XCTAssertEqual([refreshTokens count], 1);
+    
+    NSArray *accessTokens = [self getAllLegacyAccessTokens];
+    XCTAssertEqual([accessTokens count], 1);
+    
+    // Get token
+    MSIDConfiguration *configuration = [MSIDTestConfiguration configurationWithAuthority:@"https://login.windows.net/common"
+                                                                                clientId:@"test_client_id"
+                                                                             redirectUri:nil
+                                                                                  target:@"graph"];
+    configuration.applicationIdentifier = @"myapp3";
+    configuration.enrollmentId = @"myenrollmentid1";
+    
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithLegacyAccountId:@"upn@test.com" homeAccountId:nil];
+    NSError *error = nil;
+    MSIDLegacyAccessToken *accessToken = [_legacyAccessor getAccessTokenForAccount:account configuration:configuration context:nil error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertNil(accessToken);
+}
+
 - (void)testGetAccessTokenForAccount_whenAccessTokensInSecondaryCache_shouldNotReturnToken
 {
     // Save first token
@@ -2382,6 +2481,35 @@
            additionalFields:(NSDictionary *)additionalFields
                    accessor:(id<MSIDCacheAccessor>)accessor
 {
+    [self saveResponseWithUPN:upn
+                     clientId:clientId
+                    authority:authority
+             responseResource:responseResource
+                inputResource:inputResource
+                          uid:uid
+                         utid:utid
+                  accessToken:accessToken
+                 refreshToken:refreshToken
+             additionalFields:additionalFields
+                 enrollmentId:nil
+                appIdentifier:nil
+                     accessor:accessor];
+}
+
+- (void)saveResponseWithUPN:(NSString *)upn
+                   clientId:(NSString *)clientId
+                  authority:(NSString *)authority
+           responseResource:(NSString *)responseResource
+              inputResource:(NSString *)inputResource
+                        uid:(NSString *)uid
+                       utid:(NSString *)utid
+                accessToken:(NSString *)accessToken
+               refreshToken:(NSString *)refreshToken
+           additionalFields:(NSDictionary *)additionalFields
+               enrollmentId:(NSString *)enrollmentId
+              appIdentifier:(NSString *)appIdentifier
+                   accessor:(id<MSIDCacheAccessor>)accessor
+{
     NSString *idToken = [MSIDTestIdTokenUtil idTokenWithName:DEFAULT_TEST_ID_TOKEN_NAME upn:upn tenantId:@"tid"];
 
     MSIDTokenResponse *response = [MSIDTestTokenResponse v1TokenResponseWithAT:accessToken
@@ -2396,6 +2524,9 @@
                                                                                 clientId:clientId
                                                                              redirectUri:nil
                                                                                   target:inputResource];
+    
+    configuration.applicationIdentifier = appIdentifier;
+    configuration.enrollmentId = enrollmentId;
 
     NSError *error = nil;
     // Save first token


### PR DESCRIPTION
This is an update to the previous enrollment ID cache implementation.
This one applies it only for ADAL pieces, MSAL and broker updates will come separately.

- Enrollment ID is an Intune MAM SDK artifact that's used to differentiate app installation and record the fact that MAM policies have been properly enforced. ADAL and MSAL are passing Intune Enrollment ID to all token requests. If True MAM policies have been applied, ESTS won't return an access token without app providing a valid enrollment ID in the request. 
- Enrollment ID enforcement works properly unless broker is involved. When broker is involved, access tokens are cached in a shared location, where any authorized app can access them. However, current cache schema doesn't ensure that apps have a valid enrollment ID and that Intune MAM policies are applied. 
- Additionally, access tokens are cached by clientID, which means that apps sharing the same client ID will be able to read each other's access tokens on iOS through keychain sharing or broker.
Previous design recommended caching each Access token with its own enrollment ID. Additionally, it suggested using enrollment ID as part of the cache key for the access token. This design has been adopted in iOS v2 broker. 
However, additional analysis of the previous design has revealed a few issues:
1. If application's enrollment ID changes, the access token cached by previous enrollment ID will be left in cache without deletion. 
2. There're many entries created in cache for an essentially same access token which introduces additional performance issues when there're many tokens. 

This PR is a slight improvement over previous design:

Cache access tokens per physical application bundle ID and verify enrollment ID validity before returning the token. 
* It addresses the problem of enrollment ID mutability and presence of stale tokens, because it uses immutable application identifier (e.g. bundle Identifier) for token caching. 