### PR TITLE
Propagate return only signed in accounts flag

### DIFF
--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.h
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.h
@@ -36,6 +36,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 @property (nonatomic, readonly) MSIDRequestParameters *requestParameters;
 
 - (nullable instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
+                        returnOnlySignedInAccounts:(BOOL)returnOnlySignedInAccounts
                                              error:(NSError * _Nullable * _Nullable)error;
 
 - (void)executeRequestWithCompletion:(nonnull MSIDGetAccountsRequestCompletionBlock)completionBlock;

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
@@ -41,12 +41,14 @@
 @property (nonatomic) MSIDSSOExtensionOperationRequestDelegate *extensionDelegate;
 @property (nonatomic) ASAuthorizationSingleSignOnProvider *ssoProvider;
 @property (nonatomic) MSIDRequestParameters *requestParameters;
-
+@property (nonatomic) BOOL returnOnlySignedInAccounts;
+ 
 @end
 
 @implementation MSIDSSOExtensionGetAccountsRequest
 
 - (nullable instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
+                        returnOnlySignedInAccounts:(BOOL)returnOnlySignedInAccounts
                                              error:(NSError * _Nullable * _Nullable)error
 {
     self = [super init];
@@ -64,6 +66,7 @@
     if (self)
     {
         _requestParameters = requestParameters;
+        _returnOnlySignedInAccounts = returnOnlySignedInAccounts;
         
         _extensionDelegate = [MSIDSSOExtensionOperationRequestDelegate new];
         _extensionDelegate.context = requestParameters;
@@ -105,6 +108,7 @@
 {
     MSIDBrokerOperationGetAccountsRequest *getAccountsRequest = [MSIDBrokerOperationGetAccountsRequest new];
     getAccountsRequest.clientId = self.requestParameters.clientId;
+    getAccountsRequest.returnOnlySignedInAccounts = self.returnOnlySignedInAccounts;
     // TODO: pass familyId, will be addressed in a separate PR
     // TODO: pass returnOnlySignedInAccounts == false, will be addressed in a separate PR
     

--- a/IdentityCore/tests/integration/MSIDSSOExtensionGetAccountsRequestIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDSSOExtensionGetAccountsRequestIntegrationTests.m
@@ -50,7 +50,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
     params.clientId = nil;
     
     NSError *error;
-    MSIDSSOExtensionGetAccountsRequest *request = [[MSIDSSOExtensionGetAccountsRequest alloc] initWithRequestParameters:params error:&error];
+    MSIDSSOExtensionGetAccountsRequest *request = [[MSIDSSOExtensionGetAccountsRequest alloc] initWithRequestParameters:params returnOnlySignedInAccounts:YES error:&error];
     XCTAssertNotNil(request);
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Execute request"];
@@ -73,7 +73,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 {
     MSIDRequestParameters *params = [MSIDTestParametersProvider testInteractiveParameters];
     
-    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params error:nil];
+    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params returnOnlySignedInAccounts:YES error:nil];
     XCTAssertNotNil(request);
     
     MSIDAuthorizationControllerMock *authorizationControllerMock = [[MSIDAuthorizationControllerMock alloc] initWithAuthorizationRequests:@[[[ASAuthorizationSingleSignOnProvider msidSharedProvider] createRequest]]];
@@ -113,7 +113,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 {
     MSIDRequestParameters *params = [MSIDTestParametersProvider testInteractiveParameters];
     
-    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params error:nil];
+    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params returnOnlySignedInAccounts:YES error:nil];
     XCTAssertNotNil(request);
     
     MSIDAuthorizationControllerMock *authorizationControllerMock = [[MSIDAuthorizationControllerMock alloc] initWithAuthorizationRequests:@[[[ASAuthorizationSingleSignOnProvider msidSharedProvider] createRequest]]];
@@ -158,7 +158,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 {
     MSIDRequestParameters *params = [MSIDTestParametersProvider testInteractiveParameters];
     
-    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params error:nil];
+    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params returnOnlySignedInAccounts:YES error:nil];
     XCTAssertNotNil(request);
     
     MSIDAuthorizationControllerMock *authorizationControllerMock = [[MSIDAuthorizationControllerMock alloc] initWithAuthorizationRequests:@[[[ASAuthorizationSingleSignOnProvider msidSharedProvider] createRequest]]];
@@ -242,7 +242,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 {
     MSIDRequestParameters *params = [MSIDTestParametersProvider testInteractiveParameters];
     
-    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params error:nil];
+    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params returnOnlySignedInAccounts:YES error:nil];
     XCTAssertNotNil(request);
     
     MSIDAuthorizationControllerMock *authorizationControllerMock = [[MSIDAuthorizationControllerMock alloc] initWithAuthorizationRequests:@[[[ASAuthorizationSingleSignOnProvider msidSharedProvider] createRequest]]];
@@ -309,7 +309,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 {
     MSIDRequestParameters *params = [MSIDTestParametersProvider testInteractiveParameters];
     
-    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params error:nil];
+    MSIDSSOExtensionGetAccountsRequestMock *request = [[MSIDSSOExtensionGetAccountsRequestMock alloc] initWithRequestParameters:params returnOnlySignedInAccounts:YES error:nil];
     XCTAssertNotNil(request);
     
     MSIDAuthorizationControllerMock *authorizationControllerMock = [[MSIDAuthorizationControllerMock alloc] initWithAuthorizationRequests:@[[[ASAuthorizationSingleSignOnProvider msidSharedProvider] createRequest]]];


### PR DESCRIPTION
This PR enables propagation of returnOnlySignedInAccounts into SSO extension request. Previously this was not set. 