### PR TITLE
Rebuild background task for iOS 13

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -730,6 +730,7 @@
 		B27551C32081705300AA7A38 /* MSIDJWTHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7590C207EE9A400C1FE74 /* MSIDJWTHelper.m */; };
 		B279835A20D33A0A0051167F /* MSIDIdTokenClaimsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B279835920D33A090051167F /* MSIDIdTokenClaimsTests.m */; };
 		B279835B20D33A0A0051167F /* MSIDIdTokenClaimsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B279835920D33A090051167F /* MSIDIdTokenClaimsTests.m */; };
+		B27ACA6B22EBC4450049ACE0 /* MSIDBackgroundTaskManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B27ACA6922EBC4450049ACE0 /* MSIDBackgroundTaskManager.m */; };
 		B27CCDD1229E205C00CAD565 /* NSJSONSerialization+MSIDExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = B27CCDCF229E205B00CAD565 /* NSJSONSerialization+MSIDExtensions.h */; };
 		B27CCDD2229E205C00CAD565 /* NSJSONSerialization+MSIDExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B27CCDD0229E205B00CAD565 /* NSJSONSerialization+MSIDExtensions.m */; };
 		B27CCDD3229E205C00CAD565 /* NSJSONSerialization+MSIDExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B27CCDD0229E205B00CAD565 /* NSJSONSerialization+MSIDExtensions.m */; };
@@ -1789,6 +1790,8 @@
 		B275520A208185E600AA7A38 /* KeyvaultAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyvaultAuthentication.swift; sourceTree = "<group>"; };
 		B275520D208186F500AA7A38 /* MSIDAutomation-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDAutomation-Bridging-Header.h"; sourceTree = "<group>"; };
 		B279835920D33A090051167F /* MSIDIdTokenClaimsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIdTokenClaimsTests.m; sourceTree = "<group>"; };
+		B27ACA6822EBC4450049ACE0 /* MSIDBackgroundTaskManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBackgroundTaskManager.h; sourceTree = "<group>"; };
+		B27ACA6922EBC4450049ACE0 /* MSIDBackgroundTaskManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBackgroundTaskManager.m; sourceTree = "<group>"; };
 		B27CCDCF229E205B00CAD565 /* NSJSONSerialization+MSIDExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSJSONSerialization+MSIDExtensions.h"; sourceTree = "<group>"; };
 		B27CCDD0229E205B00CAD565 /* NSJSONSerialization+MSIDExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSJSONSerialization+MSIDExtensions.m"; sourceTree = "<group>"; };
 		B27CCDD4229EF2C000CAD565 /* MSIDDictionaryExtensionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDDictionaryExtensionsTests.m; sourceTree = "<group>"; };
@@ -2576,6 +2579,7 @@
 		96235F8F207D7128007EAB36 /* webview */ = {
 			isa = PBXGroup;
 			children = (
+				B27ACA6722EBC42E0049ACE0 /* background */,
 				96B8D57820946D1900E3F4A6 /* pkce */,
 				96F94A2420816B2F0034676C /* systemWebview */,
 				96F94A22208169380034676C /* embeddedWebview */,
@@ -3129,6 +3133,15 @@
 				B27551FD208182BE00AA7A38 /* AuthHeader.swift */,
 			);
 			path = keyvault;
+			sourceTree = "<group>";
+		};
+		B27ACA6722EBC42E0049ACE0 /* background */ = {
+			isa = PBXGroup;
+			children = (
+				B27ACA6822EBC4450049ACE0 /* MSIDBackgroundTaskManager.h */,
+				B27ACA6922EBC4450049ACE0 /* MSIDBackgroundTaskManager.m */,
+			);
+			path = background;
 			sourceTree = "<group>";
 		};
 		B28BDA77217E95D9003E5670 /* b2c */ = {
@@ -5036,6 +5049,7 @@
 				B2BE924721A2279A00F5AB8C /* MSIDTelemetryBrokerEvent.m in Sources */,
 				9641B52A1FCF3F3A00AFA0EC /* MSIDKeyedArchiverSerializer.m in Sources */,
 				23BDA66E1FC78B7E00FE14BE /* NSMutableDictionary+MSIDExtensions.m in Sources */,
+				B27ACA6B22EBC4450049ACE0 /* MSIDBackgroundTaskManager.m in Sources */,
 				96891A972190F15E00D7F437 /* MSIDWPJChallengeHandler.m in Sources */,
 				238E19DB2086FE28004DF483 /* MSIDAuthorizationCodeGrantRequest.m in Sources */,
 				B2C7B3BB213C69C8009FFCC1 /* MSIDDefaultErrorConverter.m in Sources */,

--- a/IdentityCore/src/webview/background/MSIDBackgroundTaskManager.h
+++ b/IdentityCore/src/webview/background/MSIDBackgroundTaskManager.h
@@ -29,7 +29,7 @@
 
 typedef NS_ENUM(NSInteger, MSIDBackgroundTaskType)
 {
-    MSIDInteractiveRequestType = 0
+    MSIDBackgroundTaskTypeInteractiveRequest = 0
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/IdentityCore/src/webview/background/MSIDBackgroundTaskManager.h
+++ b/IdentityCore/src/webview/background/MSIDBackgroundTaskManager.h
@@ -1,0 +1,49 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, MSIDBackgroundTaskType)
+{
+    MSIDInteractiveRequestType = 0
+};
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDBackgroundTaskManager : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
++ (MSIDBackgroundTaskManager *)sharedInstance;
+
+- (void)startOperationWithType:(MSIDBackgroundTaskType)type;
+- (void)stopOperationWithType:(MSIDBackgroundTaskType)type;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/webview/background/MSIDBackgroundTaskManager.m
+++ b/IdentityCore/src/webview/background/MSIDBackgroundTaskManager.m
@@ -27,10 +27,11 @@
 
 #import "MSIDBackgroundTaskManager.h"
 #import "MSIDAppExtensionUtil.h"
+#import "MSIDCache.h"
 
 @interface MSIDBackgroundTaskManager()
 
-@property (nonatomic) NSMutableDictionary *taskDictionary;
+@property (nonatomic) MSIDCache *taskCache;
 
 @end
 
@@ -43,7 +44,7 @@
     self = [super init];
     if (self)
     {
-        _taskDictionary = [NSMutableDictionary new];
+        _taskCache = [MSIDCache new];
     }
     return self;
 }
@@ -69,16 +70,6 @@
 
 - (void)startOperationWithType:(MSIDBackgroundTaskType)type
 {
-    if (![NSThread isMainThread])
-    {
-        // UIKit operations should be executed from main thread
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self startOperationWithType:type];
-        });
-        
-        return;
-    }
-    
     UIBackgroundTaskIdentifier backgroundTask = [self backgroundTaskWithType:type];
     
     if (backgroundTask != UIBackgroundTaskInvalid)
@@ -100,15 +91,6 @@
 
 - (void)stopOperationWithType:(MSIDBackgroundTaskType)type
 {
-    if (![NSThread isMainThread])
-    {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self stopOperationWithType:type];
-        });
-        
-        return;
-    }
-    
     UIBackgroundTaskIdentifier backgroundTask = [self backgroundTaskWithType:type];
     
     if (backgroundTask == UIBackgroundTaskInvalid)
@@ -126,12 +108,12 @@
 
 - (UIBackgroundTaskIdentifier)backgroundTaskWithType:(MSIDBackgroundTaskType)type
 {
-    return [self.taskDictionary[@(type)] integerValue];
+    return [[self.taskCache objectForKey:@(type)] integerValue];
 }
 
 - (void)setBackgroundTask:(UIBackgroundTaskIdentifier)backgroundTask forType:(MSIDBackgroundTaskType)type
 {
-    self.taskDictionary[@(type)] = @(backgroundTask);
+    [self.taskCache setObject:@(backgroundTask) forKey:@(type)];
 }
 
 @end

--- a/IdentityCore/src/webview/background/MSIDBackgroundTaskManager.m
+++ b/IdentityCore/src/webview/background/MSIDBackgroundTaskManager.m
@@ -1,0 +1,137 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSIDBackgroundTaskManager.h"
+#import "MSIDAppExtensionUtil.h"
+
+@interface MSIDBackgroundTaskManager()
+
+@property (nonatomic) NSMutableDictionary *taskDictionary;
+
+@end
+
+@implementation MSIDBackgroundTaskManager
+
+#pragma mark - Init
+
+- (id)initInternal
+{
+    self = [super init];
+    if (self)
+    {
+        _taskDictionary = [NSMutableDictionary new];
+    }
+    return self;
+}
+
++ (MSIDBackgroundTaskManager *)sharedInstance
+{
+    static dispatch_once_t once;
+    static MSIDBackgroundTaskManager *singleton = nil;
+    
+    dispatch_once(&once, ^{
+        singleton = [[MSIDBackgroundTaskManager alloc] initInternal];
+    });
+    
+    return singleton;
+}
+
+#pragma mark - Implementation
+
+/*
+ Background task execution:
+ https://forums.developer.apple.com/message/253232#253232
+ */
+
+- (void)startOperationWithType:(MSIDBackgroundTaskType)type
+{
+    if (![NSThread isMainThread])
+    {
+        // UIKit operations should be executed from main thread
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self startOperationWithType:type];
+        });
+        
+        return;
+    }
+    
+    UIBackgroundTaskIdentifier backgroundTask = [self backgroundTaskWithType:type];
+    
+    if (backgroundTask != UIBackgroundTaskInvalid)
+    {
+        // Background task already started
+        return;
+    }
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Start background app task with type %ld", (long)type);
+    
+    backgroundTask = [[MSIDAppExtensionUtil sharedApplication] beginBackgroundTaskWithName:@"Interactive login"
+                                                                  expirationHandler:^{
+                                                                      MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Background task expired for type %ld", (long)type);
+                                                                      [self stopOperationWithType:type];
+                                                                  }];
+    
+    [self setBackgroundTask:backgroundTask forType:type];
+}
+
+- (void)stopOperationWithType:(MSIDBackgroundTaskType)type
+{
+    if (![NSThread isMainThread])
+    {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self stopOperationWithType:type];
+        });
+        
+        return;
+    }
+    
+    UIBackgroundTaskIdentifier backgroundTask = [self backgroundTaskWithType:type];
+    
+    if (backgroundTask == UIBackgroundTaskInvalid)
+    {
+        // Background task not started
+        return;
+    }
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Stop background task with type %ld", (long)type);
+    [[MSIDAppExtensionUtil sharedApplication] endBackgroundTask:backgroundTask];
+    [self setBackgroundTask:UIBackgroundTaskInvalid forType:type];
+}
+
+#pragma mark - Task dictionary
+
+- (UIBackgroundTaskIdentifier)backgroundTaskWithType:(MSIDBackgroundTaskType)type
+{
+    return [self.taskDictionary[@(type)] integerValue];
+}
+
+- (void)setBackgroundTask:(UIBackgroundTaskIdentifier)backgroundTask forType:(MSIDBackgroundTaskType)type
+{
+    self.taskDictionary[@(type)] = @(backgroundTask);
+}
+
+@end

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -60,14 +60,14 @@ static WKWebViewConfiguration *s_webConfig;
 
 -(void)dealloc
 {
-    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
 }
 
 - (BOOL)loadView:(NSError **)error;
 {
     /* Start background transition tracking,
      so we can start a background task, when app transitions to background */
-    [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDInteractiveRequestType];
+    [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
     
     if (_webView)
     {
@@ -119,7 +119,7 @@ static WKWebViewConfiguration *s_webConfig;
 
 - (void)dismissWebview:(void (^)(void))completion
 {
-    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
     
     //if webview is created by us, dismiss and then complete and return;
     //otherwise just complete and return.

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -26,16 +26,13 @@
 #import "MSIDWebviewUIController.h"
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDAppExtensionUtil.h"
+#import "MSIDBackgroundTaskManager.h"
 
 static WKWebViewConfiguration *s_webConfig;
 
 @interface MSIDWebviewUIController ( )
 {
     UIActivityIndicatorView *_loadingIndicator;
-    
-    UIBackgroundTaskIdentifier _bgTask;
-    id _bgObserver;
-    id _foregroundObserver;
 }
 
 @end
@@ -63,17 +60,14 @@ static WKWebViewConfiguration *s_webConfig;
 
 -(void)dealloc
 {
-    [self cleanupBackgroundTask];
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
 }
 
 - (BOOL)loadView:(NSError **)error;
 {
     /* Start background transition tracking,
      so we can start a background task, when app transitions to background */
-    if (![MSIDAppExtensionUtil isExecutingInAppExtension])
-    {
-        [self startTrackingBackroundAppTransition];
-    }
+    [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDInteractiveRequestType];
     
     if (_webView)
     {
@@ -125,7 +119,7 @@ static WKWebViewConfiguration *s_webConfig;
 
 - (void)dismissWebview:(void (^)(void))completion
 {
-    [self cleanupBackgroundTask];
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
     
     //if webview is created by us, dismiss and then complete and return;
     //otherwise just complete and return.
@@ -190,110 +184,6 @@ static WKWebViewConfiguration *s_webConfig;
 - (void)userCancel
 {
     // Overridden in subclass with userCancel logic
-}
-
-#pragma mark - Background task
-
-- (void)startTrackingBackroundAppTransition
-{
-    if (_bgObserver)
-    {
-        return;
-    }
-    
-    _bgObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationWillResignActiveNotification
-                                                                    object:nil
-                                                                     queue:nil
-                                                                usingBlock:^(__unused NSNotification *notification)
-                   {
-                       MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,_context, @"Application will resign active");
-                       [self startTrackingForegroundAppTransition];
-                       [self startBackgroundTask];
-                   }];
-}
-
-- (void)stopTrackingBackgroundAppTransition
-{
-    if (_bgObserver)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,_context, @"Stop background application tracking");
-        [[NSNotificationCenter defaultCenter] removeObserver:_bgObserver];
-        _bgObserver = nil;
-    }
-}
-
-- (void)startTrackingForegroundAppTransition
-{
-    if (_foregroundObserver)
-    {
-        return;
-    }
-    
-    _foregroundObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
-                                                                            object:nil
-                                                                             queue:nil
-                                                                        usingBlock:^(__unused NSNotification * _Nonnull note) {
-                                                                            
-                                                                            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,_context, @"Application did become active");
-                                                                            [self stopBackgroundTask];
-                                                                            [self stopTrackingForegroundAppTransition];
-                                                                        }];
-}
-
-- (void)stopTrackingForegroundAppTransition
-{
-    if (_foregroundObserver)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,_context, @"Stop foreground application tracking");
-        
-        [[NSNotificationCenter defaultCenter] removeObserver:_foregroundObserver];
-        _foregroundObserver = nil;
-    }
-}
-
-/*
- Background task execution:
- https://forums.developer.apple.com/message/253232#253232
- */
-
-- (void)startBackgroundTask
-{
-    if (_bgTask != UIBackgroundTaskInvalid)
-    {
-        // Background task already started
-        return;
-    }
-    
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, _context, @"Start background app task");
-    
-    _bgTask = [[MSIDAppExtensionUtil sharedApplication] beginBackgroundTaskWithName:@"Interactive login"
-                                                                  expirationHandler:^{
-                                                                      MSID_LOG_WITH_CTX(MSIDLogLevelInfo, _context, @"Background task expired");
-                                                                      [self stopBackgroundTask];
-                                                                      [self stopTrackingForegroundAppTransition];
-                                                                  }];
-}
-
-- (void)stopBackgroundTask
-{
-    if (_bgTask == UIBackgroundTaskInvalid)
-    {
-        // Background task already ended or not started
-        return;
-    }
-    
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, _context, @"Stop background task");
-    [[MSIDAppExtensionUtil sharedApplication] endBackgroundTask:_bgTask];
-    _bgTask = UIBackgroundTaskInvalid;
-}
-
-- (void)cleanupBackgroundTask
-{
-    [self stopTrackingBackgroundAppTransition];
-    
-    // If authentication is stopped while app is in background
-    [self stopTrackingForegroundAppTransition];
-    [self stopBackgroundTask];
 }
 
 @end

--- a/IdentityCore/src/webview/systemWebview/ios/MSIDAuthenticationSession.m
+++ b/IdentityCore/src/webview/systemWebview/ios/MSIDAuthenticationSession.m
@@ -108,7 +108,7 @@
 
 #if !MSID_EXCLUDE_WEBKIT
     
-    [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDInteractiveRequestType];
+    [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
 
     NSError *error = nil;
     
@@ -192,7 +192,7 @@
 - (void)notifyEndWebAuthWithURL:(NSURL *)url
                           error:(NSError *)error
 {
-    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
     
     if (error)
     {
@@ -206,7 +206,7 @@
 
 - (void)dealloc
 {
-    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
 }
 
 @end

--- a/IdentityCore/src/webview/systemWebview/ios/MSIDAuthenticationSession.m
+++ b/IdentityCore/src/webview/systemWebview/ios/MSIDAuthenticationSession.m
@@ -35,6 +35,7 @@
 #import "MSIDTelemetryUIEvent.h"
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDNotifications.h"
+#import "MSIDBackgroundTaskManager.h"
 #if !MSID_EXCLUDE_WEBKIT
 #import <SafariServices/SafariServices.h>
 #import <AuthenticationServices/AuthenticationServices.h>
@@ -106,6 +107,8 @@
     }
 
 #if !MSID_EXCLUDE_WEBKIT
+    
+    [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDInteractiveRequestType];
 
     NSError *error = nil;
     
@@ -189,6 +192,8 @@
 - (void)notifyEndWebAuthWithURL:(NSURL *)url
                           error:(NSError *)error
 {
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
+    
     if (error)
     {
         [MSIDNotifications notifyWebAuthDidFailWithError:error];
@@ -197,6 +202,11 @@
     {
         [MSIDNotifications notifyWebAuthDidCompleteWithURL:url];
     }
+}
+
+- (void)dealloc
+{
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
 }
 
 @end

--- a/IdentityCore/src/webview/systemWebview/ios/MSIDSafariViewController.m
+++ b/IdentityCore/src/webview/systemWebview/ios/MSIDSafariViewController.m
@@ -37,6 +37,7 @@
 #import "MSIDTelemetryUIEvent.h"
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDNotifications.h"
+#import "MSIDBackgroundTaskManager.h"
 
 @interface MSIDSafariViewController() <SFSafariViewControllerDelegate>
 
@@ -92,6 +93,7 @@
     }
     
     dispatch_async(dispatch_get_main_queue(), ^{
+        
         UIViewController *viewController = _parentController ? _parentController :
         [UIApplication msidCurrentViewController];
         if (!viewController)
@@ -101,6 +103,8 @@
             completionHandler(nil, error);
             return;
         }
+        
+        [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDInteractiveRequestType];
         
         _completionHandler = [completionHandler copy];
         
@@ -147,11 +151,16 @@
     }
     
     [MSIDNotifications notifyWebAuthDidCompleteWithURL:url];
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
 
     _completionHandler(url, nil);
     return YES;
 }
 
+- (void)dealloc
+{
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
+}
 
 #pragma mark - SFSafariViewControllerDelegate
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller

--- a/IdentityCore/src/webview/systemWebview/ios/MSIDSafariViewController.m
+++ b/IdentityCore/src/webview/systemWebview/ios/MSIDSafariViewController.m
@@ -104,7 +104,7 @@
             return;
         }
         
-        [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDInteractiveRequestType];
+        [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
         
         _completionHandler = [completionHandler copy];
         
@@ -151,7 +151,7 @@
     }
     
     [MSIDNotifications notifyWebAuthDidCompleteWithURL:url];
-    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
 
     _completionHandler(url, nil);
     return YES;
@@ -159,7 +159,7 @@
 
 - (void)dealloc
 {
-    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDInteractiveRequestType];
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
 }
 
 #pragma mark - SFSafariViewControllerDelegate


### PR DESCRIPTION
Looks like on iOS 13 system browser suffers from same "network connection lost" during MFA like embedded webview on previous versions, so added background task for system browser as well.

Additionally, Apple recommends (in its 2019 WWDC background tasks video) starting background task on user action and there's no need to wait until app is about to go to background - apparently it simply signals the system that there's a task going on. This PR changes that as well and starts background task on user action. 