### PR TITLE
Fix Build Break for Anaheim as consumer of OneAuth

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -80,8 +80,10 @@ typedef void (^MSIDGetAccountsRequestCompletionBlock)(NSArray<MSIDAccount *> * _
 typedef void (^MSIDGetDeviceInfoRequestCompletionBlock)(MSIDDeviceInfo * _Nullable deviceInfo, NSError * _Nullable error);
 
 #if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
 @compatibility_alias MSIDViewController UIViewController;
 #else
+#import <AppKit/AppKit.h>
 @compatibility_alias MSIDViewController NSViewController;
 #endif
 

--- a/IdentityCore/src/controllers/broker/MSIDSSOExtensionInteractiveTokenRequestController.m
+++ b/IdentityCore/src/controllers/broker/MSIDSSOExtensionInteractiveTokenRequestController.m
@@ -50,7 +50,7 @@
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Beginning interactive broker extension flow.");
     
-    __weak typeof(self) weakSelf = self;
+    __typeof__(self) __weak weakSelf = self;
     MSIDRequestCompletionBlock completionBlockWrapper = ^(MSIDTokenResult *result, NSError *error)
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, weakSelf.requestParameters, @"Interactive broker extension flow finished. Result %@, error: %ld error domain: %@", _PII_NULLIFY(result), (long)error.code, error.domain);

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
@@ -70,7 +70,7 @@
         
         _extensionDelegate = [MSIDSSOExtensionOperationRequestDelegate new];
         _extensionDelegate.context = requestParameters;
-        __weak typeof(self) weakSelf = self;
+        __typeof__(self) __weak weakSelf = self;
         _extensionDelegate.completionBlock = ^(MSIDBrokerNativeAppOperationResponse *operationResponse, NSError *error)
         {
             NSArray *resultAccounts = nil;

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.m
@@ -65,7 +65,7 @@
         
         _extensionDelegate = [MSIDSSOExtensionOperationRequestDelegate new];
         _extensionDelegate.context = requestParameters;
-        __weak typeof(self) weakSelf = self;
+        __typeof__(self) __weak weakSelf = self;
         _extensionDelegate.completionBlock = ^(MSIDBrokerNativeAppOperationResponse *operationResponse, NSError *error)
         {
             NSError *resultError = error;

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionInteractiveTokenRequest.m
@@ -75,7 +75,7 @@
         _ssoTokenResponseHandler = [MSIDSSOTokenResponseHandler new];
         _extensionDelegate = [MSIDSSOExtensionTokenRequestDelegate new];
         _extensionDelegate.context = parameters;
-        __weak typeof(self) weakSelf = self;
+        __typeof__(self) __weak weakSelf = self;
         _extensionDelegate.completionBlock = ^(MSIDBrokerOperationTokenResponse *operationResponse, NSError *error)
         {
 #if TARGET_OS_IPHONE

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
@@ -71,7 +71,7 @@
     {
         _extensionDelegate = [MSIDSSOExtensionOperationRequestDelegate new];
         _extensionDelegate.context = parameters;
-        __weak typeof(self) weakSelf = self;
+        __typeof__(self) __weak weakSelf = self;
         _extensionDelegate.completionBlock = ^(MSIDBrokerNativeAppOperationResponse *operationResponse, NSError *error)
         {
             if (!operationResponse.success)

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
@@ -75,7 +75,7 @@
         _ssoTokenResponseHandler = [MSIDSSOTokenResponseHandler new];
         _extensionDelegate = [MSIDSSOExtensionTokenRequestDelegate new];
         _extensionDelegate.context = parameters;
-        __weak typeof(self) weakSelf = self;
+        __typeof__(self) __weak weakSelf = self;
         _extensionDelegate.completionBlock = ^(MSIDBrokerOperationTokenResponse *operationResponse, NSError *error)
         {
 #if TARGET_OS_OSX


### PR DESCRIPTION
## Proposed changes

Fix Build Break for Anaheim. 
1. As Anaheim's build system is using -std=c11 so that the usage of the typeof will break their build.
2. Anaheim team has issue with adding IdentityCore.pch into pre-compile. So added #include in MSIDConstant.h to help them avoid build break 

## Type of change

- [ ] Feature work
- [X ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
An open question: Is that possible to switch language mode in order to avoid future breaks?
