### PR TITLE
[Interface draft] Serverside telemetry

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -461,6 +461,15 @@
 		96A2D5A8209D102900F80E3A /* MSIDWebviewConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A2D5A6209D102900F80E3A /* MSIDWebviewConfiguration.m */; };
 		96A2D5A9209D102900F80E3A /* MSIDWebviewConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A2D5A6209D102900F80E3A /* MSIDWebviewConfiguration.m */; };
 		96A3E9B9208941D700BE5262 /* MSIDSystemWebviewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A3E9B8208941D700BE5262 /* MSIDSystemWebviewController.m */; };
+		96ADF6AB235EC813001289ED /* MSIDServersideTelemetry.h in Headers */ = {isa = PBXBuildFile; fileRef = 96ADF6A9235EC813001289ED /* MSIDServersideTelemetry.h */; };
+		96ADF6AC235EC813001289ED /* MSIDServersideTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = 96ADF6AA235EC813001289ED /* MSIDServersideTelemetry.m */; };
+		96ADF6AD235EC813001289ED /* MSIDServersideTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = 96ADF6AA235EC813001289ED /* MSIDServersideTelemetry.m */; };
+		96ADF6B5235ECAD2001289ED /* MSIDServersideTelemetryLast.h in Headers */ = {isa = PBXBuildFile; fileRef = 96ADF6B3235ECAD2001289ED /* MSIDServersideTelemetryLast.h */; };
+		96ADF6B6235ECAD2001289ED /* MSIDServersideTelemetryLast.m in Sources */ = {isa = PBXBuildFile; fileRef = 96ADF6B4235ECAD2001289ED /* MSIDServersideTelemetryLast.m */; };
+		96ADF6B7235ECAD2001289ED /* MSIDServersideTelemetryLast.m in Sources */ = {isa = PBXBuildFile; fileRef = 96ADF6B4235ECAD2001289ED /* MSIDServersideTelemetryLast.m */; };
+		96ADF6BA235ECB40001289ED /* MSIDServersideTelemetrySerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 96ADF6B8235ECB40001289ED /* MSIDServersideTelemetrySerializer.h */; };
+		96ADF6BB235ECB40001289ED /* MSIDServersideTelemetrySerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 96ADF6B9235ECB40001289ED /* MSIDServersideTelemetrySerializer.m */; };
+		96ADF6BC235ECB40001289ED /* MSIDServersideTelemetrySerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 96ADF6B9235ECB40001289ED /* MSIDServersideTelemetrySerializer.m */; };
 		96B8D57B20946D2600E3F4A6 /* MSIDPkce.m in Sources */ = {isa = PBXBuildFile; fileRef = 96B8D57920946D2600E3F4A6 /* MSIDPkce.m */; };
 		96B8D57C20946D2600E3F4A6 /* MSIDPkce.m in Sources */ = {isa = PBXBuildFile; fileRef = 96B8D57920946D2600E3F4A6 /* MSIDPkce.m */; };
 		96B8D57D20946D2600E3F4A6 /* MSIDPkce.h in Headers */ = {isa = PBXBuildFile; fileRef = 96B8D57A20946D2600E3F4A6 /* MSIDPkce.h */; };
@@ -1615,6 +1624,12 @@
 		96A3E9B7208941D700BE5262 /* MSIDSystemWebviewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSystemWebviewController.h; sourceTree = "<group>"; };
 		96A3E9B8208941D700BE5262 /* MSIDSystemWebviewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSystemWebviewController.m; sourceTree = "<group>"; };
 		96A3E9C020895CCE00BE5262 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
+		96ADF6A9235EC813001289ED /* MSIDServersideTelemetry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDServersideTelemetry.h; sourceTree = "<group>"; };
+		96ADF6AA235EC813001289ED /* MSIDServersideTelemetry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDServersideTelemetry.m; sourceTree = "<group>"; };
+		96ADF6B3235ECAD2001289ED /* MSIDServersideTelemetryLast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDServersideTelemetryLast.h; sourceTree = "<group>"; };
+		96ADF6B4235ECAD2001289ED /* MSIDServersideTelemetryLast.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDServersideTelemetryLast.m; sourceTree = "<group>"; };
+		96ADF6B8235ECB40001289ED /* MSIDServersideTelemetrySerializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDServersideTelemetrySerializer.h; sourceTree = "<group>"; };
+		96ADF6B9235ECB40001289ED /* MSIDServersideTelemetrySerializer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDServersideTelemetrySerializer.m; sourceTree = "<group>"; };
 		96B82B6E208DD88F00CAB843 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.2.sdk/System/Library/Frameworks/SafariServices.framework; sourceTree = DEVELOPER_DIR; };
 		96B8D57920946D2600E3F4A6 /* MSIDPkce.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDPkce.m; sourceTree = "<group>"; };
 		96B8D57A20946D2600E3F4A6 /* MSIDPkce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDPkce.h; sourceTree = "<group>"; };
@@ -2772,6 +2787,19 @@
 			path = webview;
 			sourceTree = "<group>";
 		};
+		96ADF6A8235EC7F3001289ED /* serversideTelemetry */ = {
+			isa = PBXGroup;
+			children = (
+				96ADF6A9235EC813001289ED /* MSIDServersideTelemetry.h */,
+				96ADF6AA235EC813001289ED /* MSIDServersideTelemetry.m */,
+				96ADF6B3235ECAD2001289ED /* MSIDServersideTelemetryLast.h */,
+				96ADF6B4235ECAD2001289ED /* MSIDServersideTelemetryLast.m */,
+				96ADF6B8235ECB40001289ED /* MSIDServersideTelemetrySerializer.h */,
+				96ADF6B9235ECB40001289ED /* MSIDServersideTelemetrySerializer.m */,
+			);
+			path = serversideTelemetry;
+			sourceTree = "<group>";
+		};
 		96B8D57820946D1900E3F4A6 /* pkce */ = {
 			isa = PBXGroup;
 			children = (
@@ -2817,6 +2845,7 @@
 		B206578A1FC917D900412B7D /* telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				96ADF6A8235EC7F3001289ED /* serversideTelemetry */,
 				B20657981FC91BE000412B7D /* MSIDTelemetryEventInterface.h */,
 				B20657A41FC91C1600412B7D /* MSIDTelemetryDispatcher.h */,
 				B20657A71FC91DA900412B7D /* MSIDTelemetry.h */,
@@ -3817,7 +3846,6 @@
 				B27CCDD4229EF2C000CAD565 /* MSIDDictionaryExtensionsTests.m */,
 				B223B0A222ADEE4500FB8713 /* MSIDMaskedUsernameLogParameterTests.m */,
 				B223B0A522ADEE5900FB8713 /* MSIDMaskedLogParameterTests.m */,
-				B203197E217BF191006488D0 /* MSIDClientCapabilitiesTests.m */,
 				B2525C742330623E006FBA4B /* MSIDMainThreadUtilTests.m */,
 			);
 			path = tests;
@@ -3967,6 +3995,7 @@
 				238EF03D208FE4730035ABE6 /* MSIDRefreshTokenGrantRequest.h in Headers */,
 				B2C707F02192516700D917B8 /* MSIDTokenRequestProviding.h in Headers */,
 				B20657A81FC91EC900412B7D /* MSIDTelemetry.h in Headers */,
+				96ADF6AB235EC813001289ED /* MSIDServersideTelemetry.h in Headers */,
 				233E96F622652D3A007FCE2A /* MSIDAggregatedDispatcher.h in Headers */,
 				B251CC202040F6C6005E0179 /* MSIDDefaultCredentialCacheKey.h in Headers */,
 				9686480420C7711400EF7E73 /* MSIDAADV1WebviewFactory.h in Headers */,
@@ -4028,6 +4057,7 @@
 				968647FD20C76C6700EF7E73 /* MSIDAADV2WebviewFactory.h in Headers */,
 				238F80A122C2BE1600437CB1 /* MSIDGetV1IdTokenHttpEvent.h in Headers */,
 				23FB5C2F22551866002BF1EB /* MSIDClaimsRequest+ClientCapabilities.h in Headers */,
+				96ADF6B5235ECAD2001289ED /* MSIDServersideTelemetryLast.h in Headers */,
 				B28BDABF221F7F230055FFE6 /* MSIDCBAWebAADAuthResponse.h in Headers */,
 				238EF02F208FD0200035ABE6 /* MSIDHttpRequestConfiguratorProtocol.h in Headers */,
 				B20657AF1FC91FC900412B7D /* MSIDTelemetryEventStrings.h in Headers */,
@@ -4053,6 +4083,7 @@
 				B2C708B4219A620E00D917B8 /* MSIDBrokerCryptoProvider.h in Headers */,
 				B2CDB5791FE33A46003A4B5C /* MSIDAccount.h in Headers */,
 				233E970122655E97007FCE2A /* MSIDTestTelemetryEventsObserver.h in Headers */,
+				96ADF6BA235ECB40001289ED /* MSIDServersideTelemetrySerializer.h in Headers */,
 				B2AF1D40218BD10A0080C1A0 /* MSIDRequestParameters.h in Headers */,
 				B2C7089721991D0000D917B8 /* MSIDAADV2BrokerResponse.h in Headers */,
 				239DF9CA20E05873002D428B /* MSIDConstants.h in Headers */,
@@ -4742,6 +4773,7 @@
 				B210F44C1FDDF5A7005A8F76 /* MSIDClientInfo.m in Sources */,
 				23B37D1C20C9ECFB0018722F /* MSIDCache.m in Sources */,
 				1EFD58C722B44BA200ECD86E /* MSIDMacCredentialStorageItem.m in Sources */,
+				96ADF6BC235ECB40001289ED /* MSIDServersideTelemetrySerializer.m in Sources */,
 				235480C820DDF81000246F72 /* MSIDAuthorityFactory.m in Sources */,
 				968647FF20C76C6700EF7E73 /* MSIDAADV2WebviewFactory.m in Sources */,
 				B27CCDD3229E205C00CAD565 /* NSJSONSerialization+MSIDExtensions.m in Sources */,
@@ -4765,9 +4797,11 @@
 				606830102098E94100CCA6AB /* MSIDCertificateChooser.m in Sources */,
 				B281B336226BB83C009619AB /* MSIDOAuthRequestConfigurator.m in Sources */,
 				B2AF1D23218BCD870080C1A0 /* MSIDSilentController.m in Sources */,
+				96ADF6AD235EC813001289ED /* MSIDServersideTelemetry.m in Sources */,
 				60B3856020A96E2700D546D0 /* MSIDWebviewUIController.m in Sources */,
 				B251CC412041058D005E0179 /* MSIDRefreshToken.m in Sources */,
 				B28BDA7C217E961F003E5670 /* MSIDB2COauth2Factory.m in Sources */,
+				96ADF6B7235ECAD2001289ED /* MSIDServersideTelemetryLast.m in Sources */,
 				2338ECD8208A7B3200809B9E /* MSIDTestContext.m in Sources */,
 				9658103320C7E1180025F4A4 /* MSIDWebviewResponse.m in Sources */,
 				B214C3A51FE855290070C4F2 /* MSIDDefaultTokenCacheAccessor.m in Sources */,
@@ -5170,6 +5204,7 @@
 				B227035A22A3678A00030ADC /* MSIDMaskedUsernameLogParameter.m in Sources */,
 				96A2D5A8209D102900F80E3A /* MSIDWebviewConfiguration.m in Sources */,
 				B23ECEF01FF2F6270015FC1D /* MSIDAADV2IdTokenClaims.m in Sources */,
+				96ADF6BB235ECB40001289ED /* MSIDServersideTelemetrySerializer.m in Sources */,
 				60B3855E20A96E0600D546D0 /* MSIDWebviewUIController.m in Sources */,
 				23FB5C3022551866002BF1EB /* MSIDClaimsRequest+ClientCapabilities.m in Sources */,
 				23FB5C2C225517AA002BF1EB /* MSIDIndividualClaimRequest.m in Sources */,
@@ -5193,9 +5228,11 @@
 				B2C7089821991D0000D917B8 /* MSIDAADV2BrokerResponse.m in Sources */,
 				B28BDA85217E9676003E5670 /* MSIDB2CIdTokenClaims.m in Sources */,
 				B2AF1D27218BCD900080C1A0 /* MSIDBrokerInteractiveController.m in Sources */,
+				96ADF6AC235EC813001289ED /* MSIDServersideTelemetry.m in Sources */,
 				B210F4381FDDEA23005A8F76 /* MSIDAADV1TokenResponse.m in Sources */,
 				B2968C8522F3C3E8005AFC33 /* MSIDBrokerInvocationOptions.m in Sources */,
 				600D19B620964D2F0004CD43 /* MSIDWorkPlaceJoinConstants.m in Sources */,
+				96ADF6B6235ECAD2001289ED /* MSIDServersideTelemetryLast.m in Sources */,
 				96B8D57B20946D2600E3F4A6 /* MSIDPkce.m in Sources */,
 				B28D90A6218FD1E800E230D6 /* MSIDLegacyTokenResponseValidator.m in Sources */,
 				B20657BA1FC9248000412B7D /* MSIDTelemetryAPIEvent.m in Sources */,

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -77,6 +77,10 @@
 
 - (NSURL *)tokenEndpoint;
 
+#pragma mark - Additional serverside telemetry from ADAL/MSAL
+// These are SDK specific and most likely be static
+@property (nonatomic) NSDictionary *additionalTelemetry;
+
 #pragma mark Methods
 - (void)setCloudAuthorityWithCloudHostName:(NSString *)cloudHostName;
 - (NSString *)allTokenRequestScopes;

--- a/IdentityCore/src/requests/MSIDBrokerTokenRequest.h
+++ b/IdentityCore/src/requests/MSIDBrokerTokenRequest.h
@@ -26,6 +26,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class MSIDInteractiveRequestParameters;
+@class MSIDServersideTelemetry;
 
 @interface MSIDBrokerTokenRequest : NSObject
 
@@ -33,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSDictionary *resumeDictionary;
 @property (nonatomic, readonly, nullable) NSURL *brokerRequestURL;
 @property (nonatomic, readonly, nullable) NSString *brokerNonce;
+@property (nonatomic, nullable) MSIDServersideTelemetry *serversideTelemetry;
 
 - (instancetype)initWithRequestParameters:(MSIDInteractiveRequestParameters *)parameters
                                 brokerKey:(NSString *)brokerKey

--- a/IdentityCore/src/requests/MSIDInteractiveTokenRequest.h
+++ b/IdentityCore/src/requests/MSIDInteractiveTokenRequest.h
@@ -30,6 +30,7 @@
 @class MSIDTokenResponseValidator;
 @class MSIDWebWPJResponse;
 @class MSIDAccountMetadataCacheAccessor;
+@class MSIDServersideTelemetry;
 
 #if TARGET_OS_OSX
 @class MSIDExternalAADCacheSeeder;
@@ -44,6 +45,8 @@ typedef void (^MSIDInteractiveRequestCompletionBlock)(MSIDTokenResult * _Nullabl
 @property (nonatomic, readonly, nonnull) id<MSIDCacheAccessor> tokenCache;
 @property (nonatomic, readonly, nonnull) MSIDAccountMetadataCacheAccessor *accountMetadataCache;
 @property (nonatomic, readonly, nonnull) MSIDOauth2Factory *oauthFactory;
+
+@property (nonatomic, nullable) MSIDServersideTelemetry *serversideTelemetry;
 
 #if TARGET_OS_OSX
 @property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;

--- a/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
@@ -83,6 +83,8 @@
 
 - (void)executeRequestWithCompletion:(nonnull MSIDInteractiveRequestCompletionBlock)completionBlock
 {
+    // TODO: Serverside telemetry handling in resolve and/or loadOpenIdMetadata depending on
+    // whether or not we should send telemetry to all endpoints.
     NSString *upn = self.requestParameters.accountIdentifier.displayableId ?: self.requestParameters.loginHint;
 
     [self.requestParameters.authority resolveAndValidate:self.requestParameters.validateAuthority
@@ -244,8 +246,12 @@
                                                                                                                authCode:authCode
                                                                                                           homeAccountId:self.authCodeClientInfo.accountIdentifier];
 
+    // TODO:
+    //   add serverside telemetry to the tokenrequest
     [tokenRequest sendWithBlock:^(MSIDTokenResponse *tokenResponse, NSError *error)
     {
+        
+        // TODO: handle serverside telemetry response and set last telemetry  in MSIDTelemetry
         if (error)
         {
             completionBlock(nil, error, nil);

--- a/IdentityCore/src/telemetry/MSIDTelemetry.h
+++ b/IdentityCore/src/telemetry/MSIDTelemetry.h
@@ -23,6 +23,8 @@
 
 #import "MSIDTelemetryDispatcher.h"
 
+@class MSIDServersideTelemetryLast;
+
 /*!
     @class ADTelemetry
  
@@ -65,5 +67,10 @@
  Remove all telemetry dispatchers added to the dispatchers collection.
  */
 - (void)removeAllDispatchers;
+
+/*!
+ Last server side telemetry data
+*/
+@property (nullable) MSIDServersideTelemetryLast *lastTelemetry;
 
 @end

--- a/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetry.h
+++ b/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetry.h
@@ -22,32 +22,20 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "MSIDConstants.h"
-#import "MSIDCacheAccessor.h"
 
-@class MSIDRequestParameters;
-@class MSIDOauth2Factory;
-@class MSIDTokenResponseValidator;
-@class MSIDServersideTelemetry;
+NS_ASSUME_NONNULL_BEGIN
 
-#if TARGET_OS_OSX
-@class MSIDExternalAADCacheSeeder;
-#endif
+@class MSIDTelemetry;
 
-@interface MSIDSilentTokenRequest : NSObject
+@interface MSIDServersideTelemetry : NSObject
 
-@property (nonatomic, readonly, nullable) MSIDRequestParameters *requestParameters;
-@property (nonatomic, nullable) MSIDServersideTelemetry *serversideTelemetry;
+@property NSDictionary *additionalTelemetry;
+// should this be MSIDTelemetryBaseEvent? do we really need/want to reuse the property?
+@property MSIDTelemetry *telemetryEvent;
 
-#if TARGET_OS_OSX
-@property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;
-#endif
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
-                                      forceRefresh:(BOOL)forceRefresh
-                                      oauthFactory:(nonnull MSIDOauth2Factory *)oauthFactory
-                            tokenResponseValidator:(nonnull MSIDTokenResponseValidator *)tokenResponseValidator;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDRequestCompletionBlock)completionBlock;
+// retrieve payload in key value pair
+@property (readonly) NSDictionary *payload;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetry.m
+++ b/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetry.m
@@ -21,33 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import "MSIDConstants.h"
-#import "MSIDCacheAccessor.h"
+#import "MSIDServersideTelemetry.h"
 
-@class MSIDRequestParameters;
-@class MSIDOauth2Factory;
-@class MSIDTokenResponseValidator;
-@class MSIDServersideTelemetry;
-
-#if TARGET_OS_OSX
-@class MSIDExternalAADCacheSeeder;
-#endif
-
-@interface MSIDSilentTokenRequest : NSObject
-
-@property (nonatomic, readonly, nullable) MSIDRequestParameters *requestParameters;
-@property (nonatomic, nullable) MSIDServersideTelemetry *serversideTelemetry;
-
-#if TARGET_OS_OSX
-@property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;
-#endif
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
-                                      forceRefresh:(BOOL)forceRefresh
-                                      oauthFactory:(nonnull MSIDOauth2Factory *)oauthFactory
-                            tokenResponseValidator:(nonnull MSIDTokenResponseValidator *)tokenResponseValidator;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDRequestCompletionBlock)completionBlock;
+@implementation MSIDServersideTelemetry
 
 @end

--- a/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetryLast.h
+++ b/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetryLast.h
@@ -22,32 +22,14 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "MSIDConstants.h"
-#import "MSIDCacheAccessor.h"
 
-@class MSIDRequestParameters;
-@class MSIDOauth2Factory;
-@class MSIDTokenResponseValidator;
-@class MSIDServersideTelemetry;
+NS_ASSUME_NONNULL_BEGIN
 
-#if TARGET_OS_OSX
-@class MSIDExternalAADCacheSeeder;
-#endif
+@interface MSIDServersideTelemetryLast : NSObject
 
-@interface MSIDSilentTokenRequest : NSObject
-
-@property (nonatomic, readonly, nullable) MSIDRequestParameters *requestParameters;
-@property (nonatomic, nullable) MSIDServersideTelemetry *serversideTelemetry;
-
-#if TARGET_OS_OSX
-@property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;
-#endif
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
-                                      forceRefresh:(BOOL)forceRefresh
-                                      oauthFactory:(nonnull MSIDOauth2Factory *)oauthFactory
-                            tokenResponseValidator:(nonnull MSIDTokenResponseValidator *)tokenResponseValidator;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDRequestCompletionBlock)completionBlock;
+// retrieve payload in key value pair
+@property (readonly) NSDictionary *payload;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetryLast.m
+++ b/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetryLast.m
@@ -21,33 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import "MSIDConstants.h"
-#import "MSIDCacheAccessor.h"
+#import "MSIDServersideTelemetryLast.h"
 
-@class MSIDRequestParameters;
-@class MSIDOauth2Factory;
-@class MSIDTokenResponseValidator;
-@class MSIDServersideTelemetry;
-
-#if TARGET_OS_OSX
-@class MSIDExternalAADCacheSeeder;
-#endif
-
-@interface MSIDSilentTokenRequest : NSObject
-
-@property (nonatomic, readonly, nullable) MSIDRequestParameters *requestParameters;
-@property (nonatomic, nullable) MSIDServersideTelemetry *serversideTelemetry;
-
-#if TARGET_OS_OSX
-@property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;
-#endif
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
-                                      forceRefresh:(BOOL)forceRefresh
-                                      oauthFactory:(nonnull MSIDOauth2Factory *)oauthFactory
-                            tokenResponseValidator:(nonnull MSIDTokenResponseValidator *)tokenResponseValidator;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDRequestCompletionBlock)completionBlock;
+@implementation MSIDServersideTelemetryLast
 
 @end

--- a/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetrySerializer.h
+++ b/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetrySerializer.h
@@ -22,32 +22,13 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "MSIDConstants.h"
-#import "MSIDCacheAccessor.h"
 
-@class MSIDRequestParameters;
-@class MSIDOauth2Factory;
-@class MSIDTokenResponseValidator;
-@class MSIDServersideTelemetry;
+NS_ASSUME_NONNULL_BEGIN
 
-#if TARGET_OS_OSX
-@class MSIDExternalAADCacheSeeder;
-#endif
+@interface MSIDServersideTelemetrySerializer : NSObject
 
-@interface MSIDSilentTokenRequest : NSObject
-
-@property (nonatomic, readonly, nullable) MSIDRequestParameters *requestParameters;
-@property (nonatomic, nullable) MSIDServersideTelemetry *serversideTelemetry;
-
-#if TARGET_OS_OSX
-@property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;
-#endif
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
-                                      forceRefresh:(BOOL)forceRefresh
-                                      oauthFactory:(nonnull MSIDOauth2Factory *)oauthFactory
-                            tokenResponseValidator:(nonnull MSIDTokenResponseValidator *)tokenResponseValidator;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDRequestCompletionBlock)completionBlock;
++ (NSString *)format:(NSDictionary *)payloadDictl;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetrySerializer.m
+++ b/IdentityCore/src/telemetry/serversideTelemetry/MSIDServersideTelemetrySerializer.m
@@ -21,33 +21,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import "MSIDConstants.h"
-#import "MSIDCacheAccessor.h"
+#import "MSIDServersideTelemetrySerializer.h"
 
-@class MSIDRequestParameters;
-@class MSIDOauth2Factory;
-@class MSIDTokenResponseValidator;
-@class MSIDServersideTelemetry;
+@implementation MSIDServersideTelemetrySerializer
 
-#if TARGET_OS_OSX
-@class MSIDExternalAADCacheSeeder;
-#endif
-
-@interface MSIDSilentTokenRequest : NSObject
-
-@property (nonatomic, readonly, nullable) MSIDRequestParameters *requestParameters;
-@property (nonatomic, nullable) MSIDServersideTelemetry *serversideTelemetry;
-
-#if TARGET_OS_OSX
-@property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;
-#endif
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
-                                      forceRefresh:(BOOL)forceRefresh
-                                      oauthFactory:(nonnull MSIDOauth2Factory *)oauthFactory
-                            tokenResponseValidator:(nonnull MSIDTokenResponseValidator *)tokenResponseValidator;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDRequestCompletionBlock)completionBlock;
++ (NSString *)format:(NSDictionary *)payloadDict
+{
+    // make it conform to the format
+    return @"";
+}
 
 @end


### PR DESCRIPTION
Context:
MSAL will need to set "additionalTelemetry" for it's specific needs. This is most likely going to be static. 
For common serverside telemetry, there is current and last.
-  Last will be stored in the msidtelemetry singleton's property at the response handling of a http request
-  current will be set/sent with the request

 Open discussion would be on how much of this should be commonly used or integrated with the currentl telemetry implementation which seems to be focused on the clientside telemetry.