### PR TITLE
Fixed authority validation for developer known authorities

### DIFF
--- a/IdentityCore/src/validation/MSIDAuthority.h
+++ b/IdentityCore/src/validation/MSIDAuthority.h
@@ -53,6 +53,8 @@ typedef void(^MSIDOpenIdConfigurationInfoBlock)(MSIDOpenIdProviderMetadata * _Nu
 
 @property (readonly, nullable) MSIDOpenIdProviderMetadata *metadata;
 
+@property (nonatomic) BOOL isDeveloperKnown;
+
 - (instancetype _Nullable )init NS_UNAVAILABLE;
 + (instancetype _Nullable )new NS_UNAVAILABLE;
 

--- a/IdentityCore/src/validation/MSIDAuthority.m
+++ b/IdentityCore/src/validation/MSIDAuthority.m
@@ -173,7 +173,7 @@ NSString *const MSID_AUTHORITY_TYPE_JSON_KEY = @"authority_type";
 - (BOOL)isKnown
 {
     // TODO: Can we move it out from here? What about ADFS & B2C?
-    return [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:self.url.host.lowercaseString];
+    return [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:self.url.host.lowercaseString] || self.isDeveloperKnown;
 }
 
 - (BOOL)supportsBrokeredAuthentication

--- a/IdentityCore/tests/MSIDAADAuthorityTests.m
+++ b/IdentityCore/tests/MSIDAADAuthorityTests.m
@@ -536,6 +536,14 @@
     XCTAssertFalse([authority isKnown]);
 }
 
+- (void)testIsKnownHost_whenAADAuhorityAndHostIsNotInListOfKnownHost_butAuthorityIsDeclaredAsKnownByDeveloper_shouldReturnYES
+{
+    NSURL *authorityUrl = [[NSURL alloc] initWithString:@"https://some.net/common"];
+    __auto_type authority = [[MSIDAADAuthority alloc] initWithURL:authorityUrl context:nil error:nil];
+    authority.isDeveloperKnown = YES;
+    XCTAssertTrue([authority isKnown]);
+}
+
 #pragma mark - legacyAccessTokenLookupAuthorities
 
 - (void)testLegacyAccessTokenLookupAuthorities_whenAuthorityProvided_shouldReturnAllAliases


### PR DESCRIPTION
## Proposed changes

There's currently a problem when developer declares a custom AAD authority, because it would still go to login.microsoftonline.com to download the aliases instead of using actual authority host. If login.microsoftonline.com is unavailable, this would cause failures for validation.
Since developer explicitly declared authority as known and trusted, it is fine to go to actual authority for validation.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/913
