### PR TITLE
Remove obsolete todo comment

### DIFF
--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.h
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.h
@@ -25,7 +25,6 @@
 #import "MSIDExtendedTokenCacheDataSource.h"
 #import "MSIDMacACLKeychainAccessor.h"
 
-// TODO: Use a subclass or protocol: https://identitydivision.visualstudio.com/DevEx/_workitems/edit/660964
 @interface MSIDMacKeychainTokenCache : MSIDMacACLKeychainAccessor <MSIDExtendedTokenCacheDataSource>
 
 /*!

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 * Ignore duplicate certificate authentication challenge in system webview.
-Version 1.5.6
 
+Version 1.5.6
 * Limit telemetry archive size on disk, and save unserialized telemetry (#837)
 * Normalize home account id in cache lookups #839
 * Support forgetting cached account (#830)
@@ -32,7 +32,7 @@ Version 1.5.5
 
 Version 1.5.4
 -----
-* Support for proof of posession for access tokens (#738)
+* Support for proof of possession for access tokens (#738)
 * Allow brokered authentication for /consumers authority (#774)
 * Account metadata cleanup on account removal (#791)
 * Fix an issue with guest accounts when UPN mismatches across tenants (#797)


### PR DESCRIPTION
Remove obsolete TODO that causes OneAuth-MSAL automation open bugs.