### PR TITLE
Authority fix for account metadata cache

### DIFF
--- a/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
@@ -128,14 +128,16 @@
     
     if (!updatedItem)
     {
-        return item;
+        // return a copy because we don't want external change on the cache status
+        return [item copy];
     }
     
     dispatch_barrier_async(_synchronizationQueue, ^{
         _memoryCache[key] = item;
     });
     
-    return item;
+    // return a copy because we don't want external change on the cache status
+    return [item copy];
 }
 
 - (BOOL)removeAccountMetadataForKey:(MSIDCacheKey *)key

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
@@ -248,17 +248,21 @@
     
     //save metadata
     NSError *updateMetadataError = nil;
-    [accountMetadataCache updateAuthorityURL:tokenResult.authority.url
-                               forRequestURL:parameters.authority.url
-                               homeAccountId:tokenResult.accessToken.accountIdentifier.homeAccountId
-                                    clientId:parameters.clientId
-                               instanceAware:parameters.instanceAware
-                                     context:parameters
-                                       error:&updateMetadataError];
-    
-    if (updateMetadataError)
+    MSIDAuthority *cacheAuthority = [factory resultAuthorityWithConfiguration:parameters.msidConfiguration tokenResponse:tokenResponse error:&updateMetadataError];
+    if (cacheAuthority && !updateMetadataError)
     {
-       MSID_LOG_WITH_CTX(MSIDLogLevelError, parameters, @"Failed to update auhtority map in cache. Error %@", MSID_PII_LOG_MASKABLE(updateMetadataError));
+        [accountMetadataCache updateAuthorityURL:cacheAuthority.url
+                                   forRequestURL:parameters.authority.url
+                                   homeAccountId:tokenResult.accessToken.accountIdentifier.homeAccountId
+                                        clientId:parameters.clientId
+                                   instanceAware:parameters.instanceAware
+                                         context:parameters
+                                           error:&updateMetadataError];
+        
+        if (updateMetadataError)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, parameters, @"Failed to update auhtority map in cache. Error %@", MSID_PII_LOG_MASKABLE(updateMetadataError));
+        }
     }
 
     NSError *savingError = nil;

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
@@ -248,10 +248,10 @@
     
     //save metadata
     NSError *updateMetadataError = nil;
-    MSIDAuthority *cacheAuthority = [factory resultAuthorityWithConfiguration:parameters.msidConfiguration tokenResponse:tokenResponse error:&updateMetadataError];
-    if (cacheAuthority && !updateMetadataError)
+    MSIDAuthority *resultingAuthority = [factory resultAuthorityWithConfiguration:parameters.msidConfiguration tokenResponse:tokenResponse error:&updateMetadataError];
+    if (resultingAuthority && !updateMetadataError)
     {
-        [accountMetadataCache updateAuthorityURL:cacheAuthority.url
+        [accountMetadataCache updateAuthorityURL:resultingAuthority.url
                                    forRequestURL:parameters.authority.url
                                    homeAccountId:tokenResult.accessToken.accountIdentifier.homeAccountId
                                         clientId:parameters.clientId


### PR DESCRIPTION
broker: https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/363
MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/639