### PR TITLE
[Broker patch] Fixed account lookups and validation with the same email

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.h
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.h
@@ -53,6 +53,7 @@
 
 - (MSIDAccount *)getAccountForIdentifier:(MSIDAccountIdentifier *)accountIdentifier
                                authority:(MSIDAuthority *)authority
+                               realmHint:(NSString *)realmHint
                                  context:(id<MSIDRequestContext>)context
                                    error:(NSError **)error;
 

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -505,6 +505,9 @@
         MSIDAccount *account = [[MSIDAccount alloc] initWithAccountCacheItem:cacheItem];
         if (!account) continue;
 
+        /*
+        Note that lookup by realmHint is a best effort (hence it is a hint), because developer might be requesting token for tenantId not previously requested, in which case there will be no account in cache. We still want to ensure best effort account lookup in that scenario. In case we lookup wrong account (e.g. we find MSA account and developer wanted to get a token for Google B2B account), silent broker request will fail and we fall back to interactive request, which will resolve account correctly. Server side ensures here final account resolution based on which account is present in the tenant, and possibly a user choice during interactive token acquisition.
+         */
         if (realmHint && [account.realm isEqualToString:realmHint])
         {
             return account;

--- a/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.h
@@ -38,6 +38,7 @@
 @property (nonatomic) MSIDWebviewType webviewType;
 @property (nonatomic) WKWebView *customWebview;
 @property (readwrite) NSMutableDictionary<NSString *, NSString *> *customWebviewHeaders;
+@property (readwrite, nonatomic) BOOL shouldValidateResultAccount;
 #if TARGET_OS_IPHONE
 @property (nonatomic) UIViewController *parentViewController;
 @property (nonatomic) UIModalPresentationStyle presentationType;

--- a/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
@@ -39,6 +39,7 @@
 #import "MSIDTokenResult.h"
 #import "MSIDAccountIdentifier.h"
 #import "MSIDWebviewFactory.h"
+#import "MSIDAccount.h"
 
 #if TARGET_OS_IPHONE
 #import "MSIDAppExtensionUtil.h"
@@ -290,7 +291,9 @@
                                                                  correlationID:self.requestParameters.correlationId
                                                                          error:&validationError];
             
-            if (!accountChecked)
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.requestParameters, @"Validated result account with result %d, old account %@, new account %@", accountChecked, MSID_PII_LOG_TRACKABLE(self.requestParameters.accountIdentifier.uid), MSID_PII_LOG_TRACKABLE(tokenResult.account.accountIdentifier.uid));
+            
+            if (!accountChecked && self.requestParameters.shouldValidateResultAccount)
             {
                 completionBlock(nil, validationError, nil);
                 return;

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
@@ -120,6 +120,7 @@
 
     MSIDAccount *account = [self.defaultAccessor getAccountForIdentifier:self.requestParameters.accountIdentifier
                                                                authority:self.requestParameters.authority
+                                                               realmHint:nil
                                                                  context:self.requestParameters
                                                                    error:&cacheError];
 

--- a/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
@@ -1622,7 +1622,7 @@
                                                                                  homeAccountId:@"home.id"];
 
     MSIDAuthority *authority = [@"https://login.windows.net/common" aadAuthority];
-    MSIDAccount *account = [_defaultAccessor getAccountForIdentifier:identifier authority:authority context:nil error:&error];
+    MSIDAccount *account = [_defaultAccessor getAccountForIdentifier:identifier authority:authority realmHint:nil context:nil error:&error];
 
     XCTAssertNil(error);
     XCTAssertNil(account);
@@ -1649,13 +1649,88 @@
 
     MSIDAuthority *authority = [@"https://login.windows.net/contoso.com" aadAuthority];
 
-    MSIDAccount *account = [_defaultAccessor getAccountForIdentifier:identifier authority:authority context:nil error:&error];
+    MSIDAccount *account = [_defaultAccessor getAccountForIdentifier:identifier authority:authority realmHint:nil context:nil error:&error];
 
     XCTAssertNil(error);
     XCTAssertNotNil(account);
     XCTAssertEqualObjects(account.accountIdentifier.homeAccountId, @"home.contoso.com");
     XCTAssertEqualObjects(account.accountIdentifier.displayableId, @"legacy.id");
 }
+
+- (void)testGetAccount_whenMultipleAccountsPresent_andRealmHintProvided_shouldReturnMatchingAccount
+{
+    [self saveResponseWithUPN:@"legacy.id"
+                     clientId:@"test_client_id"
+                    authority:@"https://login.windows.net/non.matching.realm"
+               responseScopes:@"user.read user.write"
+                  inputScopes:@"user.read user.write"
+                          uid:@"home"
+                         utid:@"contoso.com"
+                     tenantId:@"non.matching.realm"
+                  accessToken:@"access token"
+                 refreshToken:@"refresh token"
+                     familyId:nil
+                appIdentifier:nil
+                     accessor:_defaultAccessor];
+
+     [self saveResponseWithUPN:@"legacy.id"
+                     clientId:@"test_client_id"
+                    authority:@"https://login.windows.net/matching.realm"
+               responseScopes:@"user.read user.write"
+                  inputScopes:@"user.read user.write"
+                          uid:@"home"
+                         utid:@"contoso.com"
+                     tenantId:@"matching.realm"
+                  accessToken:@"access token"
+                 refreshToken:@"refresh token"
+                     familyId:nil
+                appIdentifier:nil
+                     accessor:_defaultAccessor];
+
+     MSIDAccountIdentifier *identifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
+                                                                                 homeAccountId:@"home.contoso.com"];
+
+     NSError *error = nil;
+
+     MSIDAccount *account = [_defaultAccessor getAccountForIdentifier:identifier authority:nil realmHint:@"matching.realm" context:nil error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(account);
+    XCTAssertEqualObjects(account.accountIdentifier.homeAccountId, @"home.contoso.com");
+    XCTAssertEqualObjects(account.accountIdentifier.displayableId, @"legacy.id");
+    XCTAssertEqualObjects(account.realm, @"matching.realm");
+}
+
+ - (void)testGetAccount_whenMultipleAccountsPresent_andNonMatchingRealmHintProvided_shouldReturnAnyAccount
+{
+    [self saveResponseWithUPN:@"legacy.id"
+                     clientId:@"test_client_id"
+                    authority:@"https://login.windows.net/non.matching.realm2"
+               responseScopes:@"user.read user.write"
+                  inputScopes:@"user.read user.write"
+                          uid:@"home"
+                         utid:@"contoso.com"
+                     tenantId:@"non.matching.realm2"
+                  accessToken:@"access token"
+                 refreshToken:@"refresh token"
+                     familyId:nil
+                appIdentifier:nil
+                     accessor:_defaultAccessor];
+
+     MSIDAccountIdentifier *identifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
+                                                                                 homeAccountId:@"home.contoso.com"];
+
+     NSError *error = nil;
+
+     MSIDAccount *account = [_defaultAccessor getAccountForIdentifier:identifier authority:nil realmHint:@"matching.realm" context:nil error:&error];
+
+     XCTAssertNil(error);
+    XCTAssertNotNil(account);
+    XCTAssertEqualObjects(account.accountIdentifier.homeAccountId, @"home.contoso.com");
+    XCTAssertEqualObjects(account.accountIdentifier.displayableId, @"legacy.id");
+    XCTAssertEqualObjects(account.realm, @"non.matching.realm2");
+}
+
 
 #pragma mark - Get access tokens
 
@@ -2523,7 +2598,36 @@
               appIdentifier:(NSString *)appIdentifier
                    accessor:(id<MSIDCacheAccessor>)accessor
 {
-    NSString *idToken = [MSIDTestIdTokenUtil idTokenWithPreferredUsername:upn subject:@"subject" givenName:@"Hello" familyName:@"World" name:@"Hello World" version:@"2.0" tid:utid];
+       [self saveResponseWithUPN:upn
+                         clientId:clientId
+                        authority:authority
+                   responseScopes:responseScopes
+                      inputScopes:inputScopes
+                              uid:uid
+                             utid:utid
+                         tenantId:utid
+                      accessToken:accessToken
+                     refreshToken:refreshToken
+                         familyId:familyId
+                    appIdentifier:appIdentifier
+                         accessor:accessor];
+}
+
+ - (void)saveResponseWithUPN:(NSString *)upn
+                   clientId:(NSString *)clientId
+                  authority:(NSString *)authority
+             responseScopes:(NSString *)responseScopes
+                inputScopes:(NSString *)inputScopes
+                        uid:(NSString *)uid
+                       utid:(NSString *)utid
+                   tenantId:(NSString *)tenantId
+                accessToken:(NSString *)accessToken
+               refreshToken:(NSString *)refreshToken
+                   familyId:(NSString *)familyId
+              appIdentifier:(NSString *)appIdentifier
+                   accessor:(id<MSIDCacheAccessor>)accessor
+{
+    NSString *idToken = [MSIDTestIdTokenUtil idTokenWithPreferredUsername:upn subject:@"subject" givenName:@"Hello" familyName:@"World" name:@"Hello World" version:@"2.0" tid:tenantId];
 
     MSIDTokenResponse *response = [MSIDTestTokenResponse v2TokenResponseWithAT:accessToken
                                                                             RT:refreshToken

--- a/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
@@ -286,7 +286,7 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
-- (void)testInteractiveRequestFlow_whenAccountMismatch_shouldReturnNilResultWithError
+- (void)testInteractiveRequestFlow_whenAccountMismatch_andShouldValidateResultAccountYES_shouldReturnNilResultWithError
 {
     __block NSUUID *correlationId = [NSUUID new];
 
@@ -305,6 +305,7 @@
     parameters.authority.openIdConfigurationEndpoint = [NSURL URLWithString:@"https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"];
     parameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:@"1.1234-5678-90abcdefg"];
     parameters.enablePkce = YES;
+    parameters.shouldValidateResultAccount = YES;
 
     MSIDInteractiveTokenRequest *request = [[MSIDInteractiveTokenRequest alloc] initWithRequestParameters:parameters oauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new] tokenCache:self.tokenCache accountMetadataCache:self.metadataCache];
 

--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@ from timeit import default_timer as timer
 
 script_start_time = timer()
 
-ios_sim_device = "iPhone 6"
+ios_sim_device = "iPhone 8"
 ios_sim_dest = "-destination 'platform=iOS Simulator,name=" + ios_sim_device + ",OS=latest'"
 ios_sim_flags = "-sdk iphonesimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 


### PR DESCRIPTION
With the introduction of Google B2B accounts, there’s now a potential conflict between MSA accounts and Google B2B accounts with the same email address. In this scenario, home account id-s for accounts with the same email address will be different, and refresh token for one account won’t work for another account.

The mitigation for developers is to always provide us home account id, and only lookup accounts by home account id. When looking up accounts by displayable id, there’s no guarantee that we get the right account in the above mentioned scenario.  

However, to ensure backward compatibility, and not break SSO, iOS broker should still be able to lookup accounts by only email/upn. In normal scenarios, it will be reliable. In Google B2B scenarios it will be the best effort, and we fallback to interactive auth to resolve accounts. 

In current broker SDK, there were two problems that were preventing this scenario from working:
1. Broker SDK sets accountIdentifier for InteractiveTokenRequest based on the email/upn even when developer didn’t provide us accountIdentifier. In this case, if accountIdentifier mismatched, it returned account mismatch error. The fix is to only enable account verification if developer provided us account identifier. If developer only provided us displayable id, this matching is unreliable and will now be disabled.
2. Broker SDK resolves home account identifier by email without accounting for the requested tenantId. This PR introduces a fix to also account for a tenantId hint when looking up accounts. Note that this is a best effort (hence it is a hint), because developer might be requesting token for tenantId not previously requested, in which case there will be no account in cache. We still want to ensure best effort account lookup in that scenario. In case we lookup wrong account (e.g. we find MSA account and developer wanted to get a token for Google B2B account), silent broker request will fail and we fall back to interactive request, which will resolve account correctly. Server side ensures here final account resolution based on which account is present in the tenant, and possibly a user choice during interactive token acquisition. 

Other PRs for this fix:
Common core: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/668
MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/826
Broker: https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/431

Note that since broker is using MSAL 1.0.0, this hot fix is based off that release to minimize changes. 