### PR TITLE
Public APIs to generate custom WKWebViewConfiguration with PKeyAuth UserAgent Str

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -42,6 +42,8 @@ NSWindowController
 @property UIModalPresentationStyle presentationType;
 #endif
 
++ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent;
+
 - (id)initWithContext:(id<MSIDRequestContext>)context;
 
 - (BOOL)loadView:(NSError **)error;

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -42,9 +42,9 @@ NSWindowController
 @property (weak) UIViewController *parentController;
 @property UIModalPresentationStyle presentationType;
 
-+ (WKWebViewConfiguration *)defaultWKWebviewConfiguration;
-
 #endif
+
++ (WKWebViewConfiguration *)defaultWKWebviewConfiguration;
 
 - (id)initWithContext:(id<MSIDRequestContext>)context;
 

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -40,9 +40,10 @@ NSWindowController
 #if TARGET_OS_IPHONE
 @property (weak) UIViewController *parentController;
 @property UIModalPresentationStyle presentationType;
-#endif
 
 + (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent;
+
+#endif
 
 - (id)initWithContext:(id<MSIDRequestContext>)context;
 

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -25,6 +25,7 @@
 
 #import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
+#import "MSIDWorkPlaceJoinConstants.h"
 
 @interface MSIDWebviewUIController :
 #if TARGET_OS_IPHONE
@@ -41,7 +42,7 @@ NSWindowController
 @property (weak) UIViewController *parentController;
 @property UIModalPresentationStyle presentationType;
 
-+ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent;
++ (WKWebViewConfiguration *)defaultWKWebviewConfiguration;
 
 #endif
 

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -25,7 +25,6 @@
 
 #import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
-#import "MSIDWorkPlaceJoinConstants.h"
 
 @interface MSIDWebviewUIController :
 #if TARGET_OS_IPHONE

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -27,7 +27,6 @@
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDAppExtensionUtil.h"
 #import "MSIDMainThreadUtil.h"
-#import "MSIDWorkPlaceJoinConstants.h"
 
 static WKWebViewConfiguration *s_webConfig;
 
@@ -50,17 +49,11 @@ static WKWebViewConfiguration *s_webConfig;
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        s_webConfig = [WKWebViewConfiguration new];
-        s_webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
-        
-        if (@available(iOS 13.0, *))
-        {
-            s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
-        }
+        s_webConfig = [MSIDWebviewUIController defaultWKWebviewConfiguration];
     });
 }
 
-+ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent
++ (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
     WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
     webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -27,6 +27,7 @@
 #import "UIApplication+MSIDExtensions.h"
 #import "MSIDAppExtensionUtil.h"
 #import "MSIDMainThreadUtil.h"
+#import "MSIDWorkPlaceJoinConstants.h"
 
 static WKWebViewConfiguration *s_webConfig;
 

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -64,6 +64,11 @@ static WKWebViewConfiguration *s_webConfig;
 {
     WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
     webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    
+    if (@available(iOS 13.0, *))
+    {
+        webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
+    }
     return webConfig;
 }
 

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -60,6 +60,14 @@ static WKWebViewConfiguration *s_webConfig;
     });
 }
 
++ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent
+{
+    WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
+    webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    return webConfig;
+}
+
+
 - (id)initWithContext:(id<MSIDRequestContext>)context
 {
     self = [super init];

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -52,6 +52,17 @@ static WKWebViewConfiguration *s_webConfig;
     });
 }
 
++ (WKWebViewConfiguration *)defaultWKWebviewConfiguration
+{
+    WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
+
+    if (@available(macOS 10.15, *))
+    {
+        s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
+    }
+    return webConfig;
+}
+
 - (id)initWithContext:(id<MSIDRequestContext>)context
 {
     self = [super init];

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import "MSIDWebviewUIController.h"
+#import "MSIDWorkPlaceJoinConstants.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -44,12 +45,20 @@ static WKWebViewConfiguration *s_webConfig;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         s_webConfig = [WKWebViewConfiguration new];
+        s_webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
         
         if (@available(macOS 10.15, *))
         {
             s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
         }
     });
+}
+
++ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent
+{
+    WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
+    webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    return webConfig;
 }
 
 - (id)initWithContext:(id<MSIDRequestContext>)context

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -43,12 +43,8 @@ static WKWebViewConfiguration *s_webConfig;
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        s_webConfig = [WKWebViewConfiguration new];
+        s_webConfig = [MSIDWebviewUIController defaultWKWebviewConfiguration];
         
-        if (@available(macOS 10.15, *))
-        {
-            s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
-        }
     });
 }
 
@@ -58,7 +54,7 @@ static WKWebViewConfiguration *s_webConfig;
 
     if (@available(macOS 10.15, *))
     {
-        s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
+        webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
     }
     return webConfig;
 }

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 
 #import "MSIDWebviewUIController.h"
-#import "MSIDWorkPlaceJoinConstants.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -45,20 +44,12 @@ static WKWebViewConfiguration *s_webConfig;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         s_webConfig = [WKWebViewConfiguration new];
-        s_webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
         
         if (@available(macOS 10.15, *))
         {
             s_webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
         }
     });
-}
-
-+ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent
-{
-    WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
-    webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
-    return webConfig;
 }
 
 - (id)initWithContext:(id<MSIDRequestContext>)context

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,7 @@ Version 1.0.19
 -------------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server.
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS
-* Added a public API in MSIDWebviewUIController for iOS to generate a custom WKWebViewConfig with "PKeyAuth/1.0" Keyword appended to the UserAgent String.
-This API can also be used by a public API within ADAL. 
+* Added a public API in MSIDWebviewUIController for iOS & MacOS to generate a custom WKWebViewConfig with default recommended settings. Additionally, On iOS, "PKeyAuth/1.0" Keyword appended to the UserAgent String in order to enable PKeyAuth Challenge. 
 
 Version 1.0.17
 -------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 1.0.19
 -------------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server.
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS
+* Added public APIs in MSIDWebviewUIController for iOS & MacOS to generate a custom WKWebViewConfiguration with "PKeyAuth/1.0" Keyword appended to the UserAgent String.
 
 Version 1.0.17
 -------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 1.0.19
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server.
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS
 * Added a public API in MSIDWebviewUIController for iOS to generate a custom WKWebViewConfig with "PKeyAuth/1.0" Keyword appended to the UserAgent String.
+This API can also be used by a public API within ADAL. 
 
 Version 1.0.17
 -------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,8 @@
-Version 1.0.19
+Version 1.0.19 (09/24/2020)
 -------------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server.
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS
-* Added a public API in MSIDWebviewUIController for iOS & MacOS to generate a custom WKWebViewConfig with default recommended settings. Additionally, On iOS, "PKeyAuth/1.0" Keyword appended to the UserAgent String in order to enable PKeyAuth Challenge. 
+* Added a public API in MSIDWebviewUIController for iOS & MacOS to generate a custom WKWebViewConfig with default recommended settings for developers. Additionally, On iOS, "PKeyAuth/1.0" Keyword appended to the UserAgent String in order to enable PKeyAuth Challenge. 
 
 Version 1.0.17
 -------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@ Version 1.0.19
 -------------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server.
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS
-* Added public APIs in MSIDWebviewUIController for iOS & MacOS to generate a custom WKWebViewConfiguration with "PKeyAuth/1.0" Keyword appended to the UserAgent String.
+* Added a public API in MSIDWebviewUIController for iOS to generate a custom WKWebViewConfig with "PKeyAuth/1.0" Keyword appended to the UserAgent String.
 
 Version 1.0.17
 -------------


### PR DESCRIPTION
## Proposed changes

Added public APIs on iOS & MacOS to generate custom WKWebViewConfiguration with PKeyAuth UserAgent Keyword.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

