### PR TITLE
Make account metadata accessor optional

### DIFF
--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenRequestProvider.h
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenRequestProvider.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable instancetype)initWithOauthFactory:(MSIDOauth2Factory *)oauthFactory
                               defaultAccessor:(MSIDDefaultTokenCacheAccessor *)defaultAccessor
-                      accountMetadataAccessor:(MSIDAccountMetadataCacheAccessor *)accountMetadataAccessor
+                      accountMetadataAccessor:(nullable MSIDAccountMetadataCacheAccessor *)accountMetadataAccessor
                        tokenResponseValidator:(MSIDTokenResponseValidator *)tokenResponseValidator;
 
 @end


### PR DESCRIPTION
## Proposed changes

There're cases where account metadata update is unneeded (e.g. PRT flows).
Hence, making account metadata accessor optional. 

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

