### PR TITLE
[ADAL-backport] Set default WKWebView content mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode11
 
 # Set up our rubygems (slather and xcpretty, namely)
 install: 

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -48,6 +48,11 @@ static WKWebViewConfiguration *s_webConfig;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         s_webConfig = [WKWebViewConfiguration new];
+        
+        if (@available(iOS 13.0, *))
+        {
+            s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
+        }
     });
 }
 

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -44,6 +44,11 @@ static WKWebViewConfiguration *s_webConfig;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         s_webConfig = [WKWebViewConfiguration new];
+        
+        if (@available(macOS 10.15, *))
+        {
+            s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
+        }
     });
 }
 

--- a/IdentityCore/tests/util/network/MSIDTestURLSession.h
+++ b/IdentityCore/tests/util/network/MSIDTestURLSession.h
@@ -51,4 +51,7 @@
 // Helper dispatch method that URLSessionTask can utilize
 - (void)dispatchIfNeed:(void (^)(void))block;
 
+// Required method to mock NSURLSession on iOS 13.
+- (void)defaultTaskGroup;
+
 @end

--- a/IdentityCore/tests/util/network/MSIDTestURLSession.m
+++ b/IdentityCore/tests/util/network/MSIDTestURLSession.m
@@ -328,6 +328,8 @@ static NSMutableArray* s_responses = nil;
     self.delegateQueue = nil;
 }
 
-
+- (void)defaultTaskGroup
+{
+}
 
 @end

--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@ from timeit import default_timer as timer
 
 script_start_time = timer()
 
-ios_sim_device = "iPhone 6"
+ios_sim_device = "iPhone 8"
 ios_sim_dest = "-destination 'platform=iOS Simulator,name=" + ios_sim_device + ",OS=latest'"
 ios_sim_flags = "-sdk iphonesimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 


### PR DESCRIPTION
This change sets WKWebView content mode to Mobile for iOS libraries and Desktop for macOS libraries. This is needed to achieve consistency in User-Agent and UI between embedded web view and system webview (ASWebAuthenticationSession uses Mobile as well on iOS).

This is back porting [fix](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/659) to an older ADAL-compatible common core version. 