### PR TITLE
[ADAL backport] Fix a presentation bug when both parent controller and webview are set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode11
 
 # Set up our rubygems (slather and xcpretty, namely)
 install: 

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -39,6 +39,8 @@ static WKWebViewConfiguration *s_webConfig;
     id _foregroundObserver;
 }
 
+@property (nonatomic) BOOL presentInParentController;
+
 @end
 
 @implementation MSIDWebviewUIController
@@ -78,6 +80,7 @@ static WKWebViewConfiguration *s_webConfig;
     
     if (_webView)
     {
+        self.presentInParentController = NO;
         return YES;
     }
     
@@ -111,11 +114,15 @@ static WKWebViewConfiguration *s_webConfig;
     [rootView addSubview:_webView];
     [rootView addSubview:_loadingIndicator];
     
+    self.presentInParentController = YES;
+    
     return YES;
 }
 
 - (void)presentView
 {
+    if (!self.presentInParentController) return;
+    
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:self];
     [navController setModalPresentationStyle:_presentationType];
     
@@ -137,7 +144,7 @@ static WKWebViewConfiguration *s_webConfig;
     
     //if webview is created by us, dismiss and then complete and return;
     //otherwise just complete and return.
-    if (_parentController)
+    if (_parentController && self.presentInParentController)
     {
         [_parentController dismissViewControllerAnimated:YES completion:completion];
     }

--- a/IdentityCore/tests/util/network/MSIDTestURLSession.h
+++ b/IdentityCore/tests/util/network/MSIDTestURLSession.h
@@ -51,4 +51,7 @@
 // Helper dispatch method that URLSessionTask can utilize
 - (void)dispatchIfNeed:(void (^)(void))block;
 
+// Required method to mock NSURLSession on iOS 13.
+- (void)defaultTaskGroup;
+
 @end

--- a/IdentityCore/tests/util/network/MSIDTestURLSession.m
+++ b/IdentityCore/tests/util/network/MSIDTestURLSession.m
@@ -328,6 +328,8 @@ static NSMutableArray* s_responses = nil;
     self.delegateQueue = nil;
 }
 
-
+- (void)defaultTaskGroup
+{
+}
 
 @end

--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@ from timeit import default_timer as timer
 
 script_start_time = timer()
 
-ios_sim_device = "iPhone 6"
+ios_sim_device = "iPhone 8"
 ios_sim_dest = "-destination 'platform=iOS Simulator,name=" + ios_sim_device + ",OS=latest'"
 ios_sim_flags = "-sdk iphonesimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 


### PR DESCRIPTION
Fixing an issue where setting both parent controller and webview for ADAL 4.0.x results in unexpected behavior (we display an empty navigation controller, and user is blocked).