### PR TITLE
New fix - Guest account with different UPN can't find cached access token

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -535,7 +535,7 @@
     cacheQuery.homeAccountId = accountIdentifier.homeAccountId;
     cacheQuery.environmentAliases = [authority defaultCacheEnvironmentAliases];
     cacheQuery.realm = authority.realm;
-    cacheQuery.username = accountIdentifier.displayableId;
+    cacheQuery.username = [NSString msidIsStringNilOrBlank:accountIdentifier.homeAccountId] ? accountIdentifier.displayableId : nil;
     cacheQuery.accountType = MSIDAccountTypeMSSTS;
 
     NSArray<MSIDAccountCacheItem *> *accountCacheItems = [_accountCredentialCache getAccountsWithQuery:cacheQuery context:context error:error];

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -535,8 +535,11 @@
     cacheQuery.homeAccountId = accountIdentifier.homeAccountId;
     cacheQuery.environmentAliases = [authority defaultCacheEnvironmentAliases];
     cacheQuery.realm = authority.realm;
-    cacheQuery.username = [NSString msidIsStringNilOrBlank:accountIdentifier.homeAccountId] ? accountIdentifier.displayableId : nil;
     cacheQuery.accountType = MSIDAccountTypeMSSTS;
+    
+    // If homeAccountId is present, username is not needed for account lookup. Leaving it nil allows accounts to appear in guest
+    // tenants under a different upn and still acquire tokens silently.
+    cacheQuery.username = [NSString msidIsStringNilOrBlank:accountIdentifier.homeAccountId] ? accountIdentifier.displayableId : nil;
 
     NSArray<MSIDAccountCacheItem *> *accountCacheItems = [_accountCredentialCache getAccountsWithQuery:cacheQuery context:context error:error];
 


### PR DESCRIPTION
An issue came from Yammer where a developer was not able to use an access token in the cache when acquiring token silently from a guest tenant. The account had a different UPN in the guest tenant than it did in its home tenant, which caused the account to not be found when creating the access token result from cache. When looking up an account in the cache, only the homeAccountID is necessary if the account has been used with MSAL, while using username in the lookupAccountIdentifier is only necessary for ADAL and for migrating from ADAL to MSAL.

The previous fix for this issues caused a regression, so the is the resulting new fix. Since the fix is within the default account cache accessor, it should not affect ADAL functionality.

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

