### PR TITLE
changed MSID_BROKER_APP_BUNDLE_ID & MSID_BROKER_APP_BUNDLE_ID_DF to h…

### DIFF
--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -26,8 +26,13 @@ NSString *const MSID_BROKER_SYMMETRIC_KEY_TAG      = @"com.microsoft.adBrokerKey
 NSString *const MSID_BROKER_ADAL_SCHEME            = @"msauth";
 NSString *const MSID_BROKER_MSAL_SCHEME            = @"msauthv2";
 NSString *const MSID_BROKER_NONCE_SCHEME           = @"msauthv3";
-NSString *const MSID_BROKER_APP_BUNDLE_ID          = @"com.microsoft.azureauthenticator";
-NSString *const MSID_BROKER_APP_BUNDLE_ID_DF       = @"com.microsoft.azureauthenticator-df";
+#if TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST
+    NSString *const MSID_BROKER_APP_BUNDLE_ID          = @"com.microsoft.azureauthenticator";
+    NSString *const MSID_BROKER_APP_BUNDLE_ID_DF       = @"com.microsoft.azureauthenticator-df";
+#elif TARGET_OS_OSX
+    NSString *const MSID_BROKER_APP_BUNDLE_ID          = @"com.microsoft.CompanyPortalMac";
+    NSString *const MSID_BROKER_APP_BUNDLE_ID_DF       = @"com.microsoft.CompanyPortalMac";
+#endif
 NSString *const MSID_BROKER_MAX_PROTOCOL_VERSION   = @"max_protocol_ver";
 NSString *const MSID_BROKER_PROTOCOL_VERSION_KEY   = @"msg_protocol_ver";
 NSInteger const MSID_BROKER_PROTOCOL_VERSION_2     = 2;


### PR DESCRIPTION
To have different BUNDLE ID values for iOS vs MacOS

## Proposed changes

The purpose is to have different BUNDLE_ID/BUNDLE_ID DOGFOOD values for iOS vs MacOS to support the changes in broker code per this PR -  https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/492

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

