### PR TITLE
Add OEAP SHA1 decryption to AssymetricKeyPair

### DIFF
--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.h
@@ -40,6 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithPrivateKey:(SecKeyRef)privateKey
                                   publicKey:(SecKeyRef)publicKey;
 
+- (nullable NSData *)decrypt:(nonnull NSString *)encryptedMessageString;
+- (nullable NSString *)encryptForTest:(nonnull NSString *)messageString;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/tests/MSIDAssymetricKeychainGeneratorTests.m
+++ b/IdentityCore/tests/MSIDAssymetricKeychainGeneratorTests.m
@@ -94,7 +94,14 @@ NSString *publicKeyIdentifier = @"com.msal.unittest.publicKey";
     
     XCTAssertNotNil([result keyExponent]);
     XCTAssertNotNil([result keyModulus]);
-
+    
+    NSString *messageString = [@"Sample Message To Encrypt/Decrypt" msidBase64UrlEncode];
+    NSString *encryptedMessage = [result encryptForTest:messageString];
+    XCTAssertNotNil(encryptedMessage);
+    NSData *decryptedMessageInBytes = [result decrypt:encryptedMessage];
+    XCTAssertNotNil(decryptedMessageInBytes);
+    NSString *decryptedMessageString = [NSString msidBase64UrlEncodedStringFromData:decryptedMessageInBytes];
+    XCTAssertEqualObjects(messageString, decryptedMessageString);
 }
 
 - (void)testGenerateKeyPair_whenKeyExists_shouldGenerateNewKeyAndReturnIt


### PR DESCRIPTION
## Proposed changes

Add OEAP SHA1 decryption to AssymetricKeyPair

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

