### PR TITLE
Fixed issue with webview cancellation

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -67,8 +67,6 @@
     if ([requestURL.scheme.lowercaseString isEqualToString:@"msauth"] ||
         [requestURL.scheme.lowercaseString isEqualToString:@"browser"] )
     {
-        self.complete = YES;
-        
         NSURL *url = navigationAction.request.URL;
         [self completeWebAuthWithURL:url];
         

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -88,7 +88,7 @@
 
         _context = context;
         
-        self.complete = NO;
+        _complete = NO;
     }
     
     return self;

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -33,6 +33,9 @@ UIViewController
 #else
 NSWindowController
 #endif
+{
+    BOOL _complete;
+}
 
 @property (nonatomic) WKWebView *webView;
 @property (nonatomic) id<MSIDRequestContext> context;


### PR DESCRIPTION
## Proposed changes

Fix embedded webview response handling to set the complete flag only once in endWebAuth function. Setting this flag in multiple places was causing the webview to hang indefinitely without returning the response.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

