### PR TITLE
Peter/pKeyAuthFix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.0.19
+-------------
+* Disable WPJ Challenge & append "PKeyAuth/1.0" to the User-Agent string field to enable PKeyAuth challenge on iOS
+
 Version 1.0.17
 -------------
 * Remove SHA-1 dependency for ADAL (#696)


### PR DESCRIPTION
## Proposed changes

The purpose of this PR is to disable WPJ Challenge on iOS and also to add "PKeyAuth/1.0" keyword to the User Agent field in the HTTP header to enable PKeyAuth challenge during the embedded webview initialization/configuration stage.

There is a known issue where Apple has a bug in iOS about WKWebview handling NSURLAuthenticationMethodClientCertificate.
It swallows the challenge response rather than sending it to server. Therefore, WPJ Challenge needs to be disabled on iOS at the moment.

Also, passing in the x-ms-PkeyAuth field in the HTTP header doesn't work for the scenario where the user is first directed to Microsoft sign-in page and then redirected to another adfs sign in page.
ex:

User opens ADAL test app and then attempts to acquire token using OneDrive or Office profile.
user is redirected to Office356 login page (login.microsoft.com)
3)user types in the user id - test@unisys.com
4)user is then redirected to (adfs.unisys.com)
Embedded webview is initialized during step 1, and "x-ms-PkeyAuth" field is added to the HTTP request header.
However, when the user makes it to step 4, "x-ms-PkeyAuth" field is lost by then.

This issue can be addressed by appending "PKeyAuth/1.0" keyword to the User Agent string in the HTTP header during the embedded webview initialization/configuration stage. This complies with the PKeyAuth spec and also has been shown to retain the keyword in the User-Agent string field from step 1 through step 4. I have also verified that having the keyword in the User Agent string triggers PKeyAuth challenge using a test account that has device proof CA policy.

https://portal.microsofticm.com/imp/v3/incidents/details/200672947/home
## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

