### PR TITLE
Symmetric key support for creating a verify signature and key derivation

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -531,6 +531,11 @@
 		60FDA9C721A19DA6001E09B8 /* MSIDDefaultBrokerResponseHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FDA9C621A19DA6001E09B8 /* MSIDDefaultBrokerResponseHandlerTests.m */; };
 		60FDA9DB21A5EBCF001E09B8 /* MSIDTestCacheAccessorHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FDA9DA21A5EBCF001E09B8 /* MSIDTestCacheAccessorHelper.m */; };
 		60FDA9DC21A5EBCF001E09B8 /* MSIDTestCacheAccessorHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FDA9DA21A5EBCF001E09B8 /* MSIDTestCacheAccessorHelper.m */; };
+		6E4F658C24D488010070CA36 /* MSIDSymmetricKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E4F658B24D488010070CA36 /* MSIDSymmetricKey.h */; };
+		6E4F658E24D4883A0070CA36 /* MSIDSymmetricKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E4F658D24D4883A0070CA36 /* MSIDSymmetricKey.m */; };
+		6E4F658F24D4883A0070CA36 /* MSIDSymmetricKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E4F658D24D4883A0070CA36 /* MSIDSymmetricKey.m */; };
+		6E4F659324D48B630070CA36 /* MSIDSymmetricKeyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E4F659024D48B120070CA36 /* MSIDSymmetricKeyTests.m */; };
+		6E4F659424D48B6D0070CA36 /* MSIDSymmetricKeyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E4F659024D48B120070CA36 /* MSIDSymmetricKeyTests.m */; };
 		740340B92460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */; };
 		740340BA2460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */; };
 		740340BB2460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */; };
@@ -2081,6 +2086,9 @@
 		60FDA9C621A19DA6001E09B8 /* MSIDDefaultBrokerResponseHandlerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDDefaultBrokerResponseHandlerTests.m; sourceTree = "<group>"; };
 		60FDA9D921A5EBBA001E09B8 /* MSIDTestCacheAccessorHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTestCacheAccessorHelper.h; sourceTree = "<group>"; };
 		60FDA9DA21A5EBCF001E09B8 /* MSIDTestCacheAccessorHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTestCacheAccessorHelper.m; sourceTree = "<group>"; };
+		6E4F658B24D488010070CA36 /* MSIDSymmetricKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSymmetricKey.h; sourceTree = "<group>"; };
+		6E4F658D24D4883A0070CA36 /* MSIDSymmetricKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSymmetricKey.m; sourceTree = "<group>"; };
+		6E4F659024D48B120070CA36 /* MSIDSymmetricKeyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSymmetricKeyTests.m; sourceTree = "<group>"; };
 		740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCurrentRequestTelemetrySerializedItem.h; sourceTree = "<group>"; };
 		740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCurrentRequestTelemetrySerializedItem.m; sourceTree = "<group>"; };
 		74043F7C245CC84B00D3E7C1 /* MSIDCurrentRequestTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCurrentRequestTelemetryTests.m; sourceTree = "<group>"; };
@@ -4236,6 +4244,8 @@
 				B2C0748A246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m */,
 				B278937F2470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.h */,
 				B27893802470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m */,
+				6E4F658B24D488010070CA36 /* MSIDSymmetricKey.h */,
+				6E4F658D24D4883A0070CA36 /* MSIDSymmetricKey.m */,
 			);
 			path = crypto;
 			sourceTree = "<group>";
@@ -4851,6 +4861,7 @@
 				D626FFE91FBD200A00EE4487 /* util */,
 				1E0B144E24CF5ADD00825143 /* MSIDAssymetricKeyPair+Test.h */,
 				1E0B144F24CF5ADD00825143 /* MSIDAssymetricKeyPair+Test.m */,
+				6E4F659024D48B120070CA36 /* MSIDSymmetricKeyTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -5261,6 +5272,7 @@
 				238A04932089A3C800989EE0 /* MSIDHttpRequestTelemetry.h in Headers */,
 				B286B9C62389DE7B007833AD /* MSIDAccountMetadataCacheKey.h in Headers */,
 				B286B9DB2389DF59007833AD /* MSIDJsonSerializable.h in Headers */,
+				6E4F658C24D488010070CA36 /* MSIDSymmetricKey.h in Headers */,
 				23B39A8120993302000AA905 /* MSIDAadAuthorityResolver.h in Headers */,
 				B2C0748F246B71470008D701 /* MSIDAssymetricKeyGenerating.h in Headers */,
 				B286B9AE2389DD5E007833AD /* MSIDChallengeHandling.h in Headers */,
@@ -5772,6 +5784,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6E4F659324D48B630070CA36 /* MSIDSymmetricKeyTests.m in Sources */,
 				B2E7698E206096A7000F3F2B /* MSIDTelemetryCacheEventTests.m in Sources */,
 				B2DD4B3520A91FA70047A66E /* MSIDDefaultAccountCacheKeyTests.m in Sources */,
 				23419F5A239739AF00EA78C5 /* MSIDBrokerOperationSilentTokenRequestTests.m in Sources */,
@@ -6169,6 +6182,7 @@
 				B26CEAE923653C62009E6E54 /* MSIDASWebAuthenticationSessionHandler.m in Sources */,
 				609E74C8228DCEA1005E3FED /* MSIDAccountMetadata.m in Sources */,
 				B2AF1D30218BCEDE0080C1A0 /* MSIDInteractiveTokenRequest.m in Sources */,
+				6E4F658F24D4883A0070CA36 /* MSIDSymmetricKey.m in Sources */,
 				B227035622A3633700030ADC /* MSIDMaskedLogParameter.m in Sources */,
 				04930F961FEDB2E100FC4DCD /* MSIDAuthority.m in Sources */,
 				6080B97B2384BD17009B1322 /* MSIDAccountMetadataCacheItem.m in Sources */,
@@ -6257,6 +6271,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6E4F659424D48B6D0070CA36 /* MSIDSymmetricKeyTests.m in Sources */,
 				B29A36B620AFA03200427B63 /* MSIDOauth2FactoryTests.m in Sources */,
 				23CC944920465CEC00AA0551 /* MSIDTokenCacheDataSourceIntegrationTests.m in Sources */,
 				B86FA7D62383757A00E5195A /* MSIDMacKeychainTokenCacheTests.m in Sources */,
@@ -6488,6 +6503,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6E4F658E24D4883A0070CA36 /* MSIDSymmetricKey.m in Sources */,
 				23B39AC2209BD901000AA905 /* MSIDAdfsAuthorityResolver.m in Sources */,
 				B2000C8E20EC62DF0092790A /* MSIDAADV1IdTokenClaims.m in Sources */,
 				B2000C9020EC633C0092790A /* MSIDConfiguration.m in Sources */,

--- a/IdentityCore/src/cache/crypto/MSIDSymmetricKey.h
+++ b/IdentityCore/src/cache/crypto/MSIDSymmetricKey.h
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDSymmetricKey : NSObject
+{
+    NSData* _symmetericKey;
+}
+
+- (nullable instancetype)initWithSymmetericKeyBytes:(NSData *)symmetericKeyInBytes;
+
+- (nullable NSString *)createVerifySignature:(NSData *)context
+                                  dataToSign:(NSString *)dataToSign;
+
+- (nullable NSData *)computeKDFInCounterMode:(NSData *)ctx;
+
+- (nonnull NSString *)getRaw;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/crypto/MSIDSymmetricKey.h
+++ b/IdentityCore/src/cache/crypto/MSIDSymmetricKey.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable instancetype)initWithSymmetericKeyBytes:(NSData *)symmetericKeyInBytes;
 
+- (nullable instancetype)initWithSymmetericKeyBase64:(NSString *)symmetericKeyBase64;
+
 - (nullable NSString *)createVerifySignature:(NSData *)context
                                   dataToSign:(NSString *)dataToSign;
 

--- a/IdentityCore/src/cache/crypto/MSIDSymmetricKey.h
+++ b/IdentityCore/src/cache/crypto/MSIDSymmetricKey.h
@@ -28,19 +28,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDSymmetricKey : NSObject
 {
-    NSData* _symmetericKey;
+    NSData* _symmetricKey;
 }
 
-- (nullable instancetype)initWithSymmetericKeyBytes:(NSData *)symmetericKeyInBytes;
+@property (nonatomic, readonly) NSString *symmetricKeyBase64;
 
-- (nullable instancetype)initWithSymmetericKeyBase64:(NSString *)symmetericKeyBase64;
+- (nullable instancetype)initWithSymmetricKeyBytes:(NSData *)symmetricKeyInBytes;
+
+- (nullable instancetype)initWithSymmetricKeyBase64:(NSString *)symmetricKeyBase64;
 
 - (nullable NSString *)createVerifySignature:(NSData *)context
                                   dataToSign:(NSString *)dataToSign;
 
 - (nullable NSData *)computeKDFInCounterMode:(NSData *)ctx;
-
-- (nonnull NSString *)getRaw;
 
 @end
 

--- a/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
+++ b/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
@@ -46,6 +46,15 @@
     return self;
 }
 
+- (nullable instancetype)initWithSymmetericKeyBase64:(NSString *)symmetericKeyBase64 {
+    if (!symmetericKeyBase64)
+    {
+        return nil;
+    }
+    
+    return [self initWithSymmetericKeyBytes:[[NSData alloc] initWithBase64EncodedString:symmetericKeyBase64 options:0]];
+}
+
 - (nullable NSString *)createVerifySignature:(NSData *)context
                                   dataToSign:(NSString *)dataToSign {
     NSData *data = [dataToSign dataUsingEncoding:NSUTF8StringEncoding];

--- a/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
+++ b/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
@@ -1,0 +1,168 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "MSIDSymmetricKey.h"
+
+#import <CommonCrypto/CommonCryptor.h>
+#import <CommonCrypto/CommonHMAC.h>
+#import <CommonCrypto/CommonDigest.h>
+
+@implementation MSIDSymmetricKey
+
+- (nullable instancetype)initWithSymmetericKeyBytes:(NSData *)symmetericKey {
+    if (!symmetericKey)
+    {
+        return nil;
+    }
+    
+    self = [super init];
+    
+    if (self)
+    {
+        _symmetericKey = symmetericKey;
+    }
+    
+    return self;
+}
+
+- (nullable NSString *)createVerifySignature:(NSData *)context
+                                  dataToSign:(NSString *)dataToSign {
+    NSData *data = [dataToSign dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *derivedKey = [self computeKDFInCounterMode:context];
+    unsigned char cHMAC[CC_SHA256_DIGEST_LENGTH];
+    CCHmac(kCCHmacAlgSHA256,
+           derivedKey.bytes,
+           derivedKey.length,
+           [data bytes],
+           [data length],
+           cHMAC);
+    NSData *signedData = [[NSData alloc] initWithBytes:cHMAC length:sizeof(cHMAC)];
+
+    return [NSString msidBase64UrlEncodedStringFromData:signedData];
+}
+
+- (NSData *)computeKDFInCounterMode:(NSData *)ctx
+{
+    NSData *labelData = [@"AzureAD-SecureConversation" dataUsingEncoding:NSUTF8StringEncoding];
+    NSMutableData *mutData = [NSMutableData new];
+    [mutData appendBytes:labelData.bytes length:labelData.length];
+    Byte bytes[] = {0x00};
+    [mutData appendBytes:bytes length:1];
+    [mutData appendBytes:ctx.bytes length:ctx.length];
+    int32_t size = CFSwapInt32HostToBig(256); //make big-endian
+    [mutData appendBytes:&size length:sizeof(size)];
+    
+    uint8_t *pbDerivedKey = [self KDFCounterMode:(uint8_t*)_symmetericKey.bytes
+                          keyDerivationKeyLength:_symmetericKey.length
+                                      fixedInput:(uint8_t*)mutData.bytes
+                                fixedInputLength:mutData.length];
+    mutData = nil;
+    NSData *dataToReturn = [NSData dataWithBytes:(const void *)pbDerivedKey length:32];
+    free(pbDerivedKey);
+    
+    return dataToReturn;
+}
+
+
+- (uint8_t*) KDFCounterMode:(uint8_t*) keyDerivationKey
+     keyDerivationKeyLength:(size_t) keyDerivationKeyLength
+                 fixedInput:(uint8_t*) fixedInput
+           fixedInputLength:(size_t) fixedInputLength
+{
+    uint8_t ctr;
+    unsigned char cHMAC[CC_SHA256_DIGEST_LENGTH];
+    uint8_t *keyDerivated;
+    uint8_t *dataInput;
+    int len;
+    int numCurrentElements;
+    int numCurrentElements_bytes;
+    int outputSizeBit = 256;
+    
+    numCurrentElements = 0;
+    ctr = 1;
+    keyDerivated = (uint8_t*)malloc(outputSizeBit/8); //output is 32 bytes
+    
+    do{
+        
+        //update data using "ctr"
+        dataInput =  [self updateDataInput:ctr
+                                fixedInput:fixedInput
+                         fixedInput_length:fixedInputLength];
+        
+        CCHmac(kCCHmacAlgSHA256,
+               keyDerivationKey,
+               keyDerivationKeyLength,
+               dataInput,
+               (fixedInputLength+4), //+4 to account for ctr
+               cHMAC);
+        
+        //decide how many bytes (so the "length") copy for currently keyDerivated?
+        if (256 >= outputSizeBit) {
+            len = outputSizeBit;
+        } else {
+            len = MIN(256, outputSizeBit - numCurrentElements);
+        }
+        
+        //convert bits in byte
+        numCurrentElements_bytes = numCurrentElements/8;
+        
+        //copy KI in part of keyDerivated
+        memcpy((keyDerivated + numCurrentElements_bytes), cHMAC, 32);
+        
+        //increment ctr and numCurrentElements copied in keyDerivated
+        numCurrentElements = numCurrentElements + len;
+        ctr++;
+        
+        //deallock space in memory
+        free(dataInput);
+        
+    } while (numCurrentElements < outputSizeBit);
+    
+    return keyDerivated;
+}
+
+
+/*
+ *Function used to shift data of 1 byte. This byte is the "ctr".
+ */
+- (uint8_t*)updateDataInput:(uint8_t) ctr
+                 fixedInput:(uint8_t*) fixedInput
+          fixedInput_length:(size_t) fixedInput_length
+{
+    uint8_t *tmpFixedInput = (uint8_t *)malloc(fixedInput_length + 4); //+4 is caused from the ct
+    
+    tmpFixedInput[0] = (ctr >> 24);
+    tmpFixedInput[1] = (ctr >> 16);
+    tmpFixedInput[2] = (ctr >> 8);
+    tmpFixedInput[3] = ctr;
+    
+    memcpy(tmpFixedInput + 4, fixedInput, fixedInput_length  * sizeof(uint8_t));
+    return tmpFixedInput;
+}
+
+- (nonnull NSString *)getRaw {
+    return [_symmetericKey base64EncodedStringWithOptions:0];
+}
+
+@end

--- a/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
+++ b/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
@@ -131,12 +131,12 @@
     ctr = 1;
     keyDerivated = (uint8_t *)malloc(outputSizeBit / 8); //output is 32 bytes
     
-    do{
-        
+    do
+    {
         //update data using "ctr"
-        dataInput =  [self updateDataInput:ctr
-                                fixedInput:fixedInput
-                         fixedInput_length:fixedInputLength];
+        dataInput = [self updateDataInput:ctr
+                               fixedInput:fixedInput
+                        fixedInput_length:fixedInputLength];
         
         CCHmac(kCCHmacAlgSHA256,
                keyDerivationKey,
@@ -146,9 +146,12 @@
                cHMAC);
         
         //decide how many bytes (so the "length") copy for currently keyDerivated?
-        if (256 >= outputSizeBit) {
+        if (256 >= outputSizeBit)
+        {
             len = outputSizeBit;
-        } else {
+        }
+        else
+        {
             len = MIN(256, outputSizeBit - numCurrentElements);
         }
         

--- a/IdentityCore/tests/MSIDSymmetricKeyTests.m
+++ b/IdentityCore/tests/MSIDSymmetricKeyTests.m
@@ -37,8 +37,7 @@ NSString *expectedSignature = @"cspzWzvtSNOJUUzThP3FWWV-9q7mJ_ZB6PYzRcQwe54";
 @implementation MSIDSymmetricKeyTests
 
 - (void)testGenerateSymmetericKey_andGetRaw{
-    NSData *symmetericKeyBytes = [[NSData alloc] initWithBase64EncodedString:symmetericKeyString options:0];
-    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetericKeyBytes:symmetericKeyBytes];
+    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetericKeyBase64:symmetericKeyString];
     XCTAssertNotNil(symmetricKey);
 
     NSString *rawKey = [symmetricKey getRaw];
@@ -52,7 +51,7 @@ NSString *expectedSignature = @"cspzWzvtSNOJUUzThP3FWWV-9q7mJ_ZB6PYzRcQwe54";
     XCTAssertNotNil(symmetricKey);
 
     NSData *contextData = [NSData msidDataFromBase64UrlEncodedString:context];
-    NSString * signature = [symmetricKey createVerifySignature:contextData dataToSign:message];
+    NSString *signature = [symmetricKey createVerifySignature:contextData dataToSign:message];
     XCTAssertEqualObjects(expectedSignature, signature);
 }
 

--- a/IdentityCore/tests/MSIDSymmetricKeyTests.m
+++ b/IdentityCore/tests/MSIDSymmetricKeyTests.m
@@ -30,7 +30,6 @@
 @end
 
 NSString *symmetericKeyString = @"Zfb98mJBAt/UOpnCI/CYdQ==";
-NSString *message = @"Sample Message To Encrypt/Decrypt";
 NSString *context = @"y00sIKRcF2bPFDgbeOques0ymB+R0FP";
 NSString *expectedSignature = @"cspzWzvtSNOJUUzThP3FWWV-9q7mJ_ZB6PYzRcQwe54";
 

--- a/IdentityCore/tests/MSIDSymmetricKeyTests.m
+++ b/IdentityCore/tests/MSIDSymmetricKeyTests.m
@@ -45,6 +45,7 @@ NSString *invalidBase64 = @"invalidbase64)";
     NSString *rawKey = [symmetricKey symmetricKeyBase64];
     XCTAssertEqualObjects(symmetricKeyString, rawKey);
 }
+
 - (void)testGenerateSymmetricKey_withInvalidKey
 {
     XCTAssertNil([[NSData alloc] initWithBase64EncodedString:invalidBase64 options:0]);

--- a/IdentityCore/tests/MSIDSymmetricKeyTests.m
+++ b/IdentityCore/tests/MSIDSymmetricKeyTests.m
@@ -30,6 +30,7 @@
 @end
 
 NSString *symmetericKeyString = @"Zfb98mJBAt/UOpnCI/CYdQ==";
+NSString *message = @"Sample Message To Encrypt/Decrypt";
 NSString *context = @"y00sIKRcF2bPFDgbeOques0ymB+R0FP";
 NSString *expectedSignature = @"cspzWzvtSNOJUUzThP3FWWV-9q7mJ_ZB6PYzRcQwe54";
 

--- a/IdentityCore/tests/MSIDSymmetricKeyTests.m
+++ b/IdentityCore/tests/MSIDSymmetricKeyTests.m
@@ -29,30 +29,59 @@
 
 @end
 
-NSString *symmetericKeyString = @"Zfb98mJBAt/UOpnCI/CYdQ==";
+NSString *symmetricKeyString = @"Zfb98mJBAt/UOpnCI/CYdQ==";
 NSString *message = @"Sample Message To Encrypt/Decrypt";
 NSString *context = @"y00sIKRcF2bPFDgbeOques0ymB+R0FP";
 NSString *expectedSignature = @"cspzWzvtSNOJUUzThP3FWWV-9q7mJ_ZB6PYzRcQwe54";
+NSString *invalidBase64 = @"invalidbase64)";
 
 @implementation MSIDSymmetricKeyTests
 
-- (void)testGenerateSymmetericKey_andGetRaw{
-    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetericKeyBase64:symmetericKeyString];
+- (void)testGenerateSymmetricKey_andGetRaw
+{
+    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetricKeyBase64:symmetricKeyString];
     XCTAssertNotNil(symmetricKey);
 
-    NSString *rawKey = [symmetricKey getRaw];
-    XCTAssertEqualObjects(symmetericKeyString, rawKey);
+    NSString *rawKey = [symmetricKey symmetricKeyBase64];
+    XCTAssertEqualObjects(symmetricKeyString, rawKey);
+}
+- (void)testGenerateSymmetricKey_withInvalidKey
+{
+    XCTAssertNil([[NSData alloc] initWithBase64EncodedString:invalidBase64 options:0]);
+    XCTAssertNil([[MSIDSymmetricKey alloc] initWithSymmetricKeyBase64:invalidBase64]);
 }
 
 - (void)testCreateVerifySignature
 {
-    NSData *symmetericKeyBytes = [[NSData alloc] initWithBase64EncodedString:symmetericKeyString options:0];
-    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetericKeyBytes:symmetericKeyBytes];
+    NSData *symmetricKeyBytes = [[NSData alloc] initWithBase64EncodedString:symmetricKeyString options:0];
+    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetricKeyBytes:symmetricKeyBytes];
     XCTAssertNotNil(symmetricKey);
 
     NSData *contextData = [NSData msidDataFromBase64UrlEncodedString:context];
     NSString *signature = [symmetricKey createVerifySignature:contextData dataToSign:message];
     XCTAssertEqualObjects(expectedSignature, signature);
+}
+
+- (void)testCreateVerifySignature_withInvalidContext
+{
+    NSData *symmetricKeyBytes = [[NSData alloc] initWithBase64EncodedString:symmetricKeyString options:0];
+    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetricKeyBytes:symmetricKeyBytes];
+    XCTAssertNotNil(symmetricKey);
+
+    NSData *contextData = [[NSData alloc] initWithBase64EncodedString:invalidBase64 options:0];
+    NSString *signature = [symmetricKey createVerifySignature:contextData dataToSign:message];
+    XCTAssertNil(signature);
+}
+
+- (void)testCreateVerifySignature_withInvalidMessage
+{
+    NSData *symmetricKeyBytes = [[NSData alloc] initWithBase64EncodedString:symmetricKeyString options:0];
+    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetricKeyBytes:symmetricKeyBytes];
+    XCTAssertNotNil(symmetricKey);
+
+    NSData *contextData = [NSData msidDataFromBase64UrlEncodedString:context];
+    NSString *signature = [symmetricKey createVerifySignature:contextData dataToSign:@""];
+    XCTAssertNil(signature);
 }
 
 @end

--- a/IdentityCore/tests/MSIDSymmetricKeyTests.m
+++ b/IdentityCore/tests/MSIDSymmetricKeyTests.m
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDSymmetricKey.h"
+#import "NSData+MSIDExtensions.h"
+
+@interface MSIDSymmetricKeyTests : XCTestCase
+
+@end
+
+NSString *symmetericKeyString = @"Zfb98mJBAt/UOpnCI/CYdQ==";
+NSString *message = @"Sample Message To Encrypt/Decrypt";
+NSString *context = @"y00sIKRcF2bPFDgbeOques0ymB+R0FP";
+NSString *expectedSignature = @"cspzWzvtSNOJUUzThP3FWWV-9q7mJ_ZB6PYzRcQwe54";
+
+@implementation MSIDSymmetricKeyTests
+
+- (void)testGenerateSymmetericKey_andGetRaw{
+    NSData *symmetericKeyBytes = [[NSData alloc] initWithBase64EncodedString:symmetericKeyString options:0];
+    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetericKeyBytes:symmetericKeyBytes];
+    XCTAssertNotNil(symmetricKey);
+
+    NSString *rawKey = [symmetricKey getRaw];
+    XCTAssertEqualObjects(symmetericKeyString, rawKey);
+}
+
+- (void)testCreateVerifySignature
+{
+    NSData *symmetericKeyBytes = [[NSData alloc] initWithBase64EncodedString:symmetericKeyString options:0];
+    MSIDSymmetricKey *symmetricKey = [[MSIDSymmetricKey alloc] initWithSymmetericKeyBytes:symmetericKeyBytes];
+    XCTAssertNotNil(symmetricKey);
+
+    NSData *contextData = [NSData msidDataFromBase64UrlEncodedString:context];
+    NSString * signature = [symmetricKey createVerifySignature:contextData dataToSign:message];
+    XCTAssertEqualObjects(expectedSignature, signature);
+}
+
+@end


### PR DESCRIPTION
## Proposed changes

Symmetric key support for creating a verify signature and key derivation without AES-GCM support, which can come in a follow up item since its not supported natively in objective c.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

