### PR TITLE
Save Account Metadata from Broker Token Response

### DIFF
--- a/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
@@ -178,17 +178,16 @@
 
 - (NSDictionary *)defaultResumeDictionaryContents
 {
-    NSDictionary *resumeDictionary =
-    @{
-      @"authority"        : self.requestParameters.authority.url.absoluteString,
-      @"client_id"        : self.requestParameters.clientId,
-      @"redirect_uri"     : self.requestParameters.redirectUri,
-      @"correlation_id"   : self.requestParameters.correlationId.UUIDString,
+    NSMutableDictionary *resumeDictionary = [NSMutableDictionary new];
+    [resumeDictionary msidSetNonEmptyString:self.requestParameters.authority.url.absoluteString forKey:@"authority"];
+    [resumeDictionary msidSetNonEmptyString:self.requestParameters.clientId forKey:@"client_id"];
+    [resumeDictionary msidSetNonEmptyString:self.requestParameters.redirectUri forKey:@"redirect_uri"];
+    [resumeDictionary msidSetNonEmptyString:self.requestParameters.correlationId.UUIDString forKey:@"correlation_id"];
 #if TARGET_OS_IPHONE
-      @"keychain_group"   : self.requestParameters.keychainAccessGroup ?: MSIDKeychainTokenCache.defaultKeychainGroup,
-      @"broker_nonce"     : self.brokerNonce
+    [resumeDictionary msidSetNonEmptyString:self.requestParameters.keychainAccessGroup ?: MSIDKeychainTokenCache.defaultKeychainGroup forKey:@"keychain_group"];
+    [resumeDictionary msidSetNonEmptyString:self.brokerNonce forKey:@"broker_nonce"];
 #endif
-      };
+    
     return resumeDictionary;
 }
 

--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.h
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.h
@@ -43,6 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL sourceApplicationAvailable;
 @property (nonatomic, readonly) NSString *brokerNonce;
+@property (nonatomic, readonly) NSURL *providedAuthority;
+@property (nonatomic, readonly) BOOL instanceAware;
 
 - (nullable instancetype)initWithOauthFactory:(MSIDOauth2Factory *)factory
                        tokenResponseValidator:(MSIDTokenResponseValidator *)responseValidator;

--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
@@ -87,7 +87,7 @@
     NSUUID *correlationId = [[NSUUID alloc] initWithUUIDString:[resumeState objectForKey:@"correlation_id"]];
     NSString *keychainGroup = resumeState[@"keychain_group"];
     NSString *oidcScope = resumeState[@"oidc_scope"];
-    NSString *providedAuthorityStr = [resumeState msidStringObjectForKey:@"provided_authority_url"];
+    NSString *providedAuthorityStr = [resumeState msidStringObjectForKey:@"provided_authority_url"] ?: [resumeState msidStringObjectForKey:@"authority"];
     self.providedAuthority = providedAuthorityStr ? [NSURL URLWithString:providedAuthorityStr] : nil;
     self.instanceAware = [resumeState msidBoolObjectForKey:@"instance_aware"];
     self.brokerNonce = resumeState[@"broker_nonce"];

--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
@@ -47,6 +47,8 @@
 
 @property (nonatomic, readwrite) BOOL sourceApplicationAvailable;
 @property (nonatomic, readwrite) NSString *brokerNonce;
+@property (nonatomic, readwrite) NSURL *providedAuthority;
+@property (nonatomic, readwrite) BOOL instanceAware;
 
 @end
 
@@ -85,6 +87,9 @@
     NSUUID *correlationId = [[NSUUID alloc] initWithUUIDString:[resumeState objectForKey:@"correlation_id"]];
     NSString *keychainGroup = resumeState[@"keychain_group"];
     NSString *oidcScope = resumeState[@"oidc_scope"];
+    NSString *providedAuthorityStr = [resumeState msidStringObjectForKey:@"provided_authority_url"];
+    self.providedAuthority = providedAuthorityStr ? [NSURL URLWithString:providedAuthorityStr] : nil;
+    self.instanceAware = [resumeState msidBoolObjectForKey:@"instance_aware"];
     self.brokerNonce = resumeState[@"broker_nonce"];
     self.sourceApplicationAvailable = sourceApplication != nil;
 
@@ -154,6 +159,8 @@
     
     return [self.tokenResponseValidator validateAndSaveBrokerResponse:brokerResponse
                                                             oidcScope:oidcScope
+                                                     requestAuthority:self.providedAuthority
+                                                        instanceAware:self.instanceAware
                                                          oauthFactory:self.oauthFactory
                                                            tokenCache:self.tokenCache
                                                  accountMetadataCache:self.accountMetadataCacheAccessor

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
@@ -42,6 +42,8 @@
 
 - (nullable MSIDTokenResult *)validateAndSaveBrokerResponse:(nonnull MSIDBrokerResponse *)brokerResponse
                                                   oidcScope:(nullable NSString *)oidcScope
+                                           requestAuthority:(nullable NSURL *)requestAuthority
+                                              instanceAware:(BOOL)instanceAware
                                                oauthFactory:(nonnull MSIDOauth2Factory *)factory
                                                  tokenCache:(nonnull id<MSIDCacheAccessor>)tokenCache
                                        accountMetadataCache:(nullable MSIDAccountMetadataCacheAccessor *)accountMetadataCache

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyBrokerResponseHandler.m
@@ -124,6 +124,8 @@
         MSIDAADV1BrokerResponse *brokerResponse = [[MSIDAADV1BrokerResponse alloc] initWithDictionary:decryptedResponse error:&intuneError];
         MSIDTokenResult *intuneResult = [self.tokenResponseValidator validateAndSaveBrokerResponse:brokerResponse
                                                                                          oidcScope:oidcScope
+                                                                                  requestAuthority:self.providedAuthority
+                                                                                     instanceAware:self.instanceAware
                                                                                       oauthFactory:self.oauthFactory
                                                                                         tokenCache:self.tokenCache
                                                                               accountMetadataCache:self.accountMetadataCacheAccessor

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
@@ -98,6 +98,8 @@
             {  
                 tokenResult = [self.tokenResponseValidator validateAndSaveBrokerResponse:brokerResponse
                                                                                oidcScope:oidcScope
+                                                                        requestAuthority:self.providedAuthority
+                                                                           instanceAware:self.instanceAware
                                                                             oauthFactory:self.oauthFactory
                                                                               tokenCache:self.tokenCache
                                                                     accountMetadataCache:self.accountMetadataCacheAccessor

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
@@ -68,7 +68,7 @@
     [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.target ?: @"" forKey:@"scope"];
     [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.oidcScope ?: @"" forKey:@"oidc_scope"];
     [protocolResumeDictionary msidSetNonEmptyString:MSID_MSAL_SDK_NAME forKey:MSID_SDK_NAME_KEY];
-    [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.providedAuthority.url.absoluteString ?: self.requestParameters.authority.url.absoluteString forKey:@"provided_authority_url"];
+    [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.providedAuthority.url.absoluteString forKey:@"provided_authority_url"];
     [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.instanceAware ? @"YES" : @"NO" forKey:@"instance_aware"];
     
     return protocolResumeDictionary;

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
@@ -26,6 +26,7 @@
 #import "MSIDAccountIdentifier.h"
 #import "NSMutableDictionary+MSIDExtensions.h"
 #import "MSIDPromptType_Internal.h"
+#import "MSIDAuthority.h"
 
 @implementation MSIDDefaultBrokerTokenRequest
 
@@ -63,9 +64,14 @@
 
 - (NSDictionary *)protocolResumeDictionaryContents
 {
-    return @{@"scope": self.requestParameters.target ?: @"",
-             @"oidc_scope": self.requestParameters.oidcScope ?: @"",
-             MSID_SDK_NAME_KEY: MSID_MSAL_SDK_NAME};
+    NSMutableDictionary *protocolResumeDictionary = [NSMutableDictionary new];
+    [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.target ?: @"" forKey:@"scope"];
+    [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.oidcScope ?: @"" forKey:@"oidc_scope"];
+    [protocolResumeDictionary msidSetNonEmptyString:MSID_MSAL_SDK_NAME forKey:MSID_SDK_NAME_KEY];
+    [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.providedAuthority.url.absoluteString ?: self.requestParameters.authority.url.absoluteString forKey:@"provided_authority_url"];
+    [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.instanceAware ? @"YES" : @"NO" forKey:@"instance_aware"];
+    
+    return protocolResumeDictionary;
 }
 
 @end

--- a/IdentityCore/tests/integration/ios/MSIDDefaultBrokerRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultBrokerRequestTests.m
@@ -82,7 +82,9 @@
                                                @"scope" : @"myscope1 myscope2",
                                                @"oidc_scope" : @"oidcscope1 oidcscope2",
                                                @"sdk_name" : @"msal-objc",
-                                               @"broker_nonce": brokerNonce
+                                               @"broker_nonce": brokerNonce,
+                                               @"instance_aware" : @"NO",
+                                               @"provided_authority_url" : @"https://login.microsoftonline.com/contoso.com",
                                                };
     
     XCTAssertEqualObjects(expectedResumeDictionary, request.resumeDictionary);
@@ -171,7 +173,9 @@
                                                @"scope" : @"myscope1 myscope2",
                                                @"oidc_scope" : @"oidcscope1 oidcscope2",
                                                @"sdk_name" : @"msal-objc",
-                                               @"broker_nonce": brokerNonce
+                                               @"broker_nonce" : brokerNonce,
+                                               @"instance_aware" : @"NO",
+                                               @"provided_authority_url" : @"https://login.microsoftonline.com/contoso.com",
                                                };
     
     XCTAssertEqualObjects(expectedResumeDictionary, request.resumeDictionary);
@@ -224,7 +228,9 @@
                                                @"scope" : @"myscope1 myscope2",
                                                @"oidc_scope" : @"oidcscope1 oidcscope2",
                                                @"sdk_name" : @"msal-objc",
-                                               @"broker_nonce": brokerNonce
+                                               @"broker_nonce": brokerNonce,
+                                               @"instance_aware" : @"NO",
+                                               @"provided_authority_url" : @"https://login.microsoftonline.com/contoso.com",
                                                };
     
     XCTAssertEqualObjects(expectedResumeDictionary, request.resumeDictionary);
@@ -277,7 +283,9 @@
                                                @"scope" : @"myscope1 myscope2",
                                                @"oidc_scope" : @"oidcscope1 oidcscope2",
                                                @"sdk_name" : @"msal-objc",
-                                               @"broker_nonce": brokerNonce
+                                               @"broker_nonce": brokerNonce,
+                                               @"instance_aware" : @"NO",
+                                               @"provided_authority_url" : @"https://login.microsoftonline.com/contoso.com",
                                                };
     
     XCTAssertEqualObjects(expectedResumeDictionary, request.resumeDictionary);

--- a/IdentityCore/tests/integration/ios/MSIDDefaultBrokerRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultBrokerRequestTests.m
@@ -39,6 +39,7 @@
 - (void)testInitBrokerRequest_whenValidRequest_shouldSendScopeAndPromptAndProtocolVer
 {
     MSIDInteractiveTokenRequestParameters *parameters = [self defaultTestParameters];
+    parameters.providedAuthority = parameters.authority;
     
     NSError *error = nil;
     MSIDDefaultBrokerTokenRequest *request = [[MSIDDefaultBrokerTokenRequest alloc] initWithRequestParameters:parameters brokerKey:@"brokerKey" brokerApplicationToken:@"brokerApplicationToken" sdkCapabilities:nil error:&error];
@@ -93,6 +94,7 @@
 - (void)testInitBrokerRequest_whenInstanceAwareFlagSet_shouldSendInstanceAwareInEQP
 {
     MSIDInteractiveTokenRequestParameters *parameters = [self defaultTestParameters];
+    parameters.providedAuthority = parameters.authority;
     parameters.instanceAware = YES;
     
     NSError *error = nil;
@@ -128,6 +130,7 @@
 - (void)testInitBrokerRequest_whenAccountSet_shouldSendHomeAccountIdAndUsername
 {
     MSIDInteractiveTokenRequestParameters *parameters = [self defaultTestParameters];
+    parameters.providedAuthority = parameters.authority;
     parameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user" homeAccountId:@"myHomeAccountId"];
     
     NSError *error = nil;
@@ -230,7 +233,6 @@
                                                @"sdk_name" : @"msal-objc",
                                                @"broker_nonce": brokerNonce,
                                                @"instance_aware" : @"NO",
-                                               @"provided_authority_url" : @"https://login.microsoftonline.com/contoso.com",
                                                };
     
     XCTAssertEqualObjects(expectedResumeDictionary, request.resumeDictionary);
@@ -285,7 +287,6 @@
                                                @"sdk_name" : @"msal-objc",
                                                @"broker_nonce": brokerNonce,
                                                @"instance_aware" : @"NO",
-                                               @"provided_authority_url" : @"https://login.microsoftonline.com/contoso.com",
                                                };
     
     XCTAssertEqualObjects(expectedResumeDictionary, request.resumeDictionary);

--- a/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
@@ -45,10 +45,12 @@
 #import "MSIDRefreshToken.h"
 #import "MSIDIdToken.h"
 #import "MSIDDefaultTokenCacheAccessor.h"
+#import "MSIDAccountMetadataCacheAccessor.h"
 
 @interface MSIDDefaultBrokerResponseHandlerTests : XCTestCase
 
 @property (nonatomic) MSIDDefaultTokenCacheAccessor *cacheAccessor;
+@property (nonatomic) MSIDAccountMetadataCacheAccessor *accountMetadataCache;
 
 @end
 
@@ -62,6 +64,7 @@
     [dataSource clearWithContext:nil error:nil];
     MSIDLegacyTokenCacheAccessor *otherAccessor = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:nil];
     self.cacheAccessor = [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:@[otherAccessor]];
+    self.accountMetadataCache = [[MSIDAccountMetadataCacheAccessor alloc] initWithDataSource:dataSource];
 }
 
 - (void)tearDown {
@@ -132,6 +135,9 @@
     
     XCTAssertNotNil(result);
     XCTAssertNil(error);
+    
+    XCTAssertEqualObjects(brokerResponseHandler.providedAuthority.absoluteString, @"https://login.microsoftonline.com/common");
+    XCTAssertEqual(brokerResponseHandler.instanceAware, NO);
     
     XCTAssertEqualObjects(result.accessToken.accessToken, @"i-am-a-access-token");
     XCTAssertEqualObjects(result.accessToken.scopes, [scopes msidScopeSet]);
@@ -1139,6 +1145,79 @@
     XCTAssertNil(refreshToken.familyId);
 }
 
+- (void)testHandleBrokerResponse_whenValidBrokerResponse_shouldUpdateAccountMetadata
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    
+    NSString *idTokenString = [MSIDTestIdTokenUtil idTokenWithPreferredUsername:@"user@contoso.com"
+                                                                        subject:@"mysubject"
+                                                                      givenName:@"myGivenName"
+                                                                     familyName:@"myFamilyName"
+                                                                           name:@"Contoso"
+                                                                        version:@"2.0"
+                                                                            tid:@"contoso.com-guid"];
+    
+    NSDictionary *clientInfo = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
+    NSString *rawClientInfo = [clientInfo msidBase64UrlJson];
+    
+    NSDate *expiresOn = [NSDate dateWithTimeIntervalSinceNow:3600];
+    NSString *expiresOnString = [NSString stringWithFormat:@"%ld", (long)[expiresOn timeIntervalSince1970]];
+    
+    NSDate *extExpiresOn = [NSDate dateWithTimeIntervalSinceNow:36000];
+    NSString *extExpiresOnString = [NSString stringWithFormat:@"%ld", (long)[extExpiresOn timeIntervalSince1970]];
+    
+    NSString *correlationId = [[NSUUID UUID] UUIDString];
+    
+    NSString *scopes = @"myscope1 myscope2";
+    
+    NSDictionary *brokerResponseParams =
+    @{
+      @"authority" : @"https://login.microsoftonline.com/common",
+      @"scope" : scopes,
+      @"client_id" : @"my_client_id",
+      @"id_token" : idTokenString,
+      @"client_info" : rawClientInfo,
+      @"home_account_id" : @"1.1234-5678-90abcdefg",
+      @"access_token" : @"i-am-a-access-token",
+      @"token_type" : @"Bearer",
+      @"refresh_token" : @"i-am-a-refresh-token",
+      @"expires_on" : expiresOnString,
+      @"ext_expires_on" : extExpiresOnString,
+      @"correlation_id" : correlationId,
+      @"x-broker-app-ver" : @"1.0.0",
+      @"foci" : @"1",
+      @"success": @YES,
+      @"broker_nonce" : @"nonce"
+      };
+    
+    NSURL *brokerResponseURL = [MSIDTestBrokerResponseHelper createDefaultBrokerResponse:brokerResponseParams
+                                                                             redirectUri:@"x-msauth-test://com.microsoft.testapp"
+                                                                           encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];
+    
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+    
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+    
+    XCTAssertNotNil(result);
+    XCTAssertEqualObjects(result.accessToken.accessToken, @"i-am-a-access-token");
+    XCTAssertNil(error);
+    
+    XCTAssertEqualObjects(brokerResponseHandler.providedAuthority.absoluteString, @"https://login.microsoftonline.com/common");
+    XCTAssertEqual(brokerResponseHandler.instanceAware, NO);
+    
+    // Verify sign in state
+    MSIDAccountMetadataState signInState = [self.accountMetadataCache signInStateForHomeAccountId:@"1.1234-5678-90abcdefg" clientId:@"my_client_id" context:nil error:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual(signInState, MSIDAccountMetadataStateSignedIn);
+    
+    // Verify authority mapping
+    NSURL *retrievedCacheURL = [self.accountMetadataCache getAuthorityURL:[NSURL URLWithString:@"https://login.microsoftonline.com/common"]
+                                                            homeAccountId:@"1.1234-5678-90abcdefg"
+                                                                 clientId:@"my_client_id" instanceAware:NO context:nil error:&error];
+    XCTAssertEqualObjects(@"https://login.microsoftonline.com/contoso.com-guid", retrievedCacheURL.absoluteString);
+}
+
 -(void)testCanHandleBrokerResponse_whenProtocolVersionIs3AndRequestIntiatedByMsalAndHasCompletionBlock_shouldReturnYes
 {
     NSDictionary *resumeDictionary = @{MSID_SDK_NAME_KEY: MSID_MSAL_SDK_NAME};
@@ -1203,7 +1282,9 @@
                                   @"scope" : @"myscope1 myscope2",
                                   @"keychain_group" : @"com.microsoft.adalcache",
                                   @"redirect_uri" : @"x-msauth-test://com.microsoft.testapp",
-                                  @"broker_nonce" : @"nonce"
+                                  @"broker_nonce" : @"nonce",
+                                  @"instance_aware" : @"NO",
+                                  @"provided_authority_url" : authority,
                                   };
     
     [[NSUserDefaults standardUserDefaults] setObject:resumeState forKey:MSID_BROKER_RESUME_DICTIONARY_KEY];


### PR DESCRIPTION
Make the change to fix a bug, where we didn't save account metadata in MSAL when receives broker response.