### PR TITLE
PKeyAuth UserAgent String + WPJChallenge disabling on iOS

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
@@ -44,6 +44,10 @@
                 context:(id<MSIDRequestContext>)context
       completionHandler:(ChallengeCompletionHandler)completionHandler
 {
+
+#if TARGET_OS_IPHONE
+    return NO;
+#else
     NSString *host = challenge.protectionSpace.host;
     
     MSID_LOG_INFO(context, @"Attempting to handle client TLS challenge");
@@ -55,9 +59,8 @@
     {
         return [self handleWPJChallenge:challenge context:context completionHandler:completionHandler];
     }
-#if TARGET_OS_IPHONE
-    return NO;
-#else
+    
+    
     return [self handleCertAuthChallenge:challenge webview:webview context:context completionHandler:completionHandler];
 #endif
 }

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -27,6 +27,7 @@
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDAppExtensionUtil.h"
 #import "MSIDMainThreadUtil.h"
+#import "MSIDWorkPlaceJoinConstants.h"
 
 static WKWebViewConfiguration *s_webConfig;
 
@@ -50,6 +51,7 @@ static WKWebViewConfiguration *s_webConfig;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         s_webConfig = [WKWebViewConfiguration new];
+        s_webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
         
         if (@available(iOS 13.0, *))
         {

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinConstants.h
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinConstants.h
@@ -30,3 +30,4 @@ extern NSString *const kMSIDProtectionSpaceDistinguishedName;
 extern NSString *const kMSIDPKeyAuthUrn;
 extern NSString *const kMSIDPKeyAuthHeader;
 extern NSString *const kMSIDPKeyAuthHeaderVersion;
+extern NSString *const kMSIDPKeyAuthKeyWordForUserAgent;

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinConstants.m
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinConstants.m
@@ -28,3 +28,4 @@ NSString *const kMSIDProtectionSpaceDistinguishedName   = @"MS-Organization-Acce
 NSString *const kMSIDPKeyAuthUrn                        = @"urn:http-auth:PKeyAuth?";
 NSString *const kMSIDPKeyAuthHeader                     = @"x-ms-PkeyAuth";
 NSString *const kMSIDPKeyAuthHeaderVersion              = @"1.0";
+NSString *const kMSIDPKeyAuthKeyWordForUserAgent        = @"PKeyAuth/1.0";

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 1.0.19
+-------------
+* Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server.
+* Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS
+
 Version 1.0.17
 -------------
 * Remove SHA-1 dependency for ADAL (#696)


### PR DESCRIPTION
## Proposed changes

On iOS, passing in the x-ms-PkeyAuth field in the HTTP header doesn't work for the scenario where the user is first directed to Microsoft sign-in page and then redirected to another adfs sign in page.
ex:

User opens ADAL test app and then attempts to acquire token using OneDrive or Office profile.
user is redirected to Office356 login page (login.microsoft.com)
3)user types in the user id - test@unisys.com
4)user is then redirected to (adfs.unisys.com)
Embedded webview is initialized during step 1, and "x-ms-PkeyAuth" field is added to the HTTP request header.
However, when the user makes it to step 4, "x-ms-PkeyAuth" field is lost in the HTTP header from the server side by then.

This issue can be addressed by appending "PKeyAuth/1.0" keyword to the User Agent string in the HTTP header during the embedded webview initialization/configuration stage. This complies with the PKeyAuth spec and also has been shown to retain the keyword in the User-Agent string field from step 1 through step 4. I have also verified that having the keyword in the User Agent string triggers PKeyAuth challenge using a test account that has device proof CA policy.
## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

