### PR TITLE
Added common interface for assymetric key generation

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -919,6 +919,12 @@
 		B27551C22081705300AA7A38 /* MSIDJWTHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7590C207EE9A400C1FE74 /* MSIDJWTHelper.m */; };
 		B27551C32081705300AA7A38 /* MSIDJWTHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7590C207EE9A400C1FE74 /* MSIDJWTHelper.m */; };
 		B27893732470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B27893722470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m */; };
+		B278937C2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = B278937A2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.h */; };
+		B278937D2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = B278937B2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.m */; };
+		B278937E2470CC6D00627C28 /* MSIDAssymetricKeychainGeneratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B27893722470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m */; };
+		B27893812470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = B278937F2470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.h */; };
+		B27893822470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = B27893802470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m */; };
+		B27893832470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = B27893802470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m */; };
 		B279835A20D33A0A0051167F /* MSIDIdTokenClaimsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B279835920D33A090051167F /* MSIDIdTokenClaimsTests.m */; };
 		B279835B20D33A0A0051167F /* MSIDIdTokenClaimsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B279835920D33A090051167F /* MSIDIdTokenClaimsTests.m */; };
 		B27ACA6B22EBC4450049ACE0 /* MSIDBackgroundTaskManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B27ACA6922EBC4450049ACE0 /* MSIDBackgroundTaskManager.m */; };
@@ -2312,6 +2318,10 @@
 		B275520A208185E600AA7A38 /* KeyvaultAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyvaultAuthentication.swift; sourceTree = "<group>"; };
 		B275520D208186F500AA7A38 /* MSIDAutomation-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDAutomation-Bridging-Header.h"; sourceTree = "<group>"; };
 		B27893722470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAssymetricKeychainGeneratorTests.m; sourceTree = "<group>"; };
+		B278937A2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAssymetricKeyLoginKeychainGenerator.h; sourceTree = "<group>"; };
+		B278937B2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAssymetricKeyLoginKeychainGenerator.m; sourceTree = "<group>"; };
+		B278937F2470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAssymetricKeyGeneratorFactory.h; sourceTree = "<group>"; };
+		B27893802470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAssymetricKeyGeneratorFactory.m; sourceTree = "<group>"; };
 		B279835920D33A090051167F /* MSIDIdTokenClaimsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIdTokenClaimsTests.m; sourceTree = "<group>"; };
 		B27ACA6822EBC4450049ACE0 /* MSIDBackgroundTaskManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBackgroundTaskManager.h; sourceTree = "<group>"; };
 		B27ACA6922EBC4450049ACE0 /* MSIDBackgroundTaskManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBackgroundTaskManager.m; sourceTree = "<group>"; };
@@ -3907,6 +3917,15 @@
 			path = keyvault;
 			sourceTree = "<group>";
 		};
+		B27893792470CAF200627C28 /* mac */ = {
+			isa = PBXGroup;
+			children = (
+				B278937A2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.h */,
+				B278937B2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.m */,
+			);
+			path = mac;
+			sourceTree = "<group>";
+		};
 		B27ACA6722EBC42E0049ACE0 /* background */ = {
 			isa = PBXGroup;
 			children = (
@@ -4051,6 +4070,7 @@
 		B2C0747E246B70DC0008D701 /* crypto */ = {
 			isa = PBXGroup;
 			children = (
+				B27893792470CAF200627C28 /* mac */,
 				B2C0748E246B71470008D701 /* MSIDAssymetricKeyGenerating.h */,
 				B2C07490246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.h */,
 				B2C07491246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.m */,
@@ -4060,6 +4080,8 @@
 				B2C07485246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.m */,
 				B2C07489246B71300008D701 /* MSIDAssymetricKeyPairWithCert.h */,
 				B2C0748A246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m */,
+				B278937F2470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.h */,
+				B27893802470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m */,
 			);
 			path = crypto;
 			sourceTree = "<group>";
@@ -4832,6 +4854,7 @@
 				B214C3A31FE855290070C4F2 /* MSIDDefaultTokenCacheAccessor.h in Headers */,
 				B286B9952389DC7F007833AD /* MSIDDefaultBrokerResponseHandler.h in Headers */,
 				B286B9D12389DF09007833AD /* MSIDLogger.h in Headers */,
+				B27893812470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.h in Headers */,
 				2338ECD0208A69BE00809B9E /* MSIDHttpRequestProtocol.h in Headers */,
 				239D30192421AEB300CDA9EF /* MSIDTelemetryStringSerializable.h in Headers */,
 				B286B9BE2389DDFD007833AD /* MSIDAADEndpointProvider.h in Headers */,
@@ -4946,6 +4969,7 @@
 				B210F4551FDDFA7B005A8F76 /* MSIDBrokerResponse.h in Headers */,
 				968647FD20C76C6700EF7E73 /* MSIDAADV2WebviewFactory.h in Headers */,
 				B286B9D92389DF53007833AD /* ASAuthorizationSingleSignOnProvider+MSIDExtensions.h in Headers */,
+				B278937C2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.h in Headers */,
 				238F80A122C2BE1600437CB1 /* MSIDGetV1IdTokenHttpEvent.h in Headers */,
 				23FB5C2F22551866002BF1EB /* MSIDClaimsRequest+ClientCapabilities.h in Headers */,
 				B28BDABF221F7F230055FFE6 /* MSIDCBAWebAADAuthResponse.h in Headers */,
@@ -5747,6 +5771,7 @@
 				B25A356F1FC4D70300C7FD43 /* MSIDLogger.m in Sources */,
 				B2C7088F2198E48E00D917B8 /* NSData+AES.m in Sources */,
 				96F21B3320A65896002B87C3 /* MSIDWebviewAuthorization.m in Sources */,
+				B27893832470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m in Sources */,
 				238E19D92086FE28004DF483 /* MSIDAADRefreshTokenGrantRequest.m in Sources */,
 				233E96E42265279B007FCE2A /* MSIDTelemetryDefaultEvent.m in Sources */,
 				60F7BEA221DA698C00F1BBA1 /* MSIDPRTCacheItem.m in Sources */,
@@ -5864,6 +5889,7 @@
 				B286B9812389DC0F007833AD /* MSIDBrokerOperationTokenRequest.m in Sources */,
 				B28D90A2218FBBA200E230D6 /* MSIDTokenResponseValidator.m in Sources */,
 				B2C708232195285300D917B8 /* MSIDLegacyBrokerTokenRequest.m in Sources */,
+				B278937D2470CB0D00627C28 /* MSIDAssymetricKeyLoginKeychainGenerator.m in Sources */,
 				B2D5625A20CCD50E00FFF59C /* MSIDTelemetry+Cache.m in Sources */,
 				B253154B23DE31F400432133 /* MSIDBrokerOperationGetDeviceInfoRequest.m in Sources */,
 				B2A3C2802145D02E0082525C /* MSIDAadAuthorityCacheRecord.m in Sources */,
@@ -6031,6 +6057,7 @@
 				B252913C2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m in Sources */,
 				B2DD5B98204756580084313F /* MSIDAccountTypeTests.m in Sources */,
 				23419F5E23973AAD00EA78C5 /* MSIDBrokerOperationRequestTests.m in Sources */,
+				B278937E2470CC6D00627C28 /* MSIDAssymetricKeychainGeneratorTests.m in Sources */,
 				238EF08420913D760035ABE6 /* MSIDAADRequestConfiguratorTests.m in Sources */,
 				B29F7806213DFA5600D61FC8 /* MSIDErrorTests.m in Sources */,
 				B217860F23A578BE00839CE8 /* MSIDBrokerOperationSignoutFromDeviceRequestTests.m in Sources */,
@@ -6440,6 +6467,7 @@
 				B297E1DD20A0F5D600F370EC /* MSIDDefaultCredentialCacheQuery.m in Sources */,
 				60A504702374917B00648AC5 /* MSIDBrokerOperationGetAccountsResponse.m in Sources */,
 				B281B335226BB83C009619AB /* MSIDOAuthRequestConfigurator.m in Sources */,
+				B27893822470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m in Sources */,
 				B2115828202BD5F3005CE586 /* MSIDCacheKey.m in Sources */,
 				23B0187F2355481800207FEC /* MSIDSSOExtensionRequestDelegate.m in Sources */,
 				B28BDAC0221F7F230055FFE6 /* MSIDCBAWebAADAuthResponse.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1496,13 +1496,6 @@
 			remoteGlobalIDString = 231CE99C1FE86EA300E95D3E;
 			remoteInfo = MSIDTestsHostApp;
 		};
-		B27893752470C42200627C28 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D68FB47F1FBA698A005308BB /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 231CE99C1FE86EA300E95D3E;
-			remoteInfo = MSIDTestsHostApp;
-		};
 		D626FF501FBA6DFD00EE4487 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D68FB47F1FBA698A005308BB /* Project object */;
@@ -6566,11 +6559,6 @@
 			isa = PBXTargetDependency;
 			target = 231CE99C1FE86EA300E95D3E /* MSIDTestsHostApp */;
 			targetProxy = 231CE9B51FE86F1E00E95D3E /* PBXContainerItemProxy */;
-		};
-		B27893762470C42200627C28 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 231CE99C1FE86EA300E95D3E /* MSIDTestsHostApp */;
-			targetProxy = B27893752470C42200627C28 /* PBXContainerItemProxy */;
 		};
 		D626FF511FBA6DFD00EE4487 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -918,6 +918,7 @@
 		B274DEC821FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B274DEC621FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m */; };
 		B27551C22081705300AA7A38 /* MSIDJWTHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7590C207EE9A400C1FE74 /* MSIDJWTHelper.m */; };
 		B27551C32081705300AA7A38 /* MSIDJWTHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7590C207EE9A400C1FE74 /* MSIDJWTHelper.m */; };
+		B27893732470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B27893722470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m */; };
 		B279835A20D33A0A0051167F /* MSIDIdTokenClaimsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B279835920D33A090051167F /* MSIDIdTokenClaimsTests.m */; };
 		B279835B20D33A0A0051167F /* MSIDIdTokenClaimsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B279835920D33A090051167F /* MSIDIdTokenClaimsTests.m */; };
 		B27ACA6B22EBC4450049ACE0 /* MSIDBackgroundTaskManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B27ACA6922EBC4450049ACE0 /* MSIDBackgroundTaskManager.m */; };
@@ -1483,6 +1484,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		231CE9B51FE86F1E00E95D3E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D68FB47F1FBA698A005308BB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 231CE99C1FE86EA300E95D3E;
+			remoteInfo = MSIDTestsHostApp;
+		};
+		B27893752470C42200627C28 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D68FB47F1FBA698A005308BB /* Project object */;
 			proxyType = 1;
@@ -2303,6 +2311,7 @@
 		B27551FD208182BE00AA7A38 /* AuthHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthHeader.swift; sourceTree = "<group>"; };
 		B275520A208185E600AA7A38 /* KeyvaultAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyvaultAuthentication.swift; sourceTree = "<group>"; };
 		B275520D208186F500AA7A38 /* MSIDAutomation-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDAutomation-Bridging-Header.h"; sourceTree = "<group>"; };
+		B27893722470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAssymetricKeychainGeneratorTests.m; sourceTree = "<group>"; };
 		B279835920D33A090051167F /* MSIDIdTokenClaimsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIdTokenClaimsTests.m; sourceTree = "<group>"; };
 		B27ACA6822EBC4450049ACE0 /* MSIDBackgroundTaskManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBackgroundTaskManager.h; sourceTree = "<group>"; };
 		B27ACA6922EBC4450049ACE0 /* MSIDBackgroundTaskManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBackgroundTaskManager.m; sourceTree = "<group>"; };
@@ -4639,6 +4648,7 @@
 				23419F7E239B33E400EA78C5 /* MSIDAADV2TokenResponseTests.m */,
 				23419F81239B36F500EA78C5 /* MSIDAccountIdentifierTests.m */,
 				B217860D23A578BE00839CE8 /* MSIDBrokerOperationSignoutFromDeviceRequestTests.m */,
+				B27893722470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -5226,6 +5236,7 @@
 			dependencies = (
 				D6D9A4C71FBE719D00EFA430 /* PBXTargetDependency */,
 				D626FF6F1FBA6EDF00EE4487 /* PBXTargetDependency */,
+				B27893762470C42200627C28 /* PBXTargetDependency */,
 			);
 			name = "IdentityCoreTests Mac";
 			productName = IdentityCoreTests;
@@ -5678,6 +5689,7 @@
 				6080B9A523886DD9009B1322 /* MSIDBrokerOperationGetDeviceInfoRequestTests.m in Sources */,
 				96D3A44E20E6F7D8001BD428 /* MSIDPkceTests.m in Sources */,
 				B286BA02238A0919007833AD /* MSIDDefaultInteractiveTokenRequestTests.m in Sources */,
+				B27893732470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m in Sources */,
 				23B3A4552187BA79009070B2 /* MSIDIntuneEnrollmentIdsCacheTests.m in Sources */,
 				B2936F7420ABEFC10050C585 /* MSIDAccessTokenTests.m in Sources */,
 				B20657CF1FC92B8F00412B7D /* MSIDTelemetryUIEventTests.m in Sources */,
@@ -6527,6 +6539,11 @@
 			target = 231CE99C1FE86EA300E95D3E /* MSIDTestsHostApp */;
 			targetProxy = 231CE9B51FE86F1E00E95D3E /* PBXContainerItemProxy */;
 		};
+		B27893762470C42200627C28 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 231CE99C1FE86EA300E95D3E /* MSIDTestsHostApp */;
+			targetProxy = B27893752470C42200627C28 /* PBXContainerItemProxy */;
+		};
 		D626FF511FBA6DFD00EE4487 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D68FB4861FBA698A005308BB /* IdentityCore iOS */;
@@ -7171,6 +7188,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MSIDTestsHostApp.app/MSIDTestsHostApp";
 			};
@@ -7181,6 +7199,7 @@
 			baseConfigurationReference = D6CF4E961FC3626A00CD70C5 /* identitycore__tests__ios.xcconfig */;
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MSIDTestsHostApp.app/MSIDTestsHostApp";
 			};
@@ -7217,7 +7236,7 @@
 			buildSettings = {
 				GCC_OPTIMIZATION_LEVEL = 0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 			};
 			name = Debug;
 		};
@@ -7226,7 +7245,7 @@
 			baseConfigurationReference = D6CF4E9B1FC3626B00CD70C5 /* identitycore__tests__mac.xcconfig */;
 			buildSettings = {
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 			};
 			name = Release;
 		};

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1235,6 +1235,19 @@
 		B2BE926821A25F8300F5AB8C /* MSIDTestBrokerResponseHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B2BE926421A25F7200F5AB8C /* MSIDTestBrokerResponseHandler.m */; };
 		B2BE926921A25F8300F5AB8C /* MSIDTestBrokerResponseHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B2BE926421A25F7200F5AB8C /* MSIDTestBrokerResponseHandler.m */; };
 		B2BE926F21A2668600F5AB8C /* MSIDBrokerInteractiveControllerIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2BE926E21A2668600F5AB8C /* MSIDBrokerInteractiveControllerIntegrationTests.m */; };
+		B2C07481246B70F70008D701 /* MSIDAssymetricKeyPair.h in Headers */ = {isa = PBXBuildFile; fileRef = B2C0747F246B70F70008D701 /* MSIDAssymetricKeyPair.h */; };
+		B2C07482246B70F70008D701 /* MSIDAssymetricKeyPair.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C07480246B70F70008D701 /* MSIDAssymetricKeyPair.m */; };
+		B2C07483246B70F70008D701 /* MSIDAssymetricKeyPair.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C07480246B70F70008D701 /* MSIDAssymetricKeyPair.m */; };
+		B2C07486246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = B2C07484246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.h */; };
+		B2C07487246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C07485246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.m */; };
+		B2C07488246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C07485246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.m */; };
+		B2C0748B246B71300008D701 /* MSIDAssymetricKeyPairWithCert.h in Headers */ = {isa = PBXBuildFile; fileRef = B2C07489246B71300008D701 /* MSIDAssymetricKeyPairWithCert.h */; };
+		B2C0748C246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C0748A246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m */; };
+		B2C0748D246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C0748A246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m */; };
+		B2C0748F246B71470008D701 /* MSIDAssymetricKeyGenerating.h in Headers */ = {isa = PBXBuildFile; fileRef = B2C0748E246B71470008D701 /* MSIDAssymetricKeyGenerating.h */; };
+		B2C07492246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = B2C07490246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.h */; };
+		B2C07493246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C07491246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.m */; };
+		B2C07494246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C07491246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.m */; };
 		B2C17AEC1FC796E60070A514 /* MSIDDeviceId.m in Sources */ = {isa = PBXBuildFile; fileRef = B20E3CAD1FC4F14B0029C097 /* MSIDDeviceId.m */; };
 		B2C17AED1FC796FE0070A514 /* MSIDOAuth2Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = B20E3CB51FC4FE400029C097 /* MSIDOAuth2Constants.m */; };
 		B2C17AF01FC7A1BF0070A514 /* MSIDLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C17AEF1FC7A1BF0070A514 /* MSIDLoggerTests.m */; };
@@ -2429,6 +2442,15 @@
 		B2BE926A21A2620400F5AB8C /* MSIDTestBrokerTokenRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTestBrokerTokenRequest.h; sourceTree = "<group>"; };
 		B2BE926B21A2620400F5AB8C /* MSIDTestBrokerTokenRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTestBrokerTokenRequest.m; sourceTree = "<group>"; };
 		B2BE926E21A2668600F5AB8C /* MSIDBrokerInteractiveControllerIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBrokerInteractiveControllerIntegrationTests.m; sourceTree = "<group>"; };
+		B2C0747F246B70F70008D701 /* MSIDAssymetricKeyPair.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAssymetricKeyPair.h; sourceTree = "<group>"; };
+		B2C07480246B70F70008D701 /* MSIDAssymetricKeyPair.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAssymetricKeyPair.m; sourceTree = "<group>"; };
+		B2C07484246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAssymetricKeyLookupAttributes.h; sourceTree = "<group>"; };
+		B2C07485246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAssymetricKeyLookupAttributes.m; sourceTree = "<group>"; };
+		B2C07489246B71300008D701 /* MSIDAssymetricKeyPairWithCert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAssymetricKeyPairWithCert.h; sourceTree = "<group>"; };
+		B2C0748A246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAssymetricKeyPairWithCert.m; sourceTree = "<group>"; };
+		B2C0748E246B71470008D701 /* MSIDAssymetricKeyGenerating.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAssymetricKeyGenerating.h; sourceTree = "<group>"; };
+		B2C07490246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAssymetricKeyKeychainGenerator.h; sourceTree = "<group>"; };
+		B2C07491246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAssymetricKeyKeychainGenerator.m; sourceTree = "<group>"; };
 		B2C17AE91FC790420070A514 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		B2C17AEF1FC7A1BF0070A514 /* MSIDLoggerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLoggerTests.m; sourceTree = "<group>"; };
 		B2C17AF21FC7A56C0070A514 /* MSIDTestLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTestLogger.h; sourceTree = "<group>"; };
@@ -3359,6 +3381,7 @@
 		9641B4FF1FCF3E1400AFA0EC /* cache */ = {
 			isa = PBXGroup;
 			children = (
+				B2C0747E246B70DC0008D701 /* crypto */,
 				609E74BA228CA3C2005E3FED /* metadata */,
 				B226D85B1FFB07840012BF8B /* token */,
 				B214C39B1FE854CE0070C4F2 /* accessor */,
@@ -4014,6 +4037,22 @@
 				B2BE923A21A0FD2B00F5AB8C /* MSIDTestSwizzle.m */,
 			);
 			path = swizzle;
+			sourceTree = "<group>";
+		};
+		B2C0747E246B70DC0008D701 /* crypto */ = {
+			isa = PBXGroup;
+			children = (
+				B2C0748E246B71470008D701 /* MSIDAssymetricKeyGenerating.h */,
+				B2C07490246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.h */,
+				B2C07491246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.m */,
+				B2C0747F246B70F70008D701 /* MSIDAssymetricKeyPair.h */,
+				B2C07480246B70F70008D701 /* MSIDAssymetricKeyPair.m */,
+				B2C07484246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.h */,
+				B2C07485246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.m */,
+				B2C07489246B71300008D701 /* MSIDAssymetricKeyPairWithCert.h */,
+				B2C0748A246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m */,
+			);
+			path = crypto;
 			sourceTree = "<group>";
 		};
 		B2C707EB219247AD00D917B8 /* msal */ = {
@@ -4878,6 +4917,7 @@
 				23AE9DB72148529A00B285F3 /* NSError+MSIDExtensions.h in Headers */,
 				23AD4A32237E298C0094B87E /* NSBundle+MSIDExtensions.h in Headers */,
 				23AE209A2342DD3F00108F76 /* MSIDLocalInteractiveController+Internal.h in Headers */,
+				B2C07492246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.h in Headers */,
 				B2EB3AE022F7C74300FA400E /* MSIDBrokerInvocationOptions.h in Headers */,
 				B286B9B22389DD75007833AD /* MSIDWebOAuth2AuthCodeResponse.h in Headers */,
 				238EF042208FE88C0035ABE6 /* MSIDAADAuthorizationCodeGrantRequest.h in Headers */,
@@ -4914,12 +4954,15 @@
 				B286B96223861852007833AD /* MSIDSignoutWebRequestConfiguration.h in Headers */,
 				B20657AB1FC91F6400412B7D /* MSIDTelemetry+Internal.h in Headers */,
 				B297E1EB20A1388E00F370EC /* MSIDDefaultAccountCacheQuery.h in Headers */,
+				B2C0748B246B71300008D701 /* MSIDAssymetricKeyPairWithCert.h in Headers */,
 				B286B9562385F01A007833AD /* MSIDOIDCSignoutRequest.h in Headers */,
 				B2C708B0219A614C00D917B8 /* MSIDDefaultBrokerTokenRequest.h in Headers */,
 				B286B9D52389DF2E007833AD /* MSIDRegistrationInformation.h in Headers */,
 				B2E2A93D2392F91100BA2EA3 /* MSIDInteractiveTokenRequestParameters.h in Headers */,
+				B2C07486246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.h in Headers */,
 				B2000C7820EC47860092790A /* NSData+JWT.h in Headers */,
 				23D2048E21D1B499009B5975 /* MSIDAADJsonResponsePreprocessor.h in Headers */,
+				B2C07481246B70F70008D701 /* MSIDAssymetricKeyPair.h in Headers */,
 				B2CDB57C1FE33EC1003A4B5C /* MSIDIdTokenClaims.h in Headers */,
 				B2BE924B21A2331A00F5AB8C /* MSIDTelemetryAuthorityValidationEvent.h in Headers */,
 				23B3A4512187AFD3009070B2 /* MSIDJsonSerializer.h in Headers */,
@@ -4993,6 +5036,7 @@
 				B286B9C62389DE7B007833AD /* MSIDAccountMetadataCacheKey.h in Headers */,
 				B286B9DB2389DF59007833AD /* MSIDJsonSerializable.h in Headers */,
 				23B39A8120993302000AA905 /* MSIDAadAuthorityResolver.h in Headers */,
+				B2C0748F246B71470008D701 /* MSIDAssymetricKeyGenerating.h in Headers */,
 				B286B9AE2389DD5E007833AD /* MSIDChallengeHandling.h in Headers */,
 				B2C7089221991CED00D917B8 /* MSIDAADV1BrokerResponse.h in Headers */,
 				239E3BBE23E1004F00F7A50A /* MSIDClientSDKType.h in Headers */,
@@ -5669,6 +5713,7 @@
 				B2EB3ADF22F7C74000FA400E /* MSIDBrokerInvocationOptions.m in Sources */,
 				B2000C9620EC64620092790A /* MSIDIdTokenClaims.m in Sources */,
 				B2C708192195283500D917B8 /* MSIDBrokerTokenRequest.m in Sources */,
+				B2C07488246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.m in Sources */,
 				B28D909C218FA97400E230D6 /* MSIDBaseRequestController.m in Sources */,
 				23D2048B21D1B2E4009B5975 /* MSIDJsonResponsePreprocessor.m in Sources */,
 				B2A3C27E2145CFAC0082525C /* MSIDWebWPJResponse.m in Sources */,
@@ -5695,6 +5740,7 @@
 				60F7BEA221DA698C00F1BBA1 /* MSIDPRTCacheItem.m in Sources */,
 				B210F44C1FDDF5A7005A8F76 /* MSIDClientInfo.m in Sources */,
 				23B37D1C20C9ECFB0018722F /* MSIDCache.m in Sources */,
+				B2C07494246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.m in Sources */,
 				1EFD58C722B44BA200ECD86E /* MSIDMacCredentialStorageItem.m in Sources */,
 				235480C820DDF81000246F72 /* MSIDAuthorityFactory.m in Sources */,
 				968647FF20C76C6700EF7E73 /* MSIDAADV2WebviewFactory.m in Sources */,
@@ -5716,6 +5762,7 @@
 				B28D90AC218FD1F800E230D6 /* MSIDDefaultTokenResponseValidator.m in Sources */,
 				23F9FD4D22EC097600DAB65D /* NSKeyedArchiver+MSIDExtensions.m in Sources */,
 				B2C7089421991CED00D917B8 /* MSIDAADV1BrokerResponse.m in Sources */,
+				B2C07483246B70F70008D701 /* MSIDAssymetricKeyPair.m in Sources */,
 				B266903F243706DB00FB0117 /* MSIDBrokerBrowserOperationResponse.m in Sources */,
 				B2AF1D3A218BCF140080C1A0 /* MSIDRequestControllerFactory.m in Sources */,
 				B28BDAC1221F7F230055FFE6 /* MSIDCBAWebAADAuthResponse.m in Sources */,
@@ -5787,6 +5834,7 @@
 				D6D9A4521FBD3FB800EFA430 /* NSURL+MSIDExtensions.m in Sources */,
 				B23ECEF11FF2F6270015FC1D /* MSIDAADV2IdTokenClaims.m in Sources */,
 				239EED6A242D8FAD00162F0F /* MSIDAADTokenRequestServerTelemetry.m in Sources */,
+				B2C0748D246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m in Sources */,
 				9641B5251FCF3EEF00AFA0EC /* MSIDMacTokenCache.m in Sources */,
 				962EA03E2190D4930049C4C8 /* MSIDCertAuthHandler.m in Sources */,
 				238EF03F208FE4740035ABE6 /* MSIDRefreshTokenGrantRequest.m in Sources */,
@@ -6241,6 +6289,7 @@
 				B25A35701FC4D70300C7FD43 /* MSIDLogger.m in Sources */,
 				B210F4321FDDE7EB005A8F76 /* MSIDTokenResponse.m in Sources */,
 				600D19AE20964CC00004CD43 /* MSIDRegistrationInformation.m in Sources */,
+				B2C07482246B70F70008D701 /* MSIDAssymetricKeyPair.m in Sources */,
 				B227035F22A367A000030ADC /* MSIDMaskedHashableLogParameter.m in Sources */,
 				B2C7B3B4213C681F009FFCC1 /* MSIDErrorConverter.m in Sources */,
 				B2C7089821991D0000D917B8 /* MSIDAADV2BrokerResponse.m in Sources */,
@@ -6256,6 +6305,7 @@
 				B28D90A6218FD1E800E230D6 /* MSIDLegacyTokenResponseValidator.m in Sources */,
 				B20657BA1FC9248000412B7D /* MSIDTelemetryAPIEvent.m in Sources */,
 				1EA4547023BECE2700567EB0 /* MSIDBrokerOperationBrowserTokenRequest.m in Sources */,
+				B2C07493246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.m in Sources */,
 				04930F951FEDB2E100FC4DCD /* MSIDAuthority.m in Sources */,
 				60FDA9DB21A5EBCF001E09B8 /* MSIDTestCacheAccessorHelper.m in Sources */,
 				600D19B220964CE70004CD43 /* MSIDPkeyAuthHelper.m in Sources */,
@@ -6314,6 +6364,7 @@
 				23AD4A33237E298C0094B87E /* NSBundle+MSIDExtensions.m in Sources */,
 				23AE9DA4213A159C00B285F3 /* MSIDAADOpenIdConfigurationInfoResponseSerializer.m in Sources */,
 				B2C708222195285300D917B8 /* MSIDLegacyBrokerTokenRequest.m in Sources */,
+				B2C07487246B711B0008D701 /* MSIDAssymetricKeyLookupAttributes.m in Sources */,
 				B2D5625920CCD50E00FFF59C /* MSIDTelemetry+Cache.m in Sources */,
 				235480D520DDF88200246F72 /* MSIDAADAuthority.m in Sources */,
 				23D2048F21D1B499009B5975 /* MSIDAADJsonResponsePreprocessor.m in Sources */,
@@ -6407,6 +6458,7 @@
 				233E970222655E97007FCE2A /* MSIDTestTelemetryEventsObserver.m in Sources */,
 				B2DD4B2220A7D2F90047A66E /* MSIDLegacyAccessToken.m in Sources */,
 				23B3A44D21868766009070B2 /* MSIDCacheItemJsonSerializer.m in Sources */,
+				B2C0748C246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m in Sources */,
 				B2E2A92F239238DC00BA2EA3 /* MSIDSSOExtensionSignoutRequest.m in Sources */,
 				607123C1210FCAAD00B91068 /* MSIDAADAuthorityValidationRequest.m in Sources */,
 				B251CC4C204105A7005E0179 /* MSIDIdToken.m in Sources */,

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGenerating.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGenerating.h
@@ -36,8 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (MSIDAssymetricKeyPair *)readOrGenerateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
                                                         error:(NSError **)error;
 
-- (MSIDAssymetricKeyPair *)getKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
-                                             error:(NSError **)error;
+- (MSIDAssymetricKeyPair *)readKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
+                                              error:(NSError **)error;
 
 @end
 

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGenerating.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGenerating.h
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@class MSIDAssymetricKeyPair;
+@class MSIDAssymetricKeyLookupAttributes;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MSIDAssymetricKeyGenerating <NSObject>
+
+- (MSIDAssymetricKeyPair *)generateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
+                                                  error:(NSError **)error;
+
+- (MSIDAssymetricKeyPair *)readOrGenerateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
+                                                        error:(NSError **)error;
+
+- (MSIDAssymetricKeyPair *)getKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
+                                             error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGeneratorFactory.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGeneratorFactory.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDAssymetricKeyGenerating.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAssymetricKeyGeneratorFactory : NSObject
+
++ (id<MSIDAssymetricKeyGenerating>)defaultKeyGeneratorWithError:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGeneratorFactory.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGeneratorFactory.m
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDAssymetricKeyGeneratorFactory.h"
+#import "MSIDAssymetricKeyKeychainGenerator.h"
+#if !TARGET_OS_IPHONE
+#import "MSIDAssymetricKeyLoginKeychainGenerator.h"
+#endif
+
+@implementation MSIDAssymetricKeyGeneratorFactory
+
++ (id<MSIDAssymetricKeyGenerating>)defaultKeyGeneratorWithError:(NSError **)error
+{
+#if TARGET_OS_IPHONE
+    return [self iOSDefaultKeyGeneratorWithError:error];
+#else
+    return [self macDefaultKeyGeneratorWithError:error];
+#endif
+}
+
++ (id<MSIDAssymetricKeyGenerating>)iOSDefaultKeyGeneratorWithError:(NSError **)error
+{
+    return [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:error];
+}
+
+#if !TARGET_OS_IPHONE
++ (id<MSIDAssymetricKeyGenerating>)macDefaultKeyGeneratorWithError:(NSError **)error
+{
+    if (@available(macOS 10.15, *))
+    {
+        return [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:error];
+    }
+    else
+    {
+        return [[MSIDAssymetricKeyLoginKeychainGenerator alloc] initWithAccessRef:nil error:error];
+    }
+}
+#endif
+
+@end

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDAssymetricKeyGenerating.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAssymetricKeyKeychainGenerator : NSObject <MSIDAssymetricKeyGenerating>
+
+- (nullable instancetype)initWithGroup:(nullable NSString *)keychainGroup error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
@@ -99,6 +99,13 @@
 - (MSIDAssymetricKeyPair *)generateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
                                                   error:(NSError **)error
 {
+    if ([NSString msidIsStringNilOrBlank:attributes.privateKeyIdentifier]
+        || [NSString msidIsStringNilOrBlank:attributes.publicKeyIdentifier])
+    {
+        [self logAndFillError:@"Invalid key generation attributes provided" status:-1 error:error];
+        return nil;
+    }
+    
     // 0. Cleanup any previous state
     BOOL cleanupResult = [self cleanupKeychainForAttributes:attributes error:error];
     
@@ -120,14 +127,14 @@
     }
     
     // 2. Return keys
-    return [self getKeyPairForAttributes:attributes error:error];
+    return [self readKeyPairForAttributes:attributes error:error];
 }
 
 - (MSIDAssymetricKeyPair *)readOrGenerateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
                                                         error:(NSError **)error
 {
     NSError *readError = nil;
-    MSIDAssymetricKeyPair *keyPair = [self getKeyPairForAttributes:attributes error:&readError];
+    MSIDAssymetricKeyPair *keyPair = [self readKeyPairForAttributes:attributes error:&readError];
     
     if (keyPair || readError)
     {
@@ -138,9 +145,16 @@
     return [self generateKeyPairForAttributes:attributes error:error];
 }
 
-- (MSIDAssymetricKeyPair *)getKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
+- (MSIDAssymetricKeyPair *)readKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
                                              error:(NSError **)error
 {
+    if ([NSString msidIsStringNilOrBlank:attributes.privateKeyIdentifier]
+        || [NSString msidIsStringNilOrBlank:attributes.publicKeyIdentifier])
+    {
+        [self logAndFillError:@"Invalid key lookup attributes provided" status:-1 error:error];
+        return nil;
+    }
+    
     NSDictionary *privateKeyAttributes = [self keyAttributesWithQueryDictionary:[attributes privateKeyAttributes] keyTitle:@"private key" error:error];
     
     if (!privateKeyAttributes)

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
@@ -231,6 +231,8 @@
                             error:error];
         }
         
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Failed to find key with query %@ with status %ld", keychainQuery, (long)status);
+        
         return nil;
     }
     

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDAssymetricKeyKeychainGenerator.h"
+#import "MSIDKeychainUtil.h"
+#import "MSIDAssymetricKeyPair.h"
+#import "MSIDAssymetricKeyLookupAttributes.h"
+
+@interface MSIDAssymetricKeyKeychainGenerator()
+
+@property (nonatomic) NSString *keychainGroup;
+@property (nonatomic) NSDictionary *defaultKeychainQuery;
+
+@end
+
+@implementation MSIDAssymetricKeyKeychainGenerator
+
+#pragma mark - Init
+
+- (nullable instancetype)initWithGroup:(nullable NSString *)keychainGroup error:(NSError * _Nullable __autoreleasing * _Nullable)error
+{
+    if (!(self = [super init]))
+    {
+        return nil;
+    }
+    
+    if (!keychainGroup)
+    {
+        keychainGroup = [[NSBundle mainBundle] bundleIdentifier];
+    }
+    
+    MSIDKeychainUtil *keychainUtil = [MSIDKeychainUtil sharedInstance];
+    if (!keychainUtil.teamId)
+    {
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Failed to retrieve teamId from keychain.", nil, nil, nil, nil, nil, YES);
+        }
+        
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve teamId from keychain.");
+        return nil;
+    }
+    
+    // Add team prefix to keychain group if it is missed.
+    if (![keychainGroup hasPrefix:keychainUtil.teamId])
+    {
+        keychainGroup = [keychainUtil accessGroup:keychainGroup];
+    }
+    
+    _keychainGroup = keychainGroup;
+    
+    if (!_keychainGroup)
+    {
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Failed to set keychain access group.", nil, nil, nil, nil, nil, YES);
+        }
+        
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to set keychain access group.");
+        return nil;
+    }
+    
+    NSMutableDictionary *defaultKeychainQuery = [@{(id)kSecAttrAccessGroup : self.keychainGroup} mutableCopy];
+    
+#ifdef __MAC_OS_X_VERSION_MAX_ALLOWED
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+    if (@available(macOS 10.15, *)) {
+        defaultKeychainQuery[(id)kSecUseDataProtectionKeychain] = @YES;
+    }
+#endif
+#endif
+    
+    self.defaultKeychainQuery = defaultKeychainQuery;
+    return self;
+}
+
+#pragma mark - MSIDAssymetricKeyGenerating
+
+- (MSIDAssymetricKeyPair *)generateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
+                                                  error:(NSError **)error
+{
+    // 0. Cleanup any previous state
+    BOOL cleanupResult = [self cleanupKeychainForAttributes:attributes error:error];
+    
+    if (!cleanupResult)
+    {
+        [self logAndFillError:@"Failed to cleanup keychain prior to generating new keypair. Proceeding might result in unexpected results. Keychain might need to be manually cleaned to recover." status:-1 error:error];
+        return nil;
+    }
+    
+    // 1. Generate keypair
+    NSDictionary *keyPairAttr = [self keychainQueryWithAttributes:[attributes assymetricKeyPairAttributes]];
+    
+    OSStatus status = SecKeyGeneratePair((__bridge CFDictionaryRef)keyPairAttr, NULL, NULL);
+    
+    if (status != errSecSuccess)
+    {
+        [self logAndFillError:@"Failed to generate keypair" status:status error:error];
+        return nil;
+    }
+    
+    // 2. Return keys
+    return [self getKeyPairForAttributes:attributes error:error];
+}
+
+- (MSIDAssymetricKeyPair *)readOrGenerateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
+                                                        error:(NSError **)error
+{
+    NSError *readError = nil;
+    MSIDAssymetricKeyPair *keyPair = [self getKeyPairForAttributes:attributes error:&readError];
+    
+    if (keyPair || readError)
+    {
+        if (error) *error = readError;
+        return keyPair;
+    }
+    
+    return [self generateKeyPairForAttributes:attributes error:error];
+}
+
+- (MSIDAssymetricKeyPair *)getKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
+                                             error:(NSError **)error
+{
+    NSDictionary *privateKeyAttributes = [self keyAttributesWithQueryDictionary:[attributes privateKeyAttributes] keyTitle:@"private key" error:error];
+    
+    if (!privateKeyAttributes)
+    {
+        return nil;
+    }
+    
+    NSDictionary *publicKeyAttributes = [self keyAttributesWithQueryDictionary:[attributes publicKeyAttributes] keyTitle:@"public key" error:error];
+    
+    if (!publicKeyAttributes)
+    {
+        return nil;
+    }
+    
+    SecKeyRef privateKeyRef = (__bridge SecKeyRef)privateKeyAttributes[(__bridge id)kSecValueRef];
+    SecKeyRef publicKeyRef = (__bridge SecKeyRef)publicKeyAttributes[(__bridge id)kSecValueRef];
+    
+    if (!privateKeyRef || !publicKeyRef)
+    {
+        [self logAndFillError:@"Invalid keychain attributes. No key ref returned" status:-1 error:error];
+        return nil;
+    }
+    
+    MSIDAssymetricKeyPair *keypair = [[MSIDAssymetricKeyPair alloc] initWithPrivateKey:privateKeyRef
+                                                                             publicKey:publicKeyRef];
+
+    
+    return keypair;
+}
+
+#pragma mark - Cleanup
+
+- (BOOL)cleanupKeychainForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes error:(NSError **)error
+{
+    return [self deleteItemWithAttributes:[attributes privateKeyAttributes] itemTitle:@"private key" error:error]
+        && [self deleteItemWithAttributes:[attributes publicKeyAttributes] itemTitle:@"public key" error:error];
+}
+
+- (BOOL)deleteItemWithAttributes:(NSDictionary *)attributes itemTitle:(NSString *)itemTitle error:(NSError **)error
+{
+    NSDictionary *queryAttributes = [self keychainQueryWithAttributes:attributes];
+    OSStatus result = SecItemDelete((CFDictionaryRef)queryAttributes);
+    
+    if (result != errSecSuccess
+        && result != errSecItemNotFound)
+    {
+        [self logAndFillError:[NSString stringWithFormat:@"Failed to remove %@", itemTitle]
+                       status:result
+                        error:error];
+        return NO;
+    }
+    
+    return YES;
+}
+
+#pragma mark - Private
+
+- (NSDictionary *)keyAttributesWithQueryDictionary:(NSDictionary *)queryDictionary keyTitle:(NSString *)keyTitle error:(NSError **)error
+{
+    NSMutableDictionary *keychainQuery = [[self keychainQueryWithAttributes:queryDictionary] mutableCopy];
+    keychainQuery[(__bridge id)kSecReturnAttributes] = @YES;
+    keychainQuery[(__bridge id)kSecReturnRef] = @YES;
+    
+    CFTypeRef keyCFDict = NULL;
+    
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)keychainQuery, (CFTypeRef*)&keyCFDict);
+    
+    if (status != errSecSuccess)
+    {
+        if (status != errSecItemNotFound)
+        {
+            [self logAndFillError:[NSString stringWithFormat:@"Failed to find %@", keyTitle]
+                           status:status
+                            error:error];
+        }
+        
+        return nil;
+    }
+    
+    NSDictionary *privateKeyDict = CFBridgingRelease(keyCFDict);
+    return privateKeyDict;
+}
+
+- (NSDictionary *)keychainQueryWithAttributes:(NSDictionary *)attributes
+{
+    NSMutableDictionary *keyPairAttr = [self.defaultKeychainQuery mutableCopy];
+    [keyPairAttr addEntriesFromDictionary:attributes];
+    return keyPairAttr;
+}
+
+#pragma mark - Utils
+
+- (void)logAndFillError:(NSString *)errorTitle status:(OSStatus)status error:(NSError **)error
+{
+    NSString *description = [NSString stringWithFormat:@"Operation failed with title \"%@\", status %ld", errorTitle, (long)status];
+    MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"%@", description);
+    
+    if (error)
+    {
+        *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, description, nil, nil, nil, nil, nil, NO);
+    }
+}
+
+@end

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyLookupAttributes.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyLookupAttributes.h
@@ -30,7 +30,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *privateKeyIdentifier;
 @property (nonatomic, nullable) NSString *publicKeyIdentifier;
 @property (nonatomic, nullable) NSString *keyDisplayableLabel;
-@property (nonatomic, nullable) NSString *certLabel;
 
 - (NSDictionary *)assymetricKeyPairAttributes;
 - (NSDictionary *)privateKeyAttributes;

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyLookupAttributes.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyLookupAttributes.h
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAssymetricKeyLookupAttributes : NSObject
+
+@property (nonatomic, nullable) NSString *privateKeyIdentifier;
+@property (nonatomic, nullable) NSString *publicKeyIdentifier;
+@property (nonatomic, nullable) NSString *keyDisplayableLabel;
+@property (nonatomic, nullable) NSString *certLabel;
+
+- (NSDictionary *)assymetricKeyPairAttributes;
+- (NSDictionary *)privateKeyAttributes;
+- (NSDictionary *)publicKeyAttributes;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyLookupAttributes.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyLookupAttributes.m
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDAssymetricKeyLookupAttributes.h"
+
+@implementation MSIDAssymetricKeyLookupAttributes
+
+- (NSDictionary *)assymetricKeyPairAttributes
+{
+    NSMutableDictionary *keyPairAttr = [NSMutableDictionary new];
+    keyPairAttr[(__bridge id)kSecAttrIsPermanent] = @YES;
+    keyPairAttr[(__bridge id)kSecAttrKeyType] = (__bridge id)kSecAttrKeyTypeRSA;
+    keyPairAttr[(__bridge id)kSecAttrKeySizeInBits] = @2048;
+    keyPairAttr[(__bridge id)kSecAttrLabel] = self.keyDisplayableLabel;
+    keyPairAttr[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
+    
+    NSMutableDictionary *privateKeyAttr = [NSMutableDictionary new];
+    privateKeyAttr[(__bridge id)kSecAttrApplicationTag] = [self.privateKeyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
+    privateKeyAttr[(__bridge id)kSecAttrIsSensitive] = @YES;
+    privateKeyAttr[(__bridge id)kSecAttrIsExtractable] = @NO;
+
+    NSMutableDictionary *publicKeyAttr = [NSMutableDictionary new];
+    publicKeyAttr[(__bridge id)kSecAttrApplicationTag] = [self.publicKeyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
+    
+    keyPairAttr[(__bridge id)kSecPrivateKeyAttrs] = privateKeyAttr;
+    keyPairAttr[(__bridge id)kSecPublicKeyAttrs] = publicKeyAttr;
+    
+    return keyPairAttr;
+}
+
+- (NSDictionary *)privateKeyAttributes
+{
+    NSMutableDictionary *keyAttr = [NSMutableDictionary new];
+    keyAttr[(__bridge id)kSecAttrApplicationTag] = [self.privateKeyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
+    keyAttr[(__bridge id)kSecClass] = (__bridge id)kSecClassKey;
+    keyAttr[(__bridge id)kSecAttrKeyType] = (__bridge id)kSecAttrKeyTypeRSA;
+    return keyAttr;
+}
+
+- (NSDictionary *)publicKeyAttributes
+{
+    NSMutableDictionary *keyAttr = [NSMutableDictionary new];
+    keyAttr[(__bridge id)kSecAttrApplicationTag] = [self.publicKeyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
+    keyAttr[(__bridge id)kSecClass] = (__bridge id)kSecClassKey;
+    keyAttr[(__bridge id)kSecAttrKeyType] = (__bridge id)kSecAttrKeyTypeRSA;
+    return keyAttr;
+}
+
+@end

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAssymetricKeyPair : NSObject
+
+@property (nonatomic, readonly) SecKeyRef privateKeyRef;
+@property (nonatomic, readonly) SecKeyRef publicKeyRef;
+
+- (nullable instancetype)initWithPrivateKey:(SecKeyRef)privateKey
+                                  publicKey:(SecKeyRef)publicKey;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.m
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDAssymetricKeyPair.h"
+
+@implementation MSIDAssymetricKeyPair
+
+- (nullable instancetype)initWithPrivateKey:(SecKeyRef)privateKey
+                                  publicKey:(SecKeyRef)publicKey
+{
+    if (!privateKey || !publicKey)
+    {
+        return nil;
+    }
+    
+    self = [super init];
+    
+    if (self)
+    {
+        _privateKeyRef = privateKey;
+        CFRetain(_privateKeyRef);
+        
+        _publicKeyRef = publicKey;
+        CFRetain(_publicKeyRef);
+    }
+    
+    return self;
+}
+
+- (void)dealloc
+{
+    CFRelease(_privateKeyRef);
+    _privateKeyRef = NULL;
+    
+    CFRelease(_publicKeyRef);
+    _publicKeyRef = NULL;
+}
+
+@end

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPairWithCert.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPairWithCert.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDAssymetricKeyPair.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAssymetricKeyPairWithCert : MSIDAssymetricKeyPair
+
+@property (nonatomic, readonly) SecCertificateRef certificateRef;
+@property (nonatomic, readonly) NSData *certificateData;
+
+- (instancetype)initWithPrivateKey:(SecKeyRef)privateKey
+                         publicKey:(SecKeyRef)publicKey
+                       certificate:(SecCertificateRef)certificate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPairWithCert.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPairWithCert.m
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDAssymetricKeyPairWithCert.h"
+
+@implementation MSIDAssymetricKeyPairWithCert
+
+- (instancetype)initWithPrivateKey:(SecKeyRef)privateKey
+                         publicKey:(SecKeyRef)publicKey
+                       certificate:(SecCertificateRef)certificate
+{
+    if (!certificate)
+    {
+        return nil;
+    }
+    
+    _certificateData = (NSData *)CFBridgingRelease(SecCertificateCopyData(certificate));
+    
+    if (!_certificateData)
+    {
+        return nil;
+    }
+    
+    self = [super initWithPrivateKey:privateKey publicKey:publicKey];
+    
+    if (self)
+    {
+        _certificateRef = certificate;
+        CFRetain(_certificateRef);
+    }
+    
+    return self;
+}
+
+- (void)dealloc
+{
+    CFRelease(_certificateRef);
+    _certificateRef = NULL;
+}
+
+@end

--- a/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.h
+++ b/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDAssymetricKeyKeychainGenerator.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAssymetricKeyLoginKeychainGenerator : MSIDAssymetricKeyKeychainGenerator
+
+- (instancetype)initWithAccessRef:(nullable SecAccessRef)accessRef error:(NSError * _Nullable * _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.m
+++ b/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.m
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDAssymetricKeyLoginKeychainGenerator.h"
+
+@interface MSIDAssymetricKeyLoginKeychainGenerator()
+
+@property (nonatomic) SecAccessRef accessRef;
+
+@end
+
+@implementation MSIDAssymetricKeyLoginKeychainGenerator
+
+- (instancetype)initWithAccessRef:(SecAccessRef)accessRef error:(NSError **)error
+{
+    self = [super initWithGroup:nil error:error];
+    
+    if (self)
+    {
+        _accessRef = accessRef;
+    }
+    
+    return self;
+}
+
+- (NSDictionary *)additionalPlatformKeychainAttributes
+{
+    if (self.accessRef)
+    {
+        return @{(__bridge id)kSecAttrAccess : (__bridge id)(self.accessRef)};
+    }
+    
+    return nil;
+}
+
+@end

--- a/IdentityCore/tests/MSIDAssymetricKeychainGeneratorTests.m
+++ b/IdentityCore/tests/MSIDAssymetricKeychainGeneratorTests.m
@@ -1,0 +1,353 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDAssymetricKeyKeychainGenerator.h"
+#import "MSIDAssymetricKeyLookupAttributes.h"
+#import "MSIDAssymetricKeyPair.h"
+
+@interface MSIDAssymetricKeychainGeneratorTests : XCTestCase
+
+@end
+
+@implementation MSIDAssymetricKeychainGeneratorTests
+
+- (void)testGenerateKeyPair_whenNilAttributesProvided_shouldReturnNilAndFillError
+{
+    MSIDAssymetricKeyLookupAttributes *attr = nil;
+    
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
+    
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInternal);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Operation failed with title \"Invalid key generation attributes provided\", status -1");
+}
+
+- (void)testGenerateKeyPair_whenInvalidAttributesProvided_shouldReturnNilAndFillError
+{
+    MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
+    
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
+    
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInternal);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Operation failed with title \"Invalid key generation attributes provided\", status -1");
+}
+
+- (void)testGenerateKeyPair_whenValidAttributesProvided_andKeyDoesNotExist_shouldGenerateKeyAndReturnIt
+{
+    NSString *privateKeyIdentifier = @"com.msal.unittest.privateKey";
+    NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
+    
+    [self deleteKeyWithTag:privateKeyIdentifier];
+    [self deleteKeyWithTag:publicKeyIdentifier];
+    
+    MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
+    attr.privateKeyIdentifier = privateKeyIdentifier;
+    attr.publicKeyIdentifier = publicKeyIdentifier;
+    
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
+    
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    XCTAssertNotNil((id)result.privateKeyRef);
+    XCTAssertNotNil((id)result.publicKeyRef);
+    
+    BOOL privateKeyExists = [self keyExists:privateKeyIdentifier];
+    XCTAssertTrue(privateKeyExists);
+    
+    BOOL publicKeyExists = [self keyExists:publicKeyIdentifier];
+    XCTAssertTrue(publicKeyExists);
+}
+
+- (void)testGenerateKeyPair_whenKeyExists_shouldGenerateNewKeyAndReturnIt
+{
+    NSString *privateKeyIdentifier = @"com.msal.unittest.privateKey";
+    NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
+    
+    MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
+    attr.privateKeyIdentifier = privateKeyIdentifier;
+    attr.publicKeyIdentifier = publicKeyIdentifier;
+    
+    // Generate first time
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
+    
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    
+    // Now generate again
+    MSIDAssymetricKeyPair *secondResult = [generator generateKeyPairForAttributes:attr error:&error];
+    XCTAssertNotNil(secondResult);
+    XCTAssertNil(error);
+    
+    NSDictionary *firstPrivateAttr = CFBridgingRelease(SecKeyCopyAttributes(result.privateKeyRef));
+    NSDictionary *secondPrivateAttr = CFBridgingRelease(SecKeyCopyAttributes(secondResult.privateKeyRef));
+    
+    NSDictionary *firstPublicKeyAttr = CFBridgingRelease(SecKeyCopyAttributes(result.publicKeyRef));
+    NSDictionary *secondPublicKeyAttr = CFBridgingRelease(SecKeyCopyAttributes(secondResult.publicKeyRef));
+    
+    XCTAssertNotEqualObjects(firstPrivateAttr[@"klbl"], secondPrivateAttr[@"klbl"]);
+    XCTAssertNotEqualObjects(firstPublicKeyAttr[@"klbl"], secondPublicKeyAttr[@"klbl"]);
+    
+    BOOL privateKeyExists = [self keyExists:privateKeyIdentifier];
+    XCTAssertTrue(privateKeyExists);
+    
+    BOOL publicKeyExists = [self keyExists:publicKeyIdentifier];
+    XCTAssertTrue(publicKeyExists);
+}
+
+- (void)testReadKeyForAttributes_whenNilAttributes_shouldReturnNilAndFillError
+{
+    MSIDAssymetricKeyLookupAttributes *attr = nil;
+    
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator readKeyPairForAttributes:attr error:&error];
+    
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInternal);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Operation failed with title \"Invalid key lookup attributes provided\", status -1");
+}
+
+- (void)testReadKeyForAttributes_whenInvalidAttributes_shouldReturnNilAndFillError
+{
+    MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
+    
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator readKeyPairForAttributes:attr error:&error];
+    
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInternal);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Operation failed with title \"Invalid key lookup attributes provided\", status -1");
+}
+
+- (void)testReadKeyForAttributes_whenKeyExists_shouldReturnKeyPairAndNilError
+{
+    NSString *privateKeyIdentifier = @"com.msal.unittest.privateKey";
+    NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
+    
+    MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
+    attr.privateKeyIdentifier = privateKeyIdentifier;
+    attr.publicKeyIdentifier = publicKeyIdentifier;
+    attr.keyDisplayableLabel = @"My key";
+    
+    // First generate key
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    
+    // Now read it back
+    MSIDAssymetricKeyPair *readResult = [generator readKeyPairForAttributes:attr error:&error];
+    XCTAssertNotNil(readResult);
+    XCTAssertNil(error);
+    
+    NSDictionary *firstPrivateAttr = CFBridgingRelease(SecKeyCopyAttributes(result.privateKeyRef));
+    NSDictionary *secondPrivateAttr = CFBridgingRelease(SecKeyCopyAttributes(readResult.privateKeyRef));
+    
+    NSDictionary *firstPublicKeyAttr = CFBridgingRelease(SecKeyCopyAttributes(result.publicKeyRef));
+    NSDictionary *secondPublicKeyAttr = CFBridgingRelease(SecKeyCopyAttributes(readResult.publicKeyRef));
+    
+    XCTAssertEqualObjects(firstPrivateAttr[@"klbl"], secondPrivateAttr[@"klbl"]);
+    XCTAssertEqualObjects(firstPublicKeyAttr[@"klbl"], secondPublicKeyAttr[@"klbl"]);
+}
+
+- (void)testReadKeyForAttributes_whenKeyDoesntExist_shouldReturnNilAndNilError
+{
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSString *privateKeyIdentifier = @"com.msal.unittest.privateKey";
+    NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
+    
+    MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
+    attr.privateKeyIdentifier = privateKeyIdentifier;
+    attr.publicKeyIdentifier = publicKeyIdentifier;
+    attr.keyDisplayableLabel = @"My key";
+    
+    [self deleteKeyWithTag:privateKeyIdentifier];
+    [self deleteKeyWithTag:publicKeyIdentifier];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *readResult = [generator readKeyPairForAttributes:attr error:&error];
+    XCTAssertNil(readResult);
+    XCTAssertNil(error);
+}
+
+- (void)testReadKeyForAttributes_whenOnlyPrivateKeyExists_shouldReturnNilAndFillError
+{
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSString *privateKeyIdentifier = @"com.msal.unittest.privateKey";
+    NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
+    
+    MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
+    attr.privateKeyIdentifier = privateKeyIdentifier;
+    attr.publicKeyIdentifier = publicKeyIdentifier;
+    attr.keyDisplayableLabel = @"My key";
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    
+    // Delete public key part
+    [self deleteKeyWithTag:publicKeyIdentifier];
+    
+    // Try to read the key
+    MSIDAssymetricKeyPair *readResult = [generator readKeyPairForAttributes:attr error:&error];
+    XCTAssertNil(readResult);
+    XCTAssertNil(error);
+}
+
+- (void)testReadOrGenerateKey_whenNilAttr_shouldReturnNilAndFillError
+{
+    MSIDAssymetricKeyLookupAttributes *attr = nil;
+    
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator readOrGenerateKeyPairForAttributes:attr error:&error];
+    
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInternal);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Operation failed with title \"Invalid key lookup attributes provided\", status -1");
+}
+
+- (void)testReadOrGenerateKey_whenKeyExists_shouldReturnKey
+{
+    NSString *privateKeyIdentifier = @"com.msal.unittest.privateKey";
+    NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
+    
+    MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
+    attr.privateKeyIdentifier = privateKeyIdentifier;
+    attr.publicKeyIdentifier = publicKeyIdentifier;
+    attr.keyDisplayableLabel = @"My key";
+    
+    // First generate key
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    
+    // Now read it back
+    MSIDAssymetricKeyPair *readResult = [generator readOrGenerateKeyPairForAttributes:attr error:&error];
+    XCTAssertNotNil(readResult);
+    XCTAssertNil(error);
+    
+    NSDictionary *firstPrivateAttr = CFBridgingRelease(SecKeyCopyAttributes(result.privateKeyRef));
+    NSDictionary *secondPrivateAttr = CFBridgingRelease(SecKeyCopyAttributes(readResult.privateKeyRef));
+    
+    NSDictionary *firstPublicKeyAttr = CFBridgingRelease(SecKeyCopyAttributes(result.publicKeyRef));
+    NSDictionary *secondPublicKeyAttr = CFBridgingRelease(SecKeyCopyAttributes(readResult.publicKeyRef));
+    
+    XCTAssertEqualObjects(firstPrivateAttr[@"klbl"], secondPrivateAttr[@"klbl"]);
+    XCTAssertEqualObjects(firstPublicKeyAttr[@"klbl"], secondPublicKeyAttr[@"klbl"]);
+}
+
+- (void)testReadOrGenerateKey_whenOnlyPartialKeyExists_shouldReturnNewKey
+{
+    NSString *privateKeyIdentifier = @"com.msal.unittest.privateKey";
+    NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
+    
+    MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
+    attr.privateKeyIdentifier = privateKeyIdentifier;
+    attr.publicKeyIdentifier = publicKeyIdentifier;
+    attr.keyDisplayableLabel = @"My key";
+    
+    // First generate key
+    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    
+    NSError *error = nil;
+    MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    
+    // Delete public key part
+    [self deleteKeyWithTag:privateKeyIdentifier];
+    
+    // Now read it back
+    MSIDAssymetricKeyPair *readResult = [generator readOrGenerateKeyPairForAttributes:attr error:&error];
+    XCTAssertNotNil(readResult);
+    XCTAssertNil(error);
+    
+    NSDictionary *firstPrivateAttr = CFBridgingRelease(SecKeyCopyAttributes(result.privateKeyRef));
+    NSDictionary *secondPrivateAttr = CFBridgingRelease(SecKeyCopyAttributes(readResult.privateKeyRef));
+    
+    NSDictionary *firstPublicKeyAttr = CFBridgingRelease(SecKeyCopyAttributes(result.publicKeyRef));
+    NSDictionary *secondPublicKeyAttr = CFBridgingRelease(SecKeyCopyAttributes(readResult.publicKeyRef));
+    
+    XCTAssertNotEqualObjects(firstPrivateAttr[@"klbl"], secondPrivateAttr[@"klbl"]);
+    XCTAssertNotEqualObjects(firstPublicKeyAttr[@"klbl"], secondPublicKeyAttr[@"klbl"]);
+}
+
+#pragma mark - Helpers
+
+- (void)deleteKeyWithTag:(NSString *)tag
+{
+    NSDictionary *deleteKeyAttr = @{(id)kSecClass : (id)kSecClassKey,
+                                    (id)kSecAttrApplicationTag : (id)[tag dataUsingEncoding:NSUTF8StringEncoding]};
+    
+    OSStatus status = SecItemDelete((CFDictionaryRef)deleteKeyAttr);
+    BOOL deletionSucceeded = status == errSecSuccess || status == errSecItemNotFound;
+    XCTAssertTrue(deletionSucceeded);
+}
+
+- (BOOL)keyExists:(NSString *)tag
+{
+    NSDictionary *lookupAttr = @{(id)kSecClass : (id)kSecClassKey,
+                                 (id)kSecAttrApplicationTag : (id)[tag dataUsingEncoding:NSUTF8StringEncoding],
+                                 (id)kSecReturnRef : @YES};
+    
+    CFTypeRef result = NULL;
+    SecItemCopyMatching((CFDictionaryRef)lookupAttr, &result);
+    BOOL keyExists = result != nil;
+    if (keyExists) CFRelease(result);
+    
+    return keyExists;
+}
+
+@end

--- a/IdentityCore/tests/MSIDAssymetricKeychainGeneratorTests.m
+++ b/IdentityCore/tests/MSIDAssymetricKeychainGeneratorTests.m
@@ -25,6 +25,9 @@
 #import "MSIDAssymetricKeyKeychainGenerator.h"
 #import "MSIDAssymetricKeyLookupAttributes.h"
 #import "MSIDAssymetricKeyPair.h"
+#if !TARGET_OS_IPHONE
+#import "MSIDAssymetricKeyLoginKeychainGenerator.h"
+#endif
 
 @interface MSIDAssymetricKeychainGeneratorTests : XCTestCase
 
@@ -36,7 +39,7 @@
 {
     MSIDAssymetricKeyLookupAttributes *attr = nil;
     
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
@@ -51,7 +54,7 @@
 {
     MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
     
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
@@ -74,7 +77,7 @@
     attr.privateKeyIdentifier = privateKeyIdentifier;
     attr.publicKeyIdentifier = publicKeyIdentifier;
     
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
@@ -101,7 +104,7 @@
     attr.publicKeyIdentifier = publicKeyIdentifier;
     
     // Generate first time
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
@@ -134,7 +137,7 @@
 {
     MSIDAssymetricKeyLookupAttributes *attr = nil;
     
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator readKeyPairForAttributes:attr error:&error];
@@ -149,7 +152,7 @@
 {
     MSIDAssymetricKeyLookupAttributes *attr = [MSIDAssymetricKeyLookupAttributes new];
     
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator readKeyPairForAttributes:attr error:&error];
@@ -171,7 +174,7 @@
     attr.keyDisplayableLabel = @"My key";
     
     // First generate key
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
@@ -195,7 +198,7 @@
 
 - (void)testReadKeyForAttributes_whenKeyDoesntExist_shouldReturnNilAndNilError
 {
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSString *privateKeyIdentifier = @"com.msal.unittest.privateKey";
     NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
@@ -216,7 +219,7 @@
 
 - (void)testReadKeyForAttributes_whenOnlyPrivateKeyExists_shouldReturnNilAndFillError
 {
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSString *privateKeyIdentifier = @"com.msal.unittest.privateKey";
     NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
@@ -244,7 +247,7 @@
 {
     MSIDAssymetricKeyLookupAttributes *attr = nil;
     
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator readOrGenerateKeyPairForAttributes:attr error:&error];
@@ -266,7 +269,7 @@
     attr.keyDisplayableLabel = @"My key";
     
     // First generate key
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
@@ -299,7 +302,7 @@
     attr.keyDisplayableLabel = @"My key";
     
     // First generate key
-    MSIDAssymetricKeyKeychainGenerator *generator = [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+    MSIDAssymetricKeyKeychainGenerator *generator = [self keyGenerator];
     
     NSError *error = nil;
     MSIDAssymetricKeyPair *result = [generator generateKeyPairForAttributes:attr error:&error];
@@ -348,6 +351,15 @@
     if (keyExists) CFRelease(result);
     
     return keyExists;
+}
+
+- (MSIDAssymetricKeyKeychainGenerator *)keyGenerator
+{
+#if TARGET_OS_IPHONE
+    return [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:nil error:nil];
+#else
+    return [[MSIDAssymetricKeyLoginKeychainGenerator alloc] initWithGroup:nil error:nil];
+#endif
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

Both AT POP and PRT v3 need a common interface to handle keys.
Submitting a common interface that both features can use. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

