### PR TITLE
Revert CBA URL change

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler+iOS.h
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler+iOS.h
@@ -34,6 +34,7 @@
                    forScheme:(NSString *)scheme;
 
 + (void)setUseAuthSession:(BOOL)useAuthSession;
++ (void)setUseLastRequestURL:(BOOL)useLastRequestURL;
 
 // These are for cert auth challenge for iOS
 + (void)setCustomActivities:(NSArray<UIActivity *> *)activities;

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
@@ -38,6 +38,7 @@ static NSString *s_redirectPrefix = nil;
 static NSString *s_redirectScheme = nil;
 static MSIDSystemWebviewController *s_systemWebViewController = nil;
 static BOOL s_useAuthSession = NO;
+static BOOL s_useLastRequestURL = NO;
 
 #endif
 
@@ -55,6 +56,11 @@ static BOOL s_useAuthSession = NO;
 + (void)setUseAuthSession:(BOOL)useAuthSession
 {
     s_useAuthSession = useAuthSession;
+}
+
++ (void)setUseLastRequestURL:(BOOL)useLastRequestURL
+{
+    s_useLastRequestURL = useLastRequestURL;
 }
 
 + (void)setCustomActivities:(NSArray<UIActivity *> *)activities
@@ -134,7 +140,14 @@ static BOOL s_useAuthSession = NO;
         // This will launch a Safari view within the current Application, removing the app flip. Our control of this
         // view is extremely limited. Safari is still running in a separate sandbox almost completely isolated from us.
         
-        s_systemWebViewController = [[MSIDSystemWebviewController alloc] initWithStartURL:requestURL
+        NSURL *currentURL = requestURL;
+        
+        if (s_useLastRequestURL && webview.URL)
+        {
+            currentURL = webview.URL;
+        }
+        
+        s_systemWebViewController = [[MSIDSystemWebviewController alloc] initWithStartURL:currentURL
                                                                               redirectURI:redirectURI
                                                                          parentController:parentViewController
                                                                  useAuthenticationSession:s_useAuthSession

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
@@ -134,14 +134,7 @@ static BOOL s_useAuthSession = NO;
         // This will launch a Safari view within the current Application, removing the app flip. Our control of this
         // view is extremely limited. Safari is still running in a separate sandbox almost completely isolated from us.
         
-        NSURL *currentURL = requestURL;
-        
-        if (s_useAuthSession && webview.URL)
-        {
-            currentURL = webview.URL;
-        }
-        
-        s_systemWebViewController = [[MSIDSystemWebviewController alloc] initWithStartURL:currentURL
+        s_systemWebViewController = [[MSIDSystemWebviewController alloc] initWithStartURL:requestURL
                                                                               redirectURI:redirectURI
                                                                          parentController:parentViewController
                                                                  useAuthenticationSession:s_useAuthSession


### PR DESCRIPTION
## Proposed changes

This is a follow-up PR for this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/775
Instead of enabling using last request URL for all cert based authentication requests, this PR enforces an additional flag.
This will allow us to test out the feature and rollout through various releases with a feature flag and minimize the risk. 

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

