### PR TITLE
Additional logging updates

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1212,6 +1212,7 @@
 		05566D142204BCF9002DBA40 /* MSIDMacKeychainTokenCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMacKeychainTokenCacheTests.m; sourceTree = "<group>"; };
 		0570FE7C219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MSIDCredentialCacheItem+MSIDBaseToken.m"; sourceTree = "<group>"; };
 		0570FE7D219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDCredentialCacheItem+MSIDBaseToken.h"; sourceTree = "<group>"; };
+		05B3E0C422E625A50095833E /* MSIDLogger+Trace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDLogger+Trace.h"; sourceTree = "<group>"; };
 		1E2EDFF8219125400054FAD9 /* MSIDTokenResponse+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDTokenResponse+Internal.h"; sourceTree = "<group>"; };
 		1E3590B3216C3702003D43BE /* MSIDAppMetadataCacheItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAppMetadataCacheItem.h; sourceTree = "<group>"; };
 		1E3590B4216C3702003D43BE /* MSIDAppMetadataCacheItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAppMetadataCacheItem.m; sourceTree = "<group>"; };
@@ -3079,6 +3080,7 @@
 		B25A35681FC4D6B600C7FD43 /* logger */ = {
 			isa = PBXGroup;
 			children = (
+				05B3E0C422E625A50095833E /* MSIDLogger+Trace.h */,
 				B25A35691FC4D6B600C7FD43 /* MSIDLogger+Internal.h */,
 				B25A356A1FC4D6B600C7FD43 /* MSIDLogger.h */,
 				B25A356B1FC4D6B600C7FD43 /* MSIDLogger.m */,

--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -30,6 +30,7 @@
 #import "MSIDJsonSerializer.h"
 #import "MSIDLogger+Internal.h"
 #import "MSIDLogger.h"
+#import "MSIDLogger+Trace.h"
 #import "MSIDMacKeychainTokenCache.h"
 #import "MSIDUserInformation.h"
 #import "NSString+MSIDExtensions.h"

--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem.m
@@ -23,6 +23,7 @@
 
 #import "MSIDAccountCacheItem.h"
 #import "MSIDClientInfo.h"
+#import "MSIDLogger+Trace.h"
 #import "NSDate+MSIDExtensions.h"
 #import "NSDictionary+MSIDExtensions.h"
 

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -35,6 +35,7 @@
 #import "MSIDIdToken.h"
 #import "MSIDAADIdTokenClaimsFactory.h"
 #import "MSIDClientInfo.h"
+#import "MSIDLogger+Trace.h"
 #import "NSData+MSIDExtensions.h"
 #import "NSString+MSIDExtensions.h"
 #import "NSOrderedSet+MSIDExtensions.h"

--- a/IdentityCore/src/logger/MSIDLogger+Internal.h
+++ b/IdentityCore/src/logger/MSIDLogger+Internal.h
@@ -53,8 +53,6 @@
 #define MSID_PII_LOG_TRACKABLE(_PARAMETER) [[MSIDMaskedHashableLogParameter alloc] initWithParameterValue:_PARAMETER]
 #define MSID_PII_LOG_EMAIL(_PARAMETER) [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:_PARAMETER]
 
-#define MSID_TRACE // Unused
-
 @interface MSIDLogger (Internal)
 
 /*!

--- a/IdentityCore/src/logger/MSIDLogger+Internal.h
+++ b/IdentityCore/src/logger/MSIDLogger+Internal.h
@@ -35,12 +35,13 @@
 #define _PII_NULLIFY(_OBJ) _OBJ ? @"(not-null)" : @"(null)"
 
 #define MSID_LOG_COMMON(_LVL, _CONTEXT, _CORRELATION_ID, _PII, _FMT, ...) \
-    [[MSIDLogger sharedLogger] logWithLevel:_LVL                      \
+    [[MSIDLogger sharedLogger] logWithLevel:_LVL                          \
                                         context:_CONTEXT                  \
                                   correlationId:_CORRELATION_ID           \
                                     containsPII:_PII                      \
                                        filename:@__FILE__                 \
                                      lineNumber:__LINE__                  \
+                                       function:@(__func__)               \
                                          format:_FMT, ##__VA_ARGS__]
 
 #define MSID_LOG_WITH_CTX(_LVL, _CONTEXT, _FMT, ...) MSID_LOG_COMMON(_LVL, _CONTEXT, nil, NO, _FMT, ##__VA_ARGS__)
@@ -74,7 +75,8 @@
          containsPII:(BOOL)containsPII
             filename:(NSString *)filename
           lineNumber:(NSUInteger)lineNumber
-              format:(NSString *)format, ... NS_FORMAT_FUNCTION(7, 8);
+            function:(NSString *)function
+              format:(NSString *)format, ... NS_FORMAT_FUNCTION(8, 9);
 
 - (void)logToken:(NSString *)token
        tokenType:(NSString *)tokenType

--- a/IdentityCore/src/logger/MSIDLogger+Trace.h
+++ b/IdentityCore/src/logger/MSIDLogger+Trace.h
@@ -1,0 +1,30 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+// This macro is not used. It exists to allow msalcpp to integrate it's own tracing.
+#define MSID_TRACE // Unused
+

--- a/IdentityCore/src/logger/MSIDLogger.m
+++ b/IdentityCore/src/logger/MSIDLogger.m
@@ -104,6 +104,7 @@ static NSDateFormatter *s_dateFormatter = nil;
          containsPII:(BOOL)containsPII
             filename:(NSString *)filename
           lineNumber:(NSUInteger)lineNumber
+            function:(__unused NSString *)function
               format:(NSString *)format, ...
 {
     if (!format) return;

--- a/IdentityCore/src/logger/MSIDLogger.m
+++ b/IdentityCore/src/logger/MSIDLogger.m
@@ -104,7 +104,7 @@ static NSDateFormatter *s_dateFormatter = nil;
          containsPII:(BOOL)containsPII
             filename:(NSString *)filename
           lineNumber:(NSUInteger)lineNumber
-            function:(__unused NSString *)function
+            function:(NSString *)function
               format:(NSString *)format, ...
 {
     if (!format) return;

--- a/IdentityCore/src/logger/MSIDLogger.m
+++ b/IdentityCore/src/logger/MSIDLogger.m
@@ -155,7 +155,7 @@ static NSDateFormatter *s_dateFormatter = nil;
             NSString *sourceInfo = @"";
             if (self.SourceLineLoggingEnabled && filename.length)
             {
-                sourceInfo = [NSString stringWithFormat:@" %@:%lu:", filename.lastPathComponent, lineNumber];
+                sourceInfo = [NSString stringWithFormat:@" %@:%lu: %@", filename.lastPathComponent, lineNumber, function];
             }
             
             __auto_type threadName = [[NSThread currentThread] isMainThread] ? @" (main thread)" : nil;

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -44,7 +44,7 @@
 - (void)testLog_whenLogLevelNothingMessageValid_shouldNotThrow
 {
     [self keyValueObservingExpectationForObject:[MSIDTestLogger sharedLogger] keyPath:@"callbackInvoked" expectedValue:@1];
-    XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelNothing context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ format:@"Message"]);
+    XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelNothing context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Message"]);
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil([MSIDTestLogger sharedLogger].lastMessage);
@@ -52,7 +52,7 @@
 
 - (void)testLog_whenLogLevelErrorMessageNil_shouldNotThrow
 {
-    XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ format:nil]);
+    XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:nil]);
 }
 
 #pragma mark - PII flag
@@ -63,7 +63,7 @@
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
-    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ format:@"pii-message"];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"pii-message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
@@ -77,7 +77,7 @@
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
-    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ format:@"non-pii-message"];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"non-pii-message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
@@ -91,7 +91,7 @@
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
-    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ format:@"non-pii-message"];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"non-pii-message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
@@ -105,7 +105,7 @@
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
-    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ format:@"pii-message %@", MSID_PII_LOG_MASKABLE(@"test")];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"pii-message %@", MSID_PII_LOG_MASKABLE(@"test")];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);


### PR DESCRIPTION
* Move MSID_TRACE to a separate header for more effective overriding

* Add function name to logWithLevel: (disabled by default)