### PR TITLE
Add additional fallback logic for Team ID for MSIDKeychainUtil

### DIFF
--- a/IdentityCore/src/util/mac/MSIDKeychainUtil.m
+++ b/IdentityCore/src/util/mac/MSIDKeychainUtil.m
@@ -63,36 +63,34 @@
         if (!cfDic)
         {
             MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve code signing information");
-            CFRelease(selfCode);
-            return nil;
         }
-        
-        NSDictionary* signingDic = CFBridgingRelease(cfDic);
-        keychainTeamId = [signingDic objectForKey:(__bridge NSString*)kSecCodeInfoTeamIdentifier];
-        
-        if (!keychainTeamId)
+        else
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve team identifier. Using bundle Identifier instead.");
-            NSString *bundleIdentifier = [signingDic objectForKey:(__bridge NSString*)kSecCodeInfoIdentifier];
-            CFRelease(selfCode);
-            if (!bundleIdentifier)
-            {
-                // Attempt an alternate way of retreiving the bundle ID.
-                bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-            }
+            NSDictionary* signingDic = CFBridgingRelease(cfDic);
+            keychainTeamId = [signingDic objectForKey:(__bridge NSString*)kSecCodeInfoTeamIdentifier];
 
-            if (!bundleIdentifier)
+            if (!keychainTeamId)
             {
-                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve bundle identifier. Using process name instead.");
-                return [NSProcessInfo processInfo].processName;
+                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve team identifier. Using bundle Identifier instead.");
+                keychainTeamId = [signingDic objectForKey:(__bridge NSString*)kSecCodeInfoIdentifier];
             }
-            return bundleIdentifier;
         }
-        
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Using \"%@\" Team ID.", MSID_PII_LOG_MASKABLE(keychainTeamId));
         CFRelease(selfCode);
     }
     
+    if (!keychainTeamId)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Attempt an alternate way of retreiving the bundle ID.");
+        keychainTeamId = [[NSBundle mainBundle] bundleIdentifier];
+
+        if (!keychainTeamId)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve bundle identifier. Using process name instead.");
+            keychainTeamId = [NSProcessInfo processInfo].processName;
+        }
+    }
+
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Using \"%@\" Team ID.", MSID_PII_LOG_MASKABLE(keychainTeamId));
     return keychainTeamId;
 }
 

--- a/IdentityCore/src/util/mac/MSIDKeychainUtil.m
+++ b/IdentityCore/src/util/mac/MSIDKeychainUtil.m
@@ -75,6 +75,13 @@
             MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve team identifier. Using bundle Identifier instead.");
             NSString *bundleIdentifier = [signingDic objectForKey:(__bridge NSString*)kSecCodeInfoIdentifier];
             CFRelease(selfCode);
+#if DEBUG
+            if (!bundleIdentifier)
+            {
+                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve bundle identifier. For debug build, use a dummy identifier instead.");
+                return @"<Debug Team ID>";
+            }
+#endif //DEBUG
             return bundleIdentifier;
         }
         

--- a/IdentityCore/src/util/mac/MSIDKeychainUtil.m
+++ b/IdentityCore/src/util/mac/MSIDKeychainUtil.m
@@ -78,7 +78,13 @@
             if (!bundleIdentifier)
             {
                 // Attempt an alternate way of retreiving the bundle ID.
-                return [[NSBundle mainBundle] bundleIdentifier];
+                bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+            }
+
+            if (!bundleIdentifier)
+            {
+                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve bundle identifier. Using process name instead.");
+                return [NSProcessInfo processInfo].processName;
             }
             return bundleIdentifier;
         }

--- a/IdentityCore/src/util/mac/MSIDKeychainUtil.m
+++ b/IdentityCore/src/util/mac/MSIDKeychainUtil.m
@@ -75,13 +75,11 @@
             MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve team identifier. Using bundle Identifier instead.");
             NSString *bundleIdentifier = [signingDic objectForKey:(__bridge NSString*)kSecCodeInfoIdentifier];
             CFRelease(selfCode);
-#if DEBUG
             if (!bundleIdentifier)
             {
-                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve bundle identifier. For debug build, use a dummy identifier instead.");
-                return @"<Debug Team ID>";
+                // Attempt an alternate way of retreiving the bundle ID.
+                return [[NSBundle mainBundle] bundleIdentifier];
             }
-#endif //DEBUG
             return bundleIdentifier;
         }
         

--- a/IdentityCore/src/util/mac/MSIDKeychainUtil.m
+++ b/IdentityCore/src/util/mac/MSIDKeychainUtil.m
@@ -68,19 +68,13 @@
         {
             NSDictionary* signingDic = CFBridgingRelease(cfDic);
             keychainTeamId = [signingDic objectForKey:(__bridge NSString*)kSecCodeInfoTeamIdentifier];
-
-            if (!keychainTeamId)
-            {
-                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve team identifier. Using bundle Identifier instead.");
-                keychainTeamId = [signingDic objectForKey:(__bridge NSString*)kSecCodeInfoIdentifier];
-            }
         }
         CFRelease(selfCode);
     }
     
     if (!keychainTeamId)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Attempt an alternate way of retreiving the bundle ID.");
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve team identifier. Using bundle Identifier instead.");\
         keychainTeamId = [[NSBundle mainBundle] bundleIdentifier];
 
         if (!keychainTeamId)


### PR DESCRIPTION
Add additional fallback logic for MSIDKeychainUtil.teamId to ensure it always has a non-empty value.

Previously, it will attempt to get the team ID or the bundle ID from the code signing API.

It will now retrieve the bundle ID outside of the code signing API if no team ID is found, and fallback to the process name when there's no bundle ID.
