### PR TITLE
Enable whole mode swift compilation mode recommended by Xcode 12

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -5665,7 +5665,7 @@
 			attributes = {
 				CLASSPREFIX = MSID;
 				LastSwiftUpdateCheck = 1160;
-				LastUpgradeCheck = 0910;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					1EE8FF5524F4BB3800CA1445 = {
@@ -7937,6 +7937,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				SWIFT_COMPILATION_MODE = wholemodule;
 			};
 			name = Release;
 		};


### PR DESCRIPTION

## Proposed changes

This PR applies settings recommended by Xcode 12 to quite down issue navigator warning (as requested by [AzureAD/microsoft-authentication-library-common-for-objc#826](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/issues/826))

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

