### PR TITLE
Removed default urn redirect uri dependency

### DIFF
--- a/IdentityCore/src/MSIDBrokerConstants.h
+++ b/IdentityCore/src/MSIDBrokerConstants.h
@@ -71,6 +71,5 @@ extern NSString * _Nonnull const MSID_BROKER_WPJ_STATUS_KEY;
 extern NSString * _Nonnull const MSID_BROKER_BROKER_VERSION_KEY;
 extern NSString * _Nonnull const MSID_ADAL_BROKER_MESSAGE_VERSION;
 extern NSString * _Nonnull const MSID_MSAL_BROKER_MESSAGE_VERSION;
-extern NSString * _Nonnull const MSID_AUTHENTICATOR_REDIRECT_URI;
 extern NSString * _Nonnull const MSID_BROKER_SDK_CAPABILITIES_KEY;
 extern NSString * _Nonnull const MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY;

--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -61,6 +61,5 @@ NSString *const MSID_BROKER_WPJ_STATUS_KEY         = @"wpj_status";
 NSString *const MSID_BROKER_BROKER_VERSION_KEY     = @"broker_version";
 NSString *const MSID_ADAL_BROKER_MESSAGE_VERSION   = @"2";
 NSString *const MSID_MSAL_BROKER_MESSAGE_VERSION   = @"3";
-NSString *const MSID_AUTHENTICATOR_REDIRECT_URI    = @"urn:ietf:wg:oauth:2.0:oob";
 NSString *const MSID_BROKER_SDK_CAPABILITIES_KEY   = @"sdk_broker_capabilities";
 NSString *const MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY    = @"sso_extension";


### PR DESCRIPTION
## Proposed changes

Allow Authenticator app to use any Redirect URI, since Authenticator app will be moving away from the default urn:... Redirect URI. 

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

