### PR TITLE
Support clearing SSO extension cookies

### DIFF
--- a/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationSignoutFromDeviceRequest.h
+++ b/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationSignoutFromDeviceRequest.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite) NSString *redirectUri;
 @property (nonatomic) MSIDProviderType providerType;
 @property (nonatomic) BOOL signoutFromBrowser;
+@property (nonatomic) BOOL clearSSOExtensionCookies;
 
 @end
 

--- a/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationSignoutFromDeviceRequest.m
+++ b/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationSignoutFromDeviceRequest.m
@@ -32,6 +32,7 @@
 #import "MSIDJsonSerializableTypes.h"
 
 NSString *const MSID_SIGNOUT_FROM_BROWSER_KEY = @"signout_from_browser";
+NSString *const MSID_CLEAR_SSO_EXT_COOKIES_KEY = @"clear_sso_extension_cookies";
 
 @implementation MSIDBrokerOperationSignoutFromDeviceRequest
 
@@ -65,6 +66,7 @@ NSString *const MSID_SIGNOUT_FROM_BROWSER_KEY = @"signout_from_browser";
         _redirectUri = [json msidStringObjectForKey:MSID_REDIRECT_URI_JSON_KEY];
         _providerType = MSIDProviderTypeFromString([json msidStringObjectForKey:MSID_PROVIDER_TYPE_JSON_KEY]);
         _signoutFromBrowser = [json msidBoolObjectForKey:MSID_SIGNOUT_FROM_BROWSER_KEY];
+        _clearSSOExtensionCookies = [json msidBoolObjectForKey:MSID_CLEAR_SSO_EXT_COOKIES_KEY];
     }
     
     return self;
@@ -93,6 +95,7 @@ NSString *const MSID_SIGNOUT_FROM_BROWSER_KEY = @"signout_from_browser";
     
     json[MSID_PROVIDER_TYPE_JSON_KEY] = MSIDProviderTypeToString(self.providerType);
     json[MSID_SIGNOUT_FROM_BROWSER_KEY] = @(_signoutFromBrowser);
+    json[MSID_CLEAR_SSO_EXT_COOKIES_KEY] = @(_clearSSOExtensionCookies);
     
     return json;
 }

--- a/IdentityCore/src/controllers/broker/MSIDSSOExtensionSignoutController.m
+++ b/IdentityCore/src/controllers/broker/MSIDSSOExtensionSignoutController.m
@@ -43,6 +43,7 @@
     
     self.currentSSORequest = [[MSIDSSOExtensionSignoutRequest alloc] initWithRequestParameters:self.parameters
                                                                       shouldSignoutFromBrowser:NO
+                                                                      clearSSOExtensionCookies:NO
                                                                                   oauthFactory:self.factory];
         
     [self.currentSSORequest executeRequestWithCompletion:^(BOOL success, NSError * _Nullable error) {

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.h
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.h
@@ -32,9 +32,11 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 @interface MSIDSSOExtensionSignoutRequest : MSIDOIDCSignoutRequest
 
 @property (nonatomic, readonly) BOOL shouldSignoutFromBrowser;
+@property (nonatomic, readonly) BOOL clearSSOExtensionCookies;
 
 - (nullable instancetype)initWithRequestParameters:(MSIDInteractiveRequestParameters *)parameters
                           shouldSignoutFromBrowser:(BOOL)shouldSignoutFromBrowser
+                          clearSSOExtensionCookies:(BOOL)clearSSOExtensionCookies
                                       oauthFactory:(MSIDOauth2Factory *)oauthFactory;
 
 @end

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
@@ -43,6 +43,7 @@
 @property (nonatomic) ASAuthorizationSingleSignOnProvider *ssoProvider;
 @property (nonatomic, readonly) MSIDProviderType providerType;
 @property (nonatomic) BOOL shouldSignoutFromBrowser;
+@property (nonatomic) BOOL clearSSOExtensionCookies;
 
 @end
 
@@ -50,6 +51,7 @@
 
 - (nullable instancetype)initWithRequestParameters:(nonnull MSIDInteractiveRequestParameters *)parameters
                           shouldSignoutFromBrowser:(BOOL)shouldSignoutFromBrowser
+                          clearSSOExtensionCookies:(BOOL)clearSSOExtensionCookies
                                       oauthFactory:(nonnull MSIDOauth2Factory *)oauthFactory
 {
     self = [self initWithRequestParameters:parameters oauthFactory:oauthFactory];
@@ -57,6 +59,7 @@
     if (self)
     {
         _shouldSignoutFromBrowser = shouldSignoutFromBrowser;
+        _clearSSOExtensionCookies = clearSSOExtensionCookies;
     }
     
     return self;
@@ -111,6 +114,7 @@
     signoutRequest.providerType = self.providerType;
     signoutRequest.accountIdentifier = self.requestParameters.accountIdentifier;
     signoutRequest.signoutFromBrowser = self.shouldSignoutFromBrowser;
+    signoutRequest.clearSSOExtensionCookies = self.clearSSOExtensionCookies;
     
     [MSIDBrokerOperationRequest fillRequest:signoutRequest
                         keychainAccessGroup:self.requestParameters.keychainAccessGroup

--- a/IdentityCore/tests/MSIDBrokerOperationSignoutFromDeviceRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationSignoutFromDeviceRequestTests.m
@@ -76,6 +76,7 @@
     request.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"upn@upn.com" homeAccountId:@"uid.utid"];
     request.brokerKey = @"key";
     request.protocolVersion = 99;
+    request.clearSSOExtensionCookies = YES;
     
     NSDictionary *json = [request jsonDictionary];
     XCTAssertNotNil(json);
@@ -88,7 +89,8 @@
                                    @"provider_type": @"provider_aad_v2",
                                    @"redirect_uri": @"myredirect",
                                    @"signout_from_browser": @YES,
-                                   @"username": @"upn@upn.com"
+                                   @"username": @"upn@upn.com",
+                                   @"clear_sso_extension_cookies": @YES
     };
     
     XCTAssertTrue([json compareAndPrintDiff:expectedJson]);

--- a/IdentityCore/tests/integration/MSIDSSOExtensionSignoutRequestIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDSSOExtensionSignoutRequestIntegrationTests.m
@@ -49,6 +49,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
     
     MSIDSSOExtensionSignoutRequest *request = [[MSIDSSOExtensionSignoutRequest alloc] initWithRequestParameters:params
                                                                                        shouldSignoutFromBrowser:YES
+                                                                                       clearSSOExtensionCookies:NO
                                                                                                    oauthFactory:[MSIDAADV2Oauth2Factory new]];
     XCTAssertNotNil(request);
     
@@ -76,6 +77,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
     
     MSIDSSOExtensionSignoutRequest *request = [[MSIDSSOExtensionSignoutRequest alloc] initWithRequestParameters:params
                                                                                        shouldSignoutFromBrowser:YES
+                                                                                       clearSSOExtensionCookies:NO
                                                                                                    oauthFactory:[MSIDAADV2Oauth2Factory new]];
     XCTAssertNotNil(request);
     
@@ -166,6 +168,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
     
     MSIDSSOExtensionSignoutRequestMock *request = [[MSIDSSOExtensionSignoutRequestMock alloc] initWithRequestParameters:params
                                                                                                shouldSignoutFromBrowser:YES
+                                                                                               clearSSOExtensionCookies:NO
                                                                                                            oauthFactory:[MSIDAADV2Oauth2Factory new]];
     
     XCTAssertNotNil(request);
@@ -210,6 +213,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
     
     MSIDSSOExtensionSignoutRequestMock *request = [[MSIDSSOExtensionSignoutRequestMock alloc] initWithRequestParameters:params
                                                                                                shouldSignoutFromBrowser:YES
+                                                                                               clearSSOExtensionCookies:NO
                                                                                                            oauthFactory:[MSIDAADV2Oauth2Factory new]];
     
     XCTAssertNotNil(request);


### PR DESCRIPTION
## Proposed changes

Add support to pass a flag to clear SSO extension cookies in the signout operation explicitly.
This is needed for the broker host app.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

