### PR TITLE
Ameyapat/adal i os14 fixes

### DIFF
--- a/IdentityCore/tests/MSIDURLSessionDelegateTests.m
+++ b/IdentityCore/tests/MSIDURLSessionDelegateTests.m
@@ -91,9 +91,9 @@
 - (void)testSessionTaskDidReceiveChallenge_whenNoBlockProvided_shouldPerformDefaultHandling
 {
     __auto_type delegate = [MSIDURLSessionDelegate new];
-    __auto_type session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    __auto_type session = [NSURLSession sharedSession];
     __auto_type challenge = [NSURLAuthenticationChallenge new];
-    __auto_type task = [session dataTaskWithURL:[NSURL URLWithString:@""]];
+    __auto_type task = [session dataTaskWithURL:[NSURL URLWithString:@"https://microsoft.com"]];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"session:task:didReceiveChallenge:completionHandler"];
     [delegate URLSession:session task:task didReceiveChallenge:challenge completionHandler:^(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential)
@@ -110,10 +110,10 @@
 - (void)testSessionTaskDidReceiveChallenge_whenBlockProvided_shouldUseHandlingProvidedByBlock
 {
     __auto_type delegate = [MSIDURLSessionDelegate new];
-    __auto_type session = [NSURLSession new];
+    __auto_type session = [NSURLSession sharedSession];
     __auto_type challendge = [NSURLAuthenticationChallenge new];
     __auto_type credential = [NSURLCredential new];
-    __auto_type task = [NSURLSessionTask new];
+    __auto_type task = [session dataTaskWithURL:[NSURL URLWithString:@"https://microsoft.com"]];
     
     delegate.taskDidReceiveAuthenticationChallengeBlock = ^void (NSURLSession *s, NSURLSessionTask *t, NSURLAuthenticationChallenge *ch, ChallengeCompletionHandler completionHandler)
     {

--- a/IdentityCore/tests/MSIDURLSessionDelegateTests.m
+++ b/IdentityCore/tests/MSIDURLSessionDelegateTests.m
@@ -91,12 +91,12 @@
 - (void)testSessionTaskDidReceiveChallenge_whenNoBlockProvided_shouldPerformDefaultHandling
 {
     __auto_type delegate = [MSIDURLSessionDelegate new];
-    __auto_type session = [NSURLSession new];
-    __auto_type challendge = [NSURLAuthenticationChallenge new];
-    __auto_type task = [NSURLSessionTask new];
+    __auto_type session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    __auto_type challenge = [NSURLAuthenticationChallenge new];
+    __auto_type task = [session dataTaskWithURL:[NSURL URLWithString:@""]];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"session:task:didReceiveChallenge:completionHandler"];
-    [delegate URLSession:session task:task didReceiveChallenge:challendge completionHandler:^(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential)
+    [delegate URLSession:session task:task didReceiveChallenge:challenge completionHandler:^(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential)
     {
         XCTAssertEqual(disposition, NSURLSessionAuthChallengePerformDefaultHandling);
         XCTAssertNil(credential);

--- a/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDLegacyAccessorSSOIntegrationTests.m
@@ -300,6 +300,11 @@
     NSArray *legacyRefreshTokens = [self getAllLegacyRefreshTokens];
     XCTAssertEqual([legacyRefreshTokens count], 2);
     XCTAssertNotEqualObjects(legacyRefreshTokens[0], legacyRefreshTokens[1]);
+    legacyRefreshTokens = [legacyRefreshTokens sortedArrayUsingComparator:^NSComparisonResult(id a, id b) {
+        NSString *clientId1 = [(MSIDLegacyRefreshToken *)a clientId];
+        NSString *clientId2 = [(MSIDLegacyRefreshToken *)b clientId];
+        return [clientId2 compare:clientId1];
+    }];
 
     MSIDLegacyRefreshToken *refreshToken1 = legacyRefreshTokens[0];
     MSIDLegacyRefreshToken *refreshToken2 = legacyRefreshTokens[1];


### PR DESCRIPTION
## Proposed changes
Travis CI/CD fails for the below tests with Xcode 12. Fixing the test cases here.

MSIDLegacyAccessorSSOIntegrationTests.m failed because it isn't guaranteed that the refresh token array returned is in order and the later logic uses the object at index to make assertions.

Creating a new URLSession for each test case is not advised which causes failure in CI/CD job, hence replaced with shared session.
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

