### PR TITLE
Componentize macOS ACL keychain operations

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1120,6 +1120,7 @@
 		B2EF143A1FF2F225005DC1C0 /* MSIDAADV2TokenResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = B2EF14391FF2F21E005DC1C0 /* MSIDAADV2TokenResponse.h */; };
 		B2EF143B1FF2F228005DC1C0 /* MSIDAADV2TokenResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B2EF14381FF2F21D005DC1C0 /* MSIDAADV2TokenResponse.m */; };
 		B2EF143C1FF2F228005DC1C0 /* MSIDAADV2TokenResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B2EF14381FF2F21D005DC1C0 /* MSIDAADV2TokenResponse.m */; };
+		B2F7C96B2368FCAC00627A7C /* MSIDMacACLKeychainAccessorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C96A2368FCAC00627A7C /* MSIDMacACLKeychainAccessorTests.m */; };
 		B4A5ACCD21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = B4A5ACCB21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.h */; };
 		B4A5ACCF21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A5ACCC21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m */; };
 		B4A5ACD221F7F25400D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A5ACCC21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m */; };
@@ -2066,6 +2067,7 @@
 		B2ED1BB32204D26700A24E82 /* libIdentityAutomationTestLib Mac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIdentityAutomationTestLib Mac.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2EF14381FF2F21D005DC1C0 /* MSIDAADV2TokenResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV2TokenResponse.m; sourceTree = "<group>"; };
 		B2EF14391FF2F21E005DC1C0 /* MSIDAADV2TokenResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAADV2TokenResponse.h; sourceTree = "<group>"; };
+		B2F7C96A2368FCAC00627A7C /* MSIDMacACLKeychainAccessorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMacACLKeychainAccessorTests.m; sourceTree = "<group>"; };
 		B4A5ACCB21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDAccountCacheItem+MSIDAccountMatchers.h"; sourceTree = "<group>"; };
 		B4A5ACCC21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDAccountCacheItem+MSIDAccountMatchers.m"; sourceTree = "<group>"; };
 		D626000F1FBD380500EE4487 /* NSString+MSIDExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+MSIDExtensions.m"; sourceTree = "<group>"; };
@@ -3827,6 +3829,7 @@
 				B223B0A222ADEE4500FB8713 /* MSIDMaskedUsernameLogParameterTests.m */,
 				B223B0A522ADEE5900FB8713 /* MSIDMaskedLogParameterTests.m */,
 				B2525C742330623E006FBA4B /* MSIDMainThreadUtilTests.m */,
+				B2F7C96A2368FCAC00627A7C /* MSIDMacACLKeychainAccessorTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -4979,6 +4982,7 @@
 				23AE9DA8213A169200B285F3 /* MSIDOpenIdConfigurationInfoResponseSerializerTests.m in Sources */,
 				B2DD5B952047564C0084313F /* MSIDCredentialTypeTests.m in Sources */,
 				B28BBD40221267B200F51723 /* MSIDLegacyTokenResponseValidatorTests.m in Sources */,
+				B2F7C96B2368FCAC00627A7C /* MSIDMacACLKeychainAccessorTests.m in Sources */,
 				B29A36B920AFAAF200427B63 /* MSIDLegacyAccessorSSOIntegrationTests.m in Sources */,
 				B2DD5BC320479D9D0084313F /* MSIDKeyedArchiverSerializerTests.m in Sources */,
 				238EF081208FFA4C0035ABE6 /* MSIDUrlRequestSerializerTests.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -738,6 +738,8 @@
 		B26A0B942072B824006BD95A /* MSIDAADOauth2FactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B26A0B922072B824006BD95A /* MSIDAADOauth2FactoryTests.m */; };
 		B26A0B972072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B26A0B952072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m */; };
 		B26A0B9A2072BABE006BD95A /* MSIDAADV2Oauth2FactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B26A0B982072BABD006BD95A /* MSIDAADV2Oauth2FactoryTests.m */; };
+		B26CEADA23652795009E6E54 /* MSIDMacACLKeychainAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = B26CEAD823652795009E6E54 /* MSIDMacACLKeychainAccessor.h */; };
+		B26CEADB23652795009E6E54 /* MSIDMacACLKeychainAccessor.m in Sources */ = {isa = PBXBuildFile; fileRef = B26CEAD923652795009E6E54 /* MSIDMacACLKeychainAccessor.m */; };
 		B274DEC721FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */; };
 		B274DEC821FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */; };
 		B27551C22081705300AA7A38 /* MSIDJWTHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7590C207EE9A400C1FE74 /* MSIDJWTHelper.m */; };
@@ -1806,6 +1808,8 @@
 		B26A0B922072B824006BD95A /* MSIDAADOauth2FactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADOauth2FactoryTests.m; sourceTree = "<group>"; };
 		B26A0B952072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV1Oauth2FactoryTests.m; sourceTree = "<group>"; };
 		B26A0B982072BABD006BD95A /* MSIDAADV2Oauth2FactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV2Oauth2FactoryTests.m; sourceTree = "<group>"; };
+		B26CEAD823652795009E6E54 /* MSIDMacACLKeychainAccessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDMacACLKeychainAccessor.h; sourceTree = "<group>"; };
+		B26CEAD923652795009E6E54 /* MSIDMacACLKeychainAccessor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMacACLKeychainAccessor.m; sourceTree = "<group>"; };
 		B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDInteractiveRequestParametersTests.m; sourceTree = "<group>"; };
 		B27551AF20816B4800AA7A38 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		B27551C8208179EE00AA7A38 /* libIdentityAutomationAppLib iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIdentityAutomationAppLib iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3008,6 +3012,8 @@
 				05566D0F2204BB8A002DBA40 /* MSIDMacKeychainTokenCache.m */,
 				1EFD58C322B43A4500ECD86E /* MSIDMacCredentialStorageItem.h */,
 				1EFD58C422B43A4500ECD86E /* MSIDMacCredentialStorageItem.m */,
+				B26CEAD823652795009E6E54 /* MSIDMacACLKeychainAccessor.h */,
+				B26CEAD923652795009E6E54 /* MSIDMacACLKeychainAccessor.m */,
 			);
 			path = mac;
 			sourceTree = "<group>";
@@ -3814,7 +3820,6 @@
 				B27CCDD4229EF2C000CAD565 /* MSIDDictionaryExtensionsTests.m */,
 				B223B0A222ADEE4500FB8713 /* MSIDMaskedUsernameLogParameterTests.m */,
 				B223B0A522ADEE5900FB8713 /* MSIDMaskedLogParameterTests.m */,
-				B203197E217BF191006488D0 /* MSIDClientCapabilitiesTests.m */,
 				B2525C742330623E006FBA4B /* MSIDMainThreadUtilTests.m */,
 			);
 			path = tests;
@@ -3885,6 +3890,7 @@
 				232C657A2137684E002A41FE /* MSIDDRSDiscoveryResponseSerializer.h in Headers */,
 				96F94A39208184790034676C /* MSIDOAuth2EmbeddedWebviewController.h in Headers */,
 				B2000C9920EC64CA0092790A /* MSIDCredentialType.h in Headers */,
+				B26CEADA23652795009E6E54 /* MSIDMacACLKeychainAccessor.h in Headers */,
 				B223B09E22ADD86500FB8713 /* MSIDCacheItemSerializing.h in Headers */,
 				B2000C9820EC64AC0092790A /* MSIDTelemetryCacheEvent.h in Headers */,
 				B2000C9D20EC653A0092790A /* MSIDAADV1IdTokenClaims.h in Headers */,
@@ -4924,6 +4930,7 @@
 				B2CDB5741FE2F4DF003A4B5C /* NSOrderedSet+MSIDExtensions.m in Sources */,
 				96C998F120B638F60053A2D9 /* MSIDWebviewSession.m in Sources */,
 				96891A982190F15E00D7F437 /* MSIDWPJChallengeHandler.m in Sources */,
+				B26CEADB23652795009E6E54 /* MSIDMacACLKeychainAccessor.m in Sources */,
 				96090D9A20E59B2000E42B37 /* MSIDNotifications.m in Sources */,
 				23D2049521D1C274009B5975 /* MSIDTokenResponseSerializer.m in Sources */,
 				96F94A2920816B870034676C /* MSIDWebOAuth2Response.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -740,6 +740,8 @@
 		B26A0B9A2072BABE006BD95A /* MSIDAADV2Oauth2FactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B26A0B982072BABD006BD95A /* MSIDAADV2Oauth2FactoryTests.m */; };
 		B26CEADA23652795009E6E54 /* MSIDMacACLKeychainAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = B26CEAD823652795009E6E54 /* MSIDMacACLKeychainAccessor.h */; };
 		B26CEADB23652795009E6E54 /* MSIDMacACLKeychainAccessor.m in Sources */ = {isa = PBXBuildFile; fileRef = B26CEAD923652795009E6E54 /* MSIDMacACLKeychainAccessor.m */; };
+		B26CEADE2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B26CEADC2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.h */; };
+		B26CEADF2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B26CEADD2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.m */; };
 		B274DEC721FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */; };
 		B274DEC821FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */; };
 		B27551C22081705300AA7A38 /* MSIDJWTHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7590C207EE9A400C1FE74 /* MSIDJWTHelper.m */; };
@@ -1810,6 +1812,8 @@
 		B26A0B982072BABD006BD95A /* MSIDAADV2Oauth2FactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV2Oauth2FactoryTests.m; sourceTree = "<group>"; };
 		B26CEAD823652795009E6E54 /* MSIDMacACLKeychainAccessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDMacACLKeychainAccessor.h; sourceTree = "<group>"; };
 		B26CEAD923652795009E6E54 /* MSIDMacACLKeychainAccessor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMacACLKeychainAccessor.m; sourceTree = "<group>"; };
+		B26CEADC2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDMacLegacyCachePersistenceHandler.h; sourceTree = "<group>"; };
+		B26CEADD2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMacLegacyCachePersistenceHandler.m; sourceTree = "<group>"; };
 		B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDInteractiveRequestParametersTests.m; sourceTree = "<group>"; };
 		B27551AF20816B4800AA7A38 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		B27551C8208179EE00AA7A38 /* libIdentityAutomationAppLib iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIdentityAutomationAppLib iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3014,6 +3018,8 @@
 				1EFD58C422B43A4500ECD86E /* MSIDMacCredentialStorageItem.m */,
 				B26CEAD823652795009E6E54 /* MSIDMacACLKeychainAccessor.h */,
 				B26CEAD923652795009E6E54 /* MSIDMacACLKeychainAccessor.m */,
+				B26CEADC2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.h */,
+				B26CEADD2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.m */,
 			);
 			path = mac;
 			sourceTree = "<group>";
@@ -4068,6 +4074,7 @@
 				96891A962190F15E00D7F437 /* MSIDWPJChallengeHandler.h in Headers */,
 				B20657A51FC91C1600412B7D /* MSIDTelemetryDispatcher.h in Headers */,
 				B281B334226BB83C009619AB /* MSIDOAuthRequestConfigurator.h in Headers */,
+				B26CEADE2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.h in Headers */,
 				238E19CB2086FC87004DF483 /* MSIDUrlRequestSerializer.h in Headers */,
 				233E96F322652C5B007FCE2A /* MSIDTelemetryEventsObserving.h in Headers */,
 				96F21B1A20A65187002B87C3 /* MSIDWebviewInteracting.h in Headers */,
@@ -4907,6 +4914,7 @@
 				B2B1D57A204369D600DD81F0 /* MSIDAccountType.m in Sources */,
 				B210F4571FDDFA7B005A8F76 /* MSIDBrokerResponse.m in Sources */,
 				23F9FD4822EC08D800DAB65D /* NSKeyedUnarchiver+MSIDExtensions.m in Sources */,
+				B26CEADF2365311E009E6E54 /* MSIDMacLegacyCachePersistenceHandler.m in Sources */,
 				23B39AC8209BF9F2000AA905 /* MSIDOpenIdConfigurationInfoRequest.m in Sources */,
 				23D7447A2097B2DA00210C51 /* MSIDAADV1AuthorizationCodeRequest.m in Sources */,
 				23642AB8218805B000F97009 /* MSIDIntuneMAMResourcesCache.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1120,6 +1120,7 @@
 		B2EF143A1FF2F225005DC1C0 /* MSIDAADV2TokenResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = B2EF14391FF2F21E005DC1C0 /* MSIDAADV2TokenResponse.h */; };
 		B2EF143B1FF2F228005DC1C0 /* MSIDAADV2TokenResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B2EF14381FF2F21D005DC1C0 /* MSIDAADV2TokenResponse.m */; };
 		B2EF143C1FF2F228005DC1C0 /* MSIDAADV2TokenResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B2EF14381FF2F21D005DC1C0 /* MSIDAADV2TokenResponse.m */; };
+		B2F6C7E4236BD01500C8D3AE /* MSIDMacLegacyCachePersistenceHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F6C7E3236BD01500C8D3AE /* MSIDMacLegacyCachePersistenceHandlerTests.m */; };
 		B2F7C96B2368FCAC00627A7C /* MSIDMacACLKeychainAccessorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C96A2368FCAC00627A7C /* MSIDMacACLKeychainAccessorTests.m */; };
 		B4A5ACCD21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = B4A5ACCB21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.h */; };
 		B4A5ACCF21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A5ACCC21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m */; };
@@ -2067,6 +2068,7 @@
 		B2ED1BB32204D26700A24E82 /* libIdentityAutomationTestLib Mac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIdentityAutomationTestLib Mac.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2EF14381FF2F21D005DC1C0 /* MSIDAADV2TokenResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV2TokenResponse.m; sourceTree = "<group>"; };
 		B2EF14391FF2F21E005DC1C0 /* MSIDAADV2TokenResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAADV2TokenResponse.h; sourceTree = "<group>"; };
+		B2F6C7E3236BD01500C8D3AE /* MSIDMacLegacyCachePersistenceHandlerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMacLegacyCachePersistenceHandlerTests.m; sourceTree = "<group>"; };
 		B2F7C96A2368FCAC00627A7C /* MSIDMacACLKeychainAccessorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMacACLKeychainAccessorTests.m; sourceTree = "<group>"; };
 		B4A5ACCB21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDAccountCacheItem+MSIDAccountMatchers.h"; sourceTree = "<group>"; };
 		B4A5ACCC21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDAccountCacheItem+MSIDAccountMatchers.m"; sourceTree = "<group>"; };
@@ -3830,6 +3832,7 @@
 				B223B0A522ADEE5900FB8713 /* MSIDMaskedLogParameterTests.m */,
 				B2525C742330623E006FBA4B /* MSIDMainThreadUtilTests.m */,
 				B2F7C96A2368FCAC00627A7C /* MSIDMacACLKeychainAccessorTests.m */,
+				B2F6C7E3236BD01500C8D3AE /* MSIDMacLegacyCachePersistenceHandlerTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -5068,6 +5071,7 @@
 				B2DD5BB2204789FB0084313F /* MSIDIdTokenTests.m in Sources */,
 				232C657721376755002A41FE /* MSIDDRSDiscoveryResponseSerializerTests.m in Sources */,
 				B279835B20D33A0A0051167F /* MSIDIdTokenClaimsTests.m in Sources */,
+				B2F6C7E4236BD01500C8D3AE /* MSIDMacLegacyCachePersistenceHandlerTests.m in Sources */,
 				B20657D01FC92B8F00412B7D /* MSIDTelemetryUIEventTests.m in Sources */,
 				B26A0B972072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m in Sources */,
 				B2DD5BA2204761660084313F /* MSIDLegacySingleResourceTokenTests.m in Sources */,

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.h
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.h
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDMacACLKeychainAccessor : NSObject
+
+@property (readonly, nonnull) id accessControlForSharedItems;
+@property (readonly, nonnull) id accessControlForNonSharedItems;
+
+#pragma mark - Init
+
+- (nullable instancetype)initWithTrustedApplications:(nullable NSArray *)trustedApplications
+                                         accessLabel:(nonnull NSString *)accessLabel
+                                               error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+#pragma mark - Operations
+
+- (BOOL)saveData:(nonnull NSData *)data
+      attributes:(nonnull NSDictionary *)attributes
+         context:(nullable id<MSIDRequestContext>)context
+           error:(NSError * _Nullable * _Nullable)error;
+
+
+- (BOOL)removeItemWithAttributes:(nonnull NSDictionary *)attributes
+                         context:(nullable id<MSIDRequestContext>)context
+                           error:(NSError * _Nullable * _Nullable)error;
+
+
+- (nullable NSData *)getDataWithAttributes:(nonnull NSDictionary *)attributes
+                                   context:(nullable id<MSIDRequestContext>)context
+                                     error:(NSError * _Nullable * _Nullable)error;
+
+- (BOOL)clearWithAttributes:(nonnull NSDictionary *)attributes
+                    context:(nullable id<MSIDRequestContext>)context
+                      error:(NSError * _Nullable * _Nullable)error;
+
+#pragma mark - Util
+
+- (BOOL)createError:(nonnull NSString *)message
+             domain:(nonnull NSErrorDomain)domain
+          errorCode:(NSInteger)code
+              error:(NSError *_Nullable *_Nullable)error
+            context:(nullable id<MSIDRequestContext>)context;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -201,11 +201,16 @@ static dispatch_queue_t s_synchronizationQueue;
          context:(id<MSIDRequestContext>)context
            error:(NSError **)error
 {
-    assert(data);
+    if (!data)
+    {
+        [self createError:@"Nil data provided" domain:MSIDErrorDomain errorCode:MSIDErrorInvalidInternalParameter error:error context:context];
+        return NO;
+    }
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Saving keychain item");
     
     NSMutableDictionary *query = [NSMutableDictionary new];
+    query[(id)kSecClass] = (id)kSecClassGenericPassword;
     [query addEntriesFromDictionary:attributes];
     NSMutableDictionary *updateQuery = [NSMutableDictionary new];
     updateQuery[(id)kSecValueData] = data;
@@ -265,6 +270,7 @@ static dispatch_queue_t s_synchronizationQueue;
                             error:(NSError **)error
 {
     NSMutableDictionary *query = [NSMutableDictionary new];
+    query[(id)kSecClass] = (id)kSecClassGenericPassword;
     [query addEntriesFromDictionary:attributes];
     query[(id)kSecReturnAttributes] = (__bridge id)kCFBooleanTrue;
     query[(id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
@@ -311,6 +317,7 @@ static dispatch_queue_t s_synchronizationQueue;
     
     // Delete all accounts for the keychainGroup
     NSMutableDictionary *query = [NSMutableDictionary new];
+    query[(id)kSecClass] = (id)kSecClassGenericPassword;
     [query addEntriesFromDictionary:attributes];
     
     query[(id)kSecMatchLimit] = (id)kSecMatchLimitAll;

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -244,6 +244,7 @@ static dispatch_queue_t s_synchronizationQueue;
                            error:(NSError **)error
 {
     NSMutableDictionary *query = [NSMutableDictionary new];
+    query[(id)kSecClass] = (id)kSecClassGenericPassword;
     [query addEntriesFromDictionary:attributes];
     
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Trying to delete keychain items...");

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -55,12 +55,11 @@ static dispatch_queue_t s_synchronizationQueue;
             return nil;
         }
         
-        if (![trustedApplications count])
-        {
-            trustedApplications = appList;
-        }
+        NSMutableArray *allTrustedApps = [NSMutableArray new];
+        [allTrustedApps addObjectsFromArray:trustedApplications];
+        [allTrustedApps addObjectsFromArray:appList];
         
-        self.accessControlForSharedItems = [self accessCreateWithChangeACL:trustedApplications accessLabel:accessLabel error:error];
+        self.accessControlForSharedItems = [self accessCreateWithChangeACL:allTrustedApps accessLabel:accessLabel error:error];
         if (!self.accessControlForSharedItems)
         {
             return nil;

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -1,0 +1,338 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDMacACLKeychainAccessor.h"
+#import "MSIDLogger+Trace.h"
+#import "MSIDLogger+Internal.h"
+#import "MSIDKeychainUtil.h"
+
+static dispatch_queue_t s_synchronizationQueue;
+
+@interface MSIDMacACLKeychainAccessor ()
+
+@property (readwrite, nonnull) id accessControlForSharedItems;
+@property (readwrite, nonnull) id accessControlForNonSharedItems;
+
+@end
+
+@implementation MSIDMacACLKeychainAccessor
+
+#pragma mark - Init
+
+- (nullable instancetype)initWithTrustedApplications:(nullable NSArray *)trustedApplications
+                                         accessLabel:(nonnull NSString *)accessLabel
+                                               error:(NSError * _Nullable __autoreleasing * _Nullable)error
+{
+    MSID_TRACE;
+
+    self = [super init];
+    if (self)
+    {
+        NSArray *appList = [self createTrustedAppListWithCurrentApp:error];
+        
+        if (![appList count])
+        {
+            return nil;
+        }
+        
+        if (![trustedApplications count])
+        {
+            trustedApplications = appList;
+        }
+        
+        self.accessControlForSharedItems = [self accessCreateWithChangeACL:trustedApplications accessLabel:accessLabel error:error];
+        if (!self.accessControlForSharedItems)
+        {
+            return nil;
+        }
+        
+        self.accessControlForNonSharedItems = [self accessCreateWithChangeACL:appList accessLabel:accessLabel error:error];
+        if (!self.accessControlForNonSharedItems)
+        {
+            return nil;
+        }
+
+        // Note: Apple seems to recommend serializing keychain API calls on macOS in this document:
+        // https://developer.apple.com/documentation/security/certificate_key_and_trust_services/working_with_concurrency?language=objc
+        // However, it's not entirely clear if this applies to all keychain APIs.
+        // Since our applications often perform a large number of cache reads on mulitple threads, it would be preferable to
+        // allow concurrent readers, even if writes are serialized. For this reason this is a concurrent queue, and the
+        // dispatch queue calls are used. We intend to clarify this behavior with Apple.
+        //
+        // To protect the underlying keychain API, a single queue is used even if multiple instances of this class are allocated.
+        static dispatch_once_t s_once;
+        dispatch_once(&s_once, ^{
+            s_synchronizationQueue = dispatch_queue_create("com.microsoft.msidmackeychaintokencache", DISPATCH_QUEUE_CONCURRENT);
+        });
+
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Init MSIDMacACLPersistentTokenCache");
+    }
+
+    return self;
+}
+
+#pragma mark - Access Control Lists
+
+- (NSArray *)createTrustedAppListWithCurrentApp:(NSError **)error
+{
+    SecTrustedApplicationRef trustedApplication = nil;
+    OSStatus status = SecTrustedApplicationCreateFromPath(nil, &trustedApplication);
+    if (status != errSecSuccess)
+    {
+        [self createError:@"Failed to create SecTrustedApplicationRef for current application. Please make sure the app you're running is properly signed and keychain access group is configured."
+                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:nil];
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create SecTrustedApplicationRef for current application. Please make sure the app you're running is properly signed and keychain access group is configured (status: %d).", (int)status);
+        return nil;
+    }
+    
+    NSArray *trustedApplications = @[(__bridge_transfer id)trustedApplication];
+    return trustedApplications;
+}
+
+- (id)accessCreateWithChangeACL:(NSArray<id> *)trustedApplications
+                    accessLabel:(NSString *)accessLabel
+                          error:(NSError **)error
+{
+    SecAccessRef access;
+    OSStatus status = SecAccessCreate((__bridge CFStringRef)accessLabel, (__bridge CFArrayRef)trustedApplications, &access);
+    
+    if (status != errSecSuccess)
+    {
+        [self createError:@"Failed to create SecAccessRef for current application. Please make sure the app you're running is properly signed and keychain access group is configured."
+                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:nil];
+         MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create SecAccessRef for current application. Please make sure the app you're running is properly signed and keychain access group is configured (status: %d).", (int)status);
+        return nil;
+    }
+    
+    if (![self accessSetACLTrustedApplications:access
+                           aclAuthorizationTag:kSecACLAuthorizationDecrypt
+                           trustedApplications:trustedApplications
+                                       context:nil
+                                         error:error])
+    {
+        CFReleaseNull(access);
+        return nil;
+    }
+    
+    return CFBridgingRelease(access);
+}
+
+- (BOOL)accessSetACLTrustedApplications:(SecAccessRef)access
+                     aclAuthorizationTag:(CFStringRef)aclAuthorizationTag
+                     trustedApplications:(NSArray<id> *)trustedApplications
+                                 context:(id<MSIDRequestContext>)context
+                                   error:(NSError **)error
+{
+    NSArray *acls = (__bridge_transfer NSArray*)SecAccessCopyMatchingACLList(access, aclAuthorizationTag);
+    OSStatus status;
+    CFStringRef description = nil;
+    CFArrayRef oldtrustedAppList = nil;
+    SecKeychainPromptSelector selector;
+    
+    // TODO: handle case where tag is not found?
+    for (id acl in acls)
+    {
+        status = SecACLCopyContents((__bridge SecACLRef)acl, &oldtrustedAppList, &description, &selector);
+        
+        if (status != errSecSuccess)
+        {
+            [self createError:@"Failed to get contents from ACL. Please make sure the app you're running is properly signed and keychain access group is configured." domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
+             MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to get contents from ACL. Please make sure the app you're running is properly signed and keychain access group is configured(status: %d).", (int)status);
+            return NO;
+        }
+        
+        status = SecACLSetContents((__bridge SecACLRef)acl, (__bridge CFArrayRef)trustedApplications, description, selector);
+        
+        if (status != errSecSuccess)
+        {
+            [self createError:@"Failed to set contents for ACL. Please make sure the app you're running is properly signed and keychain access group is configured." domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to set contents for ACL. Please make sure the app you're running is properly signed and keychain access group is configured (status: %d).", (int)status);
+            CFReleaseNull(oldtrustedAppList);
+            CFReleaseNull(description);
+            return NO;
+        }
+    }
+    
+    CFReleaseNull(oldtrustedAppList);
+    CFReleaseNull(description);
+    return YES;
+}
+
+#pragma mark - Utils
+
+- (BOOL)createError:(NSString*)message
+             domain:(NSErrorDomain)domain
+          errorCode:(NSInteger)code
+              error:(NSError *_Nullable *_Nullable)error
+            context:(id<MSIDRequestContext>)context
+{
+    MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"%@", message);
+    if (error)
+    {
+        *error = MSIDCreateError(domain, code, message, nil, nil, nil, context.correlationId, nil, NO);
+    }
+    
+    return YES;
+}
+
+#pragma mark - Operations
+
+- (BOOL)saveData:(NSData *)data
+      attributes:(NSDictionary *)attributes
+         context:(id<MSIDRequestContext>)context
+           error:(NSError **)error
+{
+    assert(data);
+    
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Saving keychain item");
+    
+    NSMutableDictionary *query = [NSMutableDictionary new];
+    [query addEntriesFromDictionary:attributes];
+    NSMutableDictionary *updateQuery = [NSMutableDictionary new];
+    updateQuery[(id)kSecValueData] = data;
+    
+    __block OSStatus status;
+    dispatch_barrier_sync(s_synchronizationQueue, ^{
+        status = SecItemUpdate((CFDictionaryRef)query, (CFDictionaryRef)updateQuery);
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Keychain update status: %d.", (int)status);
+        
+        if (status == errSecItemNotFound)
+        {
+            [query addEntriesFromDictionary:updateQuery];
+            status = SecItemAdd((CFDictionaryRef)query, NULL);
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Keychain add status: %d.", (int)status);
+        }
+    });
+    
+    if (status != errSecSuccess)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to write item to keychain (status: %d).", (int)status);
+        [self createError:@"Failed to write item to keychain."
+                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (BOOL)removeItemWithAttributes:(NSDictionary *)attributes
+                         context:(id<MSIDRequestContext>)context
+                           error:(NSError **)error
+{
+    NSMutableDictionary *query = [NSMutableDictionary new];
+    [query addEntriesFromDictionary:attributes];
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Trying to delete keychain items...");
+    __block OSStatus status;
+    dispatch_barrier_sync(s_synchronizationQueue, ^{
+        status = SecItemDelete((CFDictionaryRef)query);
+    });
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Keychain delete status: %d.", (int)status);
+    
+    if (status != errSecSuccess && status != errSecItemNotFound)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to remove multiple items from keychain (status: %d).", (int)status);
+        [self createError:@"Failed to remove multiple items from keychain."
+                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (NSData *)getDataWithAttributes:(NSDictionary *)attributes
+                          context:(id<MSIDRequestContext>)context
+                            error:(NSError **)error
+{
+    NSMutableDictionary *query = [NSMutableDictionary new];
+    [query addEntriesFromDictionary:attributes];
+    query[(id)kSecReturnAttributes] = (__bridge id)kCFBooleanTrue;
+    query[(id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Trying to find keychain items...");
+    
+    __block CFDictionaryRef result = nil;
+    __block OSStatus status;
+    
+    dispatch_sync(s_synchronizationQueue, ^{
+        status = SecItemCopyMatching((CFDictionaryRef)query, (CFTypeRef *)&result);
+    });
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Keychain find status: %d.", (int)status);
+        
+    if (status == errSecSuccess)
+    {
+        NSDictionary *resultDict = (__bridge_transfer NSDictionary *)result;
+        NSData *storageData = [resultDict objectForKey:(id)kSecValueData];
+        return storageData;
+    }
+    else if (status == errSecItemNotFound)
+    {
+        return nil;
+    }
+    else
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to read stored item from keychain (status: %d).", (int)status);
+        [self createError:@"Failed to read stored item from keychain."
+                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
+        return nil;
+    }
+}
+
+#pragma mark - Clear
+
+// A test-only method that deletes all items from the cache for the given context.
+- (BOOL)clearWithAttributes:(NSDictionary *)attributes
+                    context:(id<MSIDRequestContext>)context
+                      error:(NSError **)error
+
+{
+    MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"Clearing the whole context. This should only be executed in tests.");
+    
+    // Delete all accounts for the keychainGroup
+    NSMutableDictionary *query = [NSMutableDictionary new];
+    [query addEntriesFromDictionary:attributes];
+    
+    query[(id)kSecMatchLimit] = (id)kSecMatchLimitAll;
+    MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,context, @"Trying to delete keychain items...");
+    __block OSStatus status;
+    dispatch_barrier_sync(s_synchronizationQueue, ^{
+        status = SecItemDelete((CFDictionaryRef)query);
+    });
+    MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,context, @"Keychain delete status: %d.", (int)status);
+
+    if (status != errSecSuccess && status != errSecItemNotFound)
+    {
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDKeychainErrorDomain, status, @"Failed to remove items from keychain.", nil, nil, nil, context.correlationId, nil, NO);
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to delete keychain items (status: %d).", (int)status);
+        }
+        return NO;
+    }
+
+    return YES;
+}
+
+@end

--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.h
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.h
@@ -23,9 +23,10 @@
 
 #import <Foundation/Foundation.h>
 #import "MSIDExtendedTokenCacheDataSource.h"
+#import "MSIDMacACLKeychainAccessor.h"
 
 // TODO: Use a subclass or protocol: https://identitydivision.visualstudio.com/DevEx/_workitems/edit/660964
-@interface MSIDMacKeychainTokenCache : NSObject <MSIDExtendedTokenCacheDataSource>
+@interface MSIDMacKeychainTokenCache : MSIDMacACLKeychainAccessor <MSIDExtendedTokenCacheDataSource>
 
 /*!
  The name of the group to be used by default when creating an instance of MSIDKeychainTokenCache,

--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -297,7 +297,6 @@ References(s):
 static NSString *s_defaultKeychainGroup = @"com.microsoft.identity.universalstorage";
 static NSString *s_defaultKeychainLabel = @"Microsoft Credentials";
 static MSIDMacKeychainTokenCache *s_defaultCache = nil;
-static dispatch_queue_t s_synchronizationQueue;
 static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 
 @interface MSIDMacKeychainTokenCache ()
@@ -308,8 +307,6 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 @property MSIDMacCredentialStorageItem *appStorageItem;
 @property MSIDMacCredentialStorageItem *sharedStorageItem;
 @property MSIDCacheItemJsonSerializer *serializer;
-@property (readwrite, nonnull) id accessForSharedBlob;
-@property (readwrite, nonnull) id accessForNonSharedBlob;
 
 @end
 
@@ -384,7 +381,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 {
     MSID_TRACE;
 
-    self = [super init];
+    self = [super initWithTrustedApplications:trustedApplications accessLabel:s_defaultKeychainLabel error:error];
     if (self)
     {
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
@@ -444,45 +441,8 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
             return nil;
         }
         
-        NSArray *appList = [self createTrustedAppListWithCurrentApp:error];
-        
-        if (![appList count])
-        {
-            return nil;
-        }
-        
-        if (![trustedApplications count])
-        {
-            trustedApplications = appList;
-        }
-        
-        self.accessForSharedBlob = [self accessCreateWithChangeACL:trustedApplications error:error];
-        if (!self.accessForSharedBlob)
-        {
-            return nil;
-        }
-        
-        self.accessForNonSharedBlob = [self accessCreateWithChangeACL:appList error:error];
-        if (!self.accessForNonSharedBlob)
-        {
-            return nil;
-        }
-        
         self.appIdentifier = [NSString stringWithFormat:@"%@;%d", NSBundle.mainBundle.bundleIdentifier,
                               NSProcessInfo.processInfo.processIdentifier];
-
-        // Note: Apple seems to recommend serializing keychain API calls on macOS in this document:
-        // https://developer.apple.com/documentation/security/certificate_key_and_trust_services/working_with_concurrency?language=objc
-        // However, it's not entirely clear if this applies to all keychain APIs.
-        // Since our applications often perform a large number of cache reads on mulitple threads, it would be preferable to
-        // allow concurrent readers, even if writes are serialized. For this reason this is a concurrent queue, and the
-        // dispatch queue calls are used. We intend to clarify this behavior with Apple.
-        //
-        // To protect the underlying keychain API, a single queue is used even if multiple instances of this class are allocated.
-        static dispatch_once_t s_once;
-        dispatch_once(&s_once, ^{
-            s_synchronizationQueue = dispatch_queue_create("com.microsoft.msidmackeychaintokencache", DISPATCH_QUEUE_CONCURRENT);
-        });
 
         self.defaultCacheQuery = @{
                                    // All account items are saved as generic passwords.
@@ -817,31 +777,11 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     NSMutableDictionary *query = [self.defaultCacheQuery mutableCopy];
     [query addEntriesFromDictionary:[self primaryAttributesForItem:isShared context:context error:error]];
     query[(id)kSecAttrService] = s_defaultKeychainLabel;
-    NSMutableDictionary *update = [NSMutableDictionary dictionary];
-    update[(id)kSecValueData] = itemData;
     
-    __block OSStatus status;
-    dispatch_barrier_sync(s_synchronizationQueue, ^{
-        status = SecItemUpdate((CFDictionaryRef)query, (CFDictionaryRef)update);
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Keychain update status: %d.", (int)status);
-        
-        if (status == errSecItemNotFound)
-        {
-            [query addEntriesFromDictionary:update];
-            status = SecItemAdd((CFDictionaryRef)query, NULL);
-            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Keychain add status: %d.", (int)status);
-        }
-    });
-    
-    if (status != errSecSuccess)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to write item to keychain (status: %d).", (int)status);
-        [self createError:@"Failed to write item to keychain."
-                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
-        return NO;
-    }
-    
-    return YES;
+    return [self saveData:itemData
+               attributes:query
+                  context:context
+                    error:error];
 }
 
 - (BOOL)removeStorageItem:(BOOL)isShared
@@ -852,23 +792,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     [query addEntriesFromDictionary:[self primaryAttributesForItem:isShared context:context error:error]];
     query[(id)kSecAttrService] = s_defaultKeychainLabel;
     
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Trying to delete keychain items...");
-    __block OSStatus status;
-    dispatch_barrier_sync(s_synchronizationQueue, ^{
-        status = SecItemDelete((CFDictionaryRef)query);
-    });
-    
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Keychain delete status: %d.", (int)status);
-    
-    if (status != errSecSuccess && status != errSecItemNotFound)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to remove multiple items from keychain (status: %d).", (int)status);
-        [self createError:@"Failed to remove multiple items from keychain."
-                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
-        return NO;
-    }
-    
-    return YES;
+    return [self removeItemWithAttributes:query context:context error:error];
 }
 
 - (MSIDMacCredentialStorageItem *)queryStorageItem:(BOOL)isShared
@@ -892,27 +816,15 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     NSMutableDictionary *query = [self.defaultCacheQuery mutableCopy];
     [query addEntriesFromDictionary:[self primaryAttributesForItem:isShared context:context error:error]];
     query[(id)kSecAttrService] = s_defaultKeychainLabel;
-    query[(id)kSecReturnAttributes] = (__bridge id)kCFBooleanTrue;
-    query[(id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
-    
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Trying to find keychain items...");
-    
-    __block CFDictionaryRef result = nil;
-    __block OSStatus status;
-    
-    dispatch_sync(s_synchronizationQueue, ^{
-        status = SecItemCopyMatching((CFDictionaryRef)query, (CFTypeRef *)&result);
-    });
-    
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Keychain find status: %d.", (int)status);
     
     BOOL storageItemIsEmpty = NO;
     
-    if (status == errSecSuccess)
+    NSError *readError = nil;
+    NSData *data = [self getDataWithAttributes:query context:context error:&readError];
+    
+    if (data)
     {
-        NSDictionary *resultDict = (__bridge_transfer NSDictionary *)result;
-        NSData *storageData = [resultDict objectForKey:(id)kSecValueData];
-        storageItem = (MSIDMacCredentialStorageItem *)[serializer deserializeCredentialStorageItem:storageData];
+        storageItem = (MSIDMacCredentialStorageItem *)[serializer deserializeCredentialStorageItem:data];
         
         if (!storageItem)
         {
@@ -927,15 +839,13 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
         
         storageItemIsEmpty = !storageItem.count;
     }
-    else if (status == errSecItemNotFound)
+    else if (readError)
     {
-        storageItemIsEmpty = YES;
+        if (error) *error = readError;
     }
     else
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to read stored item from keychain (status: %d).", (int)status);
-        [self createError:@"Failed to read stored item from keychain."
-                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
+        storageItemIsEmpty = YES;
     }
     
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
@@ -987,13 +897,13 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     {
         // Shareable item attributes: <keychainGroup>
         [attributes setObject:self.keychainGroup forKey:(id)kSecAttrAccount];
-        [attributes setObject:self.accessForSharedBlob forKey:(id)kSecAttrAccess];
+        [attributes setObject:self.accessControlForSharedItems forKey:(id)kSecAttrAccess];
     }
     else
     {
         // Non-Shareable item attributes: <keychainGroup>-<app_bundle_id>
         [attributes setObject:[NSString stringWithFormat:@"%@-%@", self.keychainGroup, [[NSBundle mainBundle] bundleIdentifier]] forKey:(id)kSecAttrAccount];
-        [attributes setObject:self.accessForNonSharedBlob forKey:(id)kSecAttrAccess];
+        [attributes setObject:self.accessControlForNonSharedItems forKey:(id)kSecAttrAccess];
     }
     
     return attributes;
@@ -1118,114 +1028,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
                    error:(NSError **)error
 
 {
-    MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"Clearing the whole context. This should only be executed in tests.");
-    
-    // Delete all accounts for the keychainGroup
-    NSMutableDictionary *query = [self.defaultCacheQuery mutableCopy];
-    query[(id)kSecMatchLimit] = (id)kSecMatchLimitAll;
-    MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,context, @"Trying to delete keychain items...");
-    __block OSStatus status;
-    dispatch_barrier_sync(s_synchronizationQueue, ^{
-        status = SecItemDelete((CFDictionaryRef)query);
-    });
-    MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,context, @"Keychain delete status: %d.", (int)status);
-
-    if (status != errSecSuccess && status != errSecItemNotFound)
-    {
-        if (error)
-        {
-            *error = MSIDCreateError(MSIDKeychainErrorDomain, status, @"Failed to remove items from keychain.", nil, nil, nil, context.correlationId, nil, NO);
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to delete keychain items (status: %d).", (int)status);
-        }
-        return NO;
-    }
-
-    return YES;
-}
-
-#pragma mark - Access Control Lists
-
-- (NSArray *)createTrustedAppListWithCurrentApp:(NSError **)error
-{
-    SecTrustedApplicationRef trustedApplication = nil;
-    OSStatus status = SecTrustedApplicationCreateFromPath(nil, &trustedApplication);
-    if (status != errSecSuccess)
-    {
-        [self createError:@"Failed to create SecTrustedApplicationRef for current application. Please make sure the app you're running is properly signed and keychain access group is configured."
-                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:nil];
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create SecTrustedApplicationRef for current application. Please make sure the app you're running is properly signed and keychain access group is configured (status: %d).", (int)status);
-        return nil;
-    }
-    
-    NSArray *trustedApplications = @[(__bridge_transfer id)trustedApplication];
-    return trustedApplications;
-}
-
-- (id)accessCreateWithChangeACL:(NSArray<id> *)trustedApplications error:(NSError **)error
-{
-    SecAccessRef access;
-    OSStatus status = SecAccessCreate((__bridge CFStringRef)s_defaultKeychainLabel, (__bridge CFArrayRef)trustedApplications, &access);
-    
-    if (status != errSecSuccess)
-    {
-        [self createError:@"Failed to create SecAccessRef for current application. Please make sure the app you're running is properly signed and keychain access group is configured."
-                   domain:MSIDKeychainErrorDomain errorCode:status error:error context:nil];
-         MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create SecAccessRef for current application. Please make sure the app you're running is properly signed and keychain access group is configured (status: %d).", (int)status);
-        return nil;
-    }
-    
-    if (![self accessSetACLTrustedApplications:access
-                           aclAuthorizationTag:kSecACLAuthorizationDecrypt
-                           trustedApplications:trustedApplications
-                                       context:nil
-                                         error:error])
-    {
-        CFReleaseNull(access);
-        return nil;
-    }
-    
-    return CFBridgingRelease(access);
-}
-
-- (BOOL)accessSetACLTrustedApplications:(SecAccessRef)access
-                     aclAuthorizationTag:(CFStringRef)aclAuthorizationTag
-                     trustedApplications:(NSArray<id> *)trustedApplications
-                                 context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
-{
-    NSArray *acls = (__bridge_transfer NSArray*)SecAccessCopyMatchingACLList(access, aclAuthorizationTag);
-    OSStatus status;
-    CFStringRef description = nil;
-    CFArrayRef oldtrustedAppList = nil;
-    SecKeychainPromptSelector selector;
-    
-    // TODO: handle case where tag is not found?
-    for (id acl in acls)
-    {
-        status = SecACLCopyContents((__bridge SecACLRef)acl, &oldtrustedAppList, &description, &selector);
-        
-        if (status != errSecSuccess)
-        {
-            [self createError:@"Failed to get contents from ACL. Please make sure the app you're running is properly signed and keychain access group is configured." domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
-             MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to get contents from ACL. Please make sure the app you're running is properly signed and keychain access group is configured(status: %d).", (int)status);
-            return NO;
-        }
-        
-        status = SecACLSetContents((__bridge SecACLRef)acl, (__bridge CFArrayRef)trustedApplications, description, selector);
-        
-        if (status != errSecSuccess)
-        {
-            [self createError:@"Failed to set contents for ACL. Please make sure the app you're running is properly signed and keychain access group is configured." domain:MSIDKeychainErrorDomain errorCode:status error:error context:context];
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to set contents for ACL. Please make sure the app you're running is properly signed and keychain access group is configured (status: %d).", (int)status);
-            CFReleaseNull(oldtrustedAppList);
-            CFReleaseNull(description);
-            return NO;
-        }
-    }
-    
-    CFReleaseNull(oldtrustedAppList);
-    CFReleaseNull(description);
-    return YES;
+    return [self clearWithAttributes:self.defaultCacheQuery context:context error:error];
 }
 
 #pragma mark - Utilities
@@ -1239,22 +1042,6 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
                    errorCode:MSIDErrorUnsupportedFunctionality
                        error:error
                      context:context];
-}
-
-// Allocate an NEError, logging a warning.
-- (BOOL) createError:(NSString*)message
-              domain:(NSErrorDomain)domain
-           errorCode:(NSInteger)code
-               error:(NSError *_Nullable *_Nullable)error
-             context:(id<MSIDRequestContext>)context
-{
-    MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"%@", message);
-    if (error)
-    {
-        *error = MSIDCreateError(domain, code, message, nil, nil, nil, context.correlationId, nil, NO);
-    }
-    
-    return YES;
 }
 
 - (NSString *)keychainGroupLoggingName

--- a/IdentityCore/src/cache/mac/MSIDMacLegacyCachePersistenceHandler.h
+++ b/IdentityCore/src/cache/mac/MSIDMacLegacyCachePersistenceHandler.h
@@ -1,10 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
 //
-//  MSIDMacLegacyCachePersistenceHandler.h
-//  IdentityCore Mac
+// This code is licensed under the MIT License.
 //
-//  Created by Olga Dalton on 10/26/19.
-//  Copyright © 2019 Microsoft. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "MSIDMacACLKeychainAccessor.h"

--- a/IdentityCore/src/cache/mac/MSIDMacLegacyCachePersistenceHandler.h
+++ b/IdentityCore/src/cache/mac/MSIDMacLegacyCachePersistenceHandler.h
@@ -1,0 +1,24 @@
+//
+//  MSIDMacLegacyCachePersistenceHandler.h
+//  IdentityCore Mac
+//
+//  Created by Olga Dalton on 10/26/19.
+//  Copyright © 2019 Microsoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "MSIDMacACLKeychainAccessor.h"
+#import "MSIDMacTokenCache.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDMacLegacyCachePersistenceHandler : MSIDMacACLKeychainAccessor <MSIDMacTokenCacheDelegate>
+
+- (nullable instancetype)initWithTrustedApplications:(nullable NSArray *)trustedApplications
+                                         accessLabel:(nonnull NSString *)accessLabel
+                                          attributes:(nonnull NSDictionary *)attributes
+                                               error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/mac/MSIDMacLegacyCachePersistenceHandler.m
+++ b/IdentityCore/src/cache/mac/MSIDMacLegacyCachePersistenceHandler.m
@@ -1,10 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
 //
-//  MSIDMacLegacyCachePersistenceHandler.m
-//  IdentityCore Mac
+// This code is licensed under the MIT License.
 //
-//  Created by Olga Dalton on 10/26/19.
-//  Copyright © 2019 Microsoft. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import "MSIDMacLegacyCachePersistenceHandler.h"
 

--- a/IdentityCore/src/cache/mac/MSIDMacLegacyCachePersistenceHandler.m
+++ b/IdentityCore/src/cache/mac/MSIDMacLegacyCachePersistenceHandler.m
@@ -1,0 +1,111 @@
+//
+//  MSIDMacLegacyCachePersistenceHandler.m
+//  IdentityCore Mac
+//
+//  Created by Olga Dalton on 10/26/19.
+//  Copyright © 2019 Microsoft. All rights reserved.
+//
+
+#import "MSIDMacLegacyCachePersistenceHandler.h"
+
+@interface MSIDMacLegacyCachePersistenceHandler()
+
+@property (nonatomic) NSDictionary *keychainAttributes;
+
+@end
+
+@implementation MSIDMacLegacyCachePersistenceHandler
+
+#pragma mark - Init
+
+- (nullable instancetype)initWithTrustedApplications:(nullable NSArray *)trustedApplications
+                                         accessLabel:(nonnull NSString *)accessLabel
+                                          attributes:(nonnull NSDictionary *)attributes
+                                               error:(NSError * _Nullable __autoreleasing * _Nullable)error
+{
+    self = [super initWithTrustedApplications:trustedApplications accessLabel:accessLabel error:error];
+    
+    if (self)
+    {
+        if (!attributes[(id)kSecAttrService] || !attributes[(id)kSecAttrAccount])
+        {
+            [self createError:@"Invalid attributes provided without service or account"
+                       domain:MSIDErrorDomain
+                    errorCode:MSIDErrorInvalidDeveloperParameter
+                        error:error
+                      context:nil];
+            return nil;
+        }
+        
+        self.keychainAttributes = attributes;
+    }
+    
+    return self;
+}
+
+#pragma mark - MSIDMacTokenCacheDelegate
+
+- (void)willAccessCache:(nonnull MSIDMacTokenCache *)cache
+{
+    [self readAndDeserializeWithCache:cache];
+}
+
+- (void)didAccessCache:(nonnull MSIDMacTokenCache *)cache
+{
+    
+}
+
+- (void)willWriteCache:(nonnull MSIDMacTokenCache *)cache
+{
+   [self readAndDeserializeWithCache:cache];
+}
+
+- (void)didWriteCache:(nonnull MSIDMacTokenCache *)cache
+{
+    NSData *data = [cache serialize];
+    
+    NSError *writeError = nil;
+    BOOL result = [self saveData:data attributes:[self keychainQuery] context:nil error:&writeError];
+    
+    if (!result)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, nil, @"Failed to write data to keychain with error %@", MSID_PII_LOG_MASKABLE(writeError));
+    }
+}
+
+#pragma mark - Internal
+
+- (void)readAndDeserializeWithCache:(nonnull MSIDMacTokenCache *)cache
+{
+    NSError *readError = nil;
+    NSData *data = [self getDataWithAttributes:[self keychainQuery] context:nil error:&readError];
+    
+    if (readError)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, nil, @"Failed to read cache with error %@", MSID_PII_LOG_MASKABLE(readError));
+        return;
+    }
+    
+    if (data)
+    {
+        [cache deserialize:data error:&readError];
+    }
+    
+    if (readError)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, nil, @"Failed to deserialize cache with error %@", MSID_PII_LOG_MASKABLE(readError));
+    }
+}
+
+- (NSDictionary *)keychainQuery
+{
+    NSMutableDictionary *query = [NSMutableDictionary new];
+    [query addEntriesFromDictionary:self.keychainAttributes];
+    
+    query[(id)kSecClass] = (id)kSecClassGenericPassword;
+    query[(id)kSecAttrAccess] = self.accessControlForSharedItems;
+    
+    return query;
+}
+
+@end

--- a/IdentityCore/tests/MSIDMacACLKeychainAccessorTests.m
+++ b/IdentityCore/tests/MSIDMacACLKeychainAccessorTests.m
@@ -170,12 +170,49 @@
 
 - (void)testRemoveItem_whenItemDoesntExist_shouldNotRemoveOtherItems
 {
+    MSIDMacACLKeychainAccessor *accessor = [[MSIDMacACLKeychainAccessor alloc] initWithTrustedApplications:nil accessLabel:@"label" error:nil];
     
+    NSError *error = nil;
+    NSDictionary *attributes = @{(id)kSecAttrService : @"test-service",
+                                 (id)kSecAttrAccount : @"test-account",
+                                 (id)kSecAttrLabel : @"my-xctest-msal-label"};
+
+    BOOL result = [accessor removeItemWithAttributes:attributes context:nil error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
 }
 
 - (void)testRemoveItem_whenItemExists_shouldRemoveItem
 {
+    MSIDMacACLKeychainAccessor *accessor = [[MSIDMacACLKeychainAccessor alloc] initWithTrustedApplications:nil accessLabel:@"label" error:nil];
     
+    NSError *error = nil;
+    NSData *data = [@"test data" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *data2 = [@"test data 2" dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *attributes = @{(id)kSecAttrService : @"test-service",
+                                 (id)kSecAttrAccount : @"test-account",
+                                 (id)kSecAttrLabel : @"my-xctest-msal-label"};
+    NSDictionary *attributes2 = @{(id)kSecAttrService : @"test-service2",
+                                  (id)kSecAttrAccount : @"test-account2",
+                                  (id)kSecAttrLabel : @"my-xctest-msal-label"};
+    BOOL result = [accessor saveData:data attributes:attributes context:nil error:&error];
+    XCTAssertTrue(result);
+    result = [accessor saveData:data2 attributes:attributes2 context:nil error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    
+    BOOL removalResult = [accessor removeItemWithAttributes:attributes context:nil error:&error];
+    XCTAssertTrue(removalResult);
+    XCTAssertNil(error);
+    
+    NSData *writtenData1 = [accessor getDataWithAttributes:attributes context:nil error:&error];
+    XCTAssertNil(writtenData1);
+    XCTAssertNil(error);
+    
+    NSData *writtenData2 = [accessor getDataWithAttributes:attributes2 context:nil error:&error];
+    XCTAssertNotNil(writtenData2);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(writtenData2, data2);
 }
 
 - (void)testGetDataWithAttributes_whenNoDataFound_shouldReturnNil

--- a/IdentityCore/tests/MSIDMacACLKeychainAccessorTests.m
+++ b/IdentityCore/tests/MSIDMacACLKeychainAccessorTests.m
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDMacKeychainTokenCache.h"
+#import "MSIDMacACLKeychainAccessor.h"
+#import "MSIDKeychainUtil+Internal.h"
+
+@interface MSIDMacACLKeychainAccessorTests : XCTestCase
+
+@end
+
+@implementation MSIDMacACLKeychainAccessorTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    MSIDKeychainUtil *keychainUtil = [MSIDKeychainUtil sharedInstance];
+    keychainUtil.teamId = @"FakeTeamId";
+    
+    [[MSIDMacKeychainTokenCache new] clearWithContext:nil error:nil];
+}
+
+- (void)testInitWithTrustedApplications_whenNilTrustedApplications_shouldInitWithSelfOnly
+{
+    NSError *error = nil;
+    MSIDMacACLKeychainAccessor *accessor = [[MSIDMacACLKeychainAccessor alloc] initWithTrustedApplications:nil accessLabel:@"label" error:&error];
+    
+    XCTAssertNotNil(accessor);
+    XCTAssertNil(error);
+    
+    XCTAssertNotNil(accessor.accessControlForSharedItems);
+    
+    NSArray *sharedItems = [self trustedAppsForAccess:accessor.accessControlForSharedItems authorizationTag:kSecACLAuthorizationDecrypt];
+    XCTAssertEqual([sharedItems count], 1);
+    XCTAssertEqualObjects(sharedItems[0], [self executablePath]);
+    
+    XCTAssertNotNil(accessor.accessControlForNonSharedItems);
+    NSArray *nonSharedItems = [self trustedAppsForAccess:accessor.accessControlForNonSharedItems authorizationTag:kSecACLAuthorizationDecrypt];
+    XCTAssertEqual([nonSharedItems count], 1);
+    XCTAssertEqualObjects(nonSharedItems[0], [self executablePath]);
+}
+
+- (void)testInitWithTrustedApplications_whenEmptyTrustedApplications_shouldInitWithSelfOnly
+{
+    NSError *error = nil;
+    MSIDMacACLKeychainAccessor *accessor = [[MSIDMacACLKeychainAccessor alloc] initWithTrustedApplications:@[] accessLabel:@"label" error:&error];
+    
+    XCTAssertNotNil(accessor);
+    XCTAssertNil(error);
+    
+    XCTAssertNotNil(accessor.accessControlForSharedItems);
+    
+    NSArray *sharedItems = [self trustedAppsForAccess:accessor.accessControlForSharedItems authorizationTag:kSecACLAuthorizationDecrypt];
+    XCTAssertEqual([sharedItems count], 1);
+    XCTAssertEqualObjects(sharedItems[0], [self executablePath]);
+    
+    XCTAssertNotNil(accessor.accessControlForNonSharedItems);
+    NSArray *nonSharedItems = [self trustedAppsForAccess:accessor.accessControlForNonSharedItems authorizationTag:kSecACLAuthorizationDecrypt];
+    XCTAssertEqual([nonSharedItems count], 1);
+    XCTAssertEqualObjects(nonSharedItems[0], [self executablePath]);
+}
+
+- (void)testInitWithTrustedApplications_whenProvidedTrustedApplications_shouldShareCacheWithTrustedApps
+{
+    NSString *path1 = @"/Applications/Safari.app\0";
+    SecTrustedApplicationRef appRef1 = nil;
+    SecTrustedApplicationCreateFromPath([path1 UTF8String], &appRef1);
+    id appReference = (__bridge_transfer id)appRef1;
+    XCTAssertNotNil(appReference);
+    
+    NSError *error = nil;
+    MSIDMacACLKeychainAccessor *accessor = [[MSIDMacACLKeychainAccessor alloc] initWithTrustedApplications:@[appReference] accessLabel:@"label" error:&error];
+    
+    XCTAssertNotNil(accessor);
+    XCTAssertNil(error);
+    
+    XCTAssertNotNil(accessor.accessControlForSharedItems);
+    
+    NSArray *sharedItems = [self trustedAppsForAccess:accessor.accessControlForSharedItems authorizationTag:kSecACLAuthorizationDecrypt];
+    XCTAssertEqual([sharedItems count], 2);
+    XCTAssertEqualObjects(sharedItems[0], path1);
+    XCTAssertEqualObjects(sharedItems[1], [self executablePath]);
+    
+    XCTAssertNotNil(accessor.accessControlForNonSharedItems);
+    NSArray *nonSharedItems = [self trustedAppsForAccess:accessor.accessControlForNonSharedItems authorizationTag:kSecACLAuthorizationDecrypt];
+    XCTAssertEqual([nonSharedItems count], 1);
+    XCTAssertEqualObjects(nonSharedItems[0], [self executablePath]);
+}
+
+- (void)testSaveData_withNilData_shouldReturnNoAndFillError
+{
+    
+}
+
+- (void)testSaveData_whenItemDoesntExist_shouldCreateItem
+{
+    
+}
+
+- (void)testSaveData_whenItemExists_shouldUpdateItem
+{
+    
+}
+
+- (void)testRemoveItem_whenItemDoesntExist_shouldNotRemoveOtherItems
+{
+    
+}
+
+- (void)testRemoveItem_whenItemExists_shouldRemoveItem
+{
+    
+}
+
+- (void)testGetDataWithAttributes_whenNoDataFound_shouldReturnNil
+{
+    
+}
+
+- (void)testGetDataWithAttributes_whenDataFound_shouldReturnData
+{
+    
+}
+
+- (void)testClearWithAttributes_whenNoMatchingItemsExist_shouldNotClear
+{
+    
+}
+
+- (void)testClearWithAttributes_whenAttributesProvided_shouldClear
+{
+    
+}
+
+#pragma mark - Helper
+
+- (NSString *)executablePath
+{
+    return [NSString stringWithFormat:@"%@\0", [[NSBundle mainBundle] executablePath]];
+}
+
+- (NSArray *)trustedAppsForAccess:(id)access authorizationTag:(CFStringRef)authorizationTag
+{
+    SecAccessRef accessRef = (__bridge SecAccessRef)access;
+    NSArray *sharedACLs = (__bridge_transfer NSArray*)SecAccessCopyMatchingACLList(accessRef, authorizationTag);
+    NSMutableArray *resultArray = [NSMutableArray new];
+    
+    for (id acl in sharedACLs)
+    {
+        CFArrayRef trustedAppsList = nil;
+        CFStringRef description = nil;
+        SecKeychainPromptSelector selector;
+        SecACLCopyContents((__bridge SecACLRef)acl, &trustedAppsList, &description, &selector);
+        
+        if (!trustedAppsList)
+        {
+            return nil;
+        }
+        
+        NSArray *trustedApps = (__bridge NSArray*)trustedAppsList;
+        
+        for (id trustedApp in trustedApps)
+        {
+            SecTrustedApplicationRef trustedAppRef = (__bridge SecTrustedApplicationRef)trustedApp;
+            CFDataRef trustedDataRef = NULL;
+            SecTrustedApplicationCopyData(trustedAppRef, &trustedDataRef);
+            
+            if (trustedDataRef)
+            {
+                NSString *appPath = [[NSString alloc] initWithData:(__bridge NSData * _Nonnull)(trustedDataRef) encoding:NSUTF8StringEncoding];
+                [resultArray addObject:appPath];
+                CFRelease(trustedDataRef);
+            }
+        }
+        
+        CFRelease(trustedAppsList);
+        
+        if (description) CFRelease(description);
+    }
+    
+    return resultArray;
+}
+
+@end

--- a/IdentityCore/tests/MSIDMacACLKeychainAccessorTests.m
+++ b/IdentityCore/tests/MSIDMacACLKeychainAccessorTests.m
@@ -229,16 +229,6 @@
     XCTAssertNil(error);
 }
 
-- (void)testClearWithAttributes_whenNoMatchingItemsExist_shouldNotClear
-{
-    
-}
-
-- (void)testClearWithAttributes_whenAttributesProvided_shouldClear
-{
-    
-}
-
 #pragma mark - Helper
 
 - (NSString *)executablePath

--- a/IdentityCore/tests/MSIDMacLegacyCachePersistenceHandlerTests.m
+++ b/IdentityCore/tests/MSIDMacLegacyCachePersistenceHandlerTests.m
@@ -1,0 +1,250 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDMacLegacyCachePersistenceHandler.h"
+#import "MSIDMacTokenCache.h"
+#import "MSIDCredentialCacheItem.h"
+#import "MSIDKeyedArchiverSerializer.h"
+#import "MSIDMacACLKeychainAccessor.h"
+#import "MSIDLegacyTokenCacheKey.h"
+#import "MSIDLegacyTokenCacheItem.h"
+
+@interface MSIDMacLegacyCachePersistenceHandlerTests : XCTestCase
+
+@end
+
+@implementation MSIDMacLegacyCachePersistenceHandlerTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    MSIDMacACLKeychainAccessor *accessor = [[MSIDMacACLKeychainAccessor alloc] initWithTrustedApplications:nil accessLabel:@"label" error:nil];
+    
+    NSDictionary *attributes = @{(id)kSecAttrLabel : @"my-xctest-msal-label"};
+    [accessor clearWithAttributes:attributes context:nil error:nil];
+}
+
+- (void)testInitWithMissingAccountParameter_shouldReturnNilAndFillError
+{
+    NSError *error = nil;
+    MSIDMacLegacyCachePersistenceHandler *handler = [[MSIDMacLegacyCachePersistenceHandler alloc] initWithTrustedApplications:nil accessLabel:@"test" attributes:@{(id)kSecAttrService : @"myservice"} error:&error];
+    
+    XCTAssertNil(handler);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+}
+
+- (void)testInitWithMissingServiceParameter_shouldReturnNilAndFillError
+{
+    NSError *error = nil;
+    MSIDMacLegacyCachePersistenceHandler *handler = [[MSIDMacLegacyCachePersistenceHandler alloc] initWithTrustedApplications:nil accessLabel:@"test" attributes:@{(id)kSecAttrAccount : @"myaccount"} error:&error];
+    
+    XCTAssertNil(handler);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+}
+
+- (void)testInitWithCorrectParameters_shouldReturnCacheAndNilError
+{
+    NSError *error = nil;
+    MSIDMacLegacyCachePersistenceHandler *handler = [[MSIDMacLegacyCachePersistenceHandler alloc] initWithTrustedApplications:nil accessLabel:@"test" attributes:@{(id)kSecAttrAccount : @"myaccount", (id)kSecAttrService : @"myservice"} error:&error];
+    
+    XCTAssertNotNil(handler);
+    XCTAssertNil(error);
+}
+
+- (void)testTokenCacheDelegateCallbacks_whenReadingFromSerializedCache_shouldFillCache
+{
+    MSIDLegacyTokenCacheKey *key1 = [[MSIDLegacyTokenCacheKey alloc] initWithAccount:@"account" service:@"service" generic:nil type:nil];
+    MSIDCredentialCacheItem *item = [self testCredentialItem1];
+    BOOL result = [self writeTestDataWithItem:item
+                                          key:key1
+                          keychainAttrAccount:@"unit-test-account"
+                          keychainAttrService:@"unit-test-service"];
+    XCTAssertTrue(result);
+    
+    MSIDMacTokenCache *tokenCache = [MSIDMacTokenCache new];
+    [tokenCache clear];
+    
+    NSError *error = nil;
+    
+    NSDictionary *attributes = @{(id)kSecAttrAccount : @"unit-test-account",
+                                 (id)kSecAttrService : @"unit-test-service",
+                                 (id)kSecAttrLabel : @"my-xctest-msal-label"};
+    
+    MSIDMacLegacyCachePersistenceHandler *handler = [[MSIDMacLegacyCachePersistenceHandler alloc] initWithTrustedApplications:nil accessLabel:@"test" attributes:attributes error:&error];
+    
+    XCTAssertNotNil(handler);
+    XCTAssertNil(error);
+    
+    tokenCache.delegate = handler;
+    
+    MSIDCredentialCacheItem *writtenItem = [tokenCache tokenWithKey:key1 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertNotNil(writtenItem);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(writtenItem, item);
+}
+
+- (void)testTokenCacheDelegateCallbacks_whenWritingToSerializedCache_shouldFillCache
+{
+    MSIDMacTokenCache *tokenCache = [MSIDMacTokenCache new];
+    [tokenCache clear];
+    
+    NSError *error = nil;
+    
+    NSDictionary *attributes = @{(id)kSecAttrAccount : @"unit-test-account",
+                                 (id)kSecAttrService : @"unit-test-service",
+                                 (id)kSecAttrLabel : @"my-xctest-msal-label"};
+    
+    MSIDMacLegacyCachePersistenceHandler *handler = [[MSIDMacLegacyCachePersistenceHandler alloc] initWithTrustedApplications:nil accessLabel:@"test" attributes:attributes error:&error];
+    
+    XCTAssertNotNil(handler);
+    XCTAssertNil(error);
+    
+    tokenCache.delegate = handler;
+    
+    MSIDLegacyTokenCacheKey *key1 = [[MSIDLegacyTokenCacheKey alloc] initWithAccount:@"account" service:@"service" generic:nil type:nil];
+    MSIDLegacyTokenCacheKey *key2 = [[MSIDLegacyTokenCacheKey alloc] initWithAccount:@"account2" service:@"service2" generic:nil type:nil];
+    MSIDCredentialCacheItem *item1 = [self testCredentialItem1];
+    
+    BOOL result = [tokenCache saveToken:item1 key:key1 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    
+    MSIDCredentialCacheItem *item2 = [item1 copy];
+    item2.clientId = @"client2";
+    
+    BOOL result2 = [tokenCache saveToken:item2 key:key2 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertTrue(result2);
+    XCTAssertNil(error);
+    
+    MSIDMacTokenCache *newTokenCache = [MSIDMacTokenCache new];
+    [newTokenCache clear];
+    newTokenCache.delegate = handler;
+    
+    MSIDCredentialCacheItem *writtenItem1 = [newTokenCache tokenWithKey:key1 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertNotNil(writtenItem1);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(item1, writtenItem1);
+    
+    MSIDCredentialCacheItem *writtenItem2 = [newTokenCache tokenWithKey:key2 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertNotNil(writtenItem2);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(item2, writtenItem2);
+}
+
+- (void)testTokenCacheDelegateCallbacks_whenWritingToSerializedCache_andCacheModified_shouldFillCacheWithLatestUpdates
+{
+    MSIDMacTokenCache *tokenCache = [MSIDMacTokenCache new];
+    [tokenCache clear];
+    
+    NSError *error = nil;
+    
+    NSDictionary *attributes = @{(id)kSecAttrAccount : @"unit-test-account",
+                                 (id)kSecAttrService : @"unit-test-service",
+                                 (id)kSecAttrLabel : @"my-xctest-msal-label"};
+    
+    MSIDMacLegacyCachePersistenceHandler *handler = [[MSIDMacLegacyCachePersistenceHandler alloc] initWithTrustedApplications:nil accessLabel:@"test" attributes:attributes error:&error];
+    
+    XCTAssertNotNil(handler);
+    XCTAssertNil(error);
+    
+    tokenCache.delegate = handler;
+    
+    MSIDLegacyTokenCacheKey *key1 = [[MSIDLegacyTokenCacheKey alloc] initWithAccount:@"account" service:@"service" generic:nil type:nil];
+    MSIDLegacyTokenCacheKey *key2 = [[MSIDLegacyTokenCacheKey alloc] initWithAccount:@"account2" service:@"service2" generic:nil type:nil];
+    MSIDLegacyTokenCacheKey *key3 = [[MSIDLegacyTokenCacheKey alloc] initWithAccount:@"account3" service:@"service3" generic:nil type:nil];
+    MSIDCredentialCacheItem *item1 = [self testCredentialItem1];
+    
+    BOOL result = [tokenCache saveToken:item1 key:key1 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    
+    // Modify cache by a different process
+    MSIDCredentialCacheItem *item2 = [item1 copy];
+    item2.clientId = @"client2";
+    [self writeTestDataWithItem:item2 key:key2 keychainAttrAccount:@"unit-test-account" keychainAttrService:@"unit-test-service"];
+    
+    // Now write new item
+    MSIDCredentialCacheItem *item3 = [item1 copy];
+    item3.clientId = @"client3";
+    result = [tokenCache saveToken:item3 key:key3 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    
+    // Now read
+    MSIDCredentialCacheItem *writtenItem1 = [tokenCache tokenWithKey:key1 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertNil(writtenItem1);
+    XCTAssertNil(error);
+    
+    MSIDCredentialCacheItem *writtenItem2 = [tokenCache tokenWithKey:key2 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertNotNil(writtenItem2);
+    XCTAssertEqualObjects(writtenItem2, item2);
+    XCTAssertNil(error);
+    
+    MSIDCredentialCacheItem *writtenItem3 = [tokenCache tokenWithKey:key3 serializer:[MSIDKeyedArchiverSerializer new] context:nil error:&error];
+    XCTAssertNotNil(writtenItem3);
+    XCTAssertEqualObjects(writtenItem3, item3);
+    XCTAssertNil(error);
+}
+
+#pragma mark - Helpers
+
+- (BOOL)writeTestDataWithItem:(MSIDCredentialCacheItem *)item
+                          key:(MSIDCacheKey *)key
+          keychainAttrAccount:(NSString *)attrAccount
+          keychainAttrService:(NSString *)attrService
+{
+    MSIDMacTokenCache *tokenCache = [MSIDMacTokenCache new];
+    [tokenCache clear];
+    
+    BOOL saveResult = [tokenCache saveToken:item key:key serializer:[MSIDKeyedArchiverSerializer new] context:nil error:nil];
+    XCTAssertTrue(saveResult);
+    
+    NSData *serializedData = [tokenCache serialize];
+    
+    MSIDMacACLKeychainAccessor *aclKeychain = [[MSIDMacACLKeychainAccessor alloc] initWithTrustedApplications:nil accessLabel:@"test" error:nil];
+    
+    NSDictionary *attributes = @{(id)kSecAttrAccount : attrAccount, (id)kSecAttrService : attrService, (id)kSecAttrLabel : @"my-xctest-msal-label"};
+    return [aclKeychain saveData:serializedData attributes:attributes context:nil error:nil];
+}
+
+- (MSIDLegacyTokenCacheItem *)testCredentialItem1
+{
+    MSIDLegacyTokenCacheItem *item = [MSIDLegacyTokenCacheItem new];
+    item.clientId = @"client1";
+    item.credentialType = MSIDRefreshTokenType;
+    item.environment = @"login.microsoftonline.com";
+    item.secret = @"rt1";
+    item.realm = @"common";
+    item.refreshToken = @"rt1";
+    item.homeAccountId = @"uid1.utid1";
+    item.oauthTokenType = @"Bearer";
+    return item;
+}
+
+@end


### PR DESCRIPTION
Make generic ACL keychain pieces reusable
Allow reusing of existing MSAL ACL code to support backward compatibility with ADAL cache. 