### PR TITLE
Keyed unarchiver hotfix for 11.2.x iOS versions

### DIFF
--- a/IdentityCore/src/cache/token/MSIDLegacyTokenCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDLegacyTokenCacheItem.m
@@ -124,17 +124,6 @@
     self.cachedAt = [coder decodeObjectOfClass:[NSDate class] forKey:@"cachedAt"];
     self.familyId = [coder decodeObjectOfClass:[NSString class] forKey:@"familyId"];
 
-    // We support all bplist types in "additionalServer" property.
-    NSMutableDictionary *additionalServer = [[coder decodePropertyListForKey:@"additionalServer"] mutableCopy];
-    self.extendedExpiresOn = additionalServer[MSID_EXTENDED_EXPIRES_ON_CACHE_KEY];
-    [additionalServer removeObjectForKey:MSID_EXTENDED_EXPIRES_ON_CACHE_KEY];
-    self.speInfo = additionalServer[MSID_SPE_INFO_CACHE_KEY];
-    [additionalServer removeObjectForKey:MSID_SPE_INFO_CACHE_KEY];
-    if (additionalServer.count)
-    {
-        self.additionalInfo = additionalServer;
-    }
-
     self.accessToken = [coder decodeObjectOfClass:[NSString class] forKey:@"accessToken"];
     self.refreshToken = [coder decodeObjectOfClass:[NSString class] forKey:@"refreshToken"];
     self.secret = self.accessToken ? self.accessToken : self.refreshToken;
@@ -154,6 +143,18 @@
     
     self.enrollmentId = [coder decodeObjectOfClass:[NSString class] forKey:@"enrollmentId"];
     self.applicationIdentifier = [coder decodeObjectOfClass:[NSString class] forKey:@"applicationIdentifier"];
+    
+    NSSet *classes = [NSSet setWithObjects:[NSDictionary class], [NSDate class], [NSString class], [NSURL class], [NSNumber class], nil];
+    NSMutableDictionary *additionalServer = [[coder decodeObjectOfClasses:classes forKey:@"additionalServer"] mutableCopy];
+    self.extendedExpiresOn = additionalServer[MSID_EXTENDED_EXPIRES_ON_CACHE_KEY];
+    [additionalServer removeObjectForKey:MSID_EXTENDED_EXPIRES_ON_CACHE_KEY];
+    self.speInfo = additionalServer[MSID_SPE_INFO_CACHE_KEY];
+    [additionalServer removeObjectForKey:MSID_SPE_INFO_CACHE_KEY];
+    if (additionalServer.count)
+    {
+        self.additionalInfo = additionalServer;
+    }
+    
     return self;
 }
 

--- a/IdentityCore/tests/MSIDLegacyTokenCacheItemTests.m
+++ b/IdentityCore/tests/MSIDLegacyTokenCacheItemTests.m
@@ -25,6 +25,7 @@
 #import "MSIDLegacyTokenCacheItem.h"
 #import "MSIDClientInfo.h"
 #import "NSDictionary+MSIDTestUtil.h"
+#import "NSKeyedUnarchiver+MSIDExtensions.h"
 
 @interface MSIDLegacyTokenCacheItemTests : XCTestCase
 
@@ -65,7 +66,10 @@
 
     XCTAssertNotNil(data);
 
-    MSIDLegacyTokenCacheItem *newItem = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    NSKeyedUnarchiver *unarchiver = [NSKeyedUnarchiver msidCreateForReadingFromData:data error:nil];
+    XCTAssertNotNil(unarchiver);
+    
+    MSIDLegacyTokenCacheItem *newItem = [unarchiver decodeObjectOfClass:[MSIDLegacyTokenCacheItem class] forKey:NSKeyedArchiveRootObjectKey];
 
     XCTAssertNotNil(newItem);
     XCTAssertEqualObjects(newItem.accessToken, @"at");
@@ -113,14 +117,21 @@
     cacheItem.cachedAt = cachedAt;
     cacheItem.homeAccountId = @"uid.utid";
     cacheItem.speInfo = @"2";
-    NSDictionary *additionalInfo = @{@"test": @"test"};
+    NSDictionary *additionalInfo = @{@"scope": @"user_impersonation",
+                                     @"correlation_id": @"97c58ae8-bf7e-438f-8710-2ad89c69ec1c",
+                                     @"ext_expires_on": [NSDate date],
+                                     @"not_before": @1580181520,
+                                     @"url": [NSURL URLWithString:@"https://login.microsoftonline.com/common/oauth2/token"]    };
     cacheItem.additionalInfo = additionalInfo;
 
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:cacheItem];
 
     XCTAssertNotNil(data);
 
-    MSIDLegacyTokenCacheItem *newItem = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    NSKeyedUnarchiver *unarchiver = [NSKeyedUnarchiver msidCreateForReadingFromData:data error:nil];
+    XCTAssertNotNil(unarchiver);
+    
+    MSIDLegacyTokenCacheItem *newItem = [unarchiver decodeObjectOfClass:[MSIDLegacyTokenCacheItem class] forKey:NSKeyedArchiveRootObjectKey];
 
     XCTAssertNotNil(newItem);
     XCTAssertEqualObjects(newItem.accessToken, @"at");
@@ -174,7 +185,10 @@
 
     XCTAssertNotNil(data);
 
-    MSIDLegacyTokenCacheItem *newItem = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    NSKeyedUnarchiver *unarchiver = [NSKeyedUnarchiver msidCreateForReadingFromData:data error:nil];
+    XCTAssertNotNil(unarchiver);
+    
+    MSIDLegacyTokenCacheItem *newItem = [unarchiver decodeObjectOfClass:[MSIDLegacyTokenCacheItem class] forKey:NSKeyedArchiveRootObjectKey];
 
     XCTAssertNotNil(newItem);
     XCTAssertEqualObjects(newItem.refreshToken, @"rt");

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.3.5-hotfix2
+---------
+* [Broker patch] Keyed unarchiver deserialization fix for iOS 11.2
+
 Version 1.3.5-hotfix1
 ----------
 * [Broker patch] Fixed account lookups and validation with the same email (#669)


### PR DESCRIPTION
This PR fixes the problem in this line:

`NSMutableDictionary *additionalServer = [[coder decodePropertyListForKey:@"additionalServer"] mutableCopy];`

When additionalServer has NSURL type (which ADAL normally injects), this line will:
1. Fail to deserialize on any version other than iOS 11.2.x. It will also cause any line after this line to fail to deserialize so other properties wouldn't be read correctly.
2. On iOS 11.2.x only, this line will always crash:

`*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSDictionary initWithObjects:forKeys:]: count of objects (0) differs from count of keys (5)'`

This PR also moves this operation to the very end so that on non iOS 11.2.x, even if it fails, it doesn't cause other critical properties from deserializing. 