### PR TITLE
Support bypassing macOS redirectUri validation

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1530,6 +1530,7 @@
 		B2ED1BDA2204D36C00A24E82 /* NSString+MSIDAutomationUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = B25A39FD21C60A9E00213A62 /* NSString+MSIDAutomationUtils.h */; };
 		B2ED1BDB2204D36F00A24E82 /* NSString+MSIDAutomationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B25A39FE21C60A9E00213A62 /* NSString+MSIDAutomationUtils.m */; };
 		B2ED1BDC2204D36F00A24E82 /* NSString+MSIDAutomationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B25A39FE21C60A9E00213A62 /* NSString+MSIDAutomationUtils.m */; };
+		B2ED905024FDF3A900B6ED59 /* MSIDRedirectUriVerifierMacTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2ED904F24FDF3A900B6ED59 /* MSIDRedirectUriVerifierMacTests.m */; };
 		B2EE86E123751B6F00D0BC96 /* MSIDSystemWebviewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A3E9B8208941D700BE5262 /* MSIDSystemWebviewController.m */; };
 		B2EF143A1FF2F225005DC1C0 /* MSIDAADV2TokenResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = B2EF14391FF2F21E005DC1C0 /* MSIDAADV2TokenResponse.h */; };
 		B2EF143B1FF2F228005DC1C0 /* MSIDAADV2TokenResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B2EF14381FF2F21D005DC1C0 /* MSIDAADV2TokenResponse.m */; };
@@ -2764,6 +2765,7 @@
 		B2E7698D206096A7000F3F2B /* MSIDTelemetryCacheEventTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryCacheEventTests.m; sourceTree = "<group>"; };
 		B2ED1BA62204D24700A24E82 /* libIdentityAutomationTestLib iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIdentityAutomationTestLib iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2ED1BB32204D26700A24E82 /* libIdentityAutomationTestLib Mac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIdentityAutomationTestLib Mac.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B2ED904F24FDF3A900B6ED59 /* MSIDRedirectUriVerifierMacTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDRedirectUriVerifierMacTests.m; sourceTree = "<group>"; };
 		B2EF14381FF2F21D005DC1C0 /* MSIDAADV2TokenResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADV2TokenResponse.m; sourceTree = "<group>"; };
 		B2EF14391FF2F21E005DC1C0 /* MSIDAADV2TokenResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAADV2TokenResponse.h; sourceTree = "<group>"; };
 		B2F671E12467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDInteractiveAuthorizationCodeRequest.h; sourceTree = "<group>"; };
@@ -4513,6 +4515,7 @@
 				B86FA7CA2383748000E5195A /* Info.plist */,
 				B2AE0FDA2427E96800B8FAF1 /* MSIDKeychainUtilTests.m */,
 				58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */,
+				B2ED904F24FDF3A900B6ED59 /* MSIDRedirectUriVerifierMacTests.m */,
 			);
 			path = mac;
 			sourceTree = "<group>";
@@ -6476,6 +6479,7 @@
 				B2DD5BC320479D9D0084313F /* MSIDKeyedArchiverSerializerTests.m in Sources */,
 				238EF081208FFA4C0035ABE6 /* MSIDUrlRequestSerializerTests.m in Sources */,
 				B24130DD247A1C5F002E70C4 /* MSIDPrimaryRefreshTokenTests.m in Sources */,
+				B2ED905024FDF3A900B6ED59 /* MSIDRedirectUriVerifierMacTests.m in Sources */,
 				B2C17AF11FC7A1C00070A514 /* MSIDLoggerTests.m in Sources */,
 				B2DD5B9C20475E780084313F /* MSIDBaseTokenTests.m in Sources */,
 				239DF9C420E04BC9002D428B /* MSIDADFSAuthorityTests.m in Sources */,

--- a/IdentityCore/src/util/mac/MSIDRedirectUriVerifier.m
+++ b/IdentityCore/src/util/mac/MSIDRedirectUriVerifier.m
@@ -34,7 +34,7 @@
 {
     if (![NSString msidIsStringNilOrBlank:customRedirectUri])
     {
-        BOOL isBrokerCapable = [MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:customRedirectUri]];
+        BOOL isBrokerCapable = [MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:customRedirectUri]] || bypassRedirectValidation;
         return [[MSIDRedirectUri alloc] initWithRedirectUri:[NSURL URLWithString:customRedirectUri]
                                               brokerCapable:isBrokerCapable];
     }

--- a/IdentityCore/src/util/mac/MSIDRedirectUriVerifier.m
+++ b/IdentityCore/src/util/mac/MSIDRedirectUriVerifier.m
@@ -34,8 +34,16 @@
 {
     if (![NSString msidIsStringNilOrBlank:customRedirectUri])
     {
-        BOOL isBrokerCapable = [MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:customRedirectUri]] || bypassRedirectValidation;
-        return [[MSIDRedirectUri alloc] initWithRedirectUri:[NSURL URLWithString:customRedirectUri]
+        NSURL *customRedirectURL = [NSURL URLWithString:customRedirectUri];
+        
+        if (!customRedirectURL.scheme && !bypassRedirectValidation)
+        {
+            MSIDFillAndLogError(error, MSIDErrorInvalidDeveloperParameter, @"Invalid redirect URI provided", nil);
+            return nil;
+        }
+        
+        BOOL isBrokerCapable = [MSIDRedirectUri redirectUriIsBrokerCapable:customRedirectURL] || bypassRedirectValidation;
+        return [[MSIDRedirectUri alloc] initWithRedirectUri:customRedirectURL
                                               brokerCapable:isBrokerCapable];
     }
 

--- a/IdentityCore/tests/mac/MSIDRedirectUriVerifierMacTests.m
+++ b/IdentityCore/tests/mac/MSIDRedirectUriVerifierMacTests.m
@@ -1,0 +1,123 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <XCTest/XCTest.h>
+#import "MSIDRedirectUriVerifier.h"
+#import "MSIDTestBundle.h"
+#import "MSIDRedirectUri.h"
+
+@interface MSIDRedirectUriVerifierMacTests : XCTestCase
+
+@end
+
+@implementation MSIDRedirectUriVerifierMacTests
+
+- (void)setUp
+{
+    [super setUp];
+    [MSIDTestBundle overrideBundleId:@"test.bundle.identifier"];
+}
+
+- (void)testMsidRedirectUriCreation_whenCustomRedirectUriProvided_andRedirectUriBrokerCapable_shouldReturnBrokeredURL
+{
+    NSError *error = nil;
+    MSIDRedirectUri *redirectUri = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:@"msauth.test.bundle.identifier://auth"
+                                                                                clientId:@"myclient"
+                                                                bypassRedirectValidation:NO
+                                                                                   error:&error];
+    
+    XCTAssertNotNil(redirectUri);
+    XCTAssertNil(error);
+    XCTAssertTrue(redirectUri.brokerCapable);
+}
+
+- (void)testMsidRedirectUriCreation_whenCustomRedirectUriProvided_andRedirectUriNotBrokerCapable_shouldReturnNonBrokerURL
+{
+    NSError *error = nil;
+    MSIDRedirectUri *redirectUri = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:@"msauth.test.bundle.identifier2://auth"
+                                                                                clientId:@"myclient"
+                                                                bypassRedirectValidation:NO
+                                                                                   error:&error];
+    
+    XCTAssertNotNil(redirectUri);
+    XCTAssertNil(error);
+    XCTAssertFalse(redirectUri.brokerCapable);
+}
+
+- (void)testMsidRedirectUriCreation_whenCustomRedirectUriInvalid_shouldReturnNil
+{
+    NSError *error = nil;
+    MSIDRedirectUri *redirectUri = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:@"invalid_redirect"
+                                                                                clientId:@"myclient"
+                                                                bypassRedirectValidation:NO
+                                                                                   error:&error];
+    
+    XCTAssertNil(redirectUri);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+    XCTAssertFalse(redirectUri.brokerCapable);
+}
+
+- (void)testMsidRedirectUriCreation_whenCustomRedirectUriInvalid_andByPassFladEnabled_shouldReturnBrokeredURL
+{
+    NSError *error = nil;
+    MSIDRedirectUri *redirectUri = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:@"invalid_redirect"
+                                                                                clientId:@"myclient"
+                                                                bypassRedirectValidation:YES
+                                                                                   error:&error];
+    
+    XCTAssertNotNil(redirectUri);
+    XCTAssertNil(error);
+    XCTAssertTrue(redirectUri.brokerCapable);
+}
+
+- (void)testMsidRedirectUriCreation_whenNoCustomRedirectUriProvided_shouldReturnDefaultBrokeredURL
+{
+    NSError *error = nil;
+    MSIDRedirectUri *redirectUri = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:nil
+                                                                                clientId:@"myclient"
+                                                                bypassRedirectValidation:NO
+                                                                                   error:&error];
+    
+    XCTAssertNotNil(redirectUri);
+    XCTAssertNil(error);
+    XCTAssertTrue(redirectUri.brokerCapable);
+    XCTAssertEqualObjects(redirectUri.url.absoluteString, @"msauth.test.bundle.identifier://auth");
+}
+
+- (void)testMsidRedirectUriCreation_whenCustomRedirectUriProvided_andRedirectUriNotBrokerCapable_butByPassFlagEnabled_shouldReturnBrokeredURL
+{
+    NSError *error = nil;
+    MSIDRedirectUri *redirectUri = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:@"msauth.test.bundle.identifier2://auth"
+                                                                                clientId:@"myclient"
+                                                                bypassRedirectValidation:YES
+                                                                                   error:&error];
+    
+    XCTAssertNotNil(redirectUri);
+    XCTAssertNil(error);
+    XCTAssertTrue(redirectUri.brokerCapable);
+}
+
+@end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+* Support bypassing redirectUri validation also on macOS
 * Indicate whether SSO extension account is available for device wide SSO (#825)
 * Add swift static lib target to support AES GCM.
 


### PR DESCRIPTION
## Proposed changes

Allow bypassing redirect uri on macOS. This is needed to allow macOS CP app to add account for SSO. 
This flag is already in use by iOS. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

