### PR TITLE
Handle http headers in broker response properly

### DIFF
--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2BrokerResponse.h
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2BrokerResponse.h
@@ -31,6 +31,6 @@
 @property (readonly) NSString *oauthErrorCode;
 @property (readonly) NSString *errorDescription;
 @property (readonly) NSString *subError;
-@property (readonly) NSString *httpHeaders;
+@property (readonly) NSDictionary *httpHeaders;
 
 @end

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2BrokerResponse.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2BrokerResponse.m
@@ -81,9 +81,23 @@ MSID_FORM_ACCESSOR(@"scope", scope);
     return self.formDictionary[@"suberror"];
 }
 
-- (NSString *)httpHeaders
+- (NSDictionary *)httpHeaders
 {
-    return self.errorMetadata[@"http_response_headers"];
+    // Currently broker may return http headers as both dictionary or string due to bug fix,
+    // we need to handle both to support broker with/without the fix
+    id headers = self.errorMetadata[@"http_response_headers"];
+    
+    if ([headers isKindOfClass:NSDictionary.class])
+    {
+        return headers;
+    }
+    
+    if ([headers isKindOfClass:NSString.class])
+    {
+        return [NSDictionary msidDictionaryFromWWWFormURLEncodedString:headers];
+    }
+    
+    return nil;
 }
 
 @end

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
@@ -224,7 +224,7 @@
         }
     }
     //Special handling for non-string error metadata
-    NSDictionary *httpHeaders = [NSDictionary msidDictionaryFromWWWFormURLEncodedString:errorResponse.httpHeaders];
+    NSDictionary *httpHeaders = errorResponse.httpHeaders;
     if (httpHeaders)
         userInfo[MSIDHTTPHeadersKey] = httpHeaders;
     


### PR DESCRIPTION
Currently V2 broker returns http headers as a dictionary while client MSAL expects encoded string. V1 broker response doesn't have such an issue.

[V2 broker response](https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/blob/dev/ADAuthenticationBroker/ADAuthenticationBroker/ADBrokerAADv2Response.m#L134).
[V1 broker response](https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/blob/dev/ADAuthenticationBroker/ADAuthenticationBroker/ADBrokerAADv1Response.m#L111).

Such a bug will cause a crash as we pass NSDictionary as NSString when we call `[NSString msidIsStringNilOrBlank:]`.

Now V2 broker response handling has been changed to handle both dictionary and string. In the future, we may want to consider adding data type check in `NSString+MSIDExtensions.m`.


