### PR TITLE
Set account metadata in silent sso request

### DIFF
--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
@@ -62,7 +62,7 @@
                              oauthFactory:(MSIDOauth2Factory *)oauthFactory
                    tokenResponseValidator:(MSIDTokenResponseValidator *)tokenResponseValidator
                                tokenCache:(id<MSIDCacheAccessor>)tokenCache
-                     accountMetadataCache:(__unused MSIDAccountMetadataCacheAccessor *)accountMetadataCache
+                     accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
 {
     self = [super initWithRequestParameters:parameters
                                forceRefresh:forceRefresh
@@ -101,6 +101,7 @@
         _providerType = [[oauthFactory class] providerType];
         _enrollmentIdsCache = [MSIDIntuneEnrollmentIdsCache sharedCache];
         _mamResourcesCache = [MSIDIntuneMAMResourcesCache sharedCache];
+        _accountMetadataCache = accountMetadataCache;
     }
     
     return self;

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.h
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.h
@@ -42,6 +42,12 @@ struct MSIDAccountMetadataCacheMockGetAuthorityParameters
     BOOL instanceAware;
 };
 
+struct MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams
+{
+    MSIDAccountIdentifier * _Nullable principalAccountId;
+    NSString * _Nullable clientId;
+};
+
 @interface MSIDAccountMetadataCacheAccessorMock : MSIDAccountMetadataCacheAccessor
 
 @property (nonatomic) NSInteger updateAuthorityURLInvokedCount;
@@ -50,6 +56,14 @@ struct MSIDAccountMetadataCacheMockGetAuthorityParameters
 @property (nonatomic) NSInteger getAuthorityURLInvokedCount;
 @property (nonatomic) struct MSIDAccountMetadataCacheMockGetAuthorityParameters getAuthorityProvidedParams;
 @property (nonatomic) NSURL *authorityURLToReturn;
+
+@property (nonatomic, nullable) MSIDAccountIdentifier *mockedPrincipalAccountId;
+@property (nonatomic, nullable) NSError *mockedPrincipalAccountIdError;
+
+@property (nonatomic) BOOL updatePrincipalAccountIdResult;
+@property (nonatomic) NSError *updatePrincipalAccountIdError;
+@property (nonatomic) NSInteger updatePrincipalAccountIdInvokedCount;
+@property (nonatomic) struct MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams updatePrincipalAccountIdParams;
 
 @end
 

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
@@ -73,4 +73,29 @@
     return YES;
 }
 
+- (MSIDAccountIdentifier *)principalAccountIdForClientId:(__unused NSString *)clientId
+                                                 context:(__unused id<MSIDRequestContext>)context
+                                                   error:(NSError **)error
+{
+    if (error) *error = self.mockedPrincipalAccountIdError;
+    return self.mockedPrincipalAccountId;
+}
+
+- (BOOL)updatePrincipalAccountIdForClientId:(NSString *)clientId
+                         principalAccountId:(MSIDAccountIdentifier *)principalAccountId
+                                    context:(__unused id<MSIDRequestContext>)context
+                                      error:(NSError **)error
+{
+    if (error) *error = self.updatePrincipalAccountIdError;
+    
+    struct MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams s  = self.updatePrincipalAccountIdParams;
+    s.principalAccountId = principalAccountId;
+    s.clientId = clientId;
+    self.updatePrincipalAccountIdParams = s;
+    
+    self.updatePrincipalAccountIdInvokedCount++;
+    
+    return self.updatePrincipalAccountIdResult;
+}
+
 @end


### PR DESCRIPTION
Fixes an issue where account metadata was never updated in Silent SSO extension requests