### PR TITLE
Pass enrollmentId in ADAL when saving broker response

### DIFF
--- a/IdentityCore/src/cache/MSIDCacheAccessor.h
+++ b/IdentityCore/src/cache/MSIDCacheAccessor.h
@@ -58,6 +58,7 @@
  */
 - (BOOL)saveTokensWithBrokerResponse:(MSIDBrokerResponse *)response
                        appIdentifier:(NSString *)appIdentifier
+                        enrollmentId:(NSString *)enrollmentId
                     saveSSOStateOnly:(BOOL)saveSSOStateOnly
                              context:(id<MSIDRequestContext>)context
                                error:(NSError **)error;

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -94,6 +94,7 @@
 
 - (BOOL)saveTokensWithBrokerResponse:(MSIDBrokerResponse *)response
                        appIdentifier:(NSString *)appIdentifier
+                        enrollmentId:(NSString *)enrollmentId
                     saveSSOStateOnly:(BOOL)saveSSOStateOnly
                              context:(id<MSIDRequestContext>)context
                                error:(NSError *__autoreleasing *)error

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -103,6 +103,7 @@
 
 - (BOOL)saveTokensWithBrokerResponse:(MSIDBrokerResponse *)response
                        appIdentifier:(NSString *)appIdentifier
+                        enrollmentId:(NSString *)enrollmentId
                     saveSSOStateOnly:(BOOL)saveSSOStateOnly
                              context:(id<MSIDRequestContext>)context
                                error:(NSError **)error
@@ -128,6 +129,7 @@
     }
     
     configuration.applicationIdentifier = appIdentifier;
+    configuration.enrollmentId = enrollmentId;
 
     return [self saveTokensWithConfiguration:configuration
                                     response:response.tokenResponse

--- a/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
@@ -400,6 +400,7 @@
 
     BOOL result = [_defaultAccessor saveTokensWithBrokerResponse:brokerResponse
                                                    appIdentifier:nil
+                                                    enrollmentId:nil
                                                 saveSSOStateOnly:NO
                                                          context:nil
                                                            error:&error];

--- a/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
@@ -521,6 +521,7 @@
 
     BOOL result = [_legacyAccessor saveTokensWithBrokerResponse:brokerResponse
                                                   appIdentifier:nil
+                                                   enrollmentId:nil
                                                saveSSOStateOnly:NO
                                                         context:nil
                                                           error:&error];
@@ -629,6 +630,7 @@
 
     BOOL result = [_legacyAccessor saveTokensWithBrokerResponse:brokerResponse
                                                   appIdentifier:nil
+                                                   enrollmentId:nil
                                                saveSSOStateOnly:YES
                                                         context:nil
                                                           error:&error];


### PR DESCRIPTION
ADAL wasn't passing enrollmentId before when saving broker response