### PR TITLE
Update broker key provider to accept custom tag

### DIFF
--- a/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.h
+++ b/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.h
@@ -25,6 +25,8 @@
 
 @interface MSIDBrokerCryptoProvider : NSObject
 
+@property (nonatomic, readonly, nonnull) NSData *encryptionKey;
+
 - (nullable instancetype)initWithEncryptionKey:(nonnull NSData *)encryptionKey;
 
 - (nullable NSDictionary *)decryptBrokerResponse:(nonnull NSDictionary *)response

--- a/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.h
+++ b/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.h
@@ -40,6 +40,12 @@ enum {
 
 - (instancetype)initWithGroup:(NSString *)keychainGroup;
 
+- (instancetype)initWithGroup:(NSString *)keychainGroup
+                keyIdentifier:(NSString *)keyIdentifier NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (NSData *)brokerKeyWithError:(NSError **)error;
 
 @end

--- a/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.m
@@ -32,12 +32,19 @@
 @interface MSIDBrokerKeyProvider()
 
 @property (nonatomic) NSString *keychainAccessGroup;
+@property (nonatomic) NSString *keyIdentifier;
 
 @end
 
 @implementation MSIDBrokerKeyProvider
 
 - (instancetype)initWithGroup:(NSString *)keychainGroup
+{
+    return [self initWithGroup:keychainGroup keyIdentifier:MSID_BROKER_SYMMETRIC_KEY_TAG];
+}
+
+- (instancetype)initWithGroup:(NSString *)keychainGroup
+                keyIdentifier:(NSString *)keyIdentifier
 {
     self = [super init];
 
@@ -62,6 +69,13 @@
         }
 
         _keychainAccessGroup = keychainGroup;
+        _keyIdentifier = keyIdentifier;
+        
+        if (!keyIdentifier)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Nil key identifier provided. Cannot generate broker key");
+            return nil;
+        }
     }
 
     return self;
@@ -71,7 +85,7 @@
 {
     OSStatus err = noErr;
 
-    NSData *symmetricTag = [MSID_BROKER_SYMMETRIC_KEY_TAG dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *symmetricTag = [self.keyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
 
     NSDictionary *symmetricKeyQuery =
     @{
@@ -146,7 +160,7 @@
     NSData *keyData = [[NSData alloc] initWithBytes:symmetricKey length:kChosenCipherKeySize * sizeof(uint8_t)];
     free(symmetricKey);
 
-    NSData *symmetricTag = [MSID_BROKER_SYMMETRIC_KEY_TAG dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *symmetricTag = [self.keyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
 
     NSDictionary *symmetricKeyAttr =
     @{
@@ -185,7 +199,7 @@
 {
     OSStatus err = noErr;
 
-    NSData *symmetricTag = [MSID_BROKER_SYMMETRIC_KEY_TAG dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *symmetricTag = [self.keyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
 
     NSDictionary* symmetricKeyQuery =
     @{

--- a/IdentityCore/tests/integration/ios/MSIDBrokerKeyProviderTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerKeyProviderTests.m
@@ -104,6 +104,25 @@
     XCTAssertEqualObjects(brokerKey, keyData);
 }
 
+- (void)testBrokerKeyWithError_whenKeyInKeychainWithCustomIdentifier_shouldReturnKey
+{
+    // Pre-add key to the keychain
+    NSData *keyData = [@"my-random-key-data" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    [MSIDTestBrokerKeyProviderHelper addKey:keyData
+                                accessGroup:[[NSBundle mainBundle] bundleIdentifier]
+                             applicationTag:@"custom-tag-test"];
+    
+    // Read key from broker key provider
+    MSIDBrokerKeyProvider *keyProvider = [[MSIDBrokerKeyProvider alloc] initWithGroup:nil keyIdentifier:@"custom-tag-test"];
+    NSError *error = nil;
+    NSData *brokerKey = [keyProvider brokerKeyWithError:&error];
+    
+    XCTAssertNotNil(brokerKey);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(brokerKey, keyData);
+}
+
 #pragma mark - Migration scenarios
 
 - (void)testBrokerKeyWithError_whenMultipleKeysPresent_shouldReturnOneFromSharedgroup

--- a/IdentityCore/tests/integration/ios/MSIDBrokerKeyProviderTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerKeyProviderTests.m
@@ -27,6 +27,13 @@
 #import "MSIDTestBrokerKeyProviderHelper.h"
 #import "MSIDConstants.h"
 
+@interface MSIDBrokerKeyProvider()
+
+@property (nonatomic) NSString *keychainAccessGroup;
+@property (nonatomic) NSString *keyIdentifier;
+
+@end
+
 @interface MSIDBrokerKeyProviderTests : XCTestCase
 
 @end
@@ -42,6 +49,27 @@
                             (id)kSecAttrKeyClass : (id)kSecAttrKeyClassSymmetric};
 
     SecItemDelete((CFDictionaryRef)query);
+}
+
+- (void)testInitWithGroup_whenNoKey_shouldUseDefaultKey
+{
+    MSIDBrokerKeyProvider *keyProvider = [[MSIDBrokerKeyProvider alloc] initWithGroup:@"com.test.mygroup"];
+    XCTAssertEqualObjects(keyProvider.keyIdentifier, @"com.microsoft.adBrokerKey\0");
+    XCTAssertTrue([keyProvider.keychainAccessGroup hasSuffix:@"com.test.mygroup"]);
+}
+
+- (void)testInitWithGroup_whenCustomKeyAndGroupPassed_shouldSetKey
+{
+    MSIDBrokerKeyProvider *keyProvider = [[MSIDBrokerKeyProvider alloc] initWithGroup:@"com.test.mygroup" keyIdentifier:@"com.test.mykey"];
+    XCTAssertEqualObjects(keyProvider.keyIdentifier, @"com.test.mykey");
+    XCTAssertTrue([keyProvider.keychainAccessGroup hasSuffix:@"com.test.mygroup"]);
+}
+
+- (void)testInitWithGroup_whenNoGroupProvided_shouldUseDefaultGroup
+{
+    MSIDBrokerKeyProvider *keyProvider = [[MSIDBrokerKeyProvider alloc] initWithGroup:nil keyIdentifier:@"com.test.mykey"];
+    XCTAssertEqualObjects(keyProvider.keyIdentifier, @"com.test.mykey");
+    XCTAssertTrue([keyProvider.keychainAccessGroup hasSuffix:[[NSBundle mainBundle] bundleIdentifier]]);
 }
 
 #pragma mark - Normal scenarios


### PR DESCRIPTION
Needed for iOS broker to save any broker keys other than app key.