### PR TITLE
move broker redirecturi into common which can be reused later in MSAL…

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -439,6 +439,11 @@
 		23FB5C462255A135002BF1EB /* MSIDIndividualClaimRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C29225517AA002BF1EB /* MSIDIndividualClaimRequest.m */; };
 		23FB5C472255A13A002BF1EB /* MSIDIndividualClaimRequestAdditionalInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C27225517AA002BF1EB /* MSIDIndividualClaimRequestAdditionalInfo.m */; };
 		581AB24A24B8C8780075B8CA /* MSIDWebResponseOperationFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 581AB24924B8C8780075B8CA /* MSIDWebResponseOperationFactoryTests.m */; };
+		5828740324D499E700466916 /* NSURL+MSIDBrokerRedirectUri.h in Headers */ = {isa = PBXBuildFile; fileRef = 5828740124D499E700466916 /* NSURL+MSIDBrokerRedirectUri.h */; };
+		5828740424D499E700466916 /* NSURL+MSIDBrokerRedirectUri.m in Sources */ = {isa = PBXBuildFile; fileRef = 5828740224D499E700466916 /* NSURL+MSIDBrokerRedirectUri.m */; };
+		5828740524D499E700466916 /* NSURL+MSIDBrokerRedirectUri.m in Sources */ = {isa = PBXBuildFile; fileRef = 5828740224D499E700466916 /* NSURL+MSIDBrokerRedirectUri.m */; };
+		5828740724D49C4100466916 /* MSIDBrokerRedirectUriValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5828740624D49C4100466916 /* MSIDBrokerRedirectUriValidationTests.m */; };
+		5828740824D49C4100466916 /* MSIDBrokerRedirectUriValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5828740624D49C4100466916 /* MSIDBrokerRedirectUriValidationTests.m */; };
 		58543C8B24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h in Headers */ = {isa = PBXBuildFile; fileRef = 58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */; };
 		58B81F7C24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 58B81F7A24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.h */; };
 		58B81F7D24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B81F7B24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.m */; };
@@ -1978,6 +1983,9 @@
 		23FB5C32225585E6002BF1EB /* MSIDClaimsRequestMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDClaimsRequestMock.h; sourceTree = "<group>"; };
 		23FB5C33225585E6002BF1EB /* MSIDClaimsRequestMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDClaimsRequestMock.m; sourceTree = "<group>"; };
 		581AB24924B8C8780075B8CA /* MSIDWebResponseOperationFactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWebResponseOperationFactoryTests.m; sourceTree = "<group>"; };
+		5828740124D499E700466916 /* NSURL+MSIDBrokerRedirectUri.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURL+MSIDBrokerRedirectUri.h"; sourceTree = "<group>"; };
+		5828740224D499E700466916 /* NSURL+MSIDBrokerRedirectUri.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURL+MSIDBrokerRedirectUri.m"; sourceTree = "<group>"; };
+		5828740624D49C4100466916 /* MSIDBrokerRedirectUriValidationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBrokerRedirectUriValidationTests.m; sourceTree = "<group>"; };
 		58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDMacKeychainTokenCache+Test.h"; sourceTree = "<group>"; };
 		58B81F7A24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDWebResponseOperationFactory.h; sourceTree = "<group>"; };
 		58B81F7B24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWebResponseOperationFactory.m; sourceTree = "<group>"; };
@@ -4483,6 +4491,8 @@
 				1E74094724197E8900133EF7 /* NSDictionary+MSIDLogging.m */,
 				1E00D27F248F27ED006E4BAE /* MSIDAuthScheme.h */,
 				1E00D280248F27ED006E4BAE /* MSIDAuthScheme.m */,
+				5828740124D499E700466916 /* NSURL+MSIDBrokerRedirectUri.h */,
+				5828740224D499E700466916 /* NSURL+MSIDBrokerRedirectUri.m */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -4851,6 +4861,7 @@
 				D626FFE91FBD200A00EE4487 /* util */,
 				1E0B144E24CF5ADD00825143 /* MSIDAssymetricKeyPair+Test.h */,
 				1E0B144F24CF5ADD00825143 /* MSIDAssymetricKeyPair+Test.m */,
+				5828740624D49C4100466916 /* MSIDBrokerRedirectUriValidationTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -5150,6 +5161,7 @@
 				B2E2A923239221A000BA2EA3 /* MSIDBrokerOperationSignoutFromDeviceRequest.h in Headers */,
 				B2C708B3219A620B00D917B8 /* MSIDBrokerKeyProvider.h in Headers */,
 				23B39ABC209BD47D000AA905 /* MSIDB2CAuthorityResolver.h in Headers */,
+				5828740324D499E700466916 /* NSURL+MSIDBrokerRedirectUri.h in Headers */,
 				B286B99D2389DCA6007833AD /* MSIDSSOExtensionTokenRequestDelegate.h in Headers */,
 				B210F4551FDDFA7B005A8F76 /* MSIDBrokerResponse.h in Headers */,
 				968647FD20C76C6700EF7E73 /* MSIDAADV2WebviewFactory.h in Headers */,
@@ -5793,6 +5805,7 @@
 				B2544EEB21684B2B00B4C108 /* MSIDCacheSchemaValidationTests.m in Sources */,
 				23CA0C5F220A68D400768729 /* MSIDPkeyAuthHelperTests.m in Sources */,
 				B274DEC721FC002300DB7757 /* MSIDInteractiveRequestParametersTests.m in Sources */,
+				5828740724D49C4100466916 /* MSIDBrokerRedirectUriValidationTests.m in Sources */,
 				B2936F4F20AA908F0050C585 /* MSIDCredentialCacheItemTests.m in Sources */,
 				B2936F7520ABF4940050C585 /* MSIDIdTokenTests.m in Sources */,
 				B2936F9120AE913E0050C585 /* MSIDLegacyTokenCacheIntegrationTests.m in Sources */,
@@ -6030,6 +6043,7 @@
 				B210F4331FDDE7EB005A8F76 /* MSIDTokenResponse.m in Sources */,
 				B2964BE3205103920000BC95 /* MSIDTokenFilteringHelper.m in Sources */,
 				B210F4391FDDEA23005A8F76 /* MSIDAADV1TokenResponse.m in Sources */,
+				5828740524D499E700466916 /* NSURL+MSIDBrokerRedirectUri.m in Sources */,
 				23B39A8320993302000AA905 /* MSIDAadAuthorityResolver.m in Sources */,
 				23B39ABE209BD47D000AA905 /* MSIDB2CAuthorityResolver.m in Sources */,
 				B227035B22A3678A00030ADC /* MSIDMaskedUsernameLogParameter.m in Sources */,
@@ -6398,6 +6412,7 @@
 				239DF9C020E04BC9002D428B /* MSIDAADAuthorityTests.m in Sources */,
 				D6D9A4BF1FBE712900EFA430 /* MSIDStringExtensionsTests.m in Sources */,
 				B2936F4E20AA906C0050C585 /* MSIDLegacyTokenCacheItemTests.m in Sources */,
+				5828740824D49C4100466916 /* MSIDBrokerRedirectUriValidationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6664,6 +6679,7 @@
 				04D32CB21FD62141000B123E /* MSIDError.m in Sources */,
 				B20657B01FC91FD100412B7D /* MSIDTelemetryEventStrings.m in Sources */,
 				D6D9A4511FBD3FB800EFA430 /* NSURL+MSIDExtensions.m in Sources */,
+				5828740424D499E700466916 /* NSURL+MSIDBrokerRedirectUri.m in Sources */,
 				2306D2B920AD07C400F875A3 /* MSIDURLSessionManager.m in Sources */,
 				74F04D4A246C8AC000094017 /* MSIDLastRequestTelemetrySerializedItem.m in Sources */,
 				235480D020DDF81000246F72 /* MSIDADFSAuthority.m in Sources */,

--- a/IdentityCore/src/util/NSURL+MSIDBrokerRedirectUri.h
+++ b/IdentityCore/src/util/NSURL+MSIDBrokerRedirectUri.h
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <Foundation/Foundation.h>
+
+@interface NSURL (MSIDBrokerRedirectUri)
+
++ (nullable NSURL *)defaultNonBrokerRedirectUri:(nullable NSString *)clientId;
+
++ (nullable NSURL *)defaultBrokerCapableRedirectUri;
+
++ (BOOL)redirectUriIsBrokerCapable:(nullable NSURL *)redirectUri;
+
+@end
+

--- a/IdentityCore/src/util/NSURL+MSIDBrokerRedirectUri.m
+++ b/IdentityCore/src/util/NSURL+MSIDBrokerRedirectUri.m
@@ -1,0 +1,68 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import "NSURL+MSIDBrokerRedirectUri.h"
+
+@implementation NSURL (MSIDBrokerRedirectUri)
+
++ (NSURL *)defaultNonBrokerRedirectUri:(NSString *)clientId
+{
+    if ([NSString msidIsStringNilOrBlank:clientId])
+    {
+        return nil;
+    }
+    
+    NSString *redirectUri = [NSString stringWithFormat:@"msal%@://auth", clientId];
+    return [NSURL URLWithString:redirectUri];
+}
+
++ (NSURL *)defaultBrokerCapableRedirectUri
+{
+    NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
+    NSString *redirectUri = [NSString stringWithFormat:@"msauth.%@://auth", bundleID];
+    return [NSURL URLWithString:redirectUri];
+}
+
++ (BOOL)redirectUriIsBrokerCapable:(NSURL *)redirectUri
+{
+    NSURL *defaultRedirectUri = [NSURL defaultBrokerCapableRedirectUri];
+
+    // Check default redirect MSAL format
+    if ([defaultRedirectUri isEqual:redirectUri])
+    {
+        return YES;
+    }
+
+    // Check default ADAL format
+    if ([redirectUri.host isEqualToString:[[NSBundle mainBundle] bundleIdentifier]]
+        && redirectUri.scheme.length > 0)
+    {
+        return YES;
+    }
+
+    return NO;
+}
+
+@end

--- a/IdentityCore/tests/MSIDBrokerRedirectUriValidationTests.m
+++ b/IdentityCore/tests/MSIDBrokerRedirectUriValidationTests.m
@@ -1,0 +1,103 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <XCTest/XCTest.h>
+#import "NSURL+MSIDBrokerRedirectUri.h"
+
+@interface MSIDBrokerRedirectUriValidationTests : XCTestCase
+
+@end
+
+@implementation MSIDBrokerRedirectUriValidationTests
+
+- (void)test_default_non_broker_redirectUri_with_nil_or_empty_cliendid
+{
+    NSURL *redirectUri = [NSURL defaultNonBrokerRedirectUri:nil];
+    XCTAssertNil(redirectUri);
+    
+    redirectUri = [NSURL defaultNonBrokerRedirectUri:@""];
+    XCTAssertNil(redirectUri);
+}
+
+- (void)test_default_non_broker_redirectUri_with_valid_cliendid
+{
+    NSString *clientId = @"clientId";
+    NSURL *redirectUri = [NSURL defaultNonBrokerRedirectUri:clientId];
+    XCTAssertEqualObjects(redirectUri.absoluteString, @"msalclientId://auth");
+}
+
+- (void)test_get_default_broker_capable_redirectUri
+{
+    NSURL *redirectUri = [NSURL defaultBrokerCapableRedirectUri];
+    XCTAssertNotNil(redirectUri);
+}
+
+- (void)test_redirectUri_is_broker_capable_with_nil_url
+{
+    XCTAssertFalse([NSURL redirectUriIsBrokerCapable:nil]);
+}
+
+- (void)test_redirectUri_is_broker_capable_with_invalid_url
+{
+    XCTAssertFalse([NSURL redirectUriIsBrokerCapable:[NSURL URLWithString:@"https://fakeurl.contoso.com"]]);
+}
+
+- (void)test_check_default_redirect_msal_format
+{
+    NSURL *url = nil;
+#if TARGET_OS_IPHONE
+    url = [NSURL URLWithString:@"msauth.com.microsoft.MSIDTestsHostApp://auth"];
+#else
+    url = [NSURL URLWithString:@"msauth.com.apple.dt.xctest.tool://auth"];
+#endif
+    XCTAssertTrue([NSURL redirectUriIsBrokerCapable:url]);
+
+}
+
+- (void)test_check_default_redirect_adal_format
+{
+    NSURL *url = nil;
+#if TARGET_OS_IPHONE
+    url = [NSURL URLWithString:@"myscheme://com.microsoft.MSIDTestsHostApp"];
+#else
+    url = [NSURL URLWithString:@"myscheme://com.apple.dt.xctest.tool"];
+#endif
+    XCTAssertTrue([NSURL redirectUriIsBrokerCapable:url]);
+
+}
+
+- (void)test_check_default_redirect_adal_format_without_scheme
+{
+    NSURL *url = nil;
+#if TARGET_OS_IPHONE
+    url = [NSURL URLWithString:@"com.microsoft.MSIDTestsHostApp"];
+#else
+    url = [NSURL URLWithString:@"com.apple.dt.xctest.tool"];
+#endif
+    XCTAssertFalse([NSURL redirectUriIsBrokerCapable:url]);
+
+}
+
+@end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+* Move broker redirectUri validation logic into common core from MSAL
 * Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair. #803
 * Add operation factory for broker installation integration with other framework (#779)
 


### PR DESCRIPTION
… cpp

## Proposed changes

Moving some code from MSALRedirectUri by adding a new category on NSURL. The main goal here is we can reuse the code from common from CPP side

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

