### PR TITLE
Bypass cache for account metadata in broker

### DIFF
--- a/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.h
+++ b/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.h
@@ -34,6 +34,8 @@
 
 @interface MSIDAccountMetadataCacheAccessor : NSObject
 
+@property (nonatomic) BOOL skipCacheForAccountMetadata;
+
 - (instancetype)initWithDataSource:(id<MSIDMetadataCacheDataSource>)dataSource;
 
 - (NSURL *)getAuthorityURL:(NSURL *)requestAuthorityURL

--- a/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.h
+++ b/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.h
@@ -34,7 +34,7 @@
 
 @interface MSIDAccountMetadataCacheAccessor : NSObject
 
-@property (nonatomic) BOOL skipCacheForAccountMetadata;
+@property (nonatomic) BOOL skipMemoryCacheForAccountMetadata;
 
 - (instancetype)initWithDataSource:(id<MSIDMetadataCacheDataSource>)dataSource;
 

--- a/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
+++ b/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
@@ -147,7 +147,7 @@
     }
     
     NSError *localError;
-    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId context:context error:&localError];
+    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipCacheForAccountMetadata context:context error:&localError];
     if (localError)
     {
         if (error) *error = localError;
@@ -173,7 +173,7 @@
     }
     
     NSError *localError;
-    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId context:context error:&localError];
+    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipCacheForAccountMetadata context:context error:&localError];
     if (localError)
     {
         if (error) *error = localError;
@@ -215,7 +215,7 @@
                                                  context:(id<MSIDRequestContext>)context
                                                    error:(NSError **)error
 {
-    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId context:context error:error];
+    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipCacheForAccountMetadata context:context error:error];
     
     if (!cacheItem)
     {
@@ -232,7 +232,7 @@
                                       error:(NSError **)error
 {
     NSError *accountMetadataError;
-    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId context:context error:&accountMetadataError];
+    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipCacheForAccountMetadata context:context error:&accountMetadataError];
     
     if (accountMetadataError)
     {
@@ -255,9 +255,20 @@
                                                 context:context error:error];
 }
 
+- (MSIDAccountMetadataCacheItem *)retrieveAccountMetadataCacheItemForClientId:(NSString *)clientId
+                                                                      context:(id<MSIDRequestContext>)context
+                                                                        error:(NSError **)error
+{
+    return [self retrieveAccountMetadataCacheItemForClientId:clientId
+                                                   skipCache:NO
+                                                     context:context
+                                                       error:error];
+}
+
 #pragma mark - Internal
 
 - (MSIDAccountMetadataCacheItem *)retrieveAccountMetadataCacheItemForClientId:(NSString *)clientId
+                                                                    skipCache:(BOOL)skipCache
                                                                       context:(id<MSIDRequestContext>)context
                                                                         error:(NSError **)error
 {
@@ -269,7 +280,7 @@
     
     NSError *localError;
     MSIDAccountMetadataCacheKey *key = [[MSIDAccountMetadataCacheKey alloc] initWithClientId:clientId];
-    MSIDAccountMetadataCacheItem *cacheItem = [_metadataCache accountMetadataCacheItemWithKey:key context:context error:&localError];
+    MSIDAccountMetadataCacheItem *cacheItem = [_metadataCache accountMetadataCacheItemWithKey:key skipCache:skipCache context:context error:&localError];
     if (localError && error) *error = localError;
     
     return cacheItem;

--- a/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
+++ b/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
@@ -147,7 +147,7 @@
     }
     
     NSError *localError;
-    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipCacheForAccountMetadata context:context error:&localError];
+    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipMemoryCacheForAccountMetadata context:context error:&localError];
     if (localError)
     {
         if (error) *error = localError;
@@ -173,7 +173,7 @@
     }
     
     NSError *localError;
-    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipCacheForAccountMetadata context:context error:&localError];
+    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipMemoryCacheForAccountMetadata context:context error:&localError];
     if (localError)
     {
         if (error) *error = localError;
@@ -215,7 +215,7 @@
                                                  context:(id<MSIDRequestContext>)context
                                                    error:(NSError **)error
 {
-    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipCacheForAccountMetadata context:context error:error];
+    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipMemoryCacheForAccountMetadata context:context error:error];
     
     if (!cacheItem)
     {
@@ -232,7 +232,7 @@
                                       error:(NSError **)error
 {
     NSError *accountMetadataError;
-    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipCacheForAccountMetadata context:context error:&accountMetadataError];
+    MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipMemoryCacheForAccountMetadata context:context error:&accountMetadataError];
     
     if (accountMetadataError)
     {

--- a/IdentityCore/src/cache/metadata/MSIDMetadataCache.h
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCache.h
@@ -47,4 +47,9 @@
                                                           context:(id<MSIDRequestContext>)context
                                                             error:(NSError **)error;
 
+- (MSIDAccountMetadataCacheItem *)accountMetadataCacheItemWithKey:(MSIDCacheKey *)key
+                                                        skipCache:(BOOL)skipCache
+                                                          context:(id<MSIDRequestContext>)context
+                                                            error:(NSError **)error;
+
 @end

--- a/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
@@ -102,6 +102,14 @@
                                                           context:(id<MSIDRequestContext>)context
                                                             error:(NSError **)error
 {
+    return [self accountMetadataCacheItemWithKey:key skipCache:NO context:context error:error];
+}
+
+- (MSIDAccountMetadataCacheItem *)accountMetadataCacheItemWithKey:(MSIDCacheKey *)key
+                                                        skipCache:(BOOL)skipCache
+                                                          context:(id<MSIDRequestContext>)context
+                                                            error:(NSError **)error
+{
     if (!key)
     {
         if (error)
@@ -117,7 +125,12 @@
     __block BOOL updatedItem = NO;
 
     dispatch_sync(_synchronizationQueue, ^{
-        item = _memoryCache[key];
+        
+        if (!skipCache)
+        {
+            item = _memoryCache[key];
+        }
+        
         if (!item)
         {
             item = [_dataSource accountMetadataWithKey:key serializer:_jsonSerializer context:context error:&localError];

--- a/IdentityCore/tests/MSIDAccountMetadataCacheAccessorTests.m
+++ b/IdentityCore/tests/MSIDAccountMetadataCacheAccessorTests.m
@@ -420,7 +420,7 @@
     
     
     NSError *error;
-    self.accountMetadataCache.skipCacheForAccountMetadata = YES;
+    self.accountMetadataCache.skipMemoryCacheForAccountMetadata = YES;
     MSIDAccountIdentifier *accountIdentifier = [self.accountMetadataCache principalAccountIdForClientId:clientId context:nil error:&error];
     
     XCTAssertNotNil(accountIdentifier);

--- a/IdentityCore/tests/util/MSIDTestCacheDataSource.m
+++ b/IdentityCore/tests/util/MSIDTestCacheDataSource.m
@@ -34,6 +34,7 @@
 #import "MSIDAppMetadataCacheItem.h"
 #import "MSIDAccountCacheItem.h"
 #import "MSIDAccountMetadata.h"
+#import "MSIDAccountMetadataCacheItem.h"
 
 @interface MSIDTestCacheDataSource()
 {
@@ -531,7 +532,7 @@
     return YES;
 }
 
-- (MSIDAccountMetadata *)accountMetadataWithKey:(MSIDCacheKey *)key serializer:(id<MSIDExtendedCacheItemSerializing>)serializer context:(id<MSIDRequestContext>)context error:(NSError *__autoreleasing *)error
+- (MSIDAccountMetadataCacheItem *)accountMetadataWithKey:(MSIDCacheKey *)key serializer:(id<MSIDExtendedCacheItemSerializing>)serializer context:(id<MSIDRequestContext>)context error:(NSError *__autoreleasing *)error
 {
     if (!serializer)
     {
@@ -544,10 +545,10 @@
     }
     
     NSData *data = [self itemDataWithKey:key keysDictionary:_accountKeys contentDictionary:_accountContents context:context error:error];
-    return (MSIDAccountMetadata *)[serializer deserializeCacheItem:data ofClass:[MSIDAccountMetadata class]];
+    return (MSIDAccountMetadataCacheItem *)[serializer deserializeCacheItem:data ofClass:[MSIDAccountMetadataCacheItem class]];
 }
 
-- (NSArray<MSIDAccountMetadata *> *)accountsMetadataWithKey:(MSIDCacheKey *)key serializer:(id<MSIDExtendedCacheItemSerializing>)serializer context:(id<MSIDRequestContext>)context error:(NSError *__autoreleasing *)error
+- (NSArray<MSIDAccountMetadataCacheItem *> *)accountsMetadataWithKey:(MSIDCacheKey *)key serializer:(id<MSIDExtendedCacheItemSerializing>)serializer context:(id<MSIDRequestContext>)context error:(NSError *__autoreleasing *)error
 {
     if (!serializer)
     {
@@ -564,7 +565,7 @@
     NSMutableArray *metadataItems = [NSMutableArray new];
     for(NSData *data in items)
     {
-        MSIDAccountMetadata *metadata = (MSIDAccountMetadata *)[serializer deserializeCacheItem:data ofClass:[MSIDAccountMetadata class]];
+        MSIDAccountMetadataCacheItem *metadata = (MSIDAccountMetadataCacheItem *)[serializer deserializeCacheItem:data ofClass:[MSIDAccountMetadataCacheItem class]];
         if (metadata)
         {
             [metadataItems addObject:metadata];


### PR DESCRIPTION
With the new SSO extension, there're now multiple processes reading and writing to account metadata cache. The problem arises if main app process writes something to account metadata, but SSO extension already has a cache version, or vice versa (or if you have multiple SSO extension processes running). 

Since integrity of data is critical for  account sign-in state and current account state, I made a change to bypass caching when reading those from broker process. Those will still be read from cache for MSAL requests (since it's a single process), and for authorities (since those are not critical and it will cause an extra network request if we miss it, but won't result in incorrect state for the end user). 