### PR TITLE
Prepare SSO extension to handle all requests

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1301,6 +1301,7 @@
 		B2D0A6A021D09F8D0071E0DA /* MSIDAutomationAccountsResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B2D0A69E21D09F8D0071E0DA /* MSIDAutomationAccountsResult.h */; };
 		B2D0A6A121D09F8D0071E0DA /* MSIDAutomationAccountsResult.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D0A69F21D09F8D0071E0DA /* MSIDAutomationAccountsResult.m */; };
 		B2D0A6A221D09F8D0071E0DA /* MSIDAutomationAccountsResult.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D0A69F21D09F8D0071E0DA /* MSIDAutomationAccountsResult.m */; };
+		B2D2C7AB24555FFC00FF3082 /* MSIDBrowserRequestValidating.h in Headers */ = {isa = PBXBuildFile; fileRef = B2D2C7AA24555FFC00FF3082 /* MSIDBrowserRequestValidating.h */; };
 		B2D5625820CCD50E00FFF59C /* MSIDTelemetry+Cache.h in Headers */ = {isa = PBXBuildFile; fileRef = B2D5625620CCD50E00FFF59C /* MSIDTelemetry+Cache.h */; };
 		B2D5625920CCD50E00FFF59C /* MSIDTelemetry+Cache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D5625720CCD50E00FFF59C /* MSIDTelemetry+Cache.m */; };
 		B2D5625A20CCD50E00FFF59C /* MSIDTelemetry+Cache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D5625720CCD50E00FFF59C /* MSIDTelemetry+Cache.m */; };
@@ -2459,6 +2460,7 @@
 		B2D0A69A21D09F220071E0DA /* MSIDAutomationUserInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAutomationUserInformation.m; sourceTree = "<group>"; };
 		B2D0A69E21D09F8D0071E0DA /* MSIDAutomationAccountsResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAutomationAccountsResult.h; sourceTree = "<group>"; };
 		B2D0A69F21D09F8D0071E0DA /* MSIDAutomationAccountsResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAutomationAccountsResult.m; sourceTree = "<group>"; };
+		B2D2C7AA24555FFC00FF3082 /* MSIDBrowserRequestValidating.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBrowserRequestValidating.h; sourceTree = "<group>"; };
 		B2D5625620CCD50E00FFF59C /* MSIDTelemetry+Cache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDTelemetry+Cache.h"; sourceTree = "<group>"; };
 		B2D5625720CCD50E00FFF59C /* MSIDTelemetry+Cache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDTelemetry+Cache.m"; sourceTree = "<group>"; };
 		B2D81BBC1FF5C7460093859A /* MSIDTestBrokerResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MSIDTestBrokerResponse.h; path = tests/util/MSIDTestBrokerResponse.h; sourceTree = SOURCE_ROOT; };
@@ -3052,6 +3054,7 @@
 				23B0189123554B2B00207FEC /* MSIDBrokerOperationTokenRequest.m */,
 				1EA4546E23BECE2700567EB0 /* MSIDBrokerOperationBrowserTokenRequest.h */,
 				1EA4546F23BECE2700567EB0 /* MSIDBrokerOperationBrowserTokenRequest.m */,
+				B2D2C7AA24555FFC00FF3082 /* MSIDBrowserRequestValidating.h */,
 			);
 			path = token_request;
 			sourceTree = "<group>";
@@ -4609,6 +4612,7 @@
 				B2BA498B208EC38100CE92FC /* MSIDAADIdTokenClaimsFactory.h in Headers */,
 				B2C708682198C3E800D917B8 /* MSIDBrokerResponseHandler.h in Headers */,
 				B2AF1D21218BCD870080C1A0 /* MSIDSilentController.h in Headers */,
+				B2D2C7AB24555FFC00FF3082 /* MSIDBrowserRequestValidating.h in Headers */,
 				1E5B2A862294F5CA003C579D /* MSIDKeychainUtil+Internal.h in Headers */,
 				232C65882138BDC5002A41FE /* MSIDAADAuthorityMetadataResponse.h in Headers */,
 				B2C7089C219926C200D917B8 /* MSIDBrokerResponse+Internal.h in Headers */,

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.h
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithRequest:(NSURL *)requestURL
                         headers:(NSDictionary *)headers
-                           body:(NSData *)httpBody
+                           body:(nullable NSData *)httpBody
                bundleIdentifier:(NSString *)bundleIdentifier
                requestValidator:(id<MSIDBrowserRequestValidating>)requestValidator
                           error:(NSError **)error;

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.m
@@ -33,7 +33,9 @@
 
 - (instancetype)initWithRequest:(NSURL *)requestURL
                         headers:(NSDictionary *)headers
+                           body:(NSData *)httpBody
                bundleIdentifier:(NSString *)bundleIdentifier
+               requestValidator:(id<MSIDBrowserRequestValidating>)requestValidator
                           error:(NSError **)error
 {
     self = [super init];
@@ -52,7 +54,7 @@
         
         _requestURL = requestURL;
         
-        if (![self shouldHandleURL:_requestURL])
+        if (![requestValidator shouldHandleURL:_requestURL])
         {
             if (error)
             {
@@ -64,6 +66,7 @@
         }
         
         _headers = headers;
+        _httpBody = httpBody;
         _bundleIdentifier = bundleIdentifier;
         
         MSIDAADAuthority *authority = [[MSIDAADAuthority alloc] initWithURL:_requestURL rawTenant:nil context:nil error:error];
@@ -83,27 +86,6 @@
     }
     
     return self;
-}
-
-- (BOOL)shouldHandleURL:(NSURL *)url
-{
-    if (![url msidContainsCaseInsensitivePath:@"oauth2"])
-    {
-        return NO;
-    }
-    
-    if ([url msidContainsCaseInsensitivePath:@"/oauth2/authorize"])
-    {
-        return YES;
-    }
-    
-    if ([url msidContainsCaseInsensitivePath:@"/oauth2/v2.0/authorize"])
-    {
-        return YES;
-    }
-        
-    BOOL isLogoutRequest = [url msidContainsCaseInsensitivePath:@"logout"] && [url msidContainsPathComponent:@"logout"];
-    return isLogoutRequest;
 }
 
 #pragma mark - MSIDBaseBrokerOperationRequest

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrowserRequestValidating.h
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrowserRequestValidating.h
@@ -22,28 +22,12 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "MSIDBaseBrokerOperationRequest.h"
-#import "MSIDBrowserRequestValidating.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class MSIDAADAuthority;
+@protocol MSIDBrowserRequestValidating <NSObject>
 
-@interface MSIDBrokerOperationBrowserTokenRequest : MSIDBaseBrokerOperationRequest
-
-@property (nonatomic, readonly) NSURL *requestURL;
-@property (nonatomic, readonly) NSString *bundleIdentifier;
-@property (nonatomic, readonly) MSIDAADAuthority *authority;
-@property (nonatomic, readonly) NSDictionary *headers;
-@property (nonatomic, readonly) NSUUID *correlationId;
-@property (nonatomic, readonly) NSData *httpBody;
-
-- (instancetype)initWithRequest:(NSURL *)requestURL
-                        headers:(NSDictionary *)headers
-                           body:(NSData *)httpBody
-               bundleIdentifier:(NSString *)bundleIdentifier
-               requestValidator:(id<MSIDBrowserRequestValidating>)requestValidator
-                          error:(NSError **)error;
+- (BOOL)shouldHandleURL:(NSURL *)url;
 
 @end
 

--- a/IdentityCore/src/util/NSURL+MSIDAADUtils.h
+++ b/IdentityCore/src/util/NSURL+MSIDAADUtils.h
@@ -49,6 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)msidContainsPathComponent:(NSString *)pathComponent;
 
+- (BOOL)msidContainsPathComponents:(NSArray *)allowedPathComponents;
+
 - (BOOL)msidContainsCaseInsensitivePath:(NSString *)caseInsensitivePath;
 
 @end

--- a/IdentityCore/src/util/NSURL+MSIDAADUtils.m
+++ b/IdentityCore/src/util/NSURL+MSIDAADUtils.m
@@ -124,6 +124,21 @@
     return NO;
 }
 
+- (BOOL)msidContainsPathComponents:(NSArray *)allowedPathComponents
+{
+    NSArray *pathComponents = self.pathComponents;
+    
+    for (NSString *component in pathComponents)
+    {
+        if ([allowedPathComponents containsObject:component.lowercaseString])
+        {
+            return YES;
+        }
+    }
+    
+    return NO;
+}
+
 - (BOOL)msidContainsCaseInsensitivePath:(NSString *)caseInsensitivePath
 {
     return [self.absoluteString rangeOfString:caseInsensitivePath options:NSCaseInsensitiveSearch].location != NSNotFound;


### PR DESCRIPTION
## Proposed changes

This PR includes some preparatory/refactoring work to allow SSO extension to handle all requests, including support multiple different types of handling:
- Handling where we add PRTs
- Handling where we just execute request and add existing cookies
- Handling where we add device assertion headers (not supported yet)
- Handling for SAML/WS-Fed (non OAuth2) requests (not supported yet)

The main change is in broker where there're multiple possible controllers that can handle browser requests and not all controllers have to lookup PRTs. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Request filtering got also moved to broker to allow more complex handling in the future. 
