### PR TITLE
instance aware fix for broker

### DIFF
--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -52,6 +52,7 @@
 @property (nonatomic) NSDictionary *extraURLQueryParameters;
 @property (nonatomic) NSUInteger tokenExpirationBuffer;
 @property (nonatomic) BOOL extendedLifetimeEnabled;
+@property (nonatomic) BOOL instanceAware;
 @property (nonatomic) NSString *intuneApplicationIdentifier;
 
 #pragma mark MSIDRequestContext properties

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
@@ -247,13 +247,12 @@
     }
     
     //save metadata
-    //TODO: update the instanceAware parameter with the instanceAware value in config
     NSError *updateMetadataError = nil;
     [accountMetadataCache updateAuthorityURL:tokenResult.authority.url
                                forRequestURL:parameters.authority.url
                                homeAccountId:tokenResult.accessToken.accountIdentifier.homeAccountId
                                     clientId:parameters.clientId
-                               instanceAware:NO
+                               instanceAware:parameters.instanceAware
                                      context:parameters
                                        error:&updateMetadataError];
     


### PR DESCRIPTION
Today, developers pass `instance_aware` in extra query parameters. In future, we may want to have an `instance_aware` flag in config file.

In either of the of the above case, we will populate the flag into request parameters. 
