### PR TITLE
In case the Pop request from MSAL is corrupted, fallback broker to use Bearer Scheme

### DIFF
--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
@@ -149,6 +149,8 @@
         if (error) *error = brokerError;
         return nil;
     }
+    // Sync authScheme from resume state after we decrypt response from broker
+    authScheme = [self synchronizeAuthSchemeFromBrokerResponse:authScheme brokerResponse:brokerResponse];
     
     NSString *applicationToken = brokerResponse.applicationToken;
     
@@ -307,6 +309,18 @@
              hasCompletionBlock:(__unused BOOL)hasCompletionBlock
 {
     return YES;
+}
+
+- (MSIDAuthenticationScheme *)synchronizeAuthSchemeFromBrokerResponse:(MSIDAuthenticationScheme *)authSchemeFromResumeState                                                                brokerResponse:(MSIDBrokerResponse *)brokerResponse
+{
+    if (![authSchemeFromResumeState isMemberOfClass:MSIDAuthenticationSchemePop.class]) return authSchemeFromResumeState;
+    
+    NSString *tokenType = [brokerResponse.formDictionary msidObjectForKey:MSID_OAUTH2_TOKEN_TYPE ofClass:[NSString class]];
+    if (!tokenType || MSIDAuthSchemeTypeFromString(tokenType) != MSIDAuthSchemePop)
+    {
+        return [[MSIDAuthenticationScheme alloc] initWithSchemeParameters:[NSDictionary new]];
+    }
+    return authSchemeFromResumeState;
 }
 
 @end

--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
@@ -186,7 +186,7 @@
     NSString *requestConf = resumeState[MSID_OAUTH2_REQUEST_CONFIRMATION];
     [schemeParams msidSetNonEmptyString:tokenType forKey:MSID_OAUTH2_TOKEN_TYPE];
     [schemeParams msidSetNonEmptyString:requestConf forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
-    if (tokenType && MSIDAuthSchemeTypeFromString(tokenType) == MSIDAuthSchemePop)
+    if (![NSString msidIsStringNilOrBlank:tokenType] && MSIDAuthSchemeTypeFromString(tokenType) == MSIDAuthSchemePop)
     {
         return [[MSIDAuthenticationSchemePop alloc] initWithSchemeParameters:schemeParams];
     }
@@ -316,7 +316,7 @@
     if (![authSchemeFromResumeState isMemberOfClass:MSIDAuthenticationSchemePop.class]) return authSchemeFromResumeState;
     
     NSString *tokenType = [brokerResponse.formDictionary msidObjectForKey:MSID_OAUTH2_TOKEN_TYPE ofClass:[NSString class]];
-    if (!tokenType || MSIDAuthSchemeTypeFromString(tokenType) != MSIDAuthSchemePop)
+    if ([NSString msidIsStringNilOrBlank:tokenType] || MSIDAuthSchemeTypeFromString(tokenType) != MSIDAuthSchemePop)
     {
         return [[MSIDAuthenticationScheme alloc] initWithSchemeParameters:[NSDictionary new]];
     }

--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
@@ -149,8 +149,6 @@
         if (error) *error = brokerError;
         return nil;
     }
-    // Sync authScheme from resume state after we decrypt response from broker
-    authScheme = [self synchronizeAuthSchemeFromBrokerResponse:authScheme brokerResponse:brokerResponse];
     
     NSString *applicationToken = brokerResponse.applicationToken;
     
@@ -309,18 +307,6 @@
              hasCompletionBlock:(__unused BOOL)hasCompletionBlock
 {
     return YES;
-}
-
-- (MSIDAuthenticationScheme *)synchronizeAuthSchemeFromBrokerResponse:(MSIDAuthenticationScheme *)authSchemeFromResumeState                                                                brokerResponse:(MSIDBrokerResponse *)brokerResponse
-{
-    if (![authSchemeFromResumeState isMemberOfClass:MSIDAuthenticationSchemePop.class]) return authSchemeFromResumeState;
-    
-    NSString *tokenType = [brokerResponse.formDictionary msidObjectForKey:MSID_OAUTH2_TOKEN_TYPE ofClass:[NSString class]];
-    if ([NSString msidIsStringNilOrBlank:tokenType] || MSIDAuthSchemeTypeFromString(tokenType) != MSIDAuthSchemePop)
-    {
-        return [[MSIDAuthenticationScheme alloc] initWithSchemeParameters:[NSDictionary new]];
-    }
-    return authSchemeFromResumeState;
 }
 
 @end

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
@@ -33,6 +33,8 @@
 #import "MSIDAccountMetadataCacheAccessor.h"
 #import "MSIDAccountIdentifier.h"
 #import "MSIDIntuneApplicationStateManager.h"
+#import "MSIDAuthenticationScheme.h"
+#import "MSIDAuthScheme.h"
 
 @implementation MSIDTokenResponseValidator
 
@@ -96,6 +98,15 @@
             *error = authorityError;
         }
         
+        return nil;
+    }
+    // Verify if the auth scheme from server's response match with the request
+    NSString *tokenType = [tokenResponse.tokenType lowercaseString];
+    MSIDAuthScheme scheme = configuration.authScheme.authScheme;
+    NSString *tokenTypeFromConfiguration = [MSIDAuthSchemeParamFromType(scheme) lowercaseString];
+    if (![NSString msidIsStringNilOrBlank:tokenType] && ![tokenType isEqualToString:tokenTypeFromConfiguration])
+    {
+        MSIDFillAndLogError(error, MSIDErrorServerInvalidResponse, @"Please update Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.", correlationID);
         return nil;
     }
     

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
@@ -93,7 +93,7 @@
         NSString *tokenType = [decryptedResponse msidObjectForKey:MSID_OAUTH2_TOKEN_TYPE ofClass:[NSString class]];
         if ([NSString msidIsStringNilOrBlank:tokenType] || MSIDAuthSchemeTypeFromString(tokenType) != MSIDAuthSchemePop)
         {
-            MSIDFillAndLogError(error, MSIDErrorBrokerMismatchedResumeState, @"Please update Intune Company Portal and/or Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.", correlationID);
+            MSIDFillAndLogError(error, MSIDErrorServerInvalidResponse, @"Please update Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.", correlationID);
             return nil;
         }
     }

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
@@ -87,20 +87,20 @@
         return nil;
     }
     
+    BOOL authSchemeError = FALSE;
     // In case MSAL requests AT POP but Broker response Bearer, MSAL returns error to user
     if ([authScheme isMemberOfClass:MSIDAuthenticationSchemePop.class])
     {
         NSString *tokenType = [decryptedResponse msidObjectForKey:MSID_OAUTH2_TOKEN_TYPE ofClass:[NSString class]];
         if ([NSString msidIsStringNilOrBlank:tokenType] || MSIDAuthSchemeTypeFromString(tokenType) != MSIDAuthSchemePop)
         {
-            MSIDFillAndLogError(error, MSIDErrorServerInvalidResponse, @"Please update Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.", correlationID);
-            return nil;
+            authSchemeError = TRUE;
         }
     }
     
     // Save additional tokens,
     // assuming they could come in both successful case and failure case.
-    if (decryptedResponse[@"additional_tokens"])
+    if (decryptedResponse[@"additional_tokens"] && !authSchemeError)
     {
         MSIDTokenResult *tokenResult = nil;
         NSError *additionalTokensError = nil;
@@ -136,21 +136,31 @@
         }
     }
     
-    // Successful case
-    if ([NSString msidIsStringNilOrBlank:decryptedResponse[@"broker_error_domain"]]
-        && [decryptedResponse[@"success"] boolValue])
-    {
-        return [[MSIDAADV2BrokerResponse alloc] initWithDictionary:decryptedResponse error:error];
-    }
-    
-    // Failure case
     MSIDAADV2BrokerResponse *brokerResponse = [[MSIDAADV2BrokerResponse alloc] initWithDictionary:decryptedResponse error:error];
     
+    // Error when initializing broker response
     if (!brokerResponse)
     {
         return nil;
     }
     
+    // Successful response from broker
+    if ([NSString msidIsStringNilOrBlank:decryptedResponse[@"broker_error_domain"]]
+        && [decryptedResponse[@"success"] boolValue])
+    {
+        // if authscheme is invalid, we want to return error to user
+        if (authSchemeError)
+        {
+            MSIDFillAndLogError(error, MSIDErrorServerInvalidResponse, @"Please update Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.", correlationID);
+            return nil;
+        }
+        else
+        {
+            return brokerResponse;
+        }
+    }
+    
+    // Failure response from broker
     NSError *brokerError = [self resultFromBrokerErrorResponse:brokerResponse];
     
     if (error)

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
@@ -87,13 +87,14 @@
         return nil;
     }
     
-    // In case MSAL requests AT POP but Broker response Bearer, we need to update authScheme
+    // In case MSAL requests AT POP but Broker response Bearer, MSAL returns error to user
     if ([authScheme isMemberOfClass:MSIDAuthenticationSchemePop.class])
     {
         NSString *tokenType = [decryptedResponse msidObjectForKey:MSID_OAUTH2_TOKEN_TYPE ofClass:[NSString class]];
-        if (!tokenType || MSIDAuthSchemeTypeFromString(tokenType) != MSIDAuthSchemePop)
+        if ([NSString msidIsStringNilOrBlank:tokenType] || MSIDAuthSchemeTypeFromString(tokenType) != MSIDAuthSchemePop)
         {
-            authScheme = [[MSIDAuthenticationScheme alloc] initWithSchemeParameters:[NSDictionary new]];
+            MSIDFillAndLogError(error, MSIDErrorBrokerMismatchedResumeState, @"Protocol from broker's response is mismatched", correlationID);
+            return nil;
         }
     }
     

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
@@ -93,7 +93,7 @@
         NSString *tokenType = [decryptedResponse msidObjectForKey:MSID_OAUTH2_TOKEN_TYPE ofClass:[NSString class]];
         if ([NSString msidIsStringNilOrBlank:tokenType] || MSIDAuthSchemeTypeFromString(tokenType) != MSIDAuthSchemePop)
         {
-            MSIDFillAndLogError(error, MSIDErrorBrokerMismatchedResumeState, @"Protocol from broker's response is mismatched", correlationID);
+            MSIDFillAndLogError(error, MSIDErrorBrokerMismatchedResumeState, @"Please update Intune Company Portal and/or Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.", correlationID);
             return nil;
         }
     }

--- a/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
@@ -1336,6 +1336,55 @@
     XCTAssertFalse(result);
 }
 
+
+-(void)testCanHandleBrokerResponse_whenAuthSchemeinResumeStateIsPop_AndBrokerResponseIsSuccess_AndAuthSchemeinBrokerResponseIsPop_shouldReturnBrokerResponse
+{
+    [self saveResumeStateWithauthScheme:@"Pop"];
+    NSURL *brokerResponseURL = [self createPopResponseFromBroker];
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+        NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+}
+
+-(void)testCanHandleBrokerResponse_whenAuthSchemeinResumeStateIsBearer_AndBrokerResponseIsSuccess_AndAuthSchemeinBrokerResponseIsBearer_shouldReturnBrokerResponse
+{
+    [self saveResumeStateWithauthScheme:@"Bearer"];
+    NSURL *brokerResponseURL = [self createBearerResponseFromBroker];
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+}
+
+-(void)testCanHandleBrokerResponse_whenAuthSchemeinResumeStateIsPop_AndBrokerResponseIsSuccess_AndAuthSchemeinBrokerResponseIsBearer_shouldReturnAuthSchemeError
+{
+    [self saveResumeStateWithauthScheme:@"Pop"];
+    NSURL *brokerResponseURL = [self createBearerResponseFromBroker];
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+    XCTAssertNotNil(error);
+    XCTAssertNil(result);
+    NSString *expectedErrorDescription = @"Please update Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.";
+    XCTAssertEqual(error.userInfo[MSIDErrorDescriptionKey], expectedErrorDescription);
+}
+
+-(void)testCanHandleBrokerResponse_whenAuthSchemeinResumeStateIsPop_AndBrokerResponseIsFailure_AndAuthSchemeinBrokerResponseIsBearer_shouldReturnResponseError
+{
+    [self saveResumeStateWithauthScheme:@"Pop"];
+    NSURL *brokerResponseURL = [self createFailureResponseFromBroker];
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+    XCTAssertNotNil(error);
+    XCTAssertNil(result);
+    NSString *expectedErrorDescription = @"Please update Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.";
+    XCTAssertNotEqual(error.userInfo[MSIDErrorDescriptionKey], expectedErrorDescription);
+}
+
 #pragma mark - Helpers
 
 - (void)saveResumeStateWithAuthority:(NSString *)authority
@@ -1350,6 +1399,114 @@
                                   };
     
     [[NSUserDefaults standardUserDefaults] setObject:resumeState forKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
+}
+
+- (void)saveResumeStateWithauthScheme:(NSString *)authScheme
+{
+    NSDictionary *resumeState = nil;
+    if ([authScheme isEqualToString:@"Pop"])
+    {
+        resumeState = @{@"authority" : @"https://login.microsoftonline.com/common",
+                        @"scope" : @"myscope1 myscope2",
+                        @"keychain_group" : @"com.microsoft.adalcache",
+                        @"redirect_uri" : @"x-msauth-test://com.microsoft.testapp",
+                        @"broker_nonce" : @"nonce",
+                        @"instance_aware" : @"NO",
+                        @"provided_authority_url" : @"https://login.microsoftonline.com/common",
+                        @"token_type": @"Pop",
+                        @"req_cnf": @"eyJraWQiOiJPeEF6UW55cEpBTnNtTERXTU1lRWJFZHM5ZERHbGtRS09iZkJrRW4zXzk0In0",
+        };
+    }
+    else
+    {
+        resumeState = @{@"authority" : @"https://login.microsoftonline.com/common",
+            @"scope" : @"myscope1 myscope2",
+            @"keychain_group" : @"com.microsoft.adalcache",
+            @"redirect_uri" : @"x-msauth-test://com.microsoft.testapp",
+            @"broker_nonce" : @"nonce",
+            @"instance_aware" : @"NO",
+            @"provided_authority_url" : @"https://login.microsoftonline.com/common",
+        };
+    }
+    
+    [[NSUserDefaults standardUserDefaults] setObject:resumeState forKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
+}
+
+- (NSURL *)createBearerResponseFromBroker
+{
+    NSDictionary *clientInfo = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
+    NSString *rawClientInfo = [clientInfo msidBase64UrlJson];
+    NSDictionary *brokerResponseParams =
+    @{
+        @"authority" : @"https://login.microsoftonline.com/common",
+        @"scope" : @"myscope",
+        @"client_id" : @"my_client_id",
+        @"id_token" : @"token_string",
+        @"client_info" : rawClientInfo,
+        @"home_account_id" : @"1.1234-5678-90abcdefg",
+        @"access_token" : @"i-am-a-access-token",
+        @"token_type" : @"Bearer",
+        @"refresh_token" : @"i-am-a-refresh-token",
+        @"correlation_id" : @"uuid1",
+        @"x-broker-app-ver" : @"1.0.0",
+        @"foci" : @"1",
+        @"success": @YES,
+        @"broker_nonce" : @"nonce"
+    };
+    
+    NSURL *brokerResponseURL = [MSIDTestBrokerResponseHelper createDefaultBrokerResponse:brokerResponseParams
+                                                                             redirectUri:@"x-msauth-test://com.microsoft.testapp"
+                                                                           encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];
+    return brokerResponseURL;
+}
+
+- (NSURL *)createPopResponseFromBroker
+{
+    NSDictionary *clientInfo = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
+    NSString *rawClientInfo = [clientInfo msidBase64UrlJson];
+    NSDictionary *brokerResponseParams =
+    @{
+        @"authority" : @"https://login.microsoftonline.com/common",
+        @"scope" : @"myscope",
+        @"client_id" : @"my_client_id",
+        @"id_token" : @"token_string",
+        @"client_info" : rawClientInfo,
+        @"home_account_id" : @"1.1234-5678-90abcdefg",
+        @"access_token" : @"i-am-a-access-token",
+        @"token_type" : @"Pop",
+        @"req_cnf" : @"eyJraWQiOiJPeEF6UW55cEpBTnNtTERXTU1lRWJFZHM5ZERHbGtRS09iZkJrRW4zXzk0In0",
+        @"refresh_token" : @"i-am-a-refresh-token",
+        @"correlation_id" : @"uuid1",
+        @"x-broker-app-ver" : @"1.0.0",
+        @"foci" : @"1",
+        @"success": @YES,
+        @"broker_nonce" : @"nonce"
+    };
+    
+    NSURL *brokerResponseURL = [MSIDTestBrokerResponseHelper createDefaultBrokerResponse:brokerResponseParams
+                                                                             redirectUri:@"x-msauth-test://com.microsoft.testapp"
+                                                                           encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];
+    return brokerResponseURL;
+}
+
+- (NSURL *)createFailureResponseFromBroker
+{
+    NSDictionary *brokerResponseParams =
+    @{
+        @"broker_error_code" : @"-50005",
+        @"broker_error_domain" : @"MSALErrorDomain",
+        @"broker_nonce" : @"nonce",
+        @"correlation_id" : @"uuid",
+        @"error_description" : @"Authentication error - User cancelled authentication flow",
+        @"error_metadata" : @"{}",
+        @"success" : @NO,
+        @"x-broker-app-ver" : @"1.0",
+    };
+    
+    NSURL *brokerResponseURL = [MSIDTestBrokerResponseHelper createDefaultBrokerResponse:brokerResponseParams
+                                                                             redirectUri:@"x-msauth-test://com.microsoft.testapp"
+                                                                           encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];
+    return brokerResponseURL;
 }
 
 @end

--- a/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
@@ -1381,9 +1381,23 @@
     MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
     XCTAssertNotNil(error);
     XCTAssertNil(result);
-    NSString *expectedErrorDescription = @"Please update Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.";
-    XCTAssertNotEqual(error.userInfo[MSIDErrorDescriptionKey], expectedErrorDescription);
+    NSString *authMismatchErrorDescription = @"Please update Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.";
+    XCTAssertNotEqual(error.userInfo[MSIDErrorDescriptionKey], authMismatchErrorDescription);
 }
+
+-(void)testCanHandleBrokerResponse_whenAuthSchemeinResumeStateIsPop_AndBrokerResponseIsFailure_WithAdditionalTokens_shouldReturnResponseError
+{
+    [self saveResumeStateWithauthScheme:@"Pop"];
+    NSURL *brokerResponseURL = [self createFailureResponseFromBrokerWithAdditionalToken];
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+    XCTAssertNotNil(error);
+    XCTAssertNil(result);
+    NSString *authMismatchErrorDescription = @"Please update Microsoft Authenticator to the latest version. Pop tokens are not supported with this broker version.";
+    XCTAssertNotEqual(error.userInfo[MSIDErrorDescriptionKey], authMismatchErrorDescription);
+}
+
 
 #pragma mark - Helpers
 
@@ -1503,6 +1517,28 @@
         @"x-broker-app-ver" : @"1.0",
     };
     
+    NSURL *brokerResponseURL = [MSIDTestBrokerResponseHelper createDefaultBrokerResponse:brokerResponseParams
+                                                                             redirectUri:@"x-msauth-test://com.microsoft.testapp"
+                                                                           encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];
+    return brokerResponseURL;
+}
+
+- (NSURL *)createFailureResponseFromBrokerWithAdditionalToken
+{
+    NSDictionary *brokerResponseParams =
+    @{
+            
+        @"additional_tokens" :@"{\"client_info\":\"eyJ1aWQiOiI1ODY4YWUzYS0wY2IwLTQwODUtYmI1ZC1mYzc3YzAwN2Q2ODQiLCJ1dGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIn0\",\"authority\":\"https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca\",\"token_type\":\"Bearer\",\"x-broker-app-ver\":\"1.0\",\"refresh_token\":\"refreshtoken\",\"scope\":\"https://msmamservice.api.application/user_impersonation https://msmamservice.api.application/.default\",\"ext_expires_on\":\"1594853027\",\"foci\":\"1\",\"application_token\":\"app token\",\"expires_on\":\"1594853027\",\"success\":true,\"correlation_id\":\"0D74889A-AAC4-4D0C-9956-797E47AFACFB\",\"client_id\":\"27922004-5251-4030-b22d-91ecd9a37ea4\",\"id_token\":\"idtoken\",\"vt\":\"YES\",\"access_token\":\"access token\"}",
+        @"broker_error_code" : @"-50004",
+        @"broker_error_domain" : @"MSALErrorDomain",
+        @"broker_nonce" : @"nonce",
+        @"correlation_id" : @"UUID",
+        @"error" : @"unauthorized_client",
+        @"error_description" : @"AADSTS53005: Application needs to enforce Intune protection policies",
+        @"suberror" : @"protection_policy_required",
+        @"success" : @NO,
+        @"x-broker-app-ver" : @"1.0",
+    };
     NSURL *brokerResponseURL = [MSIDTestBrokerResponseHelper createDefaultBrokerResponse:brokerResponseParams
                                                                              redirectUri:@"x-msauth-test://com.microsoft.testapp"
                                                                            encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];


### PR DESCRIPTION
## Proposed changes:
In case the Pop request from MSAL is corrupted, fallback broker to use Bearer Scheme.
Related PRs:
[MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/996)

[Broker](https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/542)
## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

