### PR TITLE
Wait for UIScene to become active before calling signout request

### DIFF
--- a/IdentityCore/src/controllers/broker/MSIDSSOExtensionSignoutController.m
+++ b/IdentityCore/src/controllers/broker/MSIDSSOExtensionSignoutController.m
@@ -62,10 +62,15 @@
             return;
         }
         
+#if TARGET_OS_IPHONE
         [self waitForSceneActivationAndCompleteSignout:completionBlock];
+#else
+        [super executeRequestWithCompletion:completionBlock];
+#endif
     }];
 }
 
+#if TARGET_OS_IPHONE
 - (void)waitForSceneActivationAndCompleteSignout:(MSIDSignoutRequestCompletionBlock)completionBlock
 {
     UIWindowScene *windowScene = self.parameters.parentViewController.view.window.windowScene;
@@ -96,6 +101,7 @@
                                                                                        usingBlock:sceneActivatedBlock];
     }
 }
+#endif
 
 + (BOOL)canPerformRequest
 {


### PR DESCRIPTION
When SSO extension request is complete, there's often a delay before UIWindowScene will become active again. This causes failures for ASWebAuthenticationSession request that follows SSO extension signet request. This PR adds additional logic to wait for scene to become active before calling signout request. 

This is one of the ways to workaround this issue. Please take a look and provide feedback. 