### PR TITLE
Enable dogfood authenticator support by default

### DIFF
--- a/IdentityCore/src/controllers/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/ios/MSIDBrokerInteractiveController.m
@@ -312,11 +312,8 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
 #if AD_BROKER
     return YES;
 #else
-    BOOL isBrokerResponse = [MSID_BROKER_APP_BUNDLE_ID isEqualToString:sourceApplication];
-
-#ifdef DOGFOOD_BROKER
-    isBrokerResponse = isBrokerResponse || [MSID_BROKER_APP_BUNDLE_ID_DF isEqualToString:sourceApplication];
-#endif
+    BOOL isBrokerResponse = [MSID_BROKER_APP_BUNDLE_ID isEqualToString:sourceApplication]
+                            || [MSID_BROKER_APP_BUNDLE_ID_DF isEqualToString:sourceApplication];
 
     return isBrokerResponse;
 #endif


### PR DESCRIPTION
This change enables dogfood broker support without app having to do custom configuration. This will ensure that all Microsoft apps have support for it by default. 