### PR TITLE
Disable unused variable warnings for tests and fix warnings

### DIFF
--- a/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.m
+++ b/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.m
@@ -31,7 +31,7 @@
 }
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json
-                                 error:(NSError * __autoreleasing *)error
+                                 error:(__unused NSError * __autoreleasing *)error
 {
     self = [super init];
 

--- a/IdentityCore/tests/automation/shared/MSIDAutomationTestResult.m
+++ b/IdentityCore/tests/automation/shared/MSIDAutomationTestResult.m
@@ -41,7 +41,7 @@
 }
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json
-                                 error:(NSError * __autoreleasing *)error
+                                 error:(__unused NSError * __autoreleasing *)error
 {
     self = [super init];
 

--- a/IdentityCore/tests/automation/shared/MSIDAutomationUserInformation.m
+++ b/IdentityCore/tests/automation/shared/MSIDAutomationUserInformation.m
@@ -42,7 +42,7 @@
     return json;
 }
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing *)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing *)error
 {
     self = [super init];
 

--- a/IdentityCore/tests/automation/ui_app_lib/MSIDClearCookiesTestAction.m
+++ b/IdentityCore/tests/automation/ui_app_lib/MSIDClearCookiesTestAction.m
@@ -43,8 +43,8 @@
     return NO;
 }
 
-- (void)performActionWithParameters:(NSDictionary *)parameters
-                containerController:(MSIDAutoViewController *)containerController
+- (void)performActionWithParameters:(__unused NSDictionary *)parameters
+                containerController:(__unused MSIDAutoViewController *)containerController
                     completionBlock:(MSIDAutoCompletionBlock)completionBlock
 {
     NSHTTPCookieStorage *cookieStore = [NSHTTPCookieStorage sharedHTTPCookieStorage];

--- a/IdentityCore/tests/automation/ui_app_lib/ios/MSIDClearKeychainTestAction.m
+++ b/IdentityCore/tests/automation/ui_app_lib/ios/MSIDClearKeychainTestAction.m
@@ -43,8 +43,8 @@
     return NO;
 }
 
-- (void)performActionWithParameters:(NSDictionary *)parameters
-                containerController:(UIViewController *)containerController
+- (void)performActionWithParameters:(__unused NSDictionary *)parameters
+                containerController:(__unused UIViewController *)containerController
                     completionBlock:(MSIDAutoCompletionBlock)completionBlock
 {
     NSArray *secItemClasses = @[(__bridge id)kSecClassGenericPassword,

--- a/IdentityCore/tests/automation/ui_app_lib/ios/MSIDOpenURLAction.m
+++ b/IdentityCore/tests/automation/ui_app_lib/ios/MSIDOpenURLAction.m
@@ -45,7 +45,7 @@
 }
 
 - (void)performActionWithParameters:(MSIDAutomationTestRequest *)parameters
-                containerController:(MSIDAutomationMainViewController *)containerController
+                containerController:(__unused MSIDAutomationMainViewController *)containerController
                     completionBlock:(MSIDAutoCompletionBlock)completionBlock
 {
     NSString *urlString = parameters.extraQueryParameters[@"url"];

--- a/IdentityCore/tests/automation/ui_app_lib/ui_common/ios/MSIDAutomationPassedInWebViewController.m
+++ b/IdentityCore/tests/automation/ui_app_lib/ui_common/ios/MSIDAutomationPassedInWebViewController.m
@@ -46,7 +46,7 @@ static MSIDAutomationCancelTappedCallback s_cancelTappedCallback;
     self.passedInWebview.frame = CGRectMake(0, 0, self.contentView.frame.size.width, self.contentView.frame.size.height);
 }
 
-- (IBAction)cancelTapped:(id)sender {
+- (IBAction)cancelTapped:(__unused id)sender {
     
     [self dismissViewControllerAnimated:YES completion:^{
         if (self.class.cancelTappedCallback)

--- a/IdentityCore/tests/automation/ui_app_lib/ui_common/ios/MSIDAutomationRequestViewController.m
+++ b/IdentityCore/tests/automation/ui_app_lib/ui_common/ios/MSIDAutomationRequestViewController.m
@@ -39,7 +39,7 @@
     self.requestInfo.text = nil;
 }
 
-- (IBAction)go:(id)sender
+- (IBAction)go:(__unused id)sender
 {
     self.requestInfo.editable = NO;
     self.requestGo.enabled = NO;

--- a/IdentityCore/xcconfig/identitycore__tests__ios.xcconfig
+++ b/IdentityCore/xcconfig/identitycore__tests__ios.xcconfig
@@ -3,3 +3,4 @@
 
 INFOPLIST_FILE = tests/ios/Info.plist
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+GCC_WARN_UNUSED_PARAMETER = NO

--- a/IdentityCore/xcconfig/identitycore__tests__mac.xcconfig
+++ b/IdentityCore/xcconfig/identitycore__tests__mac.xcconfig
@@ -3,3 +3,4 @@
 
 INFOPLIST_FILE = tests/mac/Info.plist
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/../Frameworks
+GCC_WARN_UNUSED_PARAMETER = NO


### PR DESCRIPTION
Applying some additional fixes for this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/605