### PR TITLE
[ICM] Fixed CBA handling in MSAL

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
@@ -28,6 +28,7 @@
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDMainThreadUtil.h"
 #import "MSIDSystemWebviewController.h"
+#import "NSDictionary+MSIDQueryItems.h"
 
 #if !MSID_EXCLUDE_SYSTEMWV
 
@@ -98,12 +99,15 @@ static BOOL s_useAuthSession = NO;
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Received CertAuthChallengehost from : %@", MSID_PII_LOG_TRACKABLE(challenge.protectionSpace.host));
     
     NSURL *requestURL = [currentSession.webviewController startURL];
-    NSString *redirectURI = nil;
+    
+    NSURLComponents *requestURLComponents = [NSURLComponents componentsWithURL:requestURL resolvingAgainstBaseURL:NO];
+    NSArray<NSURLQueryItem *> *queryItems = [requestURLComponents queryItems];
+    NSDictionary *queryItemsDict = [NSDictionary msidDictionaryFromQueryItems:queryItems];
+    
+    NSString *redirectURI = queryItemsDict[MSID_OAUTH2_REDIRECT_URI];
     
     if (s_redirectScheme)
     {
-        NSURLComponents *requestURLComponents = [NSURLComponents componentsWithURL:requestURL resolvingAgainstBaseURL:NO];
-        NSArray<NSURLQueryItem *> *queryItems = [requestURLComponents queryItems];
         NSMutableDictionary *newQueryItems = [NSMutableDictionary new];
         NSString *redirectSchemePrefix = [NSString stringWithFormat:@"%@://", s_redirectScheme];
         


### PR DESCRIPTION
## Proposed changes

ICM reported that MSAL interactive token acquisition hangs when certificate challenge is received. Same flow works in Microsoft Authenticator app. 

Code analysis revealed that MSAL never sets redirectUri when creating a certificate handling challenge, which causes the flow to hang. Submitting a fix that sets redirectUri to the uri in the request when custom logic for URL swapping is not applied.  

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Will require manual testing of CBA in both broker and MSAL on iOS. 
