### PR TITLE
Normalize home account id in cache lookups

### DIFF
--- a/IdentityCore/src/cache/token/Matchers/MSIDAccountCacheItem+MSIDAccountMatchers.m
+++ b/IdentityCore/src/cache/token/Matchers/MSIDAccountCacheItem+MSIDAccountMatchers.m
@@ -31,7 +31,7 @@
                      environment:(nullable NSString *)environment
               environmentAliases:(nullable NSArray<NSString *> *)environmentAliases
 {
-    if (homeAccountId && ![self.homeAccountId isEqualToString:homeAccountId])
+    if (homeAccountId && ![self.homeAccountId.msidNormalizedString isEqualToString:homeAccountId.msidNormalizedString])
     {
         return NO;
     }

--- a/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.m
@@ -24,6 +24,7 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDMaskedHashableLogParameter.h"
 #import "MSIDMaskedUsernameLogParameter.h"
+#import "NSString+MSIDExtensions.h"
 
 static NSString *const MSID_ACCOUNT_DISPLAYABLE_ID_JSON_KEY = @"username";
 static NSString *const MSID_ACCOUNT_HOME_ID_JSON_KEY = @"home_account_id";
@@ -53,7 +54,7 @@ static NSString *const MSID_ACCOUNT_HOME_ID_JSON_KEY = @"home_account_id";
     }
 
     _displayableId = legacyAccountId;
-    _homeAccountId = homeAccountId;
+    _homeAccountId = homeAccountId.msidNormalizedString;
     _maskedHomeAccountId = MSID_PII_LOG_TRACKABLE(_homeAccountId);
     _maskedDisplayableId = MSID_PII_LOG_EMAIL(_displayableId);
     _legacyAccountIdentifierType = MSIDLegacyIdentifierTypeRequiredDisplayableId;
@@ -97,7 +98,7 @@ static NSString *const MSID_ACCOUNT_HOME_ID_JSON_KEY = @"home_account_id";
 {
     if (uid && utid)
     {
-        return [NSString stringWithFormat:@"%@.%@", uid, utid];
+        return [NSString stringWithFormat:@"%@.%@", uid.msidNormalizedString, utid.msidNormalizedString];
     }
     else return nil;
 }

--- a/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
+++ b/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
@@ -2343,7 +2343,7 @@
     XCTAssertEqualObjects(results[0], account2);
 }
 
-- (void)testGetAccountsWithQuery_whenQueryNotExactMatch_andMatchingByHomeAccountId_shouldReturnAccount
+- (void)testGetAccountsWithQuery_whenQueryNotExactMatch_andMatchingByHomeAccountIdWithDifferentCasing_shouldReturnAccount
 {
     [self saveAccount:[self createTestAccountCacheItem]];
 
@@ -2355,7 +2355,7 @@
     NSError *error = nil;
 
     MSIDDefaultAccountCacheQuery *query = [MSIDDefaultAccountCacheQuery new];
-    query.homeAccountId = @"uid.utid2";
+    query.homeAccountId = @"uid.uTID2";
     XCTAssertFalse(query.exactMatch);
 
     NSArray *results = [self.cache getAccountsWithQuery:query context:nil error:&error];

--- a/IdentityCore/tests/MSIDAccountIdentifierTests.m
+++ b/IdentityCore/tests/MSIDAccountIdentifierTests.m
@@ -72,11 +72,11 @@
     XCTAssertNil(identifier.displayableId);
 }
 
-- (void)testInitWithJSONDictionary_whenDisplayableAndHomeAccountIDs_shouldInit
+- (void)testInitWithJSONDictionary_whenDisplayableAndHomeAccountIDs_shouldInitAndNormalize
 {
     NSDictionary *json = @{
         @"username": @"user@contoso.com",
-        @"home_account_id": @"1.1234-5678-90abcdefg",
+        @"home_account_id": @"1.1234-5678-90ABCdefg",
     };
     
     NSError *error;
@@ -97,10 +97,10 @@
     XCTAssertNil(json);
 }
 
-- (void)testJsonDictionary_whenAllIDsSet_shouldReturnJson
+- (void)testJsonDictionary_whenAllIDsSet_shouldReturnNormalizedJson
 {
     __auto_type identifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com"
-                                                                    homeAccountId:@"1.1234-5678-90abcdefg"];
+                                                                    homeAccountId:@"1.1234-5678-90abcdEFG"];
     
     NSDictionary *json = [identifier jsonDictionary];
     

--- a/IdentityCore/tests/integration/ios/MSIDDefaultBrokerRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultBrokerRequestTests.m
@@ -152,7 +152,7 @@
                                       @"prompt" : @"select_account",
                                       @"msg_protocol_ver" : @"3",
                                       //if account set, both of the following should be set
-                                      @"home_account_id" : @"myHomeAccountId",
+                                      @"home_account_id" : @"myhomeaccountid",
                                       @"username" : @"user",
                                       @"broker_nonce" : [MSIDTestIgnoreSentinel sentinel],
                                       @"application_token" : @"brokerApplicationToken"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 Version 1.5.6
+
 * Normalize home account id in cache lookups #839
 * Support forgetting cached account (#830)
 * Enabling XCODE 11.4 recommended settings by default per customer request.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
-<<<<<<< HEAD
 Version 1.5.6
+* Normalize home account id in cache lookups #839
 * Enabling XCODE 11.4 recommended settings by default per customer request.
 * Move correlationId to MSIDBaseBrokerOperationRequest 
 * Support bypassing redirectUri validation also on macOS


### PR DESCRIPTION
## Proposed changes

In current cache lookups not all account identifiers where properly normalized.
From looking at an issue reported by customer, I've noticed that Teams is passing home account id in following format "uid.UTID". This seems to happen because another Office app is writing account to external cache in this format. 

What is happening is that access token lookups succeeds, but account lookup fails. Therefore, we'll always make a network call to the server and after a few calls request will be dropped with the "loop detected error". After that happens, Teams will reach out to SSO extension and that will use PRT to get new token. That will also be marked as "looping" after a few tries. 

In the end of the loop, Teams will be unable to get a token.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

