### PR TITLE
Move PKeyAuth headers to a higher layer

### DIFF
--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.m
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.m
@@ -100,11 +100,20 @@
         return session;
     }
     
+    NSMutableDictionary *headers = [NSMutableDictionary new];
+    if (configuration.customHeaders)
+    {
+        [headers addEntriesFromDictionary:configuration.customHeaders];
+    }
+    
+    // Declare our client as PkeyAuth-capable
+    [headers setValue:kMSIDPKeyAuthHeaderVersion forKey:kMSIDPKeyAuthHeader];
+
     MSIDOAuth2EmbeddedWebviewController *embeddedWebviewController
     = [[MSIDOAuth2EmbeddedWebviewController alloc] initWithStartURL:configuration.startURL
                                                              endURL:[NSURL URLWithString:configuration.endRedirectUrl]
                                                             webview:webview
-                                                      customHeaders:configuration.customHeaders
+                                                      customHeaders:headers
                                                      platfromParams:nil
                                                             context:context];
     

--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -41,18 +41,9 @@
           platfromParams:(MSIDWebViewPlatformParams *)platformParams
                context:(id<MSIDRequestContext>)context
 {
-    NSMutableDictionary *headers = [NSMutableDictionary new];
-    if (customHeaders)
-    {
-        [headers addEntriesFromDictionary:customHeaders];
-    }
-    
-    // Declare our client as PkeyAuth-capable
-    [headers setValue:kMSIDPKeyAuthHeaderVersion forKey:kMSIDPKeyAuthHeader];
-        
     return [super initWithStartURL:startURL endURL:endURL
                            webview:webview
-                     customHeaders:headers
+                     customHeaders:customHeaders
                     platfromParams:platformParams
                            context:context];
 }


### PR DESCRIPTION
## Proposed changes

Change the location of the decision to do PKeyAuth to be at a higher layer.
For MSAL C++, we're directly inheriting MSIDAADOAuthEmbeddedWebviewController, which means we aren't able to make the decision about whether or not to do PKeyAuth.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

