### PR TITLE
Fix a test bug in MSIDMacKeychainTokenCacheTests.m

### DIFF
--- a/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
+++ b/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
@@ -83,7 +83,11 @@
     NSError *error;
     MSIDKeychainUtil *keychainUtil = [MSIDKeychainUtil sharedInstance];
     keychainUtil.teamId = @"FakeTeamId";
+    // To ensure that the _dataSource is initialized, we need mark the loginKeychain as non-empty.
+    // MSIDMacKeychainTokenCache::kLoginKeychainEmpty = @"LoginKeychainEmpty"
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"LoginKeychainEmpty"];
     _dataSource = [MSIDMacKeychainTokenCache new];
+    XCTAssertNotNil(_dataSource);
     _cache = [[MSIDAccountCredentialCache alloc] initWithDataSource:_dataSource];
     _serializer = [MSIDCacheItemJsonSerializer new];
     [_cache clearWithContext:nil error:nil];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,9 @@
+* Fix a test bug where the MacKeychainTokenCache could fail to initialize (#799)
 * Save last request telemetry to disk (#768)
 * Fix an incorrectly-cased filename (#808)
 * Save PRT expiry interval in cache to calculate PRT refresh interval more reliably (#804)
-* Move broker redirectUri validation logic into common core from MSAL(#807)
-* Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair. #803
+* Move broker redirectUri validation logic into common core from MSAL (#807)
+* Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair (#803)
 * Add operation factory for broker installation integration with other framework (#779)
 
 Version 1.5.4
@@ -14,7 +15,7 @@ Version 1.5.4
 * Symmetric key support for creating a verify signature and key derivation (#805)
 
 Version 1.5.3
------    
+-----
 * Switch to PkeyAuth on macOS (#734)
 * Support returning additional WPJ info (#742)
 * Fixed PkeyAuth when ADFS challenge is URL encoded (#750)
@@ -37,7 +38,7 @@ Version 1.5.1
 * Fixed authority validation for developer known authorities (#722)
 
 Version 1.5.0
------- 
+------
 * Added Safari SSO support for AAD SSO extension
 * Switched to new lab API
 * Convert access denied error to cancelled


### PR DESCRIPTION
## Proposed changes

Fix a test bug in MSIDMacKeychainTokenCacheTests.m where, if the loginKeychainEmpty key is not reset, then the test will fail, since `_dataSource` will be nil.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

