### PR TITLE
Store PRT expires in time

### DIFF
--- a/IdentityCore/src/MSIDOAuth2Constants.h
+++ b/IdentityCore/src/MSIDOAuth2Constants.h
@@ -109,6 +109,7 @@ extern NSString *const MSID_EXPIRES_ON_CACHE_KEY;
 extern NSString *const MSID_OAUTH_TOKEN_TYPE_CACHE_KEY;
 extern NSString *const MSID_CACHED_AT_CACHE_KEY;
 extern NSString *const MSID_EXTENDED_EXPIRES_ON_CACHE_KEY;
+extern NSString *const MSID_EXPIRES_IN_CACHE_KEY;
 extern NSString *const MSID_SPE_INFO_CACHE_KEY;
 extern NSString *const MSID_RESOURCE_RT_CACHE_KEY;
 extern NSString *const MSID_LOCAL_ACCOUNT_ID_CACHE_KEY;

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -111,6 +111,7 @@ NSString *const MSID_EXPIRES_ON_CACHE_KEY                = @"expires_on";
 NSString *const MSID_OAUTH_TOKEN_TYPE_CACHE_KEY          = @"access_token_type";
 NSString *const MSID_CACHED_AT_CACHE_KEY                 = @"cached_at";
 NSString *const MSID_EXTENDED_EXPIRES_ON_CACHE_KEY       = @"extended_expires_on";
+NSString *const MSID_EXPIRES_IN_CACHE_KEY                = @"expires_in";
 NSString *const MSID_SPE_INFO_CACHE_KEY                  = @"spe_info";
 NSString *const MSID_RESOURCE_RT_CACHE_KEY               = @"resource_refresh_token";
 NSString *const MSID_LOCAL_ACCOUNT_ID_CACHE_KEY          = @"local_account_id";

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.h
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.h
@@ -52,6 +52,7 @@
 @property (readwrite, nullable) NSDate *expiresOn;
 @property (readwrite, nullable) NSDate *extendedExpiresOn;
 @property (readwrite, nullable) NSDate *cachedAt;
+@property (readwrite, nullable) NSString *expiryInterval;
 
 // Family ID
 @property (readwrite, nullable) NSString *familyId;

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -133,6 +133,7 @@
     item.expiresOn = [self.expiresOn copyWithZone:zone];
     item.extendedExpiresOn = [self.extendedExpiresOn copyWithZone:zone];
     item.cachedAt = [self.cachedAt copyWithZone:zone];
+    item.expiryInterval = [self.expiryInterval copyWithZone:zone];
     item.familyId = [self.familyId copyWithZone:zone];
     item.homeAccountId = [self.homeAccountId copyWithZone:zone];
     item.speInfo = [self.speInfo copyWithZone:zone];
@@ -192,6 +193,7 @@
     _applicationIdentifier = [json msidStringObjectForKey:MSID_APPLICATION_IDENTIFIER_CACHE_KEY];
     _kid = [json msidStringObjectForKey:MSID_KID_CACHE_KEY];
     _tokenType = [json msidStringObjectForKey:MSID_OAUTH2_TOKEN_TYPE];
+    _expiryInterval = [json msidStringObjectForKey:MSID_EXPIRES_IN_CACHE_KEY];
     return self;
 }
 
@@ -218,7 +220,8 @@
     dictionary[MSID_HOME_ACCOUNT_ID_CACHE_KEY] = _homeAccountId;
     dictionary[MSID_ENROLLMENT_ID_CACHE_KEY] = _enrollmentId;
     dictionary[MSID_SPE_INFO_CACHE_KEY] = _speInfo;
-
+    dictionary[MSID_EXPIRES_IN_CACHE_KEY] = _expiryInterval;
+    
     // Last Modification info (currently used on macOS only)
     dictionary[MSID_LAST_MOD_TIME_CACHE_KEY] = [_lastModificationTime msidDateToFractionalTimestamp:3];
     dictionary[MSID_LAST_MOD_APP_CACHE_KEY] = _lastModificationApp;

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.h
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.h
@@ -33,6 +33,8 @@
 @property (nonatomic) NSString *prtProtocolVersion;
 @property (nonatomic) NSDate *expiresOn;
 @property (nonatomic) NSDate *cachedAt;
+@property (nonatomic) NSUInteger expiryInterval;
+@property (nonatomic, readonly) NSUInteger refreshInterval;
  
 - (BOOL)isDevicelessPRT;
 - (BOOL)shouldRefreshWithInterval:(NSUInteger)refreshInterval;

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
@@ -28,6 +28,8 @@
 #import "MSIDIdTokenClaims.h"
 #import "MSIDAuthority.h"
 
+static NSUInteger kDefaultPRTRefreshInterval = 10800;
+
 @implementation MSIDPrimaryRefreshToken
 
 - (instancetype)initWithTokenCacheItem:(MSIDCredentialCacheItem *)tokenCacheItem
@@ -51,6 +53,7 @@
         _prtProtocolVersion = [jsonDictionary msidObjectForKey:MSID_PRT_PROTOCOL_VERSION_CACHE_KEY ofClass:[NSString class]];
         _expiresOn = tokenCacheItem.expiresOn;
         _cachedAt = tokenCacheItem.cachedAt;
+        _expiryInterval = [tokenCacheItem.expiryInterval integerValue];
     }
     
     return self;
@@ -70,6 +73,7 @@
     prtCacheItem.prtProtocolVersion = self.prtProtocolVersion;
     prtCacheItem.expiresOn = self.expiresOn;
     prtCacheItem.cachedAt = self.cachedAt;
+    prtCacheItem.expiryInterval = [NSString stringWithFormat:@"%lu", (long)self.expiryInterval];
     return prtCacheItem;
 }
 
@@ -154,6 +158,7 @@
     item->_prtProtocolVersion = [_prtProtocolVersion copyWithZone:zone];
     item->_expiresOn = [_expiresOn copyWithZone:zone];
     item->_cachedAt = [_cachedAt copyWithZone:zone];
+    item->_expiryInterval = _expiryInterval;
     return item;
 }
 
@@ -197,6 +202,16 @@
     
     BOOL shouldRefresh = [[NSDate date] timeIntervalSinceDate:self.cachedAt] >= refreshInterval;
     return shouldRefresh;
+}
+
+- (NSUInteger)refreshInterval
+{
+    if (self.expiryInterval > 0)
+    {
+        return self.expiryInterval / 10;
+    }
+    
+    return kDefaultPRTRefreshInterval;
 }
 
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+* Save PRT expiry interval in cache to calculate PRT refresh interval more reliably (#804)
 
 Version 1.5.3
 -----    


### PR DESCRIPTION
## Proposed changes

Current broker SDK uses a hardcoded PRT refresh interval of 4 or 12 hours. That might be insufficient if tenant has configured PRT to be valid for a much shorter period of time like 4 hours. 
In order to correctly calculate PRT refresh interval related to PRT lifetime, introduce a cached property for PRT lifetime. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

