### PR TITLE
Enable SSO extension requests on macOS

### DIFF
--- a/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
+++ b/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
@@ -28,8 +28,8 @@
 #if TARGET_OS_IPHONE
 #import "MSIDAppExtensionUtil.h"
 #import "MSIDBrokerInteractiveController.h"
-#import "MSIDSSOExtensionSilentTokenRequestController.h"
 #endif
+#import "MSIDSSOExtensionSilentTokenRequestController.h"
 #import "MSIDSSOExtensionSignoutController.h"
 #import "MSIDSSOExtensionInteractiveTokenRequestController.h"
 #import "MSIDRequestParameters+Broker.h"
@@ -45,10 +45,9 @@
 {
     MSIDSilentController *brokerController;
     
-#if TARGET_OS_IPHONE
     if ([parameters shouldUseBroker])
     {
-        if (@available(iOS 13.0, *))
+        if (@available(iOS 13.0, macOS 10.15, *))
         {
             if ([MSIDSSOExtensionSilentTokenRequestController canPerformRequest])
             {
@@ -59,7 +58,6 @@
             }
         }
     }
-#endif
     
     // TODO: Performance optimization: check account source.
     // if (parameters.accountIdentifier.source == BROKER) return brokerController;
@@ -239,7 +237,6 @@
                                           shouldSignoutFromBrowser:(BOOL)shouldSignoutFromBrowser
                                                              error:(NSError **)error
 {
-#if TARGET_OS_IPHONE && MSID_ENABLE_SSO_EXTENSION
     if ([parameters shouldUseBroker])
     {
         if (@available(iOS 13.0, macos 10.15, *))
@@ -253,7 +250,6 @@
             }
         }
     }
-    #endif
     
     return [[MSIDSignoutController alloc] initWithRequestParameters:parameters
                                            shouldSignoutFromBrowser:shouldSignoutFromBrowser

--- a/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
+++ b/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
@@ -28,13 +28,11 @@
 #if TARGET_OS_IPHONE
 #import "MSIDAppExtensionUtil.h"
 #import "MSIDBrokerInteractiveController.h"
-#import "MSIDSSOExtensionInteractiveTokenRequestController.h"
 #import "MSIDSSOExtensionSilentTokenRequestController.h"
-#import "MSIDRequestParameters+Broker.h"
 #endif
-#if MSID_ENABLE_SSO_EXTENSION
 #import "MSIDSSOExtensionSignoutController.h"
-#endif
+#import "MSIDSSOExtensionInteractiveTokenRequestController.h"
+#import "MSIDRequestParameters+Broker.h"
 #import "MSIDAuthority.h"
 #import "MSIDSignoutController.h"
 
@@ -109,52 +107,96 @@
         return nil;
     }
     
-#if TARGET_OS_IPHONE
     if ([parameters shouldUseBroker])
     {
-        MSIDBrokerInteractiveController *brokerController = nil;
-        
-        NSError *brokerControllerError;
-        if ([MSIDBrokerInteractiveController canPerformRequest:parameters])
-        {
-            brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters
-                                                                                        tokenRequestProvider:tokenRequestProvider
-                                                                                          fallbackController:localController
-                                                                                                       error:&brokerControllerError];
-            
-            if (brokerControllerError)
-            {
-                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Encountered an error creating broker controller %@", MSID_PII_LOG_MASKABLE(brokerControllerError));
-            }
-        }
-        
-        if (@available(iOS 13.0, *))
-        {
-            brokerController.sdkBrokerCapabilities = @[MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY];
-            
-            if ([MSIDSSOExtensionInteractiveTokenRequestController canPerformRequest])
-            {
-                return [[MSIDSSOExtensionInteractiveTokenRequestController alloc] initWithInteractiveRequestParameters:parameters
-                                                                                                  tokenRequestProvider:tokenRequestProvider
-                                                                                                    fallbackController:brokerController
-                                                                                                                 error:error];
-            }
-        }
-        
-        if (brokerControllerError)
-        {
-            if (error) *error = brokerControllerError;
-            return nil;
-        }
-        else if (brokerController)
-        {
-            return brokerController;
-        }
+        return [self brokerController:parameters
+                 tokenRequestProvider:tokenRequestProvider
+                   fallbackController:localController
+                                error:error];
     }
-#endif
 
     return localController;
 }
+
+#if TARGET_OS_IPHONE
++ (nullable id<MSIDRequestControlling>)brokerController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
+                                   tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
+                                     fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
+                                                  error:(NSError * _Nullable * _Nullable)error
+{
+    MSIDBrokerInteractiveController *brokerController = nil;
+    
+    NSError *brokerControllerError;
+    if ([MSIDBrokerInteractiveController canPerformRequest:parameters])
+    {
+        brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters
+                                                                                    tokenRequestProvider:tokenRequestProvider
+                                                                                      fallbackController:fallbackController
+                                                                                                   error:&brokerControllerError];
+        
+        if (brokerControllerError)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Encountered an error creating broker controller %@", MSID_PII_LOG_MASKABLE(brokerControllerError));
+        }
+    }
+    
+    if (@available(iOS 13.0, *))
+    {
+        brokerController.sdkBrokerCapabilities = @[MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY];
+    }
+    
+    id<MSIDRequestControlling> ssoExtensionController = [self ssoExtensionInteractiveController:parameters
+                                                                           tokenRequestProvider:tokenRequestProvider
+                                                                             fallbackController:brokerController
+                                                                                          error:&brokerControllerError];
+    
+    if (ssoExtensionController)
+    {
+        return ssoExtensionController;
+    }
+    
+    if (brokerControllerError)
+    {
+        if (error) *error = brokerControllerError;
+        return nil;
+    }
+    else if (brokerController)
+    {
+        return brokerController;
+    }
+}
+#else
++ (nullable id<MSIDRequestControlling>)brokerController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
+                                   tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
+                                     fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
+                                                  error:(NSError * _Nullable * _Nullable)error
+{
+    return [self ssoExtensionInteractiveController:parameters
+                              tokenRequestProvider:tokenRequestProvider
+                                fallbackController:fallbackController
+                                             error:error];
+}
+#endif
+
++ (nullable id<MSIDRequestControlling>)ssoExtensionInteractiveController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
+                                                    tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
+                                                      fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
+                                                                   error:(NSError * _Nullable * _Nullable)error
+{
+    if (@available(iOS 13.0, macOS 10.15, *))
+    {
+        if ([MSIDSSOExtensionInteractiveTokenRequestController canPerformRequest])
+        {
+            return [[MSIDSSOExtensionInteractiveTokenRequestController alloc] initWithInteractiveRequestParameters:parameters
+                                                                                              tokenRequestProvider:tokenRequestProvider
+                                                                                                fallbackController:fallbackController
+                                                                                                             error:error];
+        }
+    }
+    
+    return nil;
+}
+
 
 + (nullable id<MSIDRequestControlling>)localInteractiveController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                              tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider

--- a/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
+++ b/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
@@ -109,10 +109,15 @@
     
     if ([parameters shouldUseBroker])
     {
-        return [self brokerController:parameters
-                 tokenRequestProvider:tokenRequestProvider
-                   fallbackController:localController
-                                error:error];
+        id<MSIDRequestControlling> brokerController = [self brokerController:parameters
+                                                        tokenRequestProvider:tokenRequestProvider
+                                                          fallbackController:localController
+                                                                       error:error];
+        
+        if (brokerController)
+        {
+            return brokerController;
+        }
     }
 
     return localController;

--- a/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
+++ b/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
@@ -164,6 +164,8 @@
     {
         return brokerController;
     }
+    
+    return nil;
 }
 #else
 + (nullable id<MSIDRequestControlling>)brokerController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters

--- a/IdentityCore/src/parameters/MSIDRequestParameters+Broker.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters+Broker.m
@@ -31,7 +31,6 @@
 
 - (BOOL)shouldUseBroker
 {
-#if TARGET_OS_IPHONE
     if (self.requestType != MSIDRequestBrokeredType) return NO;
 
     if (!self.authority.supportsBrokeredAuthentication) return NO;
@@ -39,9 +38,6 @@
     if (!self.validateAuthority) return NO;
 
     return YES;
-#else
-    return NO;
-#endif
 }
 
 @end

--- a/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.m
@@ -96,10 +96,12 @@
       (id)kSecAttrAccessGroup : self.keychainAccessGroup
       } mutableCopy];
     
+#if !TARGET_OS_IPHONE
     if (@available(macOS 10.15, *))
     {
         symmetricKeyQuery[(id)kSecUseDataProtectionKeychain] = @YES;
     }
+#endif
 
     // Get the key bits.
     CFDataRef symmetricKey = nil;
@@ -212,10 +214,12 @@
       (id)kSecAttrAccessGroup : self.keychainAccessGroup
       } mutableCopy];
     
+#if !TARGET_OS_IPHONE
     if (@available(macOS 10.15, *))
     {
         symmetricKeyAttr[(id)kSecUseDataProtectionKeychain] = @YES;
     }
+#endif
 
     // First delete current symmetric key.
     if (![self deleteSymmetricKeyWithError:error])

--- a/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.m
@@ -87,14 +87,19 @@
 
     NSData *symmetricTag = [self.keyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
 
-    NSDictionary *symmetricKeyQuery =
-    @{
+    NSMutableDictionary *symmetricKeyQuery =
+    [@{
       (id)kSecClass : (id)kSecClassKey,
       (id)kSecAttrApplicationTag : symmetricTag,
       (id)kSecAttrKeyType : @(CSSM_ALGID_AES),
       (id)kSecReturnData : @(YES),
       (id)kSecAttrAccessGroup : self.keychainAccessGroup
-      };
+      } mutableCopy];
+    
+    if (@available(macOS 10.15, *))
+    {
+        symmetricKeyQuery[(id)kSecUseDataProtectionKeychain] = @YES;
+    }
 
     // Get the key bits.
     CFDataRef symmetricKey = nil;
@@ -192,8 +197,8 @@
 
     NSData *symmetricTag = [self.keyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
 
-    NSDictionary *symmetricKeyAttr =
-    @{
+    NSMutableDictionary *symmetricKeyAttr =
+    [@{
       (id)kSecClass : (id)kSecClassKey,
       (id)kSecAttrKeyClass : (id)kSecAttrKeyClassSymmetric,
       (id)kSecAttrApplicationTag : (id)symmetricTag,
@@ -205,7 +210,12 @@
       (id)kSecValueData : keyData,
       (id)kSecAttrAccessible : (id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
       (id)kSecAttrAccessGroup : self.keychainAccessGroup
-      };
+      } mutableCopy];
+    
+    if (@available(macOS 10.15, *))
+    {
+        symmetricKeyAttr[(id)kSecUseDataProtectionKeychain] = @YES;
+    }
 
     // First delete current symmetric key.
     if (![self deleteSymmetricKeyWithError:error])

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenRequestProvider.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenRequestProvider.m
@@ -28,9 +28,7 @@
 #import "MSIDDefaultTokenCacheAccessor.h"
 #import "MSIDDefaultBrokerTokenRequest.h"
 #import "MSIDDefaultTokenRequestProvider+Internal.h"
-#if TARGET_OS_IOS
 #import "MSIDSSOExtensionSilentTokenRequest.h"
-#endif
 #import "MSIDSSOExtensionInteractiveTokenRequest.h"
 
 @implementation MSIDDefaultTokenRequestProvider
@@ -118,8 +116,7 @@
 - (MSIDSilentTokenRequest *)silentSSOExtensionTokenRequestWithParameters:(__unused MSIDRequestParameters *)parameters
                                                             forceRefresh:(__unused BOOL)forceRefresh
 {
-#if TARGET_OS_IOS
-    if (@available(iOS 13.0, *))
+    if (@available(iOS 13.0, macOS 10.15, *))
     {
         __auto_type request = [[MSIDSSOExtensionSilentTokenRequest alloc] initWithRequestParameters:parameters
                                                                                        forceRefresh:forceRefresh
@@ -129,7 +126,6 @@
                                                                                accountMetadataCache:self.accountMetadataCache];
         return request;
     }
-#endif
     
     return nil;
 }

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenRequestProvider.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenRequestProvider.m
@@ -30,8 +30,8 @@
 #import "MSIDDefaultTokenRequestProvider+Internal.h"
 #if TARGET_OS_IOS
 #import "MSIDSSOExtensionSilentTokenRequest.h"
-#import "MSIDSSOExtensionInteractiveTokenRequest.h"
 #endif
+#import "MSIDSSOExtensionInteractiveTokenRequest.h"
 
 @implementation MSIDDefaultTokenRequestProvider
 
@@ -102,8 +102,7 @@
 
 - (MSIDInteractiveTokenRequest *)interactiveSSOExtensionTokenRequestWithParameters:(__unused MSIDInteractiveTokenRequestParameters *)parameters
 {
-#if TARGET_OS_IOS
-    if (@available(iOS 13.0, *))
+    if (@available(iOS 13.0, macOS 10.15, *))
     {
         __auto_type request = [[MSIDSSOExtensionInteractiveTokenRequest alloc] initWithRequestParameters:parameters
                                                                                             oauthFactory:self.oauthFactory
@@ -112,7 +111,6 @@
                                                                                     accountMetadataCache:self.accountMetadataCache];
         return request;
     }
-#endif
     
     return nil;
 }


### PR DESCRIPTION
## Proposed changes

This change enables MSAL for macOS to call SSO extension

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [x] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/899