### PR TITLE
Clear in-memory storage on mac

### DIFF
--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -1050,8 +1050,8 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 
 {
     // Clear in-memory cache
-    self.appStorageItem = [MSAIMSIDMacCredentialStorageItem new];
-    self.sharedStorageItem = [MSAIMSIDMacCredentialStorageItem new];
+    self.appStorageItem = [MSIDMacCredentialStorageItem new];
+    self.sharedStorageItem = [MSIDMacCredentialStorageItem new];
 
     // Clear disk cache
     return [self clearWithAttributes:self.defaultCacheQuery context:context error:error];

--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -1049,6 +1049,11 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
                    error:(NSError **)error
 
 {
+    // Clear in-memory cache
+    self.appStorageItem = [MSAIMSIDMacCredentialStorageItem new];
+    self.sharedStorageItem = [MSAIMSIDMacCredentialStorageItem new];
+
+    // Clear disk cache
     return [self clearWithAttributes:self.defaultCacheQuery context:context error:error];
 }
 


### PR DESCRIPTION
Clearing storage should be a complete reset of the storage structure. On mac, there is a fallback cache (in memory), which is not cleared by the `clearWithContext` method.