### PR TITLE
Add a flag to disable logger queue

### DIFF
--- a/IdentityCore/src/logger/MSIDLogger.m
+++ b/IdentityCore/src/logger/MSIDLogger.m
@@ -213,8 +213,15 @@ static NSDateFormatter *s_dateFormatter = nil;
             
             BOOL lineContainsPII = self.piiLoggingEnabled ? containsPII : NO;
             
-            if (self.callback) self.callback(level, log, lineContainsPII);
-            if (self.loggerConnector) [self.loggerConnector onLogWithLevel:level lineNumber:lineNumber function:function message:log];
+            if (self.loggerConnector)
+            {
+                [self.loggerConnector onLogWithLevel:level lineNumber:lineNumber function:function message:log];
+            }
+            else if (self.callback)
+            {
+                self.callback(level, log, lineContainsPII);
+            }
+                
         }
     };
     

--- a/IdentityCore/src/logger/MSIDLogger.m
+++ b/IdentityCore/src/logger/MSIDLogger.m
@@ -156,74 +156,88 @@ static NSDateFormatter *s_dateFormatter = nil;
     __uint64_t tid;
     pthread_threadid_np(NULL, &tid);
     
-    // Prevent queue from growing infinitely large.
-    dispatch_semaphore_wait(self.queueSemaphore, DISPATCH_TIME_FOREVER);
-    
-    dispatch_async(self.loggerQueue, ^{
-        @autoreleasepool
+    void (^logBlock)(void) = ^
+    {
+        NSString *logComponent = [context logComponent];
+        NSString *componentStr = logComponent ? [NSString stringWithFormat:@" [%@]", logComponent] : @"";
+        
+        NSString *correlationIdStr = @"";
+        
+        if (correlationId)
         {
-            NSString *logComponent = [context logComponent];
-            NSString *componentStr = logComponent ? [NSString stringWithFormat:@" [%@]", logComponent] : @"";
-            
-            NSString *correlationIdStr = @"";
-            
-            if (correlationId)
+            if ([correlationId isKindOfClass:[NSUUID class]])
             {
-                if ([correlationId isKindOfClass:[NSUUID class]])
-                {
-                    correlationIdStr = [NSString stringWithFormat:@" - %@", correlationId.UUIDString];
-                }
-                else
-                {
-                    NSAssert(NO, @"Correlation ID not of NSUUID class");
-                    correlationIdStr = @"[Invalid non-NSUUID correlationID]";
-                }
+                correlationIdStr = [NSString stringWithFormat:@" - %@", correlationId.UUIDString];
             }
-            else if (context)
+            else
             {
-                correlationIdStr = [NSString stringWithFormat:@" - %@", [context correlationId]];
+                NSAssert(NO, @"Correlation ID not of NSUUID class");
+                correlationIdStr = @"[Invalid non-NSUUID correlationID]";
             }
-            
-            NSString *dateStr = [s_dateFormatter stringFromDate:[NSDate date]];
-            
-            NSString *sdkName = [MSIDVersion sdkName];
-            NSString *sdkVersion = [MSIDVersion sdkVersion];
-            
-            NSString *sourceInfo = @"";
-            if (self.sourceLineLoggingEnabled && filename.length)
-            {
-                sourceInfo = [NSString stringWithFormat:@" %@:%lu: %@", filename.lastPathComponent, (unsigned long)lineNumber, function];
-            }
-            
-            __auto_type threadName = [[NSThread currentThread] isMainThread] ? @" (main thread)" : nil;
-            if (!threadName) {
-                threadName = [NSThread currentThread].name ?: @"";
-            }
-            
-            __auto_type threadInfo = [[NSString alloc] initWithFormat:@"TID=%llu%@", tid, threadName];
-            
-            if (self.nsLoggingEnabled)
-            {
-                NSString *logLevelStr = [self stringForLogLevel:self.level];
-                
-                NSString *log = [NSString stringWithFormat:@"%@ %@ %@ %@ [%@%@]%@ %@:%@ %@", threadInfo, sdkName, sdkVersion, [MSIDDeviceId deviceOSId], dateStr, correlationIdStr, componentStr, logLevelStr, sourceInfo, message];
-                
-                NSLog(@"%@", log);
-            }
-            
-            if (self.callback || self.loggerConnector)
-            {
-                NSString *log = [NSString stringWithFormat:@"%@ %@ %@ %@ [%@%@]%@%@ %@", threadInfo, sdkName, sdkVersion, [MSIDDeviceId deviceOSId], dateStr, correlationIdStr, componentStr, sourceInfo, message];
-                
-                BOOL lineContainsPII = self.piiLoggingEnabled ? containsPII : NO;
-                
-                if (self.callback) self.callback(level, log, lineContainsPII);
-                if (self.loggerConnector) [self.loggerConnector onLogWithLevel:level lineNumber:lineNumber function:function message:log];
-            }
-            
-            dispatch_semaphore_signal(self.queueSemaphore);
         }
-    });
+        else if (context)
+        {
+            correlationIdStr = [NSString stringWithFormat:@" - %@", [context correlationId]];
+        }
+        
+        NSString *dateStr = [s_dateFormatter stringFromDate:[NSDate date]];
+        
+        NSString *sdkName = [MSIDVersion sdkName];
+        NSString *sdkVersion = [MSIDVersion sdkVersion];
+        
+        NSString *sourceInfo = @"";
+        if (self.sourceLineLoggingEnabled && filename.length)
+        {
+            sourceInfo = [NSString stringWithFormat:@" %@:%lu: %@", filename.lastPathComponent, (unsigned long)lineNumber, function];
+        }
+        
+        __auto_type threadName = [[NSThread currentThread] isMainThread] ? @" (main thread)" : nil;
+        if (!threadName) {
+            threadName = [NSThread currentThread].name ?: @"";
+        }
+        
+        __auto_type threadInfo = [[NSString alloc] initWithFormat:@"TID=%llu%@", tid, threadName];
+        
+        if (self.nsLoggingEnabled)
+        {
+            NSString *logLevelStr = [self stringForLogLevel:self.level];
+            
+            NSString *log = [NSString stringWithFormat:@"%@ %@ %@ %@ [%@%@]%@ %@:%@ %@", threadInfo, sdkName, sdkVersion, [MSIDDeviceId deviceOSId], dateStr, correlationIdStr, componentStr, logLevelStr, sourceInfo, message];
+            
+            NSLog(@"%@", log);
+        }
+        
+        if (self.callback || self.loggerConnector)
+        {
+            NSString *log = [NSString stringWithFormat:@"%@ %@ %@ %@ [%@%@]%@%@ %@", threadInfo, sdkName, sdkVersion, [MSIDDeviceId deviceOSId], dateStr, correlationIdStr, componentStr, sourceInfo, message];
+            
+            BOOL lineContainsPII = self.piiLoggingEnabled ? containsPII : NO;
+            
+            if (self.callback) self.callback(level, log, lineContainsPII);
+            if (self.loggerConnector) [self.loggerConnector onLogWithLevel:level lineNumber:lineNumber function:function message:log];
+        }
+    };
+    
+    BOOL loggingQueueEnabled = YES;
+    if (self.loggerConnector) loggingQueueEnabled = self.loggerConnector.loggingQueueEnabled;
+    
+    if (loggingQueueEnabled)
+    {
+        // Prevent queue from growing infinitely large.
+        dispatch_semaphore_wait(self.queueSemaphore, DISPATCH_TIME_FOREVER);
+        
+        dispatch_async(self.loggerQueue, ^{
+            @autoreleasepool
+            {
+                logBlock();
+                
+                dispatch_semaphore_signal(self.queueSemaphore);
+            }
+        });
+        return;
+    }
+    
+    logBlock();
 }
 
 - (NSString*)stringForLogLevel:(MSIDLogLevel)level

--- a/IdentityCore/src/logger/MSIDLoggerConnecting.h
+++ b/IdentityCore/src/logger/MSIDLoggerConnecting.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)sourceLineLoggingEnabled;
 
+- (BOOL)loggingQueueEnabled;
+
 - (void)onLogWithLevel:(MSIDLogLevel)level
             lineNumber:(NSUInteger)lineNumber
               function:(NSString *)function

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -397,10 +397,11 @@
     XCTAssertTrue([MSIDLogger sharedLogger].sourceLineLoggingEnabled);
 }
 
-- (void)testLogWithLevel_whenConnectorIsSet_shouldReturnValueFromConnector
+- (void)testLogWithLevel_whenConnectorIsSetAndLogQueueEnabled_shouldReturnValueFromConnector
 {
     MSIDLoggerConnectorMock *connectorMock = [MSIDLoggerConnectorMock new];
     connectorMock.shouldLogValue = YES;
+    connectorMock.loggingQueueEnabledValue = YES;
     [MSIDLogger sharedLogger].level = MSIDLogLevelNothing;
     [MSIDLogger sharedLogger].loggerConnector = connectorMock;
     [self keyValueObservingExpectationForObject:connectorMock keyPath:@"logMessageValue" handler:^BOOL(id observedObject, NSDictionary *change)
@@ -413,4 +414,20 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)testLogWithLevel_whenConnectorIsSetAndLogQueueDisabled_shouldReturnValueFromConnector
+{
+    MSIDLoggerConnectorMock *connectorMock = [MSIDLoggerConnectorMock new];
+    connectorMock.shouldLogValue = YES;
+    connectorMock.loggingQueueEnabledValue = NO;
+    [MSIDLogger sharedLogger].level = MSIDLogLevelNothing;
+    [MSIDLogger sharedLogger].loggerConnector = connectorMock;
+    [self keyValueObservingExpectationForObject:connectorMock keyPath:@"logMessageValue" handler:^BOOL(id observedObject, NSDictionary *change)
+    {
+        return [((MSIDLoggerConnectorMock *)observedObject).logMessageValue containsString:@"some message"];
+    }];
+    
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:nil lineNumber:1 function:nil format:@"some message"];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
 @end

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -33,6 +33,7 @@
 @property (nonatomic) BOOL piiLoggingEnabledValue;
 @property (nonatomic) BOOL shouldLogValue;
 @property (nonatomic) BOOL sourceLineLoggingEnabledValue;
+@property (nonatomic) BOOL loggingQueueEnabledValue;
 @property (nonatomic) NSString *logMessageValue;
 
 @end
@@ -67,6 +68,11 @@
 - (BOOL)sourceLineLoggingEnabled
 {
     return self.sourceLineLoggingEnabledValue;
+}
+
+- (BOOL)loggingQueueEnabled
+{
+    return self.loggingQueueEnabledValue;
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

We need to disable logger's queue when we integrate with MSAL CPP logger.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

