### PR TITLE
Support reading broker feature flags

### DIFF
--- a/IdentityCore/src/MSIDBrokerConstants.h
+++ b/IdentityCore/src/MSIDBrokerConstants.h
@@ -73,3 +73,4 @@ extern NSString * _Nonnull const MSID_ADAL_BROKER_MESSAGE_VERSION;
 extern NSString * _Nonnull const MSID_MSAL_BROKER_MESSAGE_VERSION;
 extern NSString * _Nonnull const MSID_BROKER_SDK_CAPABILITIES_KEY;
 extern NSString * _Nonnull const MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY;
+extern NSString * _Nonnull const MSID_ADDITIONAL_EXTENSION_DATA_KEY;

--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -68,3 +68,4 @@ NSString *const MSID_ADAL_BROKER_MESSAGE_VERSION   = @"2";
 NSString *const MSID_MSAL_BROKER_MESSAGE_VERSION   = @"3";
 NSString *const MSID_BROKER_SDK_CAPABILITIES_KEY   = @"sdk_broker_capabilities";
 NSString *const MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY    = @"sso_extension";
+NSString *const MSID_ADDITIONAL_EXTENSION_DATA_KEY = @"additional_extension_data";

--- a/IdentityCore/src/MSIDJsonSerializer.m
+++ b/IdentityCore/src/MSIDJsonSerializer.m
@@ -91,6 +91,11 @@
         return nil;
     }
     
+    if (!jsonDictionary)
+    {
+        return nil;
+    }
+    
     return [[klass alloc] initWithJSONDictionary:jsonDictionary error:error];
 }
 

--- a/IdentityCore/src/broker_operation/response/MSIDDeviceInfo.h
+++ b/IdentityCore/src/broker_operation/response/MSIDDeviceInfo.h
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) MSIDSSOExtensionMode ssoExtensionMode;
 @property (nonatomic) MSIDWorkPlaceJoinStatus wpjStatus;
 @property (nonatomic, nullable) NSString *brokerVersion;
+@property (nonatomic) NSDictionary *additionalExtensionData;
 
 - (instancetype)initWithDeviceMode:(MSIDDeviceMode)deviceMode
                   ssoExtensionMode:(MSIDSSOExtensionMode)ssoExtensionMode

--- a/IdentityCore/src/broker_operation/response/MSIDDeviceInfo.m
+++ b/IdentityCore/src/broker_operation/response/MSIDDeviceInfo.m
@@ -24,6 +24,7 @@
 #import "MSIDDeviceInfo.h"
 #import "MSIDConstants.h"
 #import "MSIDWorkPlaceJoinUtil.h"
+#import "NSJSONSerialization+MSIDExtensions.h"
 
 static NSArray *deviceModeEnumString;
 
@@ -59,6 +60,9 @@ static NSArray *deviceModeEnumString;
         _ssoExtensionMode = [self ssoExtensionModeEnumFromString:[json msidStringObjectForKey:MSID_BROKER_SSO_EXTENSION_MODE_KEY]];
         _wpjStatus = [self wpjStatusEnumFromString:[json msidStringObjectForKey:MSID_BROKER_WPJ_STATUS_KEY]];
         _brokerVersion = [json msidStringObjectForKey:MSID_BROKER_BROKER_VERSION_KEY];
+        
+        NSData *jsonData = [json[MSID_ADDITIONAL_EXTENSION_DATA_KEY] dataUsingEncoding:NSUTF8StringEncoding];
+        _additionalExtensionData = [NSJSONSerialization msidNormalizedDictionaryFromJsonData:jsonData error:nil];
     }
     
     return self;
@@ -72,6 +76,7 @@ static NSArray *deviceModeEnumString;
     json[MSID_BROKER_SSO_EXTENSION_MODE_KEY] = [self ssoExtensionModeStringFromEnum:self.ssoExtensionMode];
     json[MSID_BROKER_WPJ_STATUS_KEY] = [self wpjStatusStringFromEnum:self.wpjStatus];
     json[MSID_BROKER_BROKER_VERSION_KEY] = self.brokerVersion;
+    json[MSID_ADDITIONAL_EXTENSION_DATA_KEY] = [self.additionalExtensionData msidJSONSerializeWithContext:nil];
     
     return json;
 }

--- a/IdentityCore/src/util/NSJSONSerialization+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSJSONSerialization+MSIDExtensions.m
@@ -28,7 +28,7 @@
 
 + (NSDictionary *)msidNormalizedDictionaryFromJsonData:(NSData *)data error:(NSError **)error
 {
-    if (!data)
+    if (!data.length)
     {
         return nil;
     }

--- a/IdentityCore/src/util/NSJSONSerialization+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSJSONSerialization+MSIDExtensions.m
@@ -28,6 +28,11 @@
 
 + (NSDictionary *)msidNormalizedDictionaryFromJsonData:(NSData *)data error:(NSError **)error
 {
+    if (!data)
+    {
+        return nil;
+    }
+    
     NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data
                                                          options:NSJSONReadingMutableContainers
                                                            error:error];

--- a/IdentityCore/tests/MSIDDeviceInfoTests.m
+++ b/IdentityCore/tests/MSIDDeviceInfoTests.m
@@ -43,6 +43,7 @@
         MSID_BROKER_SSO_EXTENSION_MODE_KEY : @"silent_only",
         MSID_BROKER_WPJ_STATUS_KEY : @"joined",
         MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
+        MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"token\":\"\",\"dict\":{\"key\":\"value\"},\"feature_flag1\":1}"
     };
     
     NSError *error;
@@ -53,6 +54,29 @@
     XCTAssertEqual(deviceInfo.ssoExtensionMode, MSIDSSOExtensionModeSilentOnly);
     XCTAssertEqual(deviceInfo.wpjStatus, MSIDWorkPlaceJoinStatusJoined);
     XCTAssertEqualObjects(deviceInfo.brokerVersion, @"1.2.3");
+    
+    NSDictionary *expectedAdditionalData = @{@"feature_flag1":@1,@"token":@"",@"dict":@{@"key":@"value"}};
+    XCTAssertEqualObjects(deviceInfo.additionalExtensionData, expectedAdditionalData);
+}
+
+- (void)testInitWithJSONDictionary_whenJsonValid_andAdditionalDataCorrupt_shouldInitWithJsonWithoutAdditionalInfo {
+    NSDictionary *json = @{
+        MSID_BROKER_DEVICE_MODE_KEY : @"shared",
+        MSID_BROKER_SSO_EXTENSION_MODE_KEY : @"silent_only",
+        MSID_BROKER_WPJ_STATUS_KEY : @"joined",
+        MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
+        MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"token\":\"\",\"dict\":{\"key\":\"value\"},\"feature_flag1\":1"
+    };
+    
+    NSError *error;
+    MSIDDeviceInfo *deviceInfo = [[MSIDDeviceInfo alloc] initWithJSONDictionary:json error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertEqual(deviceInfo.deviceMode, MSIDDeviceModeShared);
+    XCTAssertEqual(deviceInfo.ssoExtensionMode, MSIDSSOExtensionModeSilentOnly);
+    XCTAssertEqual(deviceInfo.wpjStatus, MSIDWorkPlaceJoinStatusJoined);
+    XCTAssertEqualObjects(deviceInfo.brokerVersion, @"1.2.3");
+    XCTAssertNil(deviceInfo.additionalExtensionData);
 }
 
 - (void)testInitWithJSONDictionary_whenDeviceInfoMissing_shouldInitWithDefaultValue {
@@ -195,11 +219,15 @@
     deviceInfo.wpjStatus = MSIDWorkPlaceJoinStatusJoined;
     deviceInfo.brokerVersion = @"1.2.3";
     
+    NSDictionary *additionalData = @{@"feature_flag1":@1,@"token":@"",@"dict":@{@"key":@"value"}};
+    deviceInfo.additionalExtensionData = additionalData;
+    
     NSDictionary *expectedJson = @{
         MSID_BROKER_DEVICE_MODE_KEY : @"shared",
         MSID_BROKER_SSO_EXTENSION_MODE_KEY : @"full",
         MSID_BROKER_WPJ_STATUS_KEY : @"joined",
         MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
+        MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"token\":\"\",\"dict\":{\"key\":\"value\"},\"feature_flag1\":1}"
     };
     
     XCTAssertEqualObjects(expectedJson, [deviceInfo jsonDictionary]);


### PR DESCRIPTION
## Proposed changes

Adding additional field for the SSO extension protocol that allows passing additional information/settings.
This is needed to allow Authenticator read settings from SSO extension.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

