### PR TITLE
Ignore WPJ challenge on iOS

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDWPJChallengeHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDWPJChallengeHandler.m
@@ -37,7 +37,12 @@
     
     if ([self isWPJChallenge:distinguishedNames])
     {
+#if TARGET_OS_IPHONE
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Ignoring WPJ challenge on iOS");
+        return NO;
+#else
         return [self handleWPJChallenge:challenge context:context completionHandler:completionHandler];
+#endif
     }
     
     return NO;


### PR DESCRIPTION
Client TLS doesn't work in WKWebView on iOS (known issue). Sending certificate in that case makes WKWebView stuck. 