### PR TITLE
fix pkeyauth helper in handling a mismatch certificate issuer

### DIFF
--- a/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
+++ b/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
@@ -85,9 +85,11 @@
         
         NSURLComponents *authorizationServerComponents = [[NSURLComponents alloc] initWithURL:authorizationServer resolvingAgainstBaseURL:NO];
         authorizationServerComponents.query = nil; // Strip out query parameters.
-        
-        authToken = [NSString stringWithFormat:@"AuthToken=\"%@\",", [MSIDPkeyAuthHelper createDeviceAuthResponse:authorizationServerComponents.string nonce:[challengeData valueForKey:@"nonce"] identity:info]];
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Found WPJ Info and responded to PKeyAuth Request.");
+        if (info)
+        {
+            authToken = [NSString stringWithFormat:@"AuthToken=\"%@\",", [MSIDPkeyAuthHelper createDeviceAuthResponse:authorizationServerComponents.string nonce:[challengeData valueForKey:@"nonce"] identity:info]];
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Found WPJ Info and responded to PKeyAuth Request.");
+        }
     }
     
     return [NSString stringWithFormat:@"PKeyAuth %@ Context=\"%@\", Version=\"%@\"", authToken, challengeContext, challengeVersion];

--- a/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
+++ b/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
@@ -127,6 +127,30 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
     }
 }
 
+- (void)testCreateDeviceAuthResponse_whenCertDoesnotMatch_shouldCreateProperResponse
+{
+    if (@available(iOS 10.0, *))
+    {
+        __auto_type challengeData = @{@"Context": @"some context",
+                                      @"Version": @"1.0",
+                                      @"nonce": @"XNme6ZlnnZgIS4bMHPzY4RihkHFqCH6s1hnRgjv8Y0Q",
+                                      @"CertAuthorities": @"OU=82dbaca4-3e81-46ca-9c73-0950c1eaca97,CN=MS-Organization-Access,DC=windows,DC=net"};
+        __auto_type regInfo = [MSIDRegistrationInformationMock new];
+        regInfo.isWorkPlaceJoinedFlag = YES;
+        [regInfo setPrivateKey:[self privateKey]];
+        [regInfo setCertificateIssuer:@"XXXXXX"];
+        s_registrationInformationToReturn = regInfo;
+        __auto_type url = [[NSURL alloc] initWithString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice"];
+        
+        __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData context:nil];
+        
+        __auto_type expectedResponse = @"PKeyAuth  Context=\"some context\", Version=\"1.0\"";
+        
+        XCTAssertEqualObjects(expectedResponse, response);
+    }
+}
+
+
 #pragma mark - Private
 
 - (SecKeyRef)privateKey


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/640
https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/364