### PR TITLE
Always pass SDK capabilities for brokered requests

### DIFF
--- a/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
+++ b/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
@@ -130,10 +130,10 @@
         
         if (@available(iOS 13.0, *))
         {
+            brokerController.sdkBrokerCapabilities = @[MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY];
+            
             if ([MSIDSSOExtensionInteractiveTokenRequestController canPerformRequest])
             {
-                brokerController.sdkBrokerCapabilities = @[MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY];
-                
                 return [[MSIDSSOExtensionInteractiveTokenRequestController alloc] initWithInteractiveRequestParameters:parameters
                                                                                                   tokenRequestProvider:tokenRequestProvider
                                                                                                     fallbackController:brokerController


### PR DESCRIPTION
Previous logic was only passing SSO extension capabilities when SSO extension is present on the device. However, SSO extension capability should represent what SDK is capable of, and not what SDK+device configuration is capable of. Therefore, fixing it to always pass the flag for SSO extension capable SDKs. 