### PR TITLE
Fixed NTLM crash when app has no keywindow

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNTLMHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNTLMHandler.m
@@ -53,7 +53,7 @@
         MSID_LOG_INFO(nil, @"Attempting to handle NTLM challenge");
         MSID_LOG_INFO_PII(nil, @"Attempting to handle NTLM challenge host: %@", challenge.protectionSpace.host);
         
-        [MSIDNTLMUIPrompt presentPrompt:^(NSString *username, NSString *password, BOOL cancel)
+        [MSIDNTLMUIPrompt presentPromptWithWebView:webview completion:^(NSString *username, NSString *password, BOOL cancel)
          {
              if (cancel)
              {

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDNTLMUIPrompt.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDNTLMUIPrompt.h
@@ -23,9 +23,11 @@
 
 #import <Foundation/Foundation.h>
 
+@class WKWebView;
+
 @interface MSIDNTLMUIPrompt : NSObject
 
-+ (void)presentPrompt:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler;
++ (void)presentPromptWithWebView:(WKWebView *)webview completion:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler;
 + (void)dismissPrompt;
 
 @end

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDNTLMUIPrompt.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDNTLMUIPrompt.m
@@ -25,6 +25,7 @@
 #import "MSIDAppExtensionUtil.h"
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDMainThreadUtil.h"
+#import <WebKit/WebKit.h>
 
 @implementation MSIDNTLMUIPrompt
 
@@ -42,9 +43,8 @@ __weak static UIAlertController *_presentedPrompt = nil;
     }];
 }
 
-+ (void)presentPrompt:(void (^)(NSString *username, NSString *password, BOOL cancel))block
++ (void)presentPromptWithWebView:(__unused WKWebView *)webview completion:(void (^)(NSString *username, NSString *password, BOOL cancel))block
 {
-    
     if ([MSIDAppExtensionUtil isExecutingInAppExtension])
     {
         block(nil, nil, YES);

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDNTLMUIPrompt.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDNTLMUIPrompt.m
@@ -25,6 +25,7 @@
 #import "MSIDNTLMUIPrompt.h"
 #import "MSIDCredentialCollectionController.h"
 #import "MSIDMainThreadUtil.h"
+#import <WebKit/WebKit.h>
 
 @interface MSIDNTLMUIPrompt ()
 
@@ -46,7 +47,7 @@ __weak static NSAlert *_presentedPrompt = nil;
     }];
 }
 
-+ (void)presentPrompt:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler
++ (void)presentPromptWithWebView:(WKWebView *)webview completion:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler
 {
     [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         NSAlert *alert = [NSAlert new];
@@ -62,7 +63,9 @@ __weak static NSAlert *_presentedPrompt = nil;
         
         [[alert window] setInitialFirstResponder:view.usernameField];
         
-        [alert beginSheetModalForWindow:[NSApp keyWindow] completionHandler:^(NSModalResponse returnCode)
+        NSWindow *window = webview.window ? webview.window : [NSApp keyWindow];
+        
+        [alert beginSheetModalForWindow:window completionHandler:^(NSModalResponse returnCode)
          {
              // The first button being added is "Login" button
              if (returnCode == NSAlertFirstButtonReturn)

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -50,10 +50,7 @@
 
 - (void)testLog_whenLogLevelErrorMessageNil_shouldNotThrow
 {
-    __auto_type expectation = [self keyValueObservingExpectationForObject:[MSIDTestLogger sharedLogger] keyPath:@"callbackInvoked" expectedValue:@1];
-    [expectation setInverted:YES];
     XCTAssertNoThrow([[MSIDLogger sharedLogger] logLevel:MSIDLogLevelError context:nil correlationId:nil isPII:NO format:nil]);
-    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 #pragma mark - PII flag

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -43,12 +43,17 @@
 
 - (void)testLog_whenLogLevelNothingMessageValid_shouldNotThrow
 {
+    [self keyValueObservingExpectationForObject:[MSIDTestLogger sharedLogger] keyPath:@"callbackInvoked" expectedValue:@1];
     XCTAssertNoThrow([[MSIDLogger sharedLogger] logLevel:MSIDLogLevelNothing context:nil correlationId:nil isPII:NO format:@"Message"]);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testLog_whenLogLevelErrorMessageNil_shouldNotThrow
 {
+    __auto_type expectation = [self keyValueObservingExpectationForObject:[MSIDTestLogger sharedLogger] keyPath:@"callbackInvoked" expectedValue:@1];
+    [expectation setInverted:YES];
     XCTAssertNoThrow([[MSIDLogger sharedLogger] logLevel:MSIDLogLevelError context:nil correlationId:nil isPII:NO format:nil]);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 #pragma mark - PII flag


### PR DESCRIPTION
## Proposed changes

Office has reported an occasional crash when NTLM is triggered. 
Looks like it's caused by the situation when app has no key window, which causes WebKit to crash since no prompt is shown. The fix aligns it with Client TLS handler which uses window from the webview instead and seems to be working. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

