### PR TITLE
Fixed viewcontroller lookup and WPJ lookup

### DIFF
--- a/IdentityCore/src/util/NSKeyedArchiver+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSKeyedArchiver+MSIDExtensions.m
@@ -33,7 +33,7 @@
     {
         archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:YES];
     }
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     else
     {
         archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
@@ -67,7 +67,7 @@
     {
         result = [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:requiresSecureCoding error:error];
     }
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     else
     {
         result = [NSKeyedArchiver archivedDataWithRootObject:object];

--- a/IdentityCore/src/util/NSKeyedUnarchiver+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSKeyedUnarchiver+MSIDExtensions.m
@@ -32,7 +32,7 @@
     {
         unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:error];
     }
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     else
     {
         unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
@@ -49,7 +49,7 @@
     {
         result = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:error];
     }
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     else
     {
         result = [NSKeyedUnarchiver unarchiveObjectWithData:data];

--- a/IdentityCore/src/util/ios/MSIDKeychainUtil.m
+++ b/IdentityCore/src/util/ios/MSIDKeychainUtil.m
@@ -98,7 +98,7 @@
             || readStatus == errSecInteractionNotAllowed)
         {
             NSMutableDictionary* addQuery = [query mutableCopy];
-#if TARGET_OS_UIKITFORMAC
+#if TARGET_OS_MACCATALYST
             [addQuery setObject:(id)kSecAttrAccessibleAfterFirstUnlock forKey:(id)kSecAttrAccessible];
 #else
             [addQuery setObject:(id)kSecAttrAccessibleAlways forKey:(id)kSecAttrAccessible];

--- a/IdentityCore/src/util/ios/UIApplication+MSIDExtensions.m
+++ b/IdentityCore/src/util/ios/UIApplication+MSIDExtensions.m
@@ -29,16 +29,29 @@
 
 + (UIViewController *)msidCurrentViewController:(UIViewController *)parentController
 {
-    if (@available(iOS 13.0, *)) return [self msidCurrentViewControllerWithRootViewController:parentController];
+    if (parentController)
+    {
+        return [self msidCurrentViewControllerWithRootViewController:parentController];
+    }
     
     if ([MSIDAppExtensionUtil isExecutingInAppExtension]) return nil;
     
-#if !TARGET_OS_UIKITFORMAC
-    __auto_type controller = parentController ? parentController : [self msidCurrentViewControllerWithRootViewController:[MSIDAppExtensionUtil sharedApplication].keyWindow.rootViewController];
+#if !TARGET_OS_MACCATALYST
+    __auto_type controller = [self msidCurrentViewControllerWithRootViewController:[MSIDAppExtensionUtil sharedApplication].keyWindow.rootViewController];
     return controller;
-#endif
+#else
     
-    return [self msidCurrentViewControllerWithRootViewController:parentController];
+    for (UIWindow *window in [MSIDAppExtensionUtil sharedApplication].windows)
+    {
+        if (window.isKeyWindow)
+        {
+            return [self msidCurrentViewControllerWithRootViewController:window.rootViewController];
+        }
+    }
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Couldn't find key window");
+    return nil;
+#endif
 }
 
 + (UIViewController*)msidCurrentViewControllerWithRootViewController:(UIViewController *)rootViewController

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
@@ -48,15 +48,15 @@
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Attempting to handle client TLS challenge. host: %@", MSID_PII_LOG_TRACKABLE(host));
     
     // See if this is a challenge for the WPJ cert.
-    if ([MSIDWPJChallengeHandler handleChallenge:challenge
-                                         webview:webview
-#if TARGET_OS_IPHONE
-                                parentController:parentViewController
-#endif
-                                         context:context
-                               completionHandler:completionHandler])
+    if ([MSIDWPJChallengeHandler shouldHandleChallenge:challenge])
     {
-        return YES;
+        return [MSIDWPJChallengeHandler handleChallenge:challenge
+                                                webview:webview
+#if TARGET_OS_IPHONE
+                                       parentController:parentViewController
+#endif
+                                                context:context
+                                      completionHandler:completionHandler];
     }
     
     // If it is not WPJ challenge, it has to be CBA.

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDWPJChallengeHandler.h
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDWPJChallengeHandler.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDWPJChallengeHandler : NSObject<MSIDChallengeHandling>
 
++ (BOOL)shouldHandleChallenge:(NSURLAuthenticationChallenge *)challenge;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDWPJChallengeHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDWPJChallengeHandler.m
@@ -54,9 +54,13 @@
     return NO;
 }
 
++ (BOOL)shouldHandleChallenge:(NSURLAuthenticationChallenge *)challenge
+{
+    return [self isWPJChallenge:challenge.protectionSpace.distinguishedNames];
+}
+
 + (BOOL)isWPJChallenge:(NSArray *)distinguishedNames
 {
-    
     for (NSData *distinguishedName in distinguishedNames)
     {
         NSString *distinguishedNameString = [[[NSString alloc] initWithData:distinguishedName encoding:NSISOLatin1StringEncoding] lowercaseString];

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -184,7 +184,7 @@ static WKWebViewConfiguration *s_webConfig;
     {
         loadingIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
     }
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     else
     {
         loadingIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];

--- a/IdentityCore/src/webview/systemWebview/ios/MSIDAuthenticationSession.m
+++ b/IdentityCore/src/webview/systemWebview/ios/MSIDAuthenticationSession.m
@@ -77,7 +77,7 @@ API_AVAILABLE(ios(13.0))
 {
 #if !MSID_EXCLUDE_WEBKIT
     
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     API_AVAILABLE(ios(11.0))
     SFAuthenticationSession *_authSession;
 #endif
@@ -143,7 +143,7 @@ API_AVAILABLE(ios(13.0))
     }
     else if (@available(iOS 11.0, *))
     {
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
         if (error.code == SFAuthenticationErrorCanceledLogin) return YES;
 #endif
     }
@@ -208,7 +208,7 @@ API_AVAILABLE(ios(13.0))
         }
         else
         {
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
             _authSession = [[SFAuthenticationSession alloc] initWithURL:_startURL
                                                       callbackURLScheme:_callbackURLScheme
                                                       completionHandler:authCompletion];
@@ -238,7 +238,7 @@ API_AVAILABLE(ios(13.0))
     {
         [_webAuthSession cancel];
     }
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     else
     {
         [_authSession cancel];

--- a/IdentityCore/src/webview/systemWebview/ios/MSIDSafariViewController.m
+++ b/IdentityCore/src/webview/systemWebview/ios/MSIDSafariViewController.m
@@ -74,7 +74,7 @@
             __auto_type config = [SFSafariViewControllerConfiguration new];
             _safariViewController = [[SFSafariViewController alloc] initWithURL:url configuration:config];
         }
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
         else
         {
             _safariViewController = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:NO];


### PR DESCRIPTION
Fixed following issues flagged by release automation run:

1. ViewController lookup was broken on non iOS 13 devices when developer passes parentController. Since we would be already presenting authentication controller on top of parent controller, additional presentations (e.g. CBA controller) would not work. 

2. If client receives a WPJ challenge, but doesn't handle it, previous implementation was falling back to Cert auth handler which is incorrect. Applied a fix to not fallback to cert auth handler. 

Additionally, updated TARGET_OS_UIKITFORMAC to TARGET_OS_MACCATALYST (see here https://developer.apple.com/documentation/xcode/creating_a_mac_version_of_your_ipad_app?language=objc)