### PR TITLE
fix a failure unit test when running on 10.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11
+osx_image: xcode11.5
 
 # Set up our rubygems (slather and xcpretty, namely)
 install: 

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 		23FB5C452255A11D002BF1EB /* MSIDClaimsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C24225517AA002BF1EB /* MSIDClaimsRequest.m */; };
 		23FB5C462255A135002BF1EB /* MSIDIndividualClaimRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C29225517AA002BF1EB /* MSIDIndividualClaimRequest.m */; };
 		23FB5C472255A13A002BF1EB /* MSIDIndividualClaimRequestAdditionalInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C27225517AA002BF1EB /* MSIDIndividualClaimRequestAdditionalInfo.m */; };
+		58543C8B24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h in Headers */ = {isa = PBXBuildFile; fileRef = 58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */; };
 		600D19972095988C0004CD43 /* MSIDChallengeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 600D19962095988C0004CD43 /* MSIDChallengeHandler.m */; };
 		600D19982095988C0004CD43 /* MSIDChallengeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 600D19962095988C0004CD43 /* MSIDChallengeHandler.m */; };
 		600D199E20963B020004CD43 /* MSIDNTLMUIPrompt.m in Sources */ = {isa = PBXBuildFile; fileRef = 600D199D20963B020004CD43 /* MSIDNTLMUIPrompt.m */; };
@@ -1920,6 +1921,7 @@
 		23FB5C2E22551866002BF1EB /* MSIDClaimsRequest+ClientCapabilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDClaimsRequest+ClientCapabilities.m"; sourceTree = "<group>"; };
 		23FB5C32225585E6002BF1EB /* MSIDClaimsRequestMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDClaimsRequestMock.h; sourceTree = "<group>"; };
 		23FB5C33225585E6002BF1EB /* MSIDClaimsRequestMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDClaimsRequestMock.m; sourceTree = "<group>"; };
+		58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDMacKeychainTokenCache+Test.h"; sourceTree = "<group>"; };
 		600D1995209598770004CD43 /* MSIDChallengeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDChallengeHandler.h; sourceTree = "<group>"; };
 		600D19962095988C0004CD43 /* MSIDChallengeHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDChallengeHandler.m; sourceTree = "<group>"; };
 		600D199C20963AD50004CD43 /* MSIDNTLMUIPrompt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDNTLMUIPrompt.h; sourceTree = "<group>"; };
@@ -4294,6 +4296,7 @@
 				B86FA7C92383748000E5195A /* MSIDMacLegacyCachePersistenceHandlerTests.m */,
 				B86FA7CA2383748000E5195A /* Info.plist */,
 				B2AE0FDA2427E96800B8FAF1 /* MSIDKeychainUtilTests.m */,
+				58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */,
 			);
 			path = mac;
 			sourceTree = "<group>";
@@ -5152,6 +5155,7 @@
 				B2BE925821A24CB000F5AB8C /* MSIDTestSilentTokenRequest.h in Headers */,
 				B24DE9FE21A60F13003A651D /* MSIDTestBrokerTokenRequest.h in Headers */,
 				B2BE926721A25F7F00F5AB8C /* MSIDTestBrokerResponseHandler.h in Headers */,
+				58543C8B24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h in Headers */,
 				B253154523DD763B00432133 /* MSIDSSOExtensionGetDeviceInfoRequestMock.h in Headers */,
 				B2968CA722F67B48005AFC33 /* MSIDTestLocalInteractiveController.h in Headers */,
 				D626FFF91FBD200A00EE4487 /* MSIDTestURLSession.h in Headers */,

--- a/IdentityCore/tests/mac/MSIDMacKeychainTokenCache+Test.h
+++ b/IdentityCore/tests/mac/MSIDMacKeychainTokenCache+Test.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDMacKeychainTokenCache.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDMacKeychainTokenCache ()
+
+@property MSIDMacCredentialStorageItem *sharedStorageItem;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
+++ b/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
@@ -31,7 +31,7 @@
 #import "MSIDClientInfo.h"
 #import "MSIDDefaultAccountCacheKey.h"
 #import "MSIDDefaultAccountCacheQuery.h"
-#import "MSIDMacKeychainTokenCache.h"
+#import "MSIDMacKeychainTokenCache+Test.h"
 #import "MSIDTestIdentifiers.h"
 #import "NSDictionary+MSIDTestUtil.h"
 #import "NSString+MSIDExtensions.h"
@@ -44,6 +44,7 @@
 #import "MSIDAccountMetadataCacheKey.h"
 #import "MSIDAccountMetadata.h"
 #import "MSIDAccountMetadataCacheItem.h"
+#import "MSIDMacCredentialStorageItem.h"
 
 @interface MSIDMacKeychainTokenCache (Internal)
 
@@ -425,7 +426,10 @@
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"LoginKeychainEmpty"];
         
         [self multiAccountTestSetup];
-        
+        // remove accounts from memory only
+        for (MSIDDefaultAccountCacheKey *key in @[_keyA, _keyB, _keyC]) {
+            [_dataSource.sharedStorageItem removeStoredItemForKey:key];
+        }
         NSError *error;
         NSArray<MSIDAccountCacheItem *> *foundAccounts = [_cache getAccountsWithQuery:_queryAll context:nil error:&error];
         XCTAssertNil(error);

--- a/IdentityCore/tests/util/MSIDApplicationTestUtil.m
+++ b/IdentityCore/tests/util/MSIDApplicationTestUtil.m
@@ -61,22 +61,23 @@ static NSArray *s_canOpenURLSchemes = nil;
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 @implementation UIApplication (TestOverride)
 
-+ (void)load {
++ (void)load
+{
     
     Method openUrlStr = class_getInstanceMethod(UIApplication.class, @selector(openURL:));
-    Method To_openUrlStr = class_getInstanceMethod(UIApplication.class, @selector(TO_openURL:));
-    method_exchangeImplementations(openUrlStr, To_openUrlStr);
+    Method msidOpenUrlStr = class_getInstanceMethod(UIApplication.class, @selector(msidOpenURL:));
+    method_exchangeImplementations(openUrlStr, msidOpenUrlStr);
     
     Method openUrlOptionsCompletionHandlerStr = class_getInstanceMethod(UIApplication.class, @selector(openURL:options:completionHandler:));
-    Method To_openUrlOptionsCompletionHandlerStr = class_getInstanceMethod(UIApplication.class, @selector(TO_openURL:options:completionHandler:));
-    method_exchangeImplementations(openUrlOptionsCompletionHandlerStr, To_openUrlOptionsCompletionHandlerStr);
+    Method msidOpenUrlOptionsCompletionHandlerStr = class_getInstanceMethod(UIApplication.class, @selector(msidOpenURL:options:completionHandler:));
+    method_exchangeImplementations(openUrlOptionsCompletionHandlerStr, msidOpenUrlOptionsCompletionHandlerStr);
     
     Method canOpenUrlStr = class_getInstanceMethod(UIApplication.class, @selector(canOpenURL:));
-    Method To_canOpenUrlStr = class_getInstanceMethod(UIApplication.class, @selector(TO_canOpenURL:));
-    method_exchangeImplementations(canOpenUrlStr, To_canOpenUrlStr);
+    Method msidCanOpenUrlStr = class_getInstanceMethod(UIApplication.class, @selector(msidCanOpenURL:));
+    method_exchangeImplementations(canOpenUrlStr, msidCanOpenUrlStr);
 }
 
-- (BOOL)TO_openURL:(NSURL *)url
+- (BOOL)msidOpenURL:(NSURL *)url
 {
     if (!s_onOpenUrl)
     {
@@ -86,7 +87,7 @@ static NSArray *s_canOpenURLSchemes = nil;
     return s_onOpenUrl(url, nil);
 }
 
-- (BOOL)TO_canOpenURL:(NSURL *)url
+- (BOOL)msidCanOpenURL:(NSURL *)url
 {
     if (s_canOpenURLSchemes)
     {
@@ -96,7 +97,7 @@ static NSArray *s_canOpenURLSchemes = nil;
     return YES;
 }
 
-- (void)TO_openURL:(NSURL*)url
+- (void)msidOpenURL:(NSURL*)url
         options:(NSDictionary<NSString *, id> *)options
 completionHandler:(void (^ __nullable)(BOOL success))completionHandler
 {

--- a/IdentityCore/tests/util/MSIDApplicationTestUtil.m
+++ b/IdentityCore/tests/util/MSIDApplicationTestUtil.m
@@ -71,9 +71,9 @@ static NSArray *s_canOpenURLSchemes = nil;
     Method To_openUrlOptionsCompletionHandlerStr = class_getInstanceMethod(UIApplication.class, @selector(TO_openURL:options:completionHandler:));
     method_exchangeImplementations(openUrlOptionsCompletionHandlerStr, To_openUrlOptionsCompletionHandlerStr);
     
-    Method canOpenUrl = class_getInstanceMethod(UIApplication.class, @selector(canOpenURL:));
-    Method To_canOpenUrl = class_getInstanceMethod(UIApplication.class, @selector(TO_canOpenURL:));
-    method_exchangeImplementations(canOpenUrl, To_canOpenUrl);
+    Method canOpenUrlStr = class_getInstanceMethod(UIApplication.class, @selector(canOpenURL:));
+    Method To_canOpenUrlStr = class_getInstanceMethod(UIApplication.class, @selector(TO_canOpenURL:));
+    method_exchangeImplementations(canOpenUrlStr, To_canOpenUrlStr);
 }
 
 - (BOOL)TO_openURL:(NSURL *)url

--- a/IdentityCore/tests/util/MSIDApplicationTestUtil.m
+++ b/IdentityCore/tests/util/MSIDApplicationTestUtil.m
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import "MSIDApplicationTestUtil.h"
+#import <objc/message.h>
 
 BOOL (^s_onOpenUrl)(NSURL *url, NSDictionary<NSString *, id> *options) = nil;
 static NSArray *s_canOpenURLSchemes = nil;
@@ -60,7 +61,22 @@ static NSArray *s_canOpenURLSchemes = nil;
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 @implementation UIApplication (TestOverride)
 
-- (BOOL)openURL:(NSURL *)url
++ (void)load {
+    
+    Method openUrlStr = class_getInstanceMethod(UIApplication.class, @selector(openURL:));
+    Method To_openUrlStr = class_getInstanceMethod(UIApplication.class, @selector(TO_openURL:));
+    method_exchangeImplementations(openUrlStr, To_openUrlStr);
+    
+    Method openUrlOptionsCompletionHandlerStr = class_getInstanceMethod(UIApplication.class, @selector(openURL:options:completionHandler:));
+    Method To_openUrlOptionsCompletionHandlerStr = class_getInstanceMethod(UIApplication.class, @selector(TO_openURL:options:completionHandler:));
+    method_exchangeImplementations(openUrlOptionsCompletionHandlerStr, To_openUrlOptionsCompletionHandlerStr);
+    
+    Method canOpenUrl = class_getInstanceMethod(UIApplication.class, @selector(canOpenURL:));
+    Method To_canOpenUrl = class_getInstanceMethod(UIApplication.class, @selector(TO_canOpenURL:));
+    method_exchangeImplementations(canOpenUrl, To_canOpenUrl);
+}
+
+- (BOOL)TO_openURL:(NSURL *)url
 {
     if (!s_onOpenUrl)
     {
@@ -70,7 +86,7 @@ static NSArray *s_canOpenURLSchemes = nil;
     return s_onOpenUrl(url, nil);
 }
 
-- (BOOL)canOpenURL:(NSURL *)url
+- (BOOL)TO_canOpenURL:(NSURL *)url
 {
     if (s_canOpenURLSchemes)
     {
@@ -80,7 +96,7 @@ static NSArray *s_canOpenURLSchemes = nil;
     return YES;
 }
 
-- (void)openURL:(NSURL*)url
+- (void)TO_openURL:(NSURL*)url
         options:(NSDictionary<NSString *, id> *)options
 completionHandler:(void (^ __nullable)(BOOL success))completionHandler
 {


### PR DESCRIPTION
## Proposed changes

The change is to remove items in memory and keep those items in local cache(storage)

Describe what this PR is trying to do.

This PR is to address a unit test failure on 10.15 and above where we should not be able to get local cached items. However, the logic of query items is a combination of getting items from both local and memory which fails the unit test. This PR will help to remove the items in memory only to prove we cannot get items from local cache

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

