### PR TITLE
Support PRT refresh

### DIFF
--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.h
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.h
@@ -35,5 +35,6 @@
 @property (nonatomic) NSDate *cachedAt;
  
 - (BOOL)isDevicelessPRT;
+- (BOOL)shouldRefreshWithInterval:(NSUInteger)refreshInterval;
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.h
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.h
@@ -31,7 +31,9 @@
 @property (nonatomic) NSData *sessionKey;
 @property (nonatomic) NSString *deviceID;
 @property (nonatomic) NSString *prtProtocolVersion;
-
+@property (nonatomic) NSDate *expiresOn;
+@property (nonatomic) NSDate *cachedAt;
+ 
 - (BOOL)isDevicelessPRT;
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
@@ -49,6 +49,8 @@
         }
         
         _prtProtocolVersion = [jsonDictionary msidObjectForKey:MSID_PRT_PROTOCOL_VERSION_CACHE_KEY ofClass:[NSString class]];
+        _expiresOn = tokenCacheItem.expiresOn;
+        _cachedAt = tokenCacheItem.cachedAt;
     }
     
     return self;
@@ -66,6 +68,8 @@
     prtCacheItem.credentialType = MSIDPrimaryRefreshTokenType;
     prtCacheItem.deviceID = self.deviceID;
     prtCacheItem.prtProtocolVersion = self.prtProtocolVersion;
+    prtCacheItem.expiresOn = self.expiresOn;
+    prtCacheItem.cachedAt = self.cachedAt;
     return prtCacheItem;
 }
 
@@ -123,6 +127,8 @@
     hash = hash * 31 + self.sessionKey.hash;
     hash = hash * 31 + self.deviceID.hash;
     hash = hash * 31 + self.prtProtocolVersion.hash;
+    hash = hash * 31 + self.expiresOn.hash;
+    hash = hash * 31 + self.cachedAt.hash;
     return hash;
 }
 
@@ -135,6 +141,8 @@
     
     BOOL result = [super isEqualToItem:token];
     result &= (!self.sessionKey && !token.sessionKey) || [self.sessionKey isEqualToData:token.sessionKey];
+    result &= (!self.expiresOn && !token.expiresOn) || [self.expiresOn isEqualToDate:token.expiresOn];
+    result &= (!self.cachedAt && !token.cachedAt) || [self.cachedAt isEqualToDate:token.cachedAt];
     result &= (!self.deviceID && !token.deviceID) || [self.deviceID isEqualToString:token.deviceID];
     result &= (!self.prtProtocolVersion && !token.prtProtocolVersion) || [self.prtProtocolVersion isEqualToString:token.prtProtocolVersion];
     return result;
@@ -148,6 +156,8 @@
     item->_sessionKey = [_sessionKey copyWithZone:zone];
     item->_deviceID = [_deviceID copyWithZone:zone];
     item->_prtProtocolVersion = [_prtProtocolVersion copyWithZone:zone];
+    item->_expiresOn = [_expiresOn copyWithZone:zone];
+    item->_cachedAt = [_cachedAt copyWithZone:zone];
     return item;
 }
 

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
@@ -184,4 +184,23 @@
     return prtVersion >= 3.0 && [NSString msidIsStringNilOrBlank:self.deviceID];
 }
 
+- (BOOL)shouldRefreshWithInterval:(NSUInteger)refreshInterval
+{
+    if (!self.expiresOn)
+    {
+        return YES;
+    }
+    
+    NSDate *nowPlusBuffer = [NSDate dateWithTimeIntervalSinceNow:refreshInterval];
+    BOOL isCloseToExpiry = [self.expiresOn compare:nowPlusBuffer] == NSOrderedAscending;
+    
+    if (isCloseToExpiry)
+    {
+        return YES;
+    }
+    
+    BOOL shouldRefresh = [[NSDate date] timeIntervalSinceDate:self.cachedAt] >= refreshInterval;
+    return shouldRefresh;
+}
+
 @end

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
@@ -127,8 +127,6 @@
     hash = hash * 31 + self.sessionKey.hash;
     hash = hash * 31 + self.deviceID.hash;
     hash = hash * 31 + self.prtProtocolVersion.hash;
-    hash = hash * 31 + self.expiresOn.hash;
-    hash = hash * 31 + self.cachedAt.hash;
     return hash;
 }
 
@@ -141,8 +139,6 @@
     
     BOOL result = [super isEqualToItem:token];
     result &= (!self.sessionKey && !token.sessionKey) || [self.sessionKey isEqualToData:token.sessionKey];
-    result &= (!self.expiresOn && !token.expiresOn) || [self.expiresOn isEqualToDate:token.expiresOn];
-    result &= (!self.cachedAt && !token.cachedAt) || [self.cachedAt isEqualToDate:token.cachedAt];
     result &= (!self.deviceID && !token.deviceID) || [self.deviceID isEqualToString:token.deviceID];
     result &= (!self.prtProtocolVersion && !token.prtProtocolVersion) || [self.prtProtocolVersion isEqualToString:token.prtProtocolVersion];
     return result;

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -123,6 +123,12 @@
 
 - (NSURL *)tokenEndpoint
 {
+    if (!self.authority.metadata.tokenEndpoint)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"No token endpoint present");
+        return nil;
+    }
+    
     NSURLComponents *tokenEndpoint = [NSURLComponents componentsWithURL:self.authority.metadata.tokenEndpoint resolvingAgainstBaseURL:NO];
 
     if (self.cloudAuthority)

--- a/IdentityCore/tests/MSIDPrimaryRefreshTokenTests.m
+++ b/IdentityCore/tests/MSIDPrimaryRefreshTokenTests.m
@@ -71,6 +71,36 @@
     XCTAssertTrue(result);
 }
 
+- (void)testShouldRefreshToken_whenNoExpiryDate_shouldReturnYES
+{
+    MSIDPrimaryRefreshToken *token = [self createToken];
+    token.expiresOn = nil;
+    XCTAssertTrue([token shouldRefreshWithInterval:3600]);
+}
+
+- (void)testShouldRefreshToken_whenCloseToExpiry_shouldReturnYES
+{
+    MSIDPrimaryRefreshToken *token = [self createToken];
+    token.expiresOn = [[NSDate date] dateByAddingTimeInterval:300];
+    XCTAssertTrue([token shouldRefreshWithInterval:3600]);
+}
+
+- (void)testShouldRefreshToken_whenRecentlyRefreshed_shouldReturnNO
+{
+    MSIDPrimaryRefreshToken *token = [self createToken];
+    token.expiresOn = [[NSDate date] dateByAddingTimeInterval:10200];
+    token.cachedAt = [NSDate date];
+    XCTAssertFalse([token shouldRefreshWithInterval:3600]);
+}
+
+- (void)testShouldRefreshToken_whenNotRecentlyRefreshed_shouldReturnYES
+{
+    MSIDPrimaryRefreshToken *token = [self createToken];
+    token.expiresOn = [[NSDate date] dateByAddingTimeInterval:10200];
+    token.cachedAt = [[NSDate date] dateByAddingTimeInterval:-7200];
+    XCTAssertTrue([token shouldRefreshWithInterval:3600]);
+}
+
 #pragma mark - Private
 
 - (MSIDPrimaryRefreshToken *)createToken


### PR DESCRIPTION
## Proposed changes

As the first step to support seamless SSO in broker, we'll try to refresh PRT every couple of hours after using PRT. In order to track last PRT usage and expiry time, PRT will now utilize expiresOn and cachedAt fields. This PR includes PRT schema updates needed to support first phase of PRT refresh. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

