### PR TITLE
Save metadata cache item to memory after reading from disk

### DIFF
--- a/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
@@ -157,12 +157,9 @@
     __block BOOL success = NO;
     __block NSError *localError;
     
-    dispatch_sync(_synchronizationQueue, ^{
-        success = [_dataSource removeAccountMetadataForKey:key context:context error:&localError];
-    });
-    
     dispatch_barrier_async(_synchronizationQueue, ^{
         [_memoryCache removeObjectForKey:key];
+        success = [_dataSource removeAccountMetadataForKey:key context:context error:&localError];
     });
     
     if (error && localError) *error = localError;

--- a/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
@@ -74,8 +74,16 @@
     
     __block NSError *localError;
     __block BOOL saveSuccess = NO;
+    __block BOOL hasChanges = YES;
     
-    if ([item isEqual:_memoryCache[key]]) return YES;
+    dispatch_sync(_synchronizationQueue, ^{
+        hasChanges = ![item isEqual:_memoryCache[key]];
+    });
+    
+    if (!hasChanges)
+    {
+        return YES;
+    }
     
     dispatch_barrier_sync(_synchronizationQueue, ^{
         saveSuccess = [_dataSource saveAccountMetadata:item key:key serializer:_jsonSerializer context:context error:&localError];


### PR DESCRIPTION
Small fix of saving item into in-memory metadata cache after reading it, if it wasn't present in metadata in-memory cache before.

Also making sure nobody else is modifying in memory cache while we're removing item from it. 