### PR TITLE
Change test constants to use a GUID for home account

### DIFF
--- a/IdentityCore/tests/MSIDAADOauth2FactoryTests.m
+++ b/IdentityCore/tests/MSIDAADOauth2FactoryTests.m
@@ -131,7 +131,7 @@
 {
     MSIDAADOauth2Factory *factory = [MSIDAADOauth2Factory new];
     
-    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : DEFAULT_TEST_UTID} msidBase64UrlJson];
     MSIDAADTokenResponse *response = [[MSIDAADTokenResponse alloc] initWithJSONDictionary:@{@"access_token":@"fake_access_token",
                                                                                             @"refresh_token":@"fake_refresh_token",
                                                                                             @"client_info":rawClientInfo
@@ -226,7 +226,7 @@
     MSIDAccessToken *token = [factory accessTokenFromResponse:response configuration:configuration];
 
     XCTAssertEqualObjects(token.environment, configuration.authority.environment);
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
     XCTAssertEqualObjects(token.accountIdentifier.homeAccountId, homeAccountId);
@@ -253,7 +253,7 @@
     MSIDAccessToken *token = [factory accessTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, configuration.authority.environment);
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
     XCTAssertEqualObjects(token.accountIdentifier.homeAccountId, homeAccountId);
@@ -278,7 +278,7 @@
     MSIDRefreshToken *token = [factory refreshTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, configuration.authority.environment);
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -318,7 +318,7 @@
     MSIDIdToken *token = [factory idTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, configuration.authority.environment);
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];

--- a/IdentityCore/tests/MSIDAADV1Oauth2FactoryTests.m
+++ b/IdentityCore/tests/MSIDAADV1Oauth2FactoryTests.m
@@ -130,7 +130,7 @@
 {
     MSIDAADV1Oauth2Factory *factory = [MSIDAADV1Oauth2Factory new];
     
-    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : DEFAULT_TEST_UTID} msidBase64UrlJson];
     MSIDAADV1TokenResponse *response = [[MSIDAADV1TokenResponse alloc] initWithJSONDictionary:@{@"access_token":@"fake_access_token",
                                                                                                 @"refresh_token":@"fake_refresh_token",
                                                                                                 @"client_info":rawClientInfo
@@ -147,7 +147,7 @@
 {
     MSIDAADV1Oauth2Factory *factory = [MSIDAADV1Oauth2Factory new];
     
-    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : DEFAULT_TEST_UTID} msidBase64UrlJson];
     MSIDAADV1TokenResponse *response = [[MSIDAADV1TokenResponse alloc] initWithJSONDictionary:@{@"refresh_token":@"fake_refresh_token",
                                                                                                 @"client_info":rawClientInfo
                                                                                                 }
@@ -222,7 +222,7 @@
     MSIDBaseToken *token = [factory baseTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, configuration.authority.environment);
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -241,7 +241,7 @@
     MSIDAccessToken *token = [factory accessTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, configuration.authority.environment);
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -265,7 +265,7 @@
     MSIDRefreshToken *token = [factory refreshTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, configuration.authority.environment);
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -327,7 +327,7 @@
     MSIDIdToken *token = [factory idTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
@@ -429,7 +429,7 @@
 {
     MSIDAADV1Oauth2Factory *factory = [MSIDAADV1Oauth2Factory new];
     
-    NSString *base64String = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    NSString *base64String = [@{ @"uid" : DEFAULT_TEST_UID, @"utid" : DEFAULT_TEST_UTID} msidBase64UrlJson];
     NSString *idToken = [MSIDTestIdTokenUtil idTokenWithName:@"Eric" upn:@"eric_cartman@upn.com" tenantId:@"tenantId" additionalClaims:@{@"altsecid": @"::live.com::XXXXXX"}];
     NSDictionary *json = @{@"id_token": idToken, @"client_info": base64String};
 
@@ -445,7 +445,7 @@
 
     MSIDClientInfo *clientInfo = [[MSIDClientInfo alloc] initWithRawClientInfo:base64String error:nil];
     XCTAssertNotNil(account);
-    XCTAssertEqualObjects(account.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
+    XCTAssertEqualObjects(account.accountIdentifier.homeAccountId, DEFAULT_TEST_HOME_ACCOUNT_ID);
     XCTAssertEqualObjects(account.clientInfo, clientInfo);
     XCTAssertEqual(account.accountType, MSIDAccountTypeMSSTS);
     XCTAssertEqualObjects(account.username, @"eric_cartman@upn.com");

--- a/IdentityCore/tests/MSIDAADV2Oauth2FactoryTests.m
+++ b/IdentityCore/tests/MSIDAADV2Oauth2FactoryTests.m
@@ -129,7 +129,7 @@
 {
     MSIDAADV2Oauth2Factory *factory = [MSIDAADV2Oauth2Factory new];
     
-    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : DEFAULT_TEST_UTID} msidBase64UrlJson];
     MSIDAADV2TokenResponse *response = [[MSIDAADV2TokenResponse alloc] initWithJSONDictionary:@{@"access_token":@"fake_access_token",
                                                                                                 @"refresh_token":@"fake_refresh_token",
                                                                                                 @"client_info":rawClientInfo
@@ -146,7 +146,7 @@
 {
     MSIDAADV2Oauth2Factory *factory = [MSIDAADV2Oauth2Factory new];
     
-    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : DEFAULT_TEST_UTID} msidBase64UrlJson];
     MSIDAADV2TokenResponse *response = [[MSIDAADV2TokenResponse alloc] initWithJSONDictionary:@{@"refresh_token":@"fake_refresh_token",
                                                                                                 @"client_info":rawClientInfo
                                                                                                 }
@@ -220,7 +220,7 @@
     MSIDBaseToken *token = [factory baseTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -239,7 +239,7 @@
     MSIDAccessToken *token = [factory accessTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -265,7 +265,7 @@
     MSIDRefreshToken *token = [factory refreshTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -286,7 +286,7 @@
     MSIDIdToken *token = [factory idTokenFromResponse:response configuration:configuration];
     
     XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
     
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -398,7 +398,7 @@
     NSString *idToken = [MSIDTestIdTokenUtil idTokenWithName:@"Eric Cartman" preferredUsername:@"eric999" oid:nil tenantId:@"contoso.com"];
     
     NSOrderedSet *scopes = [NSOrderedSet orderedSetWithObjects:@"user.read", nil];
-    MSIDTokenResponse *tokenResponse = [MSIDTestTokenResponse v2TokenResponseWithAT:@"at" RT:@"rt" scopes:scopes idToken:idToken uid:@"1" utid:@"1234-5678-90abcdefg" familyId:@"1"];
+    MSIDTokenResponse *tokenResponse = [MSIDTestTokenResponse v2TokenResponseWithAT:@"at" RT:@"rt" scopes:scopes idToken:idToken uid:DEFAULT_TEST_UID utid:DEFAULT_TEST_UTID familyId:@"1"];
     
     MSIDConfiguration *configuration =
 
@@ -409,7 +409,7 @@
     
     MSIDAccount *account = [factory accountFromResponse:tokenResponse configuration:configuration];
     XCTAssertNotNil(account);
-    XCTAssertEqualObjects(account.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
+    XCTAssertEqualObjects(account.accountIdentifier.homeAccountId, DEFAULT_TEST_HOME_ACCOUNT_ID);
     XCTAssertNotNil(account.clientInfo);
     XCTAssertEqual(account.accountType, MSIDAccountTypeMSSTS);
     XCTAssertEqualObjects(account.username, @"eric999");

--- a/IdentityCore/tests/MSIDB2COauth2FactoryTests.m
+++ b/IdentityCore/tests/MSIDB2COauth2FactoryTests.m
@@ -96,7 +96,7 @@
 {
     MSIDB2COauth2Factory *factory = [MSIDB2COauth2Factory new];
 
-    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    NSString *rawClientInfo = [@{ @"uid" : DEFAULT_TEST_UID, @"utid" : DEFAULT_TEST_UTID} msidBase64UrlJson];
     MSIDB2CTokenResponse *response = [[MSIDB2CTokenResponse alloc] initWithJSONDictionary:@{@"access_token":@"fake_access_token",
                                                                                             @"refresh_token":@"fake_refresh_token",
                                                                                                 @"client_info":rawClientInfo
@@ -161,7 +161,7 @@
                                          @"refresh_token":DEFAULT_TEST_REFRESH_TOKEN,
                                          @"scope": DEFAULT_TEST_SCOPE,
                                          @"id_token": idToken,
-                                         @"client_info": [@{ @"uid" : @"1", @"utid" : utid ? utid : @"1234-5678-90abcdefg"} msidBase64UrlJson]
+                                         @"client_info": [@{ @"uid" : DEFAULT_TEST_UID, @"utid" : utid ? utid : DEFAULT_TEST_UTID} msidBase64UrlJson]
                                          };
 
     MSIDB2CTokenResponse *response = [[MSIDB2CTokenResponse alloc] initWithJSONDictionary:responseDictionary error:nil];
@@ -172,7 +172,7 @@
 {
     MSIDB2COauth2Factory *factory = [MSIDB2COauth2Factory new];
 
-    MSIDB2CTokenResponse *response = [self testB2CTokenResponseWithTenantId:@"test_tenantid" utid:@"1234-5678-90abcdefg"];
+    MSIDB2CTokenResponse *response = [self testB2CTokenResponseWithTenantId:@"test_tenantid" utid:DEFAULT_TEST_UTID];
     MSIDConfiguration *configuration = [MSIDTestConfiguration configurationWithB2CAuthority:@"https://login.microsoftonline.com/tfp/test_tenantid/policy"
                                                                                    clientId:DEFAULT_TEST_CLIENT_ID
                                                                                 redirectUri:nil
@@ -181,7 +181,7 @@
     MSIDAccessToken *token = [factory accessTokenFromResponse:response configuration:configuration];
 
     XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
 
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -208,7 +208,7 @@
     MSIDAccessToken *token = [factory accessTokenFromResponse:response configuration:configuration];
 
     XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
 
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -235,7 +235,7 @@
     MSIDRefreshToken *token = [factory refreshTokenFromResponse:response configuration:configuration];
 
     XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
 
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -250,7 +250,7 @@
 {
     MSIDB2COauth2Factory *factory = [MSIDB2COauth2Factory new];
 
-    MSIDB2CTokenResponse *response = [self testB2CTokenResponseWithTenantId:@"test_tenantid" utid:@"1234-5678-90abcdefg"];
+    MSIDB2CTokenResponse *response = [self testB2CTokenResponseWithTenantId:@"test_tenantid" utid:DEFAULT_TEST_UTID];
     MSIDConfiguration *configuration = [MSIDTestConfiguration configurationWithB2CAuthority:@"https://login.microsoftonline.com/tfp/test_tenantid/policy"
                                                                                    clientId:DEFAULT_TEST_CLIENT_ID
                                                                                 redirectUri:nil
@@ -259,7 +259,7 @@
     MSIDIdToken *token = [factory idTokenFromResponse:response configuration:configuration];
 
     XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(token.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.realm, DEFAULT_TEST_UTID);
     XCTAssertEqualObjects(token.clientId, configuration.clientId);
 
     NSString *homeAccountId = [NSString stringWithFormat:@"%@.%@", DEFAULT_TEST_UID, DEFAULT_TEST_UTID];
@@ -273,7 +273,7 @@
 {
     MSIDB2COauth2Factory *factory = [MSIDB2COauth2Factory new];
 
-    MSIDB2CTokenResponse *response = [self testB2CTokenResponseWithTenantId:@"test_tenantid" utid:@"1234-5678-90abcdefg"];
+    MSIDB2CTokenResponse *response = [self testB2CTokenResponseWithTenantId:@"test_tenantid" utid:DEFAULT_TEST_UTID];
     
     MSIDConfiguration *configuration = [MSIDTestConfiguration configurationWithB2CAuthority:@"https://login.microsoftonline.com/tfp/test_tenantid/policy"
                                                                                    clientId:@"client id"
@@ -282,7 +282,7 @@
 
     MSIDAccount *account = [factory accountFromResponse:response configuration:configuration];
     XCTAssertNotNil(account);
-    XCTAssertEqualObjects(account.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
+    XCTAssertEqualObjects(account.accountIdentifier.homeAccountId, DEFAULT_TEST_HOME_ACCOUNT_ID);
     XCTAssertNotNil(account.clientInfo);
     XCTAssertEqual(account.accountType, MSIDAccountTypeMSSTS);
     XCTAssertEqualObjects(account.username, @"Missing from the token response");
@@ -290,7 +290,7 @@
     XCTAssertEqualObjects(account.familyName, @"family");
     XCTAssertEqualObjects(account.name, @"name");
     XCTAssertEqualObjects(account.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(account.realm, @"1234-5678-90abcdefg");
+    XCTAssertEqualObjects(account.realm, DEFAULT_TEST_UTID);
 }
 
 

--- a/IdentityCore/tests/MSIDBrokerOperationInteractiveTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationInteractiveTokenRequestTests.m
@@ -106,7 +106,7 @@
     XCTAssertEqualObjects(json[@"extra_consent_scopes"], @"scope 3");
     XCTAssertEqualObjects(json[@"extra_oidc_scopes"], @"profile");
     XCTAssertEqualObjects(json[@"extra_query_param"], @"qp1=value1");
-    XCTAssertEqualObjects(json[@"home_account_id"], @"1.1234-5678-90abcdefg");
+    XCTAssertEqualObjects(json[@"home_account_id"], DEFAULT_TEST_HOME_ACCOUNT_ID);
     XCTAssertEqualObjects(json[@"instance_aware"], @"1");
     XCTAssertEqualObjects(json[@"intune_enrollment_ids"], @"{\"enrollment_ids\":[{\"tid\":\"fda5d5d9-17c3-4c29-9cf9-a27c3d3f03e1\"}]}");
     XCTAssertEqualObjects(json[@"intune_mam_resource"], @"{\"login.microsoftonline.com\":\"https:\\/\\/www.microsoft.com\\/intune\",\"login.microsoftonline.de\":\"https:\\/\\/www.microsoft.com\\/intune-de\"}");
@@ -158,7 +158,7 @@
         @"extra_consent_scopes": @"scope 3",
         @"extra_oidc_scopes": @"profile",
         @"extra_query_param": @"qp1=value1",
-        @"home_account_id": @"1.1234-5678-90abcdefg",
+        @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
         @"instance_aware": @"1",
         @"intune_enrollment_ids": @"{\"enrollment_ids\":[{\"tid\":\"fda5d5d9-17c3-4c29-9cf9-a27c3d3f03e1\"}]}",
         @"intune_mam_resource": @"{\"login.microsoftonline.com\":\"https:\\/\\/www.microsoft.com\\/intune\",\"login.microsoftonline.de\":\"https:\\/\\/www.microsoft.com\\/intune-de\"}",

--- a/IdentityCore/tests/MSIDBrokerOperationSilentTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationSilentTokenRequestTests.m
@@ -61,7 +61,7 @@
         @"extra_consent_scopes": @"scope 3",
         @"extra_oidc_scopes": @"profile",
         @"extra_query_param": @"qp1=value1",
-        @"home_account_id": @"1.1234-5678-90abcdefg",
+        @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
         @"instance_aware": @"1",
         @"intune_enrollment_ids": @"{\"enrollment_ids\":[{\"tid\":\"fda5d5d9-17c3-4c29-9cf9-a27c3d3f03e1\"}]}",
         @"intune_mam_resource": @"{\"login.microsoftonline.com\":\"https:\\/\\/www.microsoft.com\\/intune\",\"login.microsoftonline.de\":\"https:\\/\\/www.microsoft.com\\/intune-de\"}",
@@ -154,7 +154,7 @@
     XCTAssertEqualObjects(json[@"correlation_id"], @"00000000-0000-0000-0000-000000000001");
     XCTAssertEqualObjects(json[@"extra_oidc_scopes"], @"profile");
     XCTAssertEqualObjects(json[@"extra_query_param"], @"qp1=value1");
-    XCTAssertEqualObjects(json[@"home_account_id"], @"1.1234-5678-90abcdefg");
+    XCTAssertEqualObjects(json[@"home_account_id"], DEFAULT_TEST_HOME_ACCOUNT_ID);
     XCTAssertEqualObjects(json[@"instance_aware"], @"1");
     XCTAssertEqualObjects(json[@"intune_enrollment_ids"], @"{\"enrollment_ids\":[{\"tid\":\"fda5d5d9-17c3-4c29-9cf9-a27c3d3f03e1\"}]}");
     XCTAssertEqualObjects(json[@"intune_mam_resource"], @"{\"login.microsoftonline.com\":\"https:\\/\\/www.microsoft.com\\/intune\",\"login.microsoftonline.de\":\"https:\\/\\/www.microsoft.com\\/intune-de\"}");
@@ -186,7 +186,7 @@
     XCTAssertEqualObjects(json[@"authority"], @"https://login.microsoftonline.com/common");
     XCTAssertEqualObjects(json[@"broker_key"], @"broker_key_value");
     XCTAssertEqualObjects(json[@"client_id"], @"client id");
-    XCTAssertEqualObjects(json[@"home_account_id"], @"1.1234-5678-90abcdefg");
+    XCTAssertEqualObjects(json[@"home_account_id"], DEFAULT_TEST_HOME_ACCOUNT_ID);
     XCTAssertEqualObjects(json[@"instance_aware"], @"0");
     XCTAssertEqualObjects(json[@"msg_protocol_ver"], @"99");
     XCTAssertEqualObjects(json[@"provider_type"], @"provider_aad_v1");
@@ -205,7 +205,7 @@
         @"provider_type": @"provider_aad_v1",
         @"redirect_uri": @"redirect uri",
         @"scope": @"scope scope2",
-        @"home_account_id": @"1.1234-5678-90abcdefg",
+        @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
     };
     
     NSError *error;

--- a/IdentityCore/tests/integration/MSIDDefaultTokenCacheIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDDefaultTokenCacheIntegrationTests.m
@@ -424,7 +424,7 @@
 - (void)testGetTokenWithType_whenTypeAccessNoItemsInCache_shouldReturnNil
 {
     MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME
-                                                                              homeAccountId:@"1.1234-5678-90abcdefg"];
+                                                                              homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
     NSError *error = nil;
     MSIDAccessToken *token = [_cacheAccessor getAccessTokenForAccount:account
@@ -439,7 +439,7 @@
 - (void)testGetTokenWithType_whenTypeAccessMultipleAccessTokensInCache_shouldReturnRightToken
 {
     MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME
-                                                                              homeAccountId:@"1.1234-5678-90abcdefg"];
+                                                                              homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
     MSIDTokenResponse *tokenResponse = [MSIDTestTokenResponse v2DefaultTokenResponse];
 
@@ -457,8 +457,8 @@
                                                                                   RT:DEFAULT_TEST_REFRESH_TOKEN
                                                                               scopes:scopes
                                                                              idToken:[MSIDTestIdTokenUtil defaultV2IdToken]
-                                                                                 uid:@"1"
-                                                                                utid:@"1234-5678-90abcdefg"
+                                                                                 uid:DEFAULT_TEST_UID
+                                                                                utid:DEFAULT_TEST_UTID
                                                                             familyId:nil];
 
     [_cacheAccessor saveTokensWithConfiguration:[MSIDTestConfiguration v2DefaultConfigurationWithScopes:scopes]
@@ -506,7 +506,7 @@
     XCTAssertEqual([accessTokensInCache count], 4);
 
     configuration = [MSIDTestConfiguration v2DefaultConfiguration];
-    configuration.authority = [@"https://login.microsoftonline.com/1234-5678-90abcdefg" aadAuthority];
+    configuration.authority = [DEFAULT_TEST_AUTHORITY_GUID aadAuthority];
 
     // retrieve first at
     NSError *error = nil;
@@ -523,7 +523,7 @@
 - (void)testGetTokenWithType_whenTypeAccessCorrectAccountAndParameters_shouldReturnToken
 {
     MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME
-                                                                              homeAccountId:@"1.1234-5678-90abcdefg"];
+                                                                              homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
     MSIDTokenResponse *tokenResponse = [MSIDTestTokenResponse v2DefaultTokenResponse];
 
@@ -535,7 +535,7 @@
                                           error:nil];
 
     MSIDConfiguration *configuration = [MSIDTestConfiguration v2DefaultConfiguration];
-    configuration.authority = [@"https://login.microsoftonline.com/1234-5678-90abcdefg" aadAuthority];
+    configuration.authority = [DEFAULT_TEST_AUTHORITY_GUID aadAuthority];
 
     NSError *error = nil;
 
@@ -555,7 +555,7 @@
     [self setUpEnrollmentIdsCache:NO];
     
     MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME
-                                                                            homeAccountId:@"1.1234-5678-90abcdefg"];
+                                                                            homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
     MSIDTokenResponse *tokenResponse = [MSIDTestTokenResponse v2DefaultTokenResponse];
     
@@ -569,7 +569,7 @@
                                         context:nil
                                           error:nil];
     
-    configuration.authority = [@"https://login.microsoftonline.com/1234-5678-90abcdefg" aadAuthority];
+    configuration.authority = [DEFAULT_TEST_AUTHORITY_GUID aadAuthority];
     
     NSError *error = nil;
     
@@ -591,7 +591,7 @@
     MSIDTokenResponse *tokenResponse = [MSIDTestTokenResponse v2DefaultTokenResponse];
 
     MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME
-                                                                              homeAccountId:@"1.1234-5678-90abcdefg"];
+                                                                              homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
     // Save token
     [_cacheAccessor saveTokensWithConfiguration:[MSIDTestConfiguration v2DefaultConfiguration]
@@ -602,7 +602,7 @@
 
     // Retrieve token
     MSIDConfiguration *configuration = [MSIDTestConfiguration v2DefaultConfiguration];
-    configuration.authority = [@"https://login.microsoftonline.com/1234-5678-90abcdefg" aadAuthority];
+    configuration.authority = [DEFAULT_TEST_AUTHORITY_GUID aadAuthority];
 
     NSError *error = nil;
     MSIDAccessToken *returnedToken = [_cacheAccessor getAccessTokenForAccount:account
@@ -618,7 +618,7 @@
 - (void)testGetTokenWithType_whenTypeRefreshNoItemsInCache_shouldReturnNil
 {
     MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME
-                                                                              homeAccountId:@"1.1234-5678-90abcdefg"];
+                                                                              homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
     NSError *error = nil;
 
@@ -636,7 +636,7 @@
 - (void)testGetTokenWithType_whenTypeRefreshAccountWithUtidAndUidProvided_shouldReturnToken
 {
     MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
-                                                                              homeAccountId:@"1.1234-5678-90abcdefg"];
+                                                                              homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     [_cacheAccessor saveSSOStateWithConfiguration:[MSIDTestConfiguration v2DefaultConfiguration]
                                          response:[MSIDTestTokenResponse v2DefaultTokenResponse]
                                           factory:[MSIDAADV2Oauth2Factory new]
@@ -732,7 +732,7 @@
     NSDictionary *dict = @{MSID_INTUNE_ENROLLMENT_ID_KEY: @{@"enrollment_ids": @[@{
                                                                                      @"tid" : @"fda5d5d9-17c3-4c29-9cf9-a27c3d3f03e1",
                                                                                      @"oid" : @"d3444455-mike-4271-b6ea-e499cc0cab46",
-                                                                                     @"home_account_id" : @"1.1234-5678-90abcdefg",
+                                                                                     @"home_account_id" : DEFAULT_TEST_HOME_ACCOUNT_ID,
                                                                                      @"user_id" : @"mike@contoso.com",
                                                                                      @"enrollment_id" : @"enrollmentId"
                                                                                      },

--- a/IdentityCore/tests/integration/MSIDInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDInteractiveControllerIntegrationTests.m
@@ -36,6 +36,7 @@
 #import "MSIDTelemetryTestDispatcher.h"
 #import "MSIDTelemetry.h"
 #import "MSIDRefreshToken.h"
+#import "MSIDTestIdentifiers.h"
 #if TARGET_OS_IPHONE
 #import "MSIDApplicationTestUtil.h"
 #import "MSIDWebWPJResponse.h"
@@ -173,7 +174,7 @@
         XCTAssertEqualObjects(telemetryEvent[@"status"], @"succeeded");
         XCTAssertEqualObjects(telemetryEvent[@"login_hint"], @"d24dfead25359b0c562c8a02a6a0e6db8de4a8b235d56e122a75a8e1f2e473ee");
         XCTAssertEqualObjects(telemetryEvent[@"user_id"], @"d24dfead25359b0c562c8a02a6a0e6db8de4a8b235d56e122a75a8e1f2e473ee");
-        XCTAssertEqualObjects(telemetryEvent[@"tenant_id"], @"1234-5678-90abcdefg");
+        XCTAssertEqualObjects(telemetryEvent[@"tenant_id"], DEFAULT_TEST_UTID);
         XCTAssertEqualObjects(telemetryEvent[@"client_id"], @"my_client_id");
         XCTAssertNotNil(telemetryEvent[@"response_time"]);
 

--- a/IdentityCore/tests/integration/MSIDInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDInteractiveControllerIntegrationTests.m
@@ -331,7 +331,7 @@
         XCTAssertEqualObjects(telemetryEvent[@"status"], @"succeeded");
         XCTAssertEqualObjects(telemetryEvent[@"login_hint"], @"d24dfead25359b0c562c8a02a6a0e6db8de4a8b235d56e122a75a8e1f2e473ee");
         XCTAssertEqualObjects(telemetryEvent[@"user_id"], @"d24dfead25359b0c562c8a02a6a0e6db8de4a8b235d56e122a75a8e1f2e473ee");
-        XCTAssertEqualObjects(telemetryEvent[@"tenant_id"], @"1234-5678-90abcdefg");
+        XCTAssertEqualObjects(telemetryEvent[@"tenant_id"], DEFAULT_TEST_UTID);
         XCTAssertEqualObjects(telemetryEvent[@"client_id"], @"my_client_id");
         XCTAssertEqualObjects(telemetryEvent[@"correlation_id"], parameters.correlationId.UUIDString);
         XCTAssertNotNil(telemetryEvent[@"response_time"]);

--- a/IdentityCore/tests/integration/MSIDLegacyTokenCacheIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDLegacyTokenCacheIntegrationTests.m
@@ -537,7 +537,7 @@
     
     XCTAssertNil(error);
     XCTAssertNotNil(token);
-    XCTAssertEqualObjects(token.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
+    XCTAssertEqualObjects(token.accountIdentifier.homeAccountId, DEFAULT_TEST_HOME_ACCOUNT_ID);
     
     NSArray *allAccessTokens = [MSIDTestCacheAccessorHelper getAllLegacyAccessTokens:_legacyAccessor];
     XCTAssertEqual([allAccessTokens count], 2);
@@ -820,7 +820,7 @@
     XCTAssertTrue(result);
     
     account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
-                                                       homeAccountId:@"1.1234-5678-90abcdefg"];
+                                                       homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
     // Check that correct token is returned
     MSIDRefreshToken *returnedToken = [_legacyAccessor getRefreshTokenWithAccount:account

--- a/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
@@ -42,6 +42,7 @@
 #import "MSIDAadAuthorityCache.h"
 #import "NSString+MSIDTestUtil.h"
 #import "MSIDTestLocalInteractiveController.h"
+#import "MSIDTestIdentifiers.h"
 
 @interface MSIDBrokerInteractiveControllerIntegrationTests : XCTestCase
 
@@ -194,7 +195,7 @@
         XCTAssertEqualObjects(telemetryEvent[@"status"], @"succeeded");
         XCTAssertEqualObjects(telemetryEvent[@"login_hint"], @"d24dfead25359b0c562c8a02a6a0e6db8de4a8b235d56e122a75a8e1f2e473ee");
         XCTAssertEqualObjects(telemetryEvent[@"user_id"], @"d24dfead25359b0c562c8a02a6a0e6db8de4a8b235d56e122a75a8e1f2e473ee");
-        XCTAssertEqualObjects(telemetryEvent[@"tenant_id"], @"1234-5678-90abcdefg");
+        XCTAssertEqualObjects(telemetryEvent[@"tenant_id"], DEFAULT_TEST_UTID);
         XCTAssertEqualObjects(telemetryEvent[@"client_id"], @"my_client_id");
         XCTAssertEqualObjects(telemetryEvent[@"correlation_id"], parameters.correlationId.UUIDString);
         XCTAssertNotNil(telemetryEvent[@"response_time"]);
@@ -486,7 +487,7 @@
         XCTAssertEqualObjects(telemetryEvent[@"status"], @"succeeded");
         XCTAssertEqualObjects(telemetryEvent[@"login_hint"], @"d24dfead25359b0c562c8a02a6a0e6db8de4a8b235d56e122a75a8e1f2e473ee");
         XCTAssertEqualObjects(telemetryEvent[@"user_id"], @"d24dfead25359b0c562c8a02a6a0e6db8de4a8b235d56e122a75a8e1f2e473ee");
-        XCTAssertEqualObjects(telemetryEvent[@"tenant_id"], @"1234-5678-90abcdefg");
+        XCTAssertEqualObjects(telemetryEvent[@"tenant_id"], DEFAULT_TEST_UTID);
         XCTAssertEqualObjects(telemetryEvent[@"client_id"], @"my_client_id");
         XCTAssertEqualObjects(telemetryEvent[@"correlation_id"], parameters.correlationId.UUIDString);
         XCTAssertNotNil(telemetryEvent[@"response_time"]);

--- a/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
@@ -41,6 +41,7 @@
 #import "MSIDAccessToken.h"
 #import "MSIDAuthority+Internal.h"
 #import "MSIDWebWPJResponse.h"
+#import "MSIDTestIdentifiers.h"
 #if TARGET_OS_IPHONE
 #import "MSIDApplicationTestUtil.h"
 #endif
@@ -109,7 +110,7 @@
     parameters.oidcScope = @"openid profile offline_access";
     parameters.promptType = MSIDPromptTypeConsent;
     parameters.authority.openIdConfigurationEndpoint = [NSURL URLWithString:@"https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"];
-    parameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:@"1.1234-5678-90abcdefg"];
+    parameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     parameters.enablePkce = YES;
 
     MSIDInteractiveTokenRequest *request = [[MSIDInteractiveTokenRequest alloc] initWithRequestParameters:parameters oauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new] tokenCache:self.tokenCache accountMetadataCache:self.metadataCache];
@@ -179,7 +180,7 @@
         XCTAssertEqualObjects(result.accessToken.accessToken, @"i am a access token!");
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil defaultV2IdToken]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        XCTAssertEqualObjects(result.authority.url.absoluteString, @"https://login.microsoftonline.com/1234-5678-90abcdefg");
+        XCTAssertEqualObjects(result.authority.url.absoluteString, DEFAULT_TEST_AUTHORITY_GUID);
         XCTAssertNil(installBrokerResponse);
         XCTAssertNil(error);
 
@@ -278,7 +279,7 @@
         XCTAssertEqualObjects(result.accessToken.accessToken, @"i am a access token!");
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil defaultV2IdToken]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        XCTAssertEqualObjects(result.authority.url.absoluteString, @"https://contoso.onmicrosoft.cn/1234-5678-90abcdefg");
+        XCTAssertEqualObjects(result.authority.url.absoluteString, @"https://contoso.onmicrosoft.cn/"DEFAULT_TEST_UTID);
         XCTAssertNil(installBrokerResponse);
         XCTAssertNil(error);
 

--- a/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
@@ -82,7 +82,7 @@
 - (MSIDRequestParameters *)silentRequestParameters
 {
     MSIDRequestParameters *parameters = [MSIDRequestParameters new];
-    parameters.authority = [@"https://login.microsoftonline.com/1234-5678-90abcdefg" aadAuthority];
+    parameters.authority = [DEFAULT_TEST_AUTHORITY_GUID aadAuthority];
     parameters.clientId = @"my_client_id";
     parameters.target = @"user.read tasks.read";
     parameters.oidcScope = @"openid profile offline_access";
@@ -151,7 +151,7 @@
     [self saveTokensInCache:tokenCache configuration:silentParameters.msidConfiguration];
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -200,7 +200,7 @@
     
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -255,7 +255,7 @@
     BOOL removeResult = [tokenCache removeToken:idToken context:nil error:nil];
     XCTAssertTrue(removeResult);
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -271,7 +271,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:500
                                                                                     expiresIn:nil];
     
@@ -324,7 +324,7 @@
     BOOL removeResult = [tokenCache removeToken:idToken context:nil error:nil];
     XCTAssertTrue(removeResult);
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -339,7 +339,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -386,7 +386,7 @@
     BOOL removeResult = [tokenCache removeToken:accessToken context:nil error:nil];
     XCTAssertTrue(removeResult);
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -401,7 +401,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -425,7 +425,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -443,7 +443,7 @@
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     silentParameters.target = @"new.scope1 new.scope2";
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -458,7 +458,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"new.scope1 new.scope2"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -482,7 +482,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -500,7 +500,7 @@
     MSIDAccountIdentifier *accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     silentParameters.accountIdentifier = accountIdentifier;
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -515,7 +515,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -539,7 +539,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -560,7 +560,7 @@
     MSIDAccountIdentifier *accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     silentParameters.accountIdentifier = accountIdentifier;
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -573,7 +573,7 @@
                                                                                      responseError:@"invalid_grant"
                                                                                        description:@"test"
                                                                                           subError:@"my_suberror"
-                                                                                               url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                               url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                       responseCode:200];
     
     [MSIDTestURLSession addResponse:tokenResponse];
@@ -614,7 +614,7 @@
     MSIDAccountIdentifier *accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     silentParameters.accountIdentifier = accountIdentifier;
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -627,7 +627,7 @@
                                                                                      responseError:@"invalid_grant"
                                                                                        description:@"test"
                                                                                           subError:@"bad_token"
-                                                                                               url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                               url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                       responseCode:200];
     
     [MSIDTestURLSession addResponse:tokenResponse];
@@ -678,7 +678,7 @@
     
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -693,7 +693,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -717,7 +717,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -734,7 +734,7 @@
     [self saveExpiredTokensInCache:tokenCache configuration:silentParameters.msidConfiguration];
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
-    NSString *authority = @"https://login.microsoftonline.com/contoso.com";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     silentParameters.authority = [authority aadAuthority];
 
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
@@ -751,7 +751,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/contoso.com/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -775,7 +775,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -804,7 +804,7 @@
     BOOL result = [tokenCache removeToken:refreshToken context:silentParameters error:nil];
     XCTAssertTrue(result);
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -843,7 +843,7 @@
                                                                                                          tokenCache:tokenCache
                                                                                                       accountMetadataCache:self.accountMetadataCache];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -858,7 +858,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -875,7 +875,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -904,7 +904,7 @@
     BOOL result = [tokenCache removeToken:refreshToken context:silentParameters error:nil];
     XCTAssertTrue(result);
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -943,7 +943,7 @@
                                                                                                          tokenCache:tokenCache
                                                                                                       accountMetadataCache:self.accountMetadataCache];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -961,7 +961,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:differentClientInfo
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -994,7 +994,7 @@
                                                                                                          tokenCache:tokenCache
                                                                                                       accountMetadataCache:self.accountMetadataCache];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1012,7 +1012,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:differentClientInfo
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -1039,7 +1039,7 @@
     [self saveExpiredTokensInCache:tokenCache configuration:silentParameters.msidConfiguration];
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1054,7 +1054,7 @@
                                                                                         responseID:nil
                                                                                      responseScope:@"user.read tasks.read"
                                                                                 responseClientInfo:nil
-                                                                                               url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                               url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                       responseCode:500
                                                                                          expiresIn:nil];
     
@@ -1068,7 +1068,7 @@
                                                                                           responseID:nil
                                                                                        responseScope:@"user.read tasks.read"
                                                                                   responseClientInfo:nil
-                                                                                                 url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                                 url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                         responseCode:200
                                                                                            expiresIn:nil];
     
@@ -1092,7 +1092,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt 2");
         [expectation fulfill];
@@ -1109,7 +1109,7 @@
     [self saveExpiredTokensInCache:tokenCache configuration:silentParameters.msidConfiguration];
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1120,14 +1120,14 @@
     [reqHeaders setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
     
     MSIDTestURLResponse *errorTokenResponse =
-    [MSIDTestURLResponse requestURLString:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+    [MSIDTestURLResponse requestURLString:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                            requestHeaders:reqHeaders
                         requestParamsBody:@{ @"client_id" : @"my_client_id",
                                              @"scope" : @"user.read tasks.read openid profile offline_access",
                                              @"grant_type" : @"refresh_token",
                                              @"refresh_token" : DEFAULT_TEST_REFRESH_TOKEN,
                                              @"client_info" : @"1"}
-                        responseURLString:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                        responseURLString:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                              responseCode:429
                          httpHeaderFields:@{@"Retry-After": @"256",
                                             @"Other-Header-Field": @"Other header field"
@@ -1209,7 +1209,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/tfp/1234-5678-90abcdefg/signup"];
+        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/tfp/"DEFAULT_TEST_UTID@"/signup"];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -1230,7 +1230,7 @@
     NSDictionary *claimsJsonDictionary = @{@"access_token":@{@"polids":@{@"values":@[@"5ce770ea-8690-4747-aa73-c5b3cd509cd4"], @"essential":@YES}}};
     silentParameters.claimsRequest = [[MSIDClaimsRequest alloc] initWithJSONDictionary:claimsJsonDictionary error:nil];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1245,7 +1245,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -1269,7 +1269,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -1298,7 +1298,7 @@
     
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1314,7 +1314,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:500
                                                                                     expiresIn:nil];
     
@@ -1380,7 +1380,7 @@
     BOOL result = [tokenCache removeToken:refreshToken context:silentParameters error:nil];
     XCTAssertTrue(result);
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1395,7 +1395,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     
@@ -1419,7 +1419,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -1459,7 +1459,7 @@
     BOOL result = [[self accountCredentialCache] saveCredential:refreshToken.tokenCacheItem context:nil error:nil];
     XCTAssertTrue(result);
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1472,7 +1472,7 @@
                                                                                      responseError:@"invalid_grant"
                                                                                        description:nil
                                                                                           subError:nil
-                                                                                               url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                               url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                       responseCode:200];
     
     [MSIDTestURLSession addResponse:tokenResponse];
@@ -1485,7 +1485,7 @@
                                                                                        responseID:nil
                                                                                     responseScope:@"user.read tasks.read"
                                                                                responseClientInfo:nil
-                                                                                              url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                              url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                      responseCode:200
                                                                                         expiresIn:nil];
     
@@ -1509,7 +1509,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
         [expectation fulfill];
@@ -1524,7 +1524,7 @@
     MSIDDefaultTokenCacheAccessor *tokenCache = self.tokenCache;
     
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
-    silentParameters.authority = [@"https://login.windows.net/1234-5678-90abcdefg" aadAuthority];
+    silentParameters.authority = [@"https://login.windows.net/"DEFAULT_TEST_UTID aadAuthority];
 
     [self saveTokensInCache:tokenCache
               configuration:silentParameters.msidConfiguration
@@ -1550,11 +1550,11 @@
     BOOL result = [[self accountCredentialCache] saveCredential:refreshToken.tokenCacheItem context:nil error:nil];
     XCTAssertTrue(result);
     
-    NSString *authority = @"https://login.windows.net/1234-5678-90abcdefg";
+    NSString *authority = @"https://login.windows.net/"DEFAULT_TEST_UTID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
-    MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:@"https://login.microsoftonline.com/1234-5678-90abcdefg"];
+    MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:DEFAULT_TEST_AUTHORITY_GUID];
     [MSIDTestURLSession addResponse:oidcResponse];
     
     MSIDTestURLResponse *tokenResponse = [MSIDTestURLResponse errorRefreshTokenGrantResponseWithRT:@"family refresh token"
@@ -1563,7 +1563,7 @@
                                                                                      responseError:@"invalid_grant"
                                                                                        description:nil
                                                                                           subError:@"client_mismatch"
-                                                                                               url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                               url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                       responseCode:200];
     
     [MSIDTestURLSession addResponse:tokenResponse];
@@ -1576,7 +1576,7 @@
                                                                                        responseID:nil
                                                                                     responseScope:@"user.read tasks.read"
                                                                                responseClientInfo:nil
-                                                                                              url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                              url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                      responseCode:200
                                                                                         expiresIn:@"1"];
     
@@ -1600,7 +1600,7 @@
         XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.windows.net/1234-5678-90abcdefg"];
+        NSURL *tenantURL = [NSURL URLWithString:@"https://login.windows.net/"DEFAULT_TEST_UTID];
         XCTAssertEqualObjects(result.authority.url, tenantURL);
         XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new mrrt");
         
@@ -1626,7 +1626,7 @@
                                                                                     responseID:nil
                                                                                  responseScope:@"user.read tasks.read"
                                                                             responseClientInfo:nil
-                                                                                           url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                           url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                   responseCode:200
                                                                                      expiresIn:nil];
     
@@ -1682,7 +1682,7 @@
     BOOL result = [self.tokenCache removeToken:refreshToken context:nil error:nil];
     XCTAssertTrue(result);
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1695,7 +1695,7 @@
                                                                                      responseError:@"invalid_grant"
                                                                                        description:nil
                                                                                           subError:nil
-                                                                                               url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                               url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                       responseCode:200];
     
     [MSIDTestURLSession addResponse:tokenResponse];
@@ -1731,7 +1731,7 @@
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     silentParameters.target = @"new.SCOPE1 new.sCope2";
     
-    NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1746,7 +1746,7 @@
                                                                                    responseID:nil
                                                                                 responseScope:@"new.scope New.Scope1"
                                                                            responseClientInfo:nil
-                                                                                          url:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token"
+                                                                                          url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                                                                                  responseCode:200
                                                                                     expiresIn:nil];
     

--- a/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
+++ b/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
@@ -65,6 +65,9 @@
     MSIDAccountCacheItem* _accountA;
     MSIDAccountCacheItem* _accountB;
     MSIDAccountCacheItem* _accountC;
+    NSString* _homeAccountIdA;
+    NSString* _homeAccountIdB;
+    NSString* _homeAccountIdC;
     MSIDDefaultAccountCacheKey *_keyA;
     MSIDDefaultAccountCacheKey *_keyB;
     MSIDDefaultAccountCacheKey *_keyC;
@@ -84,6 +87,10 @@
     _serializer = [MSIDCacheItemJsonSerializer new];
     [_cache clearWithContext:nil error:nil];
 
+    _homeAccountIdA = @"aaaaaaaa-0000-0000-0000-000000000000.00000000-0000-0000-0000-aaaaaaaaaaaa";
+    _homeAccountIdB = @"bbbbbbbb-0000-0000-0000-000000000000.00000000-0000-0000-0000-bbbbbbbbbbbb";
+    _homeAccountIdC = @"aaaaaaaa-0000-0000-0000-000000000000.00000000-0000-0000-0000-cccccccccccc";
+
     NSDictionary *accountDictionary = @{@"authority_type": @"MSSTS",
                                          @"environment": DEFAULT_TEST_ENVIRONMENT,
                                          @"realm": @"contoso.com",
@@ -92,7 +99,7 @@
                                          @"family_name": @"Last name",
                                          @"test": @"test2",
                                          @"test3": @"test4",
-                                         @"home_account_id": @"uid.utid",
+                                         @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
                                          @"username": @"username",
                                          @"alternative_account_id": @"alt",
                                          @"name": @"test user"
@@ -112,7 +119,7 @@
                                          @"given_name": @"GivenNameA",
                                          @"family_name": @"FamilyNameA",
                                          @"middle_name": @"MiddleNameA",
-                                         @"home_account_id": @"uidA.utidA",
+                                         @"home_account_id": _homeAccountIdA,
                                          @"username": @"usernameA",
                                          @"alternative_account_id": @"AltIdA",
                                          @"name": @"NameA"
@@ -124,7 +131,7 @@
                                          @"given_name": @"GivenNameB",
                                          @"family_name": @"FamilyNameB",
                                          @"middle_name": @"MiddleNameB",
-                                         @"home_account_id": @"uidB.utidB",
+                                         @"home_account_id": _homeAccountIdB,
                                          @"username": @"usernameB",
                                          @"alternative_account_id": @"AltIdB",
                                          @"name": @"NameB"
@@ -136,7 +143,7 @@
                                          @"given_name": @"GivenNameC",
                                          @"family_name": @"FamilyNameC",
                                          @"middle_name": @"MiddleNameC",
-                                         @"home_account_id": @"uidA.utidC",
+                                         @"home_account_id": _homeAccountIdC,
                                          @"username": @"usernameC",
                                          @"alternative_account_id": @"AltIdC",
                                          @"name": @"NameC"
@@ -284,7 +291,7 @@
                                          @"given_name": @"GivenNameA",
                                          @"family_name": @"FamilyNameA",
                                          @"middle_name": @"MiddleNameA",
-                                         @"home_account_id": @"uidA.utidA",
+                                         @"home_account_id": _homeAccountIdA,
                                          @"username": @"usernameA",
                                          @"alternative_account_id": @"AltIdA",
                                          @"name": @"NameA",
@@ -614,11 +621,11 @@
     MSIDCredentialCacheItem *token1 = [MSIDCredentialCacheItem new];
     token1.clientId = @"clientId";
     token1.environment = @"environment";
-    token1.homeAccountId = @"uid.utid";
+    token1.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     token1.secret = @"secret1";
     token1.target = @"user.read user.write";
     token1.credentialType = MSIDAccessTokenType;
-    MSIDDefaultCredentialCacheKey *key1 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key1 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                            environment:@"environment"
                                                                                               clientId:@"clientId"
                                                                                         credentialType:MSIDAccessTokenType];
@@ -629,11 +636,11 @@
     MSIDCredentialCacheItem *token2 = [MSIDCredentialCacheItem new];
     token2.clientId = @"clientId";
     token2.environment = @"environment";
-    token2.homeAccountId = @"uid.utid";
+    token2.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     token2.secret = @"secret2";
     token2.credentialType = MSIDIDTokenType;
     
-    MSIDDefaultCredentialCacheKey *key2 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key2 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                            environment:@"environment"
                                                                                               clientId:@"clientId"
                                                                                         credentialType:MSIDIDTokenType];
@@ -645,17 +652,17 @@
     token3.secret = @"secret3";
     token3.clientId = @"clientId";
     token3.environment = @"environment";
-    token3.homeAccountId = @"uid.utid";
+    token3.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     token3.credentialType = MSIDRefreshTokenType;
     
-    MSIDDefaultCredentialCacheKey *key3 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key3 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                            environment:@"environment"
                                                                                               clientId:@"clientId"
                                                                                         credentialType:MSIDRefreshTokenType];
     
     [_dataSource saveToken:token3 key:key3 serializer:_serializer context:nil error:nil];
     
-    MSIDDefaultCredentialCacheKey *query = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *query = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                             environment:@"environment"
                                                                                                clientId:@"clientId"
                                                                                          credentialType:MSIDRefreshTokenType];
@@ -673,7 +680,7 @@
     MSIDAccountCacheItem *account = [MSIDAccountCacheItem new];
     account.environment = DEFAULT_TEST_ENVIRONMENT;
     account.realm = @"Contoso.COM";
-    account.homeAccountId = @"uid.utid";
+    account.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     account.localAccountId = @"homeAccountIdA";
     account.accountType = MSIDAccountTypeAADV1;
     account.username = @"UsernameA";
@@ -727,10 +734,10 @@
     token.secret = @"secret";
     token.clientId = @"clientId";
     token.environment = @"login.microsoftonline.com";
-    token.homeAccountId = @"uid.utid";
+    token.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     token.credentialType = MSIDRefreshTokenType;
     
-    MSIDDefaultCredentialCacheKey *key = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                           environment:@"login.microsoftonline.com"
                                                                                              clientId:@"clientId"
                                                                                        credentialType:MSIDRefreshTokenType];
@@ -773,7 +780,7 @@
 {
     // Item 1.
     MSIDCredentialCacheItem *accessToken = [self createTestAccessTokenCacheItem];
-    MSIDDefaultCredentialCacheKey *key1 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key1 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                            environment:@"login.microsoftonline.com"
                                                                                               clientId:@"client"
                                                                                         credentialType:MSIDAccessTokenType];
@@ -783,7 +790,7 @@
     
     // Item 2.
     MSIDCredentialCacheItem *idToken = [self createTestIDTokenCacheItem];
-    MSIDDefaultCredentialCacheKey *key2 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key2 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                            environment:@"login.microsoftonline.com"
                                                                                               clientId:@"client"
                                                                                         credentialType:MSIDIDTokenType];
@@ -793,7 +800,7 @@
     
     // Item 3.
     MSIDCredentialCacheItem *refreshToken = [self createTestRefreshToken:nil];
-    MSIDDefaultCredentialCacheKey *key3 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key3 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                            environment:@"login.microsoftonline.com"
                                                                                               clientId:@"client"
                                                                                         credentialType:MSIDRefreshTokenType];
@@ -810,10 +817,10 @@
     [_dataSource saveAppMetadata:appMetadata1 key:key4 serializer:_serializer context:nil error:nil];
     
     //Item 5
-    MSIDDefaultAccountCacheKey *key5 = [[MSIDDefaultAccountCacheKey alloc] initWithHomeAccountId:@"uid.utid" environment:@"login.microsoftonline.com" realm:@"realm" type:MSIDAccountTypeMSSTS];
+    MSIDDefaultAccountCacheKey *key5 = [[MSIDDefaultAccountCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID environment:@"login.microsoftonline.com" realm:@"realm" type:MSIDAccountTypeMSSTS];
     
     MSIDAccountCacheItem *account = [MSIDAccountCacheItem new];
-    account.homeAccountId = @"uid.utid";
+    account.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     account.environment = @"login.microsoftonline.com";
     account.accountType = MSIDAccountTypeMSSTS;
     [_dataSource saveAccount:account key:key5 serializer:_serializer context:nil error:nil];
@@ -834,7 +841,7 @@
 {
     // Item 1.
     MSIDCredentialCacheItem *accessToken = [self createTestAccessTokenCacheItem];
-    MSIDDefaultCredentialCacheKey *key1 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key1 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                            environment:@"login.microsoftonline.com"
                                                                                               clientId:@"client"
                                                                                         credentialType:MSIDAccessTokenType];
@@ -844,7 +851,7 @@
     
     // Item 2.
     MSIDCredentialCacheItem *idToken = [self createTestIDTokenCacheItem];
-    MSIDDefaultCredentialCacheKey *key2 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key2 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                            environment:@"login.microsoftonline.com"
                                                                                               clientId:@"client"
                                                                                         credentialType:MSIDIDTokenType];
@@ -854,7 +861,7 @@
     
     // Item 3.
     MSIDCredentialCacheItem *refreshToken = [self createTestRefreshToken:nil];
-    MSIDDefaultCredentialCacheKey *key3 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:@"uid.utid"
+    MSIDDefaultCredentialCacheKey *key3 = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID
                                                                                            environment:@"login.microsoftonline.com"
                                                                                               clientId:@"client"
                                                                                         credentialType:MSIDRefreshTokenType];
@@ -871,16 +878,16 @@
     [_dataSource saveAppMetadata:appMetadata1 key:key4 serializer:_serializer context:nil error:nil];
     
     //Item 5
-    MSIDDefaultAccountCacheKey *key5 = [[MSIDDefaultAccountCacheKey alloc] initWithHomeAccountId:@"uid.utid" environment:@"login.microsoftonline.com" realm:@"realm" type:MSIDAccountTypeMSSTS];
+    MSIDDefaultAccountCacheKey *key5 = [[MSIDDefaultAccountCacheKey alloc] initWithHomeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID environment:@"login.microsoftonline.com" realm:@"realm" type:MSIDAccountTypeMSSTS];
     
     MSIDAccountCacheItem *account = [MSIDAccountCacheItem new];
-    account.homeAccountId = @"uid.utid";
+    account.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     account.environment = @"login.microsoftonline.com";
     account.accountType = MSIDAccountTypeMSSTS;
     [_dataSource saveAccount:account key:key5 serializer:_serializer context:nil error:nil];
     
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
-    query.homeAccountId = @"uid.utid";
+    query.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     query.environment = @"login.microsoftonline.com";
     query.matchAnyCredentialType = YES;
     NSArray<MSIDCredentialCacheItem *> *items = [_dataSource tokensWithKey:query serializer:_serializer context:nil error:nil];
@@ -906,7 +913,7 @@
 {
     MSIDCredentialCacheItem *item = [MSIDCredentialCacheItem new];
     item.credentialType = MSIDAccessTokenType;
-    item.homeAccountId = @"uid.utid";
+    item.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     item.environment = @"login.microsoftonline.com";
     item.realm = @"contoso.com";
     item.clientId = @"client";
@@ -924,7 +931,7 @@
 {
     MSIDCredentialCacheItem *item = [MSIDCredentialCacheItem new];
     item.credentialType = MSIDIDTokenType;
-    item.homeAccountId = @"uid.utid";
+    item.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     item.environment = @"login.microsoftonline.com";
     item.clientId = @"client";
     item.realm = @"contoso.com";
@@ -948,7 +955,7 @@
 {
     MSIDCredentialCacheItem *item = [MSIDCredentialCacheItem new];
     item.credentialType = MSIDRefreshTokenType;
-    item.homeAccountId = @"uid.utid";
+    item.homeAccountId = DEFAULT_TEST_HOME_ACCOUNT_ID;
     item.environment = @"login.microsoftonline.com";
     item.clientId = @"client";
     item.familyId = familyId;

--- a/IdentityCore/tests/util/MSIDTestIdentifiers.h
+++ b/IdentityCore/tests/util/MSIDTestIdentifiers.h
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 
 #define DEFAULT_TEST_UID @"fedcba98-7654-3210-0000-000000000000"
-#define DEFAULT_TEST_UTID @"00000000-1234-5678-90abcdefffff"
+#define DEFAULT_TEST_UTID @"00000000-0000-1234-5678-90abcdefffff"
 #define DEFAULT_TEST_HOME_ACCOUNT_ID DEFAULT_TEST_UID@"."DEFAULT_TEST_UTID
 #define DEFAULT_TEST_RESOURCE @"https://graph.microsoft.com/"
 #define DEFAULT_TEST_AUTHORITY @"https://login.microsoftonline.com/common"

--- a/IdentityCore/tests/util/MSIDTestIdentifiers.h
+++ b/IdentityCore/tests/util/MSIDTestIdentifiers.h
@@ -26,6 +26,8 @@
 #define DEFAULT_TEST_HOME_ACCOUNT_ID DEFAULT_TEST_UID@"."DEFAULT_TEST_UTID
 #define DEFAULT_TEST_RESOURCE @"https://graph.microsoft.com/"
 #define DEFAULT_TEST_AUTHORITY @"https://login.microsoftonline.com/common"
+#define DEFAULT_TEST_AUTHORITY_GUID @"https://login.microsoftonline.com/"DEFAULT_TEST_UTID
+#define DEFAULT_TEST_TOKEN_ENDPOINT_GUID @"https://login.microsoftonline.com/"DEFAULT_TEST_UTID@"/oauth2/v2.0/token"
 #define DEFAULT_TEST_AUTHORIZATION_ENDPOINT @"https://login.microsoftonline.com/common/common/oauth2/authorize"
 #define DEFAULT_TEST_ENVIRONMENT @"login.microsoftonline.com"
 #define DEFAULT_TEST_CLIENT_ID @"test_client_id"

--- a/IdentityCore/tests/util/MSIDTestIdentifiers.h
+++ b/IdentityCore/tests/util/MSIDTestIdentifiers.h
@@ -21,9 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#define DEFAULT_TEST_UID @"1"
-#define DEFAULT_TEST_UTID @"1234-5678-90abcdefg"
-#define DEFAULT_TEST_HOME_ACCOUNT_ID @"1.1234-5678-90abcdefg"
+#define DEFAULT_TEST_UID @"fedcba98-7654-3210-0000-000000000000"
+#define DEFAULT_TEST_UTID @"00000000-1234-5678-90abcdefffff"
+#define DEFAULT_TEST_HOME_ACCOUNT_ID DEFAULT_TEST_UID@"."DEFAULT_TEST_UTID
 #define DEFAULT_TEST_RESOURCE @"https://graph.microsoft.com/"
 #define DEFAULT_TEST_AUTHORITY @"https://login.microsoftonline.com/common"
 #define DEFAULT_TEST_AUTHORIZATION_ENDPOINT @"https://login.microsoftonline.com/common/common/oauth2/authorize"


### PR DESCRIPTION
## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [X] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

MSAL C++ has added a sanity check in our account constructor which requires UID and UTID to both be GUIDs.
Unfortunately, this has an impact on tests. Since we would like to continue running obj-c tests, I've cleaned up (some) of the tests to use GUID identifiers.