### PR TITLE
Replace *Credetials* with *Credentials* in removeCredetialsWithQuery

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
@@ -105,7 +105,7 @@
 /*
  Removes credentials matching parameters specified in the query
  */
-- (BOOL)removeCredetialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
+- (BOOL)removeCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
                           context:(nullable id<MSIDRequestContext>)context
                             error:(NSError * _Nullable * _Nullable)error;
 

--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
@@ -282,7 +282,7 @@
 }
 
 // Remove credentials
-- (BOOL)removeCredetialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
+- (BOOL)removeCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
                           context:(nullable id<MSIDRequestContext>)context
                             error:(NSError * _Nullable * _Nullable)error
 {

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -617,7 +617,7 @@
         query.matchAnyCredentialType = YES;
 
         NSError *credentialRemovalError;
-        result = [_accountCredentialCache removeCredetialsWithQuery:query context:context error:&credentialRemovalError];
+        result = [_accountCredentialCache removeCredentialsWithQuery:query context:context error:&credentialRemovalError];
         
         if (!result)
         {
@@ -786,7 +786,7 @@
     query.credentialType = MSIDAccessTokenType;
     query.applicationIdentifier = accessToken.applicationIdentifier;
 
-    BOOL result = [_accountCredentialCache removeCredetialsWithQuery:query context:context error:error];
+    BOOL result = [_accountCredentialCache removeCredentialsWithQuery:query context:context error:error];
 
     if (!result)
     {

--- a/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
+++ b/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
@@ -1969,9 +1969,9 @@
     XCTAssertTrue([results count] == 0);
 }
 
-#pragma mark - removeCredetialsWithQuery
+#pragma mark - removeCredentialsWithQuery
 
-- (void)testRemoveCredetialsWithQuery_whenQueryIsExactMatch_andAccessTokensQuery_shouldRemoveItem
+- (void)testRemoveCredentialsWithQuery_whenQueryIsExactMatch_andAccessTokensQuery_shouldRemoveItem
 {
     [self saveItem:[self createTestAccessTokenCacheItem]];
 
@@ -1991,7 +1991,7 @@
     XCTAssertTrue(query.exactMatch);
 
     NSError *error = nil;
-    BOOL result = [self.cache removeCredetialsWithQuery:query context:nil error:&error];
+    BOOL result = [self.cache removeCredentialsWithQuery:query context:nil error:&error];
     XCTAssertTrue(result);
     XCTAssertNil(error);
 
@@ -2003,7 +2003,7 @@
     XCTAssertTrue([remainignItems containsObject:[self createTestRefreshTokenCacheItem]]);
 }
 
-- (void)testRemoveCredetialsWithQuery_whenQueryIsExactMatch_andRefreshTokensQuery_shouldRemoveItem
+- (void)testRemoveCredentialsWithQuery_whenQueryIsExactMatch_andRefreshTokensQuery_shouldRemoveItem
 {
     [self saveItem:[self createTestRefreshTokenCacheItem]];
 
@@ -2021,7 +2021,7 @@
     XCTAssertTrue(query.exactMatch);
 
     NSError *error = nil;
-    BOOL result = [self.cache removeCredetialsWithQuery:query context:nil error:&error];
+    BOOL result = [self.cache removeCredentialsWithQuery:query context:nil error:&error];
     XCTAssertTrue(result);
     XCTAssertNil(error);
 
@@ -2033,7 +2033,7 @@
     XCTAssertTrue([remainignItems containsObject:[self createTestIDTokenCacheItem]]);
 }
 
-- (void)testRemoveCredetialsWithQuery_whenQueryIsExactMatch_andIDTokensQuery_shouldRemoveItem
+- (void)testRemoveCredentialsWithQuery_whenQueryIsExactMatch_andIDTokensQuery_shouldRemoveItem
 {
     [self saveItem:[self createTestIDTokenCacheItem]];
 
@@ -2052,7 +2052,7 @@
     XCTAssertTrue(query.exactMatch);
 
     NSError *error = nil;
-    BOOL result = [self.cache removeCredetialsWithQuery:query context:nil error:&error];
+    BOOL result = [self.cache removeCredentialsWithQuery:query context:nil error:&error];
     XCTAssertTrue(result);
     XCTAssertNil(error);
 
@@ -2064,7 +2064,7 @@
     XCTAssertTrue([remainignItems containsObject:[self createTestIDTokenCacheItem]]);
 }
 
-- (void)testRemoveCredetialsWithQuery_whenQueryIsNotExactMatch_andAccessTokensQuery_shouldRemoveAllItems
+- (void)testRemoveCredentialsWithQuery_whenQueryIsNotExactMatch_andAccessTokensQuery_shouldRemoveAllItems
 {
     [self saveItem:[self createTestAccessTokenCacheItem]];
 
@@ -2081,7 +2081,7 @@
     XCTAssertFalse(query.exactMatch);
 
     NSError *error = nil;
-    BOOL result = [self.cache removeCredetialsWithQuery:query context:nil error:&error];
+    BOOL result = [self.cache removeCredentialsWithQuery:query context:nil error:&error];
     XCTAssertTrue(result);
     XCTAssertNil(error);
 


### PR DESCRIPTION
While subclassing from MSAIMSISAccountCeredentialCache in MSAL C++ codebase, I have noticed this typo. It's not a big deal, but people will keep on stumbling upon it. Since you will soon release, this seems like a good opportunity to fix.