### PR TITLE
Set web config content mode

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -47,6 +47,10 @@ static WKWebViewConfiguration *s_webConfig;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         s_webConfig = [WKWebViewConfiguration new];
+        if (@available(iOS 13.0, *))
+        {
+            s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
+        }
     });
 }
 

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -44,6 +44,11 @@ static WKWebViewConfiguration *s_webConfig;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         s_webConfig = [WKWebViewConfiguration new];
+        
+        if (@available(macOS 10.15, *))
+        {
+            s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
+        }
     });
 }
 


### PR DESCRIPTION
This change sets WKWebView content mode to Mobile for iOS libraries and Desktop for macOS libraries. This is needed to achieve consistency in User-Agent and UI between embedded web view and system webview (ASWebAuthenticationSession uses Mobile as well on iOS). 