### PR TITLE
Send redirect uri for refresh token grant flow

### DIFF
--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
@@ -32,6 +32,7 @@
 - (instancetype _Nullable)initWithEndpoint:(nonnull NSURL *)endpoint
                                 authScheme:(nonnull MSIDAuthenticationScheme *)authScheme
                                   clientId:(nonnull NSString *)clientId
+                               redirectUri:(NSString *)redirectUri
                               enrollmentId:(nullable NSString *)enrollmentId
                                      scope:(nullable NSString *)scope
                               refreshToken:(nonnull NSString *)refreshToken

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
@@ -32,7 +32,7 @@
 - (instancetype _Nullable)initWithEndpoint:(nonnull NSURL *)endpoint
                                 authScheme:(nonnull MSIDAuthenticationScheme *)authScheme
                                   clientId:(nonnull NSString *)clientId
-                               redirectUri:(NSString *)redirectUri
+                               redirectUri:(nonnull NSString *)redirectUri
                               enrollmentId:(nullable NSString *)enrollmentId
                                      scope:(nullable NSString *)scope
                               refreshToken:(nonnull NSString *)refreshToken

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
@@ -29,6 +29,7 @@
 - (instancetype)initWithEndpoint:(NSURL *)endpoint
                       authScheme:(MSIDAuthenticationScheme *)authScheme
                         clientId:(NSString *)clientId
+                     redirectUri:(NSString *)redirectUri
                     enrollmentId:(NSString *)enrollmentId
                            scope:(NSString *)scope
                     refreshToken:(NSString *)refreshToken
@@ -36,7 +37,7 @@
                  extraParameters:(NSDictionary *)extraParameters
                          context:(nullable id<MSIDRequestContext>)context
 {
-    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope refreshToken:refreshToken extraParameters:extraParameters context:context];
+    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope refreshToken:refreshToken redirectUri:redirectUri extraParameters:extraParameters context:context];
     if (self)
     {
         __auto_type requestConfigurator = [MSIDAADRequestConfigurator new];

--- a/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.h
@@ -31,6 +31,7 @@
                                    clientId:(nonnull NSString *)clientId
                                       scope:(nullable NSString *)scope
                                refreshToken:(nonnull NSString *)refreshToken
+                                redirectUri:(nonnull NSString *)redirectUri
                                    resource:(nonnull NSString *)resource
                             extraParameters:(nullable NSDictionary *)extraParameters
                                     context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;

--- a/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.m
@@ -30,11 +30,12 @@
                         clientId:(NSString *)clientId
                            scope:(NSString *)scope
                     refreshToken:(NSString *)refreshToken
+                     redirectUri:(NSString *)redirectUri
                         resource:(NSString *)resource
                  extraParameters:(NSDictionary *)extraParameters
                          context:(nullable id<MSIDRequestContext>)context
 {
-    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope refreshToken:refreshToken extraParameters:extraParameters context:context];
+    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope refreshToken:refreshToken redirectUri:redirectUri extraParameters:extraParameters context:context];
     if (self)
     {
         NSParameterAssert(resource);

--- a/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.h
@@ -31,6 +31,7 @@
                                   clientId:(nonnull NSString *)clientId
                                      scope:(nullable NSString *)scope
                               refreshToken:(nonnull NSString *)refreshToken
+                               redirectUri:(nullable NSString *)redirectUri
                            extraParameters:(nullable NSDictionary *)extraParameters
                                    context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 

--- a/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.m
@@ -30,6 +30,7 @@
                                   clientId:(nonnull NSString *)clientId
                                      scope:(nullable NSString *)scope
                               refreshToken:(nonnull NSString *)refreshToken
+                               redirectUri:(NSString *)redirectUri
                            extraParameters:(nullable NSDictionary *)extraParameters
                                    context:(nullable id<MSIDRequestContext>)context
 {
@@ -41,6 +42,7 @@
         NSMutableDictionary *parameters = [_parameters mutableCopy];
         parameters[MSID_OAUTH2_GRANT_TYPE] = MSID_OAUTH2_REFRESH_TOKEN;
         parameters[MSID_OAUTH2_REFRESH_TOKEN] = refreshToken;
+        parameters[MSID_OAUTH2_REDIRECT_URI] = redirectUri;
         
         if (extraParameters)
         {

--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.m
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.m
@@ -452,6 +452,7 @@
                                                                                                clientId:parameters.clientId
                                                                                                   scope:allScopes
                                                                                            refreshToken:refreshToken
+                                                                                            redirectUri:parameters.redirectUri
                                                                                         extraParameters:parameters.extraTokenRequestParameters
                                                                                                 context:parameters];
     tokenRequest.responseSerializer = [[MSIDTokenResponseSerializer alloc] initWithOauth2Factory:self];

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -226,6 +226,7 @@
     MSIDAADRefreshTokenGrantRequest *tokenRequest = [[MSIDAADRefreshTokenGrantRequest alloc] initWithEndpoint:parameters.tokenEndpoint
                                                                                                    authScheme:parameters.authScheme
                                                                                                      clientId:parameters.clientId
+                                                                                                  redirectUri:parameters.redirectUri
                                                                                                  enrollmentId:enrollmentId
                                                                                                         scope:allScopes
                                                                                                  refreshToken:refreshToken

--- a/IdentityCore/tests/integration/MSIDExternalAADCacheSeederIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDExternalAADCacheSeederIntegrationTests.m
@@ -153,6 +153,7 @@
                                           @"client_info": @"1",
                                           @"grant_type": @"refresh_token",
                                           @"refresh_token": @"rt",
+                                          @"redirect_uri": redirectUri,
                                           @"scope": @"scope1 scope2 openid profile offline_access"
                                           } mutableCopy];
     MSIDTestURLResponse *response =

--- a/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
@@ -1126,6 +1126,7 @@
                                              @"scope" : @"user.read tasks.read openid profile offline_access",
                                              @"grant_type" : @"refresh_token",
                                              @"refresh_token" : DEFAULT_TEST_REFRESH_TOKEN,
+                                             MSID_OAUTH2_REDIRECT_URI : [[self silentRequestParameters] redirectUri],
                                              @"client_info" : @"1"}
                         responseURLString:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
                              responseCode:429

--- a/IdentityCore/tests/util/MSIDTestURLResponse+Util.m
+++ b/IdentityCore/tests/util/MSIDTestURLResponse+Util.m
@@ -128,6 +128,7 @@
                                            @"scope" : requestScopes,
                                            @"grant_type" : @"refresh_token",
                                            @"refresh_token" : requestRT,
+                                           @"redirect_uri" : @"my_redirect_uri",
                                            @"client_info" : @"1"} mutableCopy];
 
     if (requestClaims)
@@ -179,6 +180,7 @@
                                           @"scope" : requestScopes,
                                           @"grant_type" : @"refresh_token",
                                           @"refresh_token" : requestRT,
+                                          @"redirect_uri" : @"my_redirect_uri",
                                           @"client_info" : @"1"} mutableCopy];
 
     if (requestClaims)

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Move broker redirectUri validation logic into common core from MSAL (#807)
 * Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair (#803)
 * Add operation factory for broker installation integration with other framework (#779)
+* Include redirect uri in body when redeeming refresh token at token endpoint (#815)
 
 Version 1.5.4
 -----


### PR DESCRIPTION
## Proposed changes

Make changes to send redirect uri to refresh token grant flow. With such parameter being sent, it helps server to identify client types (public client or confidential client) correctly. It is addressing [this issue](https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1020).

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

