### PR TITLE
Apply NTLM crash fix to main common core branch

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNTLMHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDNTLMHandler.m
@@ -58,7 +58,7 @@
 #if TARGET_OS_IPHONE
         [MSIDNTLMUIPrompt presentPromptInParentController:parentViewController completionHandler:^(NSString *username, NSString *password, BOOL cancel)
 #else
-        [MSIDNTLMUIPrompt presentPrompt:^(NSString *username, NSString *password, BOOL cancel)
+        [MSIDNTLMUIPrompt presentPromptWithWebView:webview completion:^(NSString *username, NSString *password, BOOL cancel)
 #endif
          {
              if (cancel)

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDNTLMUIPrompt.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDNTLMUIPrompt.h
@@ -23,13 +23,15 @@
 
 #import <Foundation/Foundation.h>
 
+@class WKWebView;
+
 @interface MSIDNTLMUIPrompt : NSObject
 
 #if TARGET_OS_IPHONE
 + (void)presentPromptInParentController:(UIViewController *)parentViewController
                       completionHandler:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler;
 #else
-+ (void)presentPrompt:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler;
++ (void)presentPromptWithWebView:(WKWebView *)webview completion:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler;
 #endif
 
 + (void)dismissPrompt;

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDNTLMUIPrompt.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDNTLMUIPrompt.m
@@ -25,6 +25,7 @@
 #import "MSIDAppExtensionUtil.h"
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDMainThreadUtil.h"
+#import <WebKit/WebKit.h>
 
 @implementation MSIDNTLMUIPrompt
 
@@ -45,7 +46,6 @@ __weak static UIAlertController *_presentedPrompt = nil;
 + (void)presentPromptInParentController:(UIViewController *)parentViewController
                       completionHandler:(void (^)(NSString *username, NSString *password, BOOL cancel))block
 {
-    
     if ([MSIDAppExtensionUtil isExecutingInAppExtension])
     {
         block(nil, nil, YES);

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDNTLMUIPrompt.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDNTLMUIPrompt.m
@@ -25,6 +25,7 @@
 #import "MSIDNTLMUIPrompt.h"
 #import "MSIDCredentialCollectionController.h"
 #import "MSIDMainThreadUtil.h"
+#import <WebKit/WebKit.h>
 
 @interface MSIDNTLMUIPrompt ()
 
@@ -46,7 +47,7 @@ __weak static NSAlert *_presentedPrompt = nil;
     }];
 }
 
-+ (void)presentPrompt:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler
++ (void)presentPromptWithWebView:(WKWebView *)webview completion:(void (^)(NSString *username, NSString *password, BOOL cancel))completionHandler
 {
     [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
         NSAlert *alert = [NSAlert new];
@@ -62,7 +63,9 @@ __weak static NSAlert *_presentedPrompt = nil;
         
         [[alert window] setInitialFirstResponder:view.usernameField];
         
-        [alert beginSheetModalForWindow:[NSApp keyWindow] completionHandler:^(NSModalResponse returnCode)
+        NSWindow *window = webview.window ? webview.window : [NSApp keyWindow];
+        
+        [alert beginSheetModalForWindow:window completionHandler:^(NSModalResponse returnCode)
          {
              // The first button being added is "Login" button
              if (returnCode == NSAlertFirstButtonReturn)

--- a/IdentityCore/tests/automation/ui_tests_lib/MSIDClientCredentialHelper.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/MSIDClientCredentialHelper.m
@@ -314,7 +314,6 @@
 {
     unsigned char hash[CC_SHA1_DIGEST_LENGTH];
     CC_SHA1(inputData.bytes, (CC_LONG)inputData.length, hash);
-    
     return [NSData dataWithBytes:hash length:CC_SHA1_DIGEST_LENGTH];
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -121,6 +121,15 @@ Version 1.1.0
 ------------
 * Added Auth broker support to common core
 
+Version 1.0.17
+-------------
+* Remove SHA-1 dependency for ADAL (#696)
+
+Version 1.0.16
+-------------
+* Fix a presentation bug when both parent controller and webview are set
+* Set default WKWebView content mode
+
 Version 1.0.15
 -------------
 * Support removing RTs from other accessors


### PR DESCRIPTION
## Proposed changes

Office has reported an occasional crash when NTLM is triggered. 
Looks like it's caused by the situation when app has no key window, which causes WebKit to crash since no prompt is shown. The fix aligns it with Client TLS handler which uses window from the webview instead and seems to be working. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
