### PR TITLE
Remove WKWebView stopLoading in cancel

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -142,16 +142,6 @@
     NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorSessionCanceledProgrammatically, @"Authorization session was cancelled programatically.", nil, nil, nil, self.context.correlationId, nil);
     
     [_telemetryEvent setIsCancelled:YES];
-    
-    if ([self.webView.navigationDelegate isEqual:self])
-    {
-        /*
-         There's an edge case scenario, where application cancels one of the requests and starts another one immediately after.
-         We want to make sure that second request doesn't get first response, so we cancel loading of webview when cancel method is called         
-         */
-        [self.webView stopLoading];
-    }
-    
     [self endWebAuthWithURL:nil error:error];
 }
 


### PR DESCRIPTION
It doesn't seem to be working and it's causing an occasional assert crash inside WebKit implementation, so reverting the change. 