### PR TITLE
Enable openURL in SSO extension

### DIFF
--- a/IdentityCore/src/util/ios/MSIDAppExtensionUtil.h
+++ b/IdentityCore/src/util/ios/MSIDAppExtensionUtil.h
@@ -26,6 +26,11 @@
 /// Collection of utilities to execute methods normally marked as non-application-extension safe. This allows us to produce a single framework that can be marked as application-extension-safe while still exercising capabilites when linked against a main app executable.
 @interface MSIDAppExtensionUtil : NSObject
 
+// Some extensions allow advanced capabilities so we should enable advanced capabilities there
+// When this property is set to YES, all non-extension compliant APIs will be executed
+// This is a process-wide setting
+@property (nonatomic, class) BOOL runningInCompliantExtension;
+
 /// Determine whether or not the host app is an application extension based on the main bundle path
 + (BOOL)isExecutingInAppExtension;
 /// Application extension safe replacement for `[UIApplication sharedApplication]`. The caller should make sure `isExecutingInAppExtension == NO` before calling this method.

--- a/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
+++ b/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
@@ -24,7 +24,19 @@
 #import "MSIDAppExtensionUtil.h"
 #import "MSIDMainThreadUtil.h"
 
+static BOOL s_isRunningInCompliantExtension = NO;
+
 @implementation MSIDAppExtensionUtil
+
++ (BOOL)runningInCompliantExtension
+{
+    return s_isRunningInCompliantExtension;
+}
+
++ (void)setRunningInCompliantExtension:(BOOL)runningInCompliantExtension
+{
+    s_isRunningInCompliantExtension = runningInCompliantExtension;
+}
 
 + (BOOL)isExecutingInAppExtension
 {
@@ -37,7 +49,7 @@
         return NO;
     }
     
-    return [mainBundlePath hasSuffix:@"appex"];
+    return [mainBundlePath hasSuffix:@"appex"] && !self.runningInCompliantExtension;
 }
 
 #pragma mark - UIApplication


### PR DESCRIPTION
Since SSO extension is showing UI, it should be able to handle non-extension safe APIs like openURL. This PR makes sure that common core doesn't treat SSO extension as a standard app extension and allows advanced APIs (for example, Company Portal install links will work now).