### PR TITLE
SSO extension log cleanup

### DIFF
--- a/IdentityCore/src/MSIDJsonSerializableFactory.m
+++ b/IdentityCore/src/MSIDJsonSerializableFactory.m
@@ -141,7 +141,9 @@ static NSMutableDictionary<NSString *, NSString *> *s_keysMap = nil;
             *error = MSIDCreateError(MSIDErrorDomain,
                                      MSIDErrorInvalidDeveloperParameter,
                                      errorMessage,
-                                     nil, nil, nil, nil, nil, YES);
+                                     nil, nil, nil, nil, nil, NO);
+            
+            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"%@", errorMessage);
         }
         
         return nil;
@@ -158,7 +160,9 @@ static NSMutableDictionary<NSString *, NSString *> *s_keysMap = nil;
             *error = MSIDCreateError(MSIDErrorDomain,
                                      MSIDErrorInvalidDeveloperParameter,
                                      errorMessage,
-                                     nil, nil, nil, nil, nil, YES);
+                                     nil, nil, nil, nil, nil, NO);
+            
+            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"%@", errorMessage);
         }
         
         return nil;

--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.m
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.m
@@ -287,7 +287,7 @@
     
     if (!token.refreshToken)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelWarning,nil, @"Trying to initialize refresh token when missing refresh token field");
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Trying to initialize refresh token when missing refresh token field");
         return NO;
     }
 

--- a/IdentityCore/src/oauth2/token/MSIDLegacyRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDLegacyRefreshToken.m
@@ -98,7 +98,7 @@
         
         if (!_refreshToken)
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Trying to initialize refresh token when missing refresh token field in cache");
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Trying to initialize refresh token when missing refresh token field in cache");
             return nil;
         }
 

--- a/IdentityCore/src/oauth2/token/MSIDRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDRefreshToken.m
@@ -87,7 +87,7 @@
         
         if (!_refreshToken)
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelWarning,nil, @"Trying to initialize refresh token when missing refresh token field");
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Trying to initialize refresh token when missing refresh token field");
             return nil;
         }
         

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+* Cleanup noisy SSO extension logs (#812)
 * Save PRT expiry interval in cache to calculate PRT refresh interval more reliably (#804)
 * Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair. #803
 * Add operation factory for broker installation integration with other framework (#779)


### PR DESCRIPTION
## Proposed changes

Clean up SSO extension logs that are too verbose.
Currently we log following on each response from SSO extension:

```
[W-AH][MSAL] TID=168600 MSAL 1.1.4 iOS 13.5.1 [2020-08-05 01:19:59] Creating Error with description: Failed to create object from json, class: MSIDAuthority wasn't registered in factory under provider_aad_v2 key.¬
TID=168600 MSAL 1.1.4 iOS 13.5.1 [2020-08-05 01:19:59] Creating Error with description: Failed to create object from json, class: MSIDTokenResponse wasn't registered in factory under provider_aad_v2 key.¬
TID=168600 MSAL 1.1.4 iOS 13.5.1 [2020-08-05 01:19:59] Failed to init id token claims in MSIDAADV2TokenResponse, error: Masked(null)
TID=168600 MSAL 1.1.4 iOS 13.5.1 [2020-08-05 01:19:59] Trying to initialize refresh token when missing refresh token field
```
Those logs are noisy and don't represent actual error. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

