### PR TITLE
Remove Account metadata when Remove Account in Broker

### DIFF
--- a/IdentityCore/src/cache/MSIDKeychainTokenCache.m
+++ b/IdentityCore/src/cache/MSIDKeychainTokenCache.m
@@ -443,7 +443,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
                                                  context:(id<MSIDRequestContext>)context
                                                    error:(NSError **)error
 {
-    NSArray *metadataItems = [self cacheItemsWithKey:key serializer:serializer cacheItemClass:MSIDAccountMetadataCacheItem.class context:context error:error];
+    NSArray *metadataItems = [self accountsMetadataWithKey:key serializer:serializer context:context error:error];
     if (!metadataItems) return nil;
     
     if (metadataItems.count < 1)
@@ -453,6 +453,14 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
     }
     
     return metadataItems[0];
+}
+
+- (NSArray<MSIDAccountMetadataCacheItem *> *)accountsMetadataWithKey:(MSIDCacheKey *)key
+                                                          serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
+                                                             context:(id<MSIDRequestContext>)context
+                                                               error:(NSError **)error
+{
+    return [self cacheItemsWithKey:key serializer:serializer cacheItemClass:MSIDAccountMetadataCacheItem.class context:context error:error];
 }
 
 #pragma mark - Removal

--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -975,16 +975,12 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
                                                  context:(id<MSIDRequestContext>)context
                                                    error:(NSError *__autoreleasing *)error
 {
-    MSIDMacCredentialStorageItem *storageItem = key.isShared ? self.sharedStorageItem : self.appStorageItem;
-    NSArray *itemList = [storageItem storedItemsForKey:key];
-    
-    /*
-     Merge in memory with persistence only if not found in memory to cover the case when 2 apps sharing the same clientId can modify the same entry in the keychain.
-     */
-    if (![itemList count])
+    NSError *localError;
+    NSArray *itemList = [self accountsMetadataWithKey:key serializer:serializer context:context error:&localError];
+    if (localError)
     {
-        storageItem = [self syncStorageItem:key.isShared serializer:serializer context:context error:error];
-        itemList = [storageItem storedItemsForKey:key];
+        if (error) *error = localError;
+        return nil;
     }
     
     if (itemList.count > 1)
@@ -999,7 +995,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     
 }
 
-- (NSArray<MSIDAccountMetadata *> *)accountsMetadataWithKey:(MSIDCacheKey *)key
+- (NSArray<MSIDAccountMetadataCacheItem *> *)accountsMetadataWithKey:(MSIDCacheKey *)key
                                                           serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                              context:(id<MSIDRequestContext>)context
                                                                error:(NSError **)error

--- a/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
+++ b/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
@@ -299,6 +299,8 @@
         return NO;
     }
     
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Remove account metadata for home account id: %@.", MSID_PII_LOG_MASKABLE(homeAccountId));
+    
     NSError *localError;
     NSArray<MSIDAccountMetadataCacheItem *> *cacheItems = [self allAccountMetadataCacheItemsWithContext:context error:&localError];
     if (localError)
@@ -307,14 +309,19 @@
         return NO;
     }
     
+    BOOL success = YES;
+    
     for (MSIDAccountMetadataCacheItem *cacheItem in cacheItems)
     {
         localError = nil;
         [cacheItem removeAccountMetadataForHomeAccountId:homeAccountId error:&localError];
         if (localError)
         {
+            success = NO;
             if (error) *error = localError;
-            return NO;
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to remove account metadata from cache item!");
+            
+            continue;
         }
         
         localError = nil;
@@ -325,12 +332,15 @@
         
         if (localError)
         {
+            success = NO;
             if (error) *error = localError;
-            return NO;
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to save cache item after removing account metadata!");
+            
+            continue;
         }
     }
     
-    return YES;
+    return success;
 }
 
 - (NSArray<MSIDAccountMetadataCacheItem *> *)allAccountMetadataCacheItemsWithContext:(id<MSIDRequestContext>)context

--- a/IdentityCore/src/cache/metadata/MSIDMetadataCache.h
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCache.h
@@ -52,4 +52,7 @@
                                                           context:(id<MSIDRequestContext>)context
                                                             error:(NSError **)error;
 
+- (NSArray<MSIDAccountMetadataCacheItem *> *)allAccountMetadataCacheItemsWithContext:(id<MSIDRequestContext>)context
+                                                                               error:(NSError **)error;
+
 @end

--- a/IdentityCore/src/cache/metadata/MSIDMetadataCacheDataSource.h
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCacheDataSource.h
@@ -39,6 +39,11 @@
                                                  context:(id<MSIDRequestContext>)context
                                                    error:(NSError **)error;
 
+- (NSArray<MSIDAccountMetadataCacheItem *> *)accountsMetadataWithKey:(MSIDCacheKey *)key
+                                                          serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
+                                                             context:(id<MSIDRequestContext>)context
+                                                               error:(NSError **)error;
+
 - (BOOL)removeAccountMetadataForKey:(MSIDCacheKey *)key
                             context:(id<MSIDRequestContext>)context
                               error:(NSError **)error;

--- a/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadataCacheItem.h
+++ b/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadataCacheItem.h
@@ -44,6 +44,9 @@ NS_ASSUME_NONNULL_BEGIN
           forHomeAccountId:(NSString *)homeAccountId
                      error:(NSError **)error;
 
+- (BOOL)removeAccountMetadataForHomeAccountId:(NSString *)homeAccountId
+                                        error:(NSError **)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadataCacheItem.m
+++ b/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadataCacheItem.m
@@ -75,6 +75,20 @@
     return YES;
 }
 
+- (BOOL)removeAccountMetadataForHomeAccountId:(NSString *)homeAccountId
+                                        error:(NSError **)error
+{
+    if ([NSString msidIsStringNilOrBlank:homeAccountId])
+    {
+        NSError *localError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"Cannot remove account metadata with empty homeAccountId!", nil, nil, nil, nil, nil, YES);
+        if (error) *error = localError;
+        return NO;
+    }
+    
+    [_accountMetadataMap removeObjectForKey:homeAccountId];
+    return YES;
+}
+
 
 #pragma mark - MSIDJsonSerializable
 

--- a/IdentityCore/tests/MSIDAccountMetadataCacheItemTests.m
+++ b/IdentityCore/tests/MSIDAccountMetadataCacheItemTests.m
@@ -83,6 +83,25 @@
     XCTAssertEqualObjects(metadata, [cacheItem accountMetadataForHomeAccountId:@"uid.utid"]);
 }
 
+- (void)testRemoveAccountMetadataForHomeAccountId_whenAccountMetadataMatched_shouldReturnIt {
+    MSIDAccountMetadataCacheItem *cacheItem = [[MSIDAccountMetadataCacheItem alloc] initWithClientId:@"client-id"];
+
+    MSIDAccountMetadata *metadata = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"uid.utid" clientId:@"client-id"];
+    MSIDAccountMetadata *metadata2 = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"uid2.utid2" clientId:@"client-id"];
+    XCTAssertTrue([cacheItem addAccountMetadata:metadata forHomeAccountId:@"uid.utid" error:nil]);
+    XCTAssertTrue([cacheItem addAccountMetadata:metadata2 forHomeAccountId:@"uid2.utid2" error:nil]);
+
+    // Remove account metadata
+    NSError *error;
+    XCTAssertTrue([cacheItem removeAccountMetadataForHomeAccountId:@"uid.utid" error:&error]);
+    XCTAssertNil(error);
+
+    
+    XCTAssertNil([cacheItem accountMetadataForHomeAccountId:@"uid.utid"]);
+    MSIDAccountMetadata *metadataFromCache = [cacheItem accountMetadataForHomeAccountId:@"uid2.utid2"];
+    XCTAssertEqualObjects(metadata2, metadataFromCache);
+}
+
 - (void)testJSONDictionary_whenAllFieldsSet_shouldReturnJSONDictionaryWithAccountKey
 {
     MSIDAccountMetadataCacheItem *cacheItem = [[MSIDAccountMetadataCacheItem alloc] initWithClientId:@"clientId"];

--- a/IdentityCore/tests/integration/ios/MSIDKeychainTokenCacheIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDKeychainTokenCacheIntegrationTests.m
@@ -696,4 +696,51 @@
     XCTAssertNil(error);
     XCTAssertNil([keychainTokenCache accountMetadataWithKey:key serializer:serializer context:nil error:nil]);
 }
+
+- (void)testAccountsMetadataWithKey_whenMultipleAccountMetadata_shouldReturnThem
+{
+    MSIDKeychainTokenCache *keychainTokenCache = [MSIDKeychainTokenCache new];
+    MSIDCacheItemJsonSerializer *serializer = [MSIDCacheItemJsonSerializer new];
+    
+    // Save account metadata item 1
+    MSIDAccountMetadataCacheKey *key1 = [[MSIDAccountMetadataCacheKey alloc] initWithClientId:@"clientId1"];
+    MSIDAccountMetadataCacheItem *cacheItem1 = [[MSIDAccountMetadataCacheItem alloc] initWithClientId:@"clientId1"];
+    
+    MSIDAccountMetadata *metadata1 = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"homeAccountId" clientId:@"clientId1"];
+    [metadata1 setCachedURL:[NSURL URLWithString:@"https://internalContoso1.com"] forRequestURL:[NSURL URLWithString:@"https://contoso1.com"] instanceAware:NO error:nil];
+    MSIDAccountMetadata *metadata2 = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"homeAccountId2" clientId:@"clientId1"];
+    [metadata2 setCachedURL:[NSURL URLWithString:@"https://internalContoso2.com"] forRequestURL:[NSURL URLWithString:@"https://contoso2.com"] instanceAware:NO error:nil];
+    [cacheItem1 addAccountMetadata:metadata1 forHomeAccountId:@"homeAccountId" error:nil];
+    [cacheItem1 addAccountMetadata:metadata2 forHomeAccountId:@"homeAccountId2" error:nil];
+
+    NSError *error;
+    XCTAssertTrue([keychainTokenCache saveAccountMetadata:cacheItem1 key:key1 serializer:serializer context:nil error:&error]);
+    XCTAssertNil(error);
+    
+    // Save account metadata item 2
+    MSIDAccountMetadataCacheKey *key2 = [[MSIDAccountMetadataCacheKey alloc] initWithClientId:@"clientId2"];
+    MSIDAccountMetadataCacheItem *cacheItem2 = [[MSIDAccountMetadataCacheItem alloc] initWithClientId:@"clientId2"];
+    
+    MSIDAccountMetadata *metadata3 = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"homeAccountId3" clientId:@"clientId2"];
+    [metadata3 setCachedURL:[NSURL URLWithString:@"https://internalContoso3.com"] forRequestURL:[NSURL URLWithString:@"https://contoso3.com"] instanceAware:NO error:nil];
+    MSIDAccountMetadata *metadata4 = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"homeAccountId4" clientId:@"clientId2"];
+    [metadata4 setCachedURL:[NSURL URLWithString:@"https://internalContoso4.com"] forRequestURL:[NSURL URLWithString:@"https://contoso4.com"] instanceAware:NO error:nil];
+    [cacheItem2 addAccountMetadata:metadata3 forHomeAccountId:@"homeAccountId3" error:nil];
+    [cacheItem2 addAccountMetadata:metadata4 forHomeAccountId:@"homeAccountId4" error:nil];
+    
+    error = nil;
+    XCTAssertTrue([keychainTokenCache saveAccountMetadata:cacheItem2 key:key2 serializer:serializer context:nil error:&error]);
+    XCTAssertNil(error);
+    
+    // Verify items from cache
+    MSIDAccountMetadataCacheKey *retrieveKey = [[MSIDAccountMetadataCacheKey alloc] initWithClientId:nil];
+    NSArray *itemsFromCache = [keychainTokenCache accountsMetadataWithKey:retrieveKey serializer:serializer context:nil error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertEqual(itemsFromCache.count, 2);
+    
+    XCTAssertEqualObjects(itemsFromCache[0], cacheItem1);
+    XCTAssertEqualObjects(itemsFromCache[1], cacheItem2);
+}
+
 @end

--- a/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
+++ b/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
@@ -1036,4 +1036,49 @@
     XCTAssertNil([_dataSource accountMetadataWithKey:key serializer:serializer context:nil error:nil]);
 }
 
+- (void)testAccountsMetadataWithKey_whenMultipleAccountMetadata_shouldReturnThem
+{
+    MSIDCacheItemJsonSerializer *serializer = [MSIDCacheItemJsonSerializer new];
+    
+    // Save account metadata item 1
+    MSIDAccountMetadataCacheKey *key1 = [[MSIDAccountMetadataCacheKey alloc] initWithClientId:@"clientId1"];
+    MSIDAccountMetadataCacheItem *cacheItem1 = [[MSIDAccountMetadataCacheItem alloc] initWithClientId:@"clientId1"];
+    
+    MSIDAccountMetadata *metadata1 = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"homeAccountId" clientId:@"clientId1"];
+    [metadata1 setCachedURL:[NSURL URLWithString:@"https://internalContoso1.com"] forRequestURL:[NSURL URLWithString:@"https://contoso1.com"] instanceAware:NO error:nil];
+    MSIDAccountMetadata *metadata2 = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"homeAccountId2" clientId:@"clientId1"];
+    [metadata2 setCachedURL:[NSURL URLWithString:@"https://internalContoso2.com"] forRequestURL:[NSURL URLWithString:@"https://contoso2.com"] instanceAware:NO error:nil];
+    [cacheItem1 addAccountMetadata:metadata1 forHomeAccountId:@"homeAccountId" error:nil];
+    [cacheItem1 addAccountMetadata:metadata2 forHomeAccountId:@"homeAccountId2" error:nil];
+
+    NSError *error;
+    XCTAssertTrue([_dataSource saveAccountMetadata:cacheItem1 key:key1 serializer:serializer context:nil error:&error]);
+    XCTAssertNil(error);
+    
+    // Save account metadata item 2
+    MSIDAccountMetadataCacheKey *key2 = [[MSIDAccountMetadataCacheKey alloc] initWithClientId:@"clientId2"];
+    MSIDAccountMetadataCacheItem *cacheItem2 = [[MSIDAccountMetadataCacheItem alloc] initWithClientId:@"clientId2"];
+    
+    MSIDAccountMetadata *metadata3 = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"homeAccountId3" clientId:@"clientId2"];
+    [metadata3 setCachedURL:[NSURL URLWithString:@"https://internalContoso3.com"] forRequestURL:[NSURL URLWithString:@"https://contoso3.com"] instanceAware:NO error:nil];
+    MSIDAccountMetadata *metadata4 = [[MSIDAccountMetadata alloc] initWithHomeAccountId:@"homeAccountId4" clientId:@"clientId2"];
+    [metadata4 setCachedURL:[NSURL URLWithString:@"https://internalContoso4.com"] forRequestURL:[NSURL URLWithString:@"https://contoso4.com"] instanceAware:NO error:nil];
+    [cacheItem2 addAccountMetadata:metadata3 forHomeAccountId:@"homeAccountId3" error:nil];
+    [cacheItem2 addAccountMetadata:metadata4 forHomeAccountId:@"homeAccountId4" error:nil];
+    
+    error = nil;
+    XCTAssertTrue([_dataSource saveAccountMetadata:cacheItem2 key:key2 serializer:serializer context:nil error:&error]);
+    XCTAssertNil(error);
+    
+    // Verify items from cache
+    MSIDAccountMetadataCacheKey *retrieveKey = [[MSIDAccountMetadataCacheKey alloc] initWithClientId:nil];
+    NSArray *itemsFromCache = [_dataSource accountsMetadataWithKey:retrieveKey serializer:serializer context:nil error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertEqual(itemsFromCache.count, 2);
+    
+    XCTAssertEqualObjects(itemsFromCache[0], cacheItem1);
+    XCTAssertEqualObjects(itemsFromCache[1], cacheItem2);
+}
+
 @end

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.h
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.h
@@ -49,6 +49,11 @@ struct MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams
     NSString * _Nullable accountEnvironment;
 };
 
+struct MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams
+{
+    NSString * _Nullable homeAccountId;
+};
+
 @interface MSIDAccountMetadataCacheAccessorMock : MSIDAccountMetadataCacheAccessor
 
 @property (nonatomic) NSInteger updateAuthorityURLInvokedCount;
@@ -65,6 +70,12 @@ struct MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams
 @property (nonatomic) NSError *updatePrincipalAccountIdError;
 @property (nonatomic) NSInteger updatePrincipalAccountIdInvokedCount;
 @property (nonatomic) struct MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams updatePrincipalAccountIdParams;
+
+@property (nonatomic) BOOL removeAccountMetadataForHomeAccountIdResult;
+@property (nonatomic) NSError *removeAccountMetadataForHomeAccountIdError;
+@property (nonatomic) NSInteger removeAccountMetadataForHomeAccountIdInvokedCount;
+@property (nonatomic) struct MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams removeAccountMetadataForHomeAccountIdParams;
+
 
 @end
 

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
@@ -101,7 +101,7 @@
 }
 
 - (BOOL)removeAccountMetadataForHomeAccountId:(NSString *)homeAccountId
-                                      context:(id<MSIDRequestContext>)context
+                                      context:(__unused id<MSIDRequestContext>)context
                                         error:(NSError **)error
 {
     if (error) *error = self.removeAccountMetadataForHomeAccountIdError;

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
@@ -100,4 +100,19 @@
     return self.updatePrincipalAccountIdResult;
 }
 
+- (BOOL)removeAccountMetadataForHomeAccountId:(NSString *)homeAccountId
+                                      context:(id<MSIDRequestContext>)context
+                                        error:(NSError **)error
+{
+    if (error) *error = self.removeAccountMetadataForHomeAccountIdError;
+    
+    struct MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams s  = self.removeAccountMetadataForHomeAccountIdParams;
+    s.homeAccountId = homeAccountId;
+    self.removeAccountMetadataForHomeAccountIdParams = s;
+    
+    self.removeAccountMetadataForHomeAccountIdInvokedCount++;
+    
+    return self.removeAccountMetadataForHomeAccountIdResult;
+}
+
 @end


### PR DESCRIPTION
## Proposed changes

Added API to `MSIDAccountMetadataCacheAccessor` to remove account metadata by home account id. Such an API will be used by broker.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

