### PR TITLE
Use correct request URL when using CBA with Auth Session

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
@@ -80,7 +80,7 @@ static BOOL s_useAuthSession = NO;
 + (void)resetHandler { }
 
 + (BOOL)handleChallenge:(NSURLAuthenticationChallenge *)challenge
-                webview:(__unused WKWebView *)webview
+                webview:(WKWebView *)webview
 #if TARGET_OS_IPHONE
        parentController:(UIViewController *)parentViewController
 #endif
@@ -134,7 +134,14 @@ static BOOL s_useAuthSession = NO;
         // This will launch a Safari view within the current Application, removing the app flip. Our control of this
         // view is extremely limited. Safari is still running in a separate sandbox almost completely isolated from us.
         
-        s_systemWebViewController = [[MSIDSystemWebviewController alloc] initWithStartURL:requestURL
+        NSURL *currentURL = requestURL;
+        
+        if (s_useAuthSession && webview.URL)
+        {
+            currentURL = webview.URL;
+        }
+        
+        s_systemWebViewController = [[MSIDSystemWebviewController alloc] initWithStartURL:currentURL
                                                                               redirectURI:redirectURI
                                                                          parentController:parentViewController
                                                                  useAuthenticationSession:s_useAuthSession


### PR DESCRIPTION
## Proposed changes

When using ASWebAuthenticationSession for certificate based auth, we don't need to change Redirect URI anymore so we can use current URL that requested the cert challenge.
This will help user to avoid additional username entry and take them directly to their on prem page. 
Note that this is the way it used to work with ADAL, and got regressed with MSAL. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

