### PR TITLE
Fixed cache saving for shared devices

### DIFF
--- a/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
@@ -231,6 +231,7 @@
                                             tokenCache:self.tokenCache
                                   accountMetadataCache:self.accountMetadataCache
                                        validateAccount:YES
+                                      saveSSOStateOnly:NO
                                                  error:error
                                        completionBlock:^(MSIDTokenResult *result, NSError *error)
          {

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -426,6 +426,7 @@
                                             tokenCache:self.tokenCache
                                   accountMetadataCache:self.metadataCache
                                        validateAccount:NO
+                                      saveSSOStateOnly:NO
                                                  error:nil
                                        completionBlock:^(MSIDTokenResult *result, NSError *error)
          {

--- a/IdentityCore/src/requests/MSIDTokenResponseHandler.h
+++ b/IdentityCore/src/requests/MSIDTokenResponseHandler.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
                  tokenCache:(id<MSIDCacheAccessor>)tokenCache
        accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
             validateAccount:(BOOL)validateAccount
+           saveSSOStateOnly:(BOOL)saveSSOStateOnly
                       error:(nullable NSError *)error
             completionBlock:(MSIDRequestCompletionBlock)completionBlock;
 

--- a/IdentityCore/src/requests/MSIDTokenResponseHandler.m
+++ b/IdentityCore/src/requests/MSIDTokenResponseHandler.m
@@ -37,6 +37,7 @@
                  tokenCache:(id<MSIDCacheAccessor>)tokenCache
        accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
             validateAccount:(BOOL)validateAccount
+           saveSSOStateOnly:(BOOL)saveSSOStateOnly
                       error:(NSError *)error
             completionBlock:(MSIDRequestCompletionBlock)completionBlock
 {
@@ -54,7 +55,7 @@
                                                                              tokenCache:tokenCache
                                                                    accountMetadataCache:accountMetadataCache
                                                                       requestParameters:requestParameters
-                                                                       saveSSOStateOnly:NO
+                                                                       saveSSOStateOnly:saveSSOStateOnly
                                                                                   error:&validationError];
        
     if (!tokenResult)

--- a/IdentityCore/src/requests/broker/MSIDSSOTokenResponseHandler.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOTokenResponseHandler.m
@@ -42,14 +42,14 @@
 {
     if (operationResponse.authority) requestParameters.cloudAuthority = operationResponse.authority;
     
+    BOOL saveSSOStateOnly = operationResponse.deviceInfo.deviceMode == MSIDDeviceModeShared;
+    
     if (operationResponse.additionalTokenResponse)
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, requestParameters, @"Saving additional token response...");
         NSError *localError;
         MSIDRequestParameters *parameters = [requestParameters copy];
         parameters.target = operationResponse.additionalTokenResponse.scope;
-        
-        BOOL saveSSOStateOnly = operationResponse.deviceInfo.deviceMode == MSIDDeviceModeShared;
         
         [tokenResponseValidator validateAndSaveTokenResponse:operationResponse.additionalTokenResponse
                                                 oauthFactory:oauthFactory
@@ -77,6 +77,7 @@
                    tokenCache:tokenCache
          accountMetadataCache:accountMetadataCache
               validateAccount:validateAccount
+             saveSSOStateOnly:saveSSOStateOnly
                         error:error
               completionBlock:completionBlock];
 }


### PR DESCRIPTION
SaveSSOStateOnly flag wasn't being propagated correctly for shared devices and therefore more information than needed was saved on shared devices in MSAL cache. 