### PR TITLE
Check for main thread before dispatching on main thread for ADAL

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -471,6 +471,8 @@
 		B2525C6A23302364006FBA4B /* MSIDMainThreadUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = B2525C6823302364006FBA4B /* MSIDMainThreadUtil.h */; };
 		B2525C6B23302364006FBA4B /* MSIDMainThreadUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B2525C6923302364006FBA4B /* MSIDMainThreadUtil.m */; };
 		B2525C6C23302364006FBA4B /* MSIDMainThreadUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B2525C6923302364006FBA4B /* MSIDMainThreadUtil.m */; };
+		B2525C752330623E006FBA4B /* MSIDMainThreadUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2525C742330623E006FBA4B /* MSIDMainThreadUtilTests.m */; };
+		B2525C762330623E006FBA4B /* MSIDMainThreadUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2525C742330623E006FBA4B /* MSIDMainThreadUtilTests.m */; };
 		B252913B2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B252913A2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m */; };
 		B252913C2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B252913A2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m */; };
 		B253BD7A20487C8A00D07F31 /* MSIDLegacyTokenCacheIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B23ECF041FF33AE70015FC1D /* MSIDLegacyTokenCacheIntegrationTests.m */; };
@@ -1192,6 +1194,7 @@
 		B251CC54204109A4005E0179 /* MSIDCredentialCacheItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCredentialCacheItem.m; sourceTree = "<group>"; };
 		B2525C6823302364006FBA4B /* MSIDMainThreadUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDMainThreadUtil.h; sourceTree = "<group>"; };
 		B2525C6923302364006FBA4B /* MSIDMainThreadUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMainThreadUtil.m; sourceTree = "<group>"; };
+		B2525C742330623E006FBA4B /* MSIDMainThreadUtilTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMainThreadUtilTests.m; sourceTree = "<group>"; };
 		B252913A2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADIdTokenClaimsFactoryTests.m; sourceTree = "<group>"; };
 		B2544EEA21684B2B00B4C108 /* MSIDCacheSchemaValidationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCacheSchemaValidationTests.m; sourceTree = "<group>"; };
 		B2561221217EA93800999876 /* MSIDB2COauth2FactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDB2COauth2FactoryTests.m; sourceTree = "<group>"; };
@@ -2497,6 +2500,7 @@
 				B29F7804213DFA5600D61FC8 /* MSIDErrorTests.m */,
 				23AE9DBA2148574F00B285F3 /* MSIDErrorExtensionsTests.m */,
 				B203197E217BF191006488D0 /* MSIDClientCapabilitiesTests.m */,
+				B2525C742330623E006FBA4B /* MSIDMainThreadUtilTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -3071,6 +3075,7 @@
 				960F915220CB00C10055A162 /* MSIDAADV2WebviewFactoryTests.m in Sources */,
 				963553BF20CA7C52005235E5 /* MSIDSystemWebviewControllerTests.m in Sources */,
 				963CFAF320AD817600BDA25F /* MSIDWebviewAuthorizationTests.m in Sources */,
+				B2525C752330623E006FBA4B /* MSIDMainThreadUtilTests.m in Sources */,
 				2338ECDA208A7CBD00809B9E /* MSIDAADRequestErrorHandlerTests.m in Sources */,
 				B2DD4B4220A934BC0047A66E /* MSIDTokenFilteringHelperTests.m in Sources */,
 				239DF9C320E04BC9002D428B /* MSIDADFSAuthorityTests.m in Sources */,
@@ -3315,6 +3320,7 @@
 				239DF9C220E04BC9002D428B /* MSIDB2CAuthorityTests.m in Sources */,
 				B2808005204CB2A700944D89 /* MSIDAADV1TokenResponseTests.m in Sources */,
 				D6D9A4BD1FBE712900EFA430 /* MSIDURLExtensionsTests.m in Sources */,
+				B2525C762330623E006FBA4B /* MSIDMainThreadUtilTests.m in Sources */,
 				960F918B20CBECAE0055A162 /* MSIDAADWebviewFactoryTests.m in Sources */,
 				238A047A2088561100989EE0 /* MSIDHttpRequestIntegrationTests.m in Sources */,
 				963CFAF420AD817600BDA25F /* MSIDWebviewAuthorizationTests.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -468,6 +468,9 @@
 		B251CC4C204105A7005E0179 /* MSIDIdToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC46204105A7005E0179 /* MSIDIdToken.m */; };
 		B251CC4D204105A7005E0179 /* MSIDIdToken.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC46204105A7005E0179 /* MSIDIdToken.m */; };
 		B251CC51204105AE005E0179 /* MSIDCredentialType.m in Sources */ = {isa = PBXBuildFile; fileRef = B251CC4F204105AD005E0179 /* MSIDCredentialType.m */; };
+		B2525C6A23302364006FBA4B /* MSIDMainThreadUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = B2525C6823302364006FBA4B /* MSIDMainThreadUtil.h */; };
+		B2525C6B23302364006FBA4B /* MSIDMainThreadUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B2525C6923302364006FBA4B /* MSIDMainThreadUtil.m */; };
+		B2525C6C23302364006FBA4B /* MSIDMainThreadUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B2525C6923302364006FBA4B /* MSIDMainThreadUtil.m */; };
 		B252913B2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B252913A2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m */; };
 		B252913C2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B252913A2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m */; };
 		B253BD7A20487C8A00D07F31 /* MSIDLegacyTokenCacheIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B23ECF041FF33AE70015FC1D /* MSIDLegacyTokenCacheIntegrationTests.m */; };
@@ -1187,6 +1190,8 @@
 		B251CC4F204105AD005E0179 /* MSIDCredentialType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDCredentialType.m; sourceTree = "<group>"; };
 		B251CC53204109A4005E0179 /* MSIDCredentialCacheItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCredentialCacheItem.h; sourceTree = "<group>"; };
 		B251CC54204109A4005E0179 /* MSIDCredentialCacheItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCredentialCacheItem.m; sourceTree = "<group>"; };
+		B2525C6823302364006FBA4B /* MSIDMainThreadUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDMainThreadUtil.h; sourceTree = "<group>"; };
+		B2525C6923302364006FBA4B /* MSIDMainThreadUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMainThreadUtil.m; sourceTree = "<group>"; };
 		B252913A2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADIdTokenClaimsFactoryTests.m; sourceTree = "<group>"; };
 		B2544EEA21684B2B00B4C108 /* MSIDCacheSchemaValidationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCacheSchemaValidationTests.m; sourceTree = "<group>"; };
 		B2561221217EA93800999876 /* MSIDB2COauth2FactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDB2COauth2FactoryTests.m; sourceTree = "<group>"; };
@@ -1753,6 +1758,8 @@
 				96C998EE20B638F60053A2D9 /* MSIDWebviewSession.m */,
 				96F21B2F20A65896002B87C3 /* MSIDWebviewAuthorization.h */,
 				96F21B3020A65896002B87C3 /* MSIDWebviewAuthorization.m */,
+				B2525C6823302364006FBA4B /* MSIDMainThreadUtil.h */,
+				B2525C6923302364006FBA4B /* MSIDMainThreadUtil.m */,
 			);
 			path = webview;
 			sourceTree = "<group>";
@@ -2643,6 +2650,7 @@
 				B20657DF1FCA208C00412B7D /* NSDate+MSIDExtensions.h in Headers */,
 				96090D9820E59B2000E42B37 /* MSIDNotifications.h in Headers */,
 				96F94A3320817C1A0034676C /* MSIDNTLMHandler.h in Headers */,
+				B2525C6A23302364006FBA4B /* MSIDMainThreadUtil.h in Headers */,
 				B297E1E620A12BDE00F370EC /* MSIDDefaultAccountCacheKey.h in Headers */,
 				B251CC3B2041058D005E0179 /* MSIDRefreshToken.h in Headers */,
 				B28BDA84217E9676003E5670 /* MSIDB2CIdTokenClaims.h in Headers */,
@@ -3183,6 +3191,7 @@
 				B20657E11FCA208C00412B7D /* NSDate+MSIDExtensions.m in Sources */,
 				B27551C22081705300AA7A38 /* MSIDJWTHelper.m in Sources */,
 				B251CC1D2040F6B5005E0179 /* MSIDLegacyTokenCacheKey.m in Sources */,
+				B2525C6C23302364006FBA4B /* MSIDMainThreadUtil.m in Sources */,
 				2306D2A020AB672A00F875A3 /* MSIDAADEndpointProvider.m in Sources */,
 				B251CC4B204105A7005E0179 /* MSIDBaseToken.m in Sources */,
 				235480D120DDF81000246F72 /* MSIDADFSAuthority.m in Sources */,
@@ -3511,6 +3520,7 @@
 				23B39ACC209CF317000AA905 /* MSIDAADNetworkConfiguration.m in Sources */,
 				2321531B1FDA101900C6960D /* MSIDUserInformation.m in Sources */,
 				232C65842138BD11002A41FE /* MSIDAADAuthorityMetadataResponseSerializer.m in Sources */,
+				B2525C6B23302364006FBA4B /* MSIDMainThreadUtil.m in Sources */,
 				B23ECEEB1FF2F56A0015FC1D /* MSIDAADTokenResponse.m in Sources */,
 				B28BDA80217E964B003E5670 /* MSIDB2CTokenResponse.m in Sources */,
 				600D19BC20964D8C0004CD43 /* MSIDWorkPlaceJoinUtil.m in Sources */,

--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.m
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.m
@@ -41,6 +41,16 @@
 
 - (MSIDWebviewSession *)embeddedWebviewSessionFromConfiguration:(MSIDWebviewConfiguration *)configuration customWebview:(WKWebView *)webview context:(id<MSIDRequestContext>)context
 {
+    if (![NSThread isMainThread])
+    {
+        __block MSIDWebviewSession *session;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            session = [self embeddedWebviewSessionFromConfiguration:configuration customWebview:webview context:context];
+        });
+        
+        return session;
+    }
+    
     NSString *state = [self generateStateValue];
     NSURL *startURL = [self startURLFromConfiguration:configuration requestState:state];
     NSURL *redirectURL = [NSURL URLWithString:configuration.redirectUri];
@@ -74,6 +84,19 @@
                                     allowSafariViewController:(BOOL)allowSafariViewController
                                                       context:(id<MSIDRequestContext>)context
 {
+    if (![NSThread isMainThread])
+    {
+        __block MSIDWebviewSession *session;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            session = [self systemWebviewSessionFromConfiguration:configuration
+                                         useAuthenticationSession:useAuthenticationSession
+                                        allowSafariViewController:allowSafariViewController
+                                                          context:context];
+        });
+        
+        return session;
+    }
+    
     NSString *state = [self generateStateValue];
     NSURL *startURL = [self startURLFromConfiguration:configuration requestState:state];
     NSURL *redirectURL = [NSURL URLWithString:configuration.redirectUri];

--- a/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
+++ b/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import "MSIDAppExtensionUtil.h"
+#import "MSIDMainThreadUtil.h"
 
 @implementation MSIDAppExtensionUtil
 
@@ -62,9 +63,10 @@
     
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    dispatch_async( dispatch_get_main_queue(), ^{
+    
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         [[self sharedApplication] performSelector:NSSelectorFromString(@"openURL:") withObject:url];
-    });
+    }];
 #pragma clang diagnostic pop
 }
 

--- a/IdentityCore/src/webview/MSIDMainThreadUtil.h
+++ b/IdentityCore/src/webview/MSIDMainThreadUtil.h
@@ -1,3 +1,5 @@
+//------------------------------------------------------------------------------
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -15,22 +17,22 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSIDHttpRequestProtocol.h"
 
-@protocol MSIDHttpRequestErrorHandling <NSObject>
+NS_ASSUME_NONNULL_BEGIN
 
-- (void)handleError:(NSError * )error
-       httpResponse:(NSHTTPURLResponse *)httpResponse
-               data:(NSData *)data
-        httpRequest:(NSObject<MSIDHttpRequestProtocol> *)httpRequest
-            context:(id<MSIDRequestContext>)context
-    completionBlock:(MSIDHttpRequestDidCompleteBlock)completionBlock;
+@interface MSIDMainThreadUtil : NSObject
+
++ (void)executeOnMainThreadIfNeeded:(void (^)(void))block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/webview/MSIDMainThreadUtil.m
+++ b/IdentityCore/src/webview/MSIDMainThreadUtil.m
@@ -1,3 +1,5 @@
+//------------------------------------------------------------------------------
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -15,22 +17,28 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
 
-#import <Foundation/Foundation.h>
-#import "MSIDHttpRequestProtocol.h"
+#import "MSIDMainThreadUtil.h"
 
-@protocol MSIDHttpRequestErrorHandling <NSObject>
+@implementation MSIDMainThreadUtil
 
-- (void)handleError:(NSError * )error
-       httpResponse:(NSHTTPURLResponse *)httpResponse
-               data:(NSData *)data
-        httpRequest:(NSObject<MSIDHttpRequestProtocol> *)httpRequest
-            context:(id<MSIDRequestContext>)context
-    completionBlock:(MSIDHttpRequestDidCompleteBlock)completionBlock;
++ (void)executeOnMainThreadIfNeeded:(void (^)(void))block
+{
+    if ([NSThread isMainThread])
+    {
+        if (block) block();
+    }
+    else
+    {
+        dispatch_async(dispatch_get_main_queue(), block);
+    }
+}
 
 @end

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -36,6 +36,7 @@
 #import "MSIDTelemetry+Internal.h"
 #import "MSIDTelemetryUIEvent.h"
 #import "MSIDTelemetryEventStrings.h"
+#import "MSIDMainThreadUtil.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -110,8 +111,8 @@
     // Save the completion block
     _completionHandler = [completionHandler copy];
     
-    dispatch_async(dispatch_get_main_queue(), ^{
-
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
+        
         NSError *error = nil;
         [self loadView:&error];
         if (error)
@@ -125,7 +126,8 @@
             [request addValue:_customHeaders[headerKey] forHTTPHeaderField:headerKey];
         
         [self startRequest:request];
-    });
+        
+    }];
 }
 
 - (void)cancel
@@ -176,9 +178,9 @@
     
     [[MSIDTelemetry sharedInstance] stopEvent:_telemetryRequestId event:_telemetryEvent];
     
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         [self dismissWebview:^{[self dispatchCompletionBlock:endURL error:error];}];
-    });
+    }];
     
     return YES;
 }

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDNTLMUIPrompt.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDNTLMUIPrompt.m
@@ -24,6 +24,7 @@
 #import "MSIDNTLMUIPrompt.h"
 #import "MSIDAppExtensionUtil.h"
 #import "UIApplication+MSIDExtensions.h"
+#import "MSIDMainThreadUtil.h"
 
 @implementation MSIDNTLMUIPrompt
 
@@ -31,15 +32,14 @@ __weak static UIAlertController *_presentedPrompt = nil;
 
 + (void)dismissPrompt
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         if (_presentedPrompt.presentingViewController)
         {
             [_presentedPrompt.presentingViewController dismissViewControllerAnimated:YES completion:nil];
         }
         
         _presentedPrompt = nil;
-    });
+    }];
 }
 
 + (void)presentPrompt:(void (^)(NSString *username, NSString *password, BOOL cancel))block
@@ -51,7 +51,7 @@ __weak static UIAlertController *_presentedPrompt = nil;
         return;
     }
     
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         UIViewController *viewController = [UIApplication msidCurrentViewController];
         if (!viewController)
         {
@@ -96,7 +96,7 @@ __weak static UIAlertController *_presentedPrompt = nil;
         [viewController presentViewController:alert animated:YES completion:^{}];
         
         _presentedPrompt = alert;
-    });
+    }];
 }
 
 @end

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -26,6 +26,7 @@
 #import "MSIDWebviewUIController.h"
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDAppExtensionUtil.h"
+#import "MSIDMainThreadUtil.h"
 
 static WKWebViewConfiguration *s_webConfig;
 
@@ -118,9 +119,9 @@ static WKWebViewConfiguration *s_webConfig;
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:self];
     [navController setModalPresentationStyle:_presentationType];
     
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         [_parentController presentViewController:navController animated:YES completion:nil];
-    });
+    }];
 }
 
 - (void)dismissWebview:(void (^)(void))completion

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDCertificateChooser.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDCertificateChooser.m
@@ -23,6 +23,7 @@
 
 #import <SecurityInterface/SFChooseIdentityPanel.h>
 #import "MSIDCertificateChooser.h"
+#import "MSIDMainThreadUtil.h"
 #import <MSIDNotifications.h>
 
 @implementation MSIDCertificateChooserHelper
@@ -70,9 +71,9 @@
 {
     MSID_LOG_INFO_CORR(_correlationId, @"Displaying Cert Selection Sheet");
     
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         [self beginSheet:identities message:message];
-    });
+    }];
 }
 
 - (void)sheetDidEnd:(__unused NSWindow *)window

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDNTLMUIPrompt.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDNTLMUIPrompt.m
@@ -24,6 +24,7 @@
 #import <AppKit/AppKit.h>
 #import "MSIDNTLMUIPrompt.h"
 #import "MSIDCredentialCollectionController.h"
+#import "MSIDMainThreadUtil.h"
 
 @interface MSIDNTLMUIPrompt ()
 
@@ -35,19 +36,19 @@ __weak static NSAlert *_presentedPrompt = nil;
 
 + (void)dismissPrompt
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         
         if (_presentedPrompt)
         {
             [_presentedPrompt.window.sheetParent endSheet:_presentedPrompt.window];
             _presentedPrompt = nil;
         }
-    });
+    }];
 }
 
 + (void)presentPrompt:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         NSAlert *alert = [NSAlert new];
         
         [alert setMessageText:NSLocalizedString(@"Enter your credentials", nil)];
@@ -83,7 +84,7 @@ __weak static NSAlert *_presentedPrompt = nil;
         [view.passwordField setNextKeyView:cancelButton];
         [cancelButton setNextKeyView:loginButton];
         [loginButton setNextKeyView:view.usernameField];
-    });
+    }];
 }
 
 @end

--- a/IdentityCore/src/webview/systemWebview/ios/MSIDSafariViewController.m
+++ b/IdentityCore/src/webview/systemWebview/ios/MSIDSafariViewController.m
@@ -37,6 +37,7 @@
 #import "MSIDTelemetryUIEvent.h"
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDNotifications.h"
+#import "MSIDMainThreadUtil.h"
 
 @interface MSIDSafariViewController() <SFSafariViewControllerDelegate>
 
@@ -89,7 +90,7 @@
         return;
     }
     
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         UIViewController *viewController = _parentController ? _parentController :
         [UIApplication msidCurrentViewController];
         if (!viewController)
@@ -111,7 +112,7 @@
         [MSIDNotifications notifyWebAuthDidStartLoad:_startURL userInfo:nil];
         
         [viewController presentViewController:_safariViewController animated:YES completion:nil];
-    });
+    }];
 }
 
 
@@ -129,11 +130,11 @@
                             context:(id<MSIDRequestContext>)context
                               error:(NSError *)error
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         [_safariViewController dismissViewControllerAnimated:YES completion:^{
             _safariViewController = nil;
         }];
-    });
+    }];
     
     [[MSIDTelemetry sharedInstance] stopEvent:_telemetryRequestId event:_telemetryEvent];
     

--- a/IdentityCore/tests/MSIDMainThreadUtilTests.m
+++ b/IdentityCore/tests/MSIDMainThreadUtilTests.m
@@ -32,22 +32,32 @@
 
 - (void)testExecuteOnMainThread_whenInvokedFromMainThread_shouldInvokeOnMainThread
 {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Main thread test"];
+    
     dispatch_async(dispatch_get_main_queue(), ^{
         
         [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
             XCTAssertTrue([NSThread isMainThread]);
+            [expectation fulfill];
         }];
         
     });
+    
+    [self waitForExpectations:@[expectation] timeout:1];
 }
 
 - (void)testExecuteOnMainThread_whenInvokedFromBgThread_shouldInvokeOnMainThread
 {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Main thread test"];
+    
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
             XCTAssertTrue([NSThread isMainThread]);
+            [expectation fulfill];
         }];
     });
+    
+    [self waitForExpectations:@[expectation] timeout:1];
 }
 
 @end

--- a/IdentityCore/tests/MSIDMainThreadUtilTests.m
+++ b/IdentityCore/tests/MSIDMainThreadUtilTests.m
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDMainThreadUtil.h"
+
+@interface MSIDMainThreadUtilTests : XCTestCase
+
+@end
+
+@implementation MSIDMainThreadUtilTests
+
+- (void)testExecuteOnMainThread_whenInvokedFromMainThread_shouldInvokeOnMainThread
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
+            XCTAssertTrue([NSThread isMainThread]);
+        }];
+        
+    });
+}
+
+- (void)testExecuteOnMainThread_whenInvokedFromBgThread_shouldInvokeOnMainThread
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
+            XCTAssertTrue([NSThread isMainThread]);
+        }];
+    });
+}
+
+@end


### PR DESCRIPTION
Also fixes warnings on macOS 10.15 and iOS 13 due to ViewController initialization on bf thread. 