### PR TITLE
Cache fix for pop tokens in login keychain.

### DIFF
--- a/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.m
+++ b/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.m
@@ -33,13 +33,8 @@
 
 - (instancetype)initWithKeychainGroup:(nullable NSString *)keychainGroup accessRef:(nullable SecAccessRef)accessRef error:(NSError * _Nullable * _Nullable)error
 {
+    _accessRef = accessRef;
     self = [super initWithGroup:keychainGroup error:error];
-    
-    if (self)
-    {
-        _accessRef = accessRef;
-    }
-    
     return self;
 }
 

--- a/IdentityCore/src/cache/key/MSIDDefaultCredentialCacheKey.m
+++ b/IdentityCore/src/cache/key/MSIDDefaultCredentialCacheKey.m
@@ -174,6 +174,7 @@ static NSInteger kCredentialTypePrefix = 2000;
     item->_target = [_target copyWithZone:zone];
     item->_applicationIdentifier = [_applicationIdentifier copyWithZone:zone];
     item->_credentialType = _credentialType;
+    item->_tokenType = [_tokenType copyWithZone:zone];
     return item;
 }
 

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -353,6 +353,7 @@
     key.realm = self.realm;
     key.target = self.target;
     key.applicationIdentifier = self.applicationIdentifier;
+    key.tokenType = self.tokenType;
     return key;
 }
 


### PR DESCRIPTION
## Proposed changes

The macOS leychain < 10.15 had a bug for AT pop tokens. This PR adds a fix for it.

## Type of change

- [ ] Feature work
- [*] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [*] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

