### PR TITLE
[Proposal] Fallback to bundle identifier when teamID is not available

### DIFF
--- a/IdentityCore/src/util/mac/MSIDKeychainUtil.m
+++ b/IdentityCore/src/util/mac/MSIDKeychainUtil.m
@@ -72,9 +72,10 @@
         
         if (!keychainTeamId)
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve team identifier");
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve team identifier. Using bundle Identifier instead.");
+            NSString *bundleIdentifier = [signingDic objectForKey:(__bridge NSString*)kSecCodeInfoIdentifier];
             CFRelease(selfCode);
-            return nil;
+            return bundleIdentifier;
         }
         
         MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Using \"%@\" Team ID.", MSID_PII_LOG_MASKABLE(keychainTeamId));


### PR DESCRIPTION
I'm imagining that many macOS developers will try our SDK with no signing enabled during development time. Differently from iOS, where to run app on test device you need to have app signed, many developers will run test apps on macOS without signing.

Current experience without signing is rather bad - we can either fail immediately on public client application creation (which will let them figure out the error faster), or have nil tokenCache and not save anything to cache.

I'm suggesting falling back to bundleId for the teamId part instead when it's not available. That way, developers can play with our SDK in early development stages. When they distribute/ship, they'll need to sign their app so cache sharing will work at that stage. At stage of early development, I think it's fine to have no cache sharing and just save for one app bundle Identifier. 