### PR TITLE
Added extra PkeyAuth logging for cert authorities matching

### DIFF
--- a/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
+++ b/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
@@ -66,6 +66,7 @@
             if (![self isValidIssuer:certAuths keychainCertIssuer:issuerOU])
             {
                 MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"PKeyAuth Error: Certificate Authority specified by device auth request does not match certificate in keychain.");
+                MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Issuer of certificate in keychain %@, requested cert authorities in the challenge %@", issuerOU, certAuths);
                 info = nil;
             }
         }


### PR DESCRIPTION
Changes in common core will log cert authorities and authority in local cert when mismatch detected for PkeyAuth challenges.