### PR TITLE
Revert signing code to fix cpp build

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		1E36589B247EF3260044A072 /* MSIDAuthenticationSchemePop.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E365899247EF3260044A072 /* MSIDAuthenticationSchemePop.h */; };
 		1E36589C247EF3260044A072 /* MSIDAuthenticationSchemePop.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E36589A247EF3260044A072 /* MSIDAuthenticationSchemePop.m */; };
 		1E36589D247EF3260044A072 /* MSIDAuthenticationSchemePop.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E36589A247EF3260044A072 /* MSIDAuthenticationSchemePop.m */; };
+		1E37AAD3252196CC00EBED3B /* NSData+JWT.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E37AAD1252196CC00EBED3B /* NSData+JWT.h */; };
+		1E37AAD4252196CC00EBED3B /* NSData+JWT.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E37AAD2252196CC00EBED3B /* NSData+JWT.m */; };
+		1E37AAD5252196CC00EBED3B /* NSData+JWT.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E37AAD2252196CC00EBED3B /* NSData+JWT.m */; };
 		1E3C0ED5217FE2A70022D61D /* MSIDAppMetadataCacheQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3C0ED4217FE2A70022D61D /* MSIDAppMetadataCacheQuery.m */; };
 		1E3C0ED6217FE2BB0022D61D /* MSIDAppMetadataCacheQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E3C0ED3217FE2A70022D61D /* MSIDAppMetadataCacheQuery.h */; };
 		1E3C0ED7217FE2BF0022D61D /* MSIDAppMetadataCacheQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3C0ED4217FE2A70022D61D /* MSIDAppMetadataCacheQuery.m */; };
@@ -1699,6 +1702,8 @@
 		1E3590B8216D210E003D43BE /* MSIDAppMetadataCacheKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAppMetadataCacheKey.m; sourceTree = "<group>"; };
 		1E365899247EF3260044A072 /* MSIDAuthenticationSchemePop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAuthenticationSchemePop.h; sourceTree = "<group>"; };
 		1E36589A247EF3260044A072 /* MSIDAuthenticationSchemePop.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAuthenticationSchemePop.m; sourceTree = "<group>"; };
+		1E37AAD1252196CC00EBED3B /* NSData+JWT.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSData+JWT.h"; sourceTree = "<group>"; };
+		1E37AAD2252196CC00EBED3B /* NSData+JWT.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSData+JWT.m"; sourceTree = "<group>"; };
 		1E3C0ED3217FE2A70022D61D /* MSIDAppMetadataCacheQuery.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAppMetadataCacheQuery.h; sourceTree = "<group>"; };
 		1E3C0ED4217FE2A70022D61D /* MSIDAppMetadataCacheQuery.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAppMetadataCacheQuery.m; sourceTree = "<group>"; };
 		1E4252342187DA0D00C149E9 /* MSIDAppMetadataCacheQueryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAppMetadataCacheQueryTests.m; sourceTree = "<group>"; };
@@ -4577,6 +4582,8 @@
 				583BFCA524D87BA40035B901 /* MSIDRedirectUri.h */,
 				583BFCA624D87BA40035B901 /* MSIDRedirectUri.m */,
 				583BFCAC24D904DE0035B901 /* MSIDRedirectUriVerifier.h */,
+				1E37AAD1252196CC00EBED3B /* NSData+JWT.h */,
+				1E37AAD2252196CC00EBED3B /* NSData+JWT.m */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -5382,6 +5389,7 @@
 				238F80A522C2C41000437CB1 /* MSIDGetV1IdTokenCacheEvent.h in Headers */,
 				B227035922A3678A00030ADC /* MSIDMaskedUsernameLogParameter.h in Headers */,
 				58B81F7C24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.h in Headers */,
+				1E37AAD3252196CC00EBED3B /* NSData+JWT.h in Headers */,
 				B286B9E32389DFB4007833AD /* MSIDBasicContext.h in Headers */,
 				B28D90A5218FD1E800E230D6 /* MSIDLegacyTokenResponseValidator.h in Headers */,
 				B2C708AA219A5A3D00D917B8 /* MSIDLegacySilentTokenRequest.h in Headers */,
@@ -6229,6 +6237,7 @@
 				B29A36C120B1289D00427B63 /* MSIDAccountIdentifier.m in Sources */,
 				B2EE86E123751B6F00D0BC96 /* MSIDSystemWebviewController.m in Sources */,
 				B266903E243706CF00FB0117 /* MSIDBrokerOperationBrowserTokenRequest.m in Sources */,
+				1E37AAD5252196CC00EBED3B /* NSData+JWT.m in Sources */,
 				B286B9872389DC24007833AD /* MSIDBrokerOperationGetAccountsRequest.m in Sources */,
 				B297E1F220A25F0C00F370EC /* MSIDLegacyTokenCacheItem.m in Sources */,
 				B286B9992389DC9D007833AD /* MSIDSSOExtensionSilentTokenRequest.m in Sources */,
@@ -6899,6 +6908,7 @@
 				B2EF143C1FF2F228005DC1C0 /* MSIDAADV2TokenResponse.m in Sources */,
 				B297E1DD20A0F5D600F370EC /* MSIDDefaultCredentialCacheQuery.m in Sources */,
 				60A504702374917B00648AC5 /* MSIDBrokerOperationGetAccountsResponse.m in Sources */,
+				1E37AAD4252196CC00EBED3B /* NSData+JWT.m in Sources */,
 				B281B335226BB83C009619AB /* MSIDOAuthRequestConfigurator.m in Sources */,
 				B27893822470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m in Sources */,
 				B2115828202BD5F3005CE586 /* MSIDCacheKey.m in Sources */,

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
@@ -149,10 +149,19 @@
         return nil;
     }
     
-    SecKeyRef publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
-    if (!publicKeyRef)
+    SecKeyRef publicKeyRef = NULL;
+    if (@available(iOS 10.0, macOS 10.12, *))
     {
-        [self logAndFillError:@"Failed to copy public key from private key." status:-1 error:error];
+        publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
+        if (!publicKeyRef)
+        {
+            [self logAndFillError:@"Failed to copy public key from private key." status:-1 error:error];
+            return nil;
+        }
+    }
+    else
+    {
+        [self logAndFillError:@"Failed to copy public key from private key due to unsupported platform." status:-1 error:error];
         return nil;
     }
     
@@ -238,10 +247,20 @@
         return nil;
     }
     
-    SecKeyRef publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
-    if (!publicKeyRef)
+    SecKeyRef publicKeyRef = NULL;
+    if (@available(iOS 10.0, macOS 10.12, *))
     {
-        [self logAndFillError:@"Failed to copy public key from private key." status:-1 error:error];
+        publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
+        if (!publicKeyRef)
+        {
+            [self logAndFillError:@"Failed to copy public key from private key." status:-1 error:error];
+            CFRelease(privateKeyRef);
+            return nil;
+        }
+    }
+    else
+    {
+        [self logAndFillError:@"Failed to copy public key from private key due to unsupported platform." status:-1 error:error];
         CFRelease(privateKeyRef);
         return nil;
     }

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
@@ -130,49 +130,48 @@
 - (MSIDAssymetricKeyPair *)readKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
                                              error:(NSError **)error
 {
-    if ([NSString msidIsStringNilOrBlank:attributes.privateKeyIdentifier])
-    {
-        [self logAndFillError:@"Invalid key lookup attributes provided" status:-1 error:error];
-        return nil;
-    }
-    
-    NSDictionary *privateKeyDict = [self keyAttributesWithQueryDictionary:[attributes privateKeyAttributes] error:error];
-    if (!privateKeyDict)
-    {
-        return nil;
-    }
-    
-    SecKeyRef privateKeyRef = (__bridge SecKeyRef)privateKeyDict[(__bridge id)kSecValueRef];
-    if (!privateKeyRef)
-    {
-        [self logAndFillError:@"Failed to query private key reference from keychain." status:-1 error:error];
-        return nil;
-    }
-    
-    SecKeyRef publicKeyRef = NULL;
     if (@available(iOS 10.0, macOS 10.12, *))
     {
-        publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
+        if ([NSString msidIsStringNilOrBlank:attributes.privateKeyIdentifier])
+        {
+            [self logAndFillError:@"Invalid key lookup attributes provided" status:-1 error:error];
+            return nil;
+        }
+        
+        NSDictionary *privateKeyDict = [self keyAttributesWithQueryDictionary:[attributes privateKeyAttributes] error:error];
+        if (!privateKeyDict)
+        {
+            return nil;
+        }
+        
+        SecKeyRef privateKeyRef = (__bridge SecKeyRef)privateKeyDict[(__bridge id)kSecValueRef];
+        if (!privateKeyRef)
+        {
+            [self logAndFillError:@"Failed to query private key reference from keychain." status:-1 error:error];
+            return nil;
+        }
+        
+        SecKeyRef publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
         if (!publicKeyRef)
         {
             [self logAndFillError:@"Failed to copy public key from private key." status:-1 error:error];
             return nil;
         }
+        
+        NSDate *creationDate = [privateKeyDict objectForKey:(__bridge NSDate *)kSecAttrCreationDate];
+        
+        MSIDAssymetricKeyPair *keypair = [[MSIDAssymetricKeyPair alloc] initWithPrivateKey:privateKeyRef
+                                                                                 publicKey:publicKeyRef
+                                                                              creationDate:creationDate];
+
+        CFRelease(publicKeyRef);
+        return keypair;
     }
     else
     {
-        [self logAndFillError:@"Failed to copy public key from private key due to unsupported platform." status:-1 error:error];
+        [self logAndFillError:@"Failed to generate asymmetric key pair due to unsupported iOS/OSX platform." status:-1 error:error];
         return nil;
     }
-    
-    NSDate *creationDate = [privateKeyDict objectForKey:(__bridge NSDate *)kSecAttrCreationDate];
-    
-    MSIDAssymetricKeyPair *keypair = [[MSIDAssymetricKeyPair alloc] initWithPrivateKey:privateKeyRef
-                                                                             publicKey:publicKeyRef
-                                                                          creationDate:creationDate];
-
-    CFRelease(publicKeyRef);
-    return keypair;
 }
 
 #pragma mark - Cleanup
@@ -237,44 +236,42 @@
 - (MSIDAssymetricKeyPair *)generateKeyPairForKeyDict:(NSDictionary *)attributes
                                                error:(NSError **)error
 {
-    CFErrorRef keyGenerationError = NULL;
-    SecKeyRef privateKeyRef = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &keyGenerationError);
-    
-    if (!privateKeyRef)
-    {
-        NSError *keyError = CFBridgingRelease(keyGenerationError);
-        [self logAndFillError:@"Failed to generate private key." status:(int)keyError.code error:error];
-        return nil;
-    }
-    
-    SecKeyRef publicKeyRef = NULL;
     if (@available(iOS 10.0, macOS 10.12, *))
     {
-        publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
+        CFErrorRef keyGenerationError = NULL;
+        SecKeyRef privateKeyRef = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &keyGenerationError);
+        
+        if (!privateKeyRef)
+        {
+            NSError *keyError = CFBridgingRelease(keyGenerationError);
+            [self logAndFillError:@"Failed to generate private key." status:(int)keyError.code error:error];
+            return nil;
+        }
+        
+        SecKeyRef publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
         if (!publicKeyRef)
         {
             [self logAndFillError:@"Failed to copy public key from private key." status:-1 error:error];
             CFRelease(privateKeyRef);
             return nil;
         }
+        
+        /*
+         Setting creationDate to nil here intentionally as it is only needed for cpp code.
+         CreationDate will be initialized using lazy loading once it is queried for the first time on key pair object.
+         */
+        MSIDAssymetricKeyPair *keyPair = [[MSIDAssymetricKeyPair alloc] initWithPrivateKey:privateKeyRef publicKey:publicKeyRef creationDate:nil];
+        
+        if (privateKeyRef) CFRelease(privateKeyRef);
+        if (publicKeyRef) CFRelease(publicKeyRef);
+        
+        return keyPair;
     }
     else
     {
-        [self logAndFillError:@"Failed to copy public key from private key due to unsupported platform." status:-1 error:error];
-        CFRelease(privateKeyRef);
+        [self logAndFillError:@"Failed to generate asymmetric key pair due to unsupported iOS/OSX platform." status:-1 error:error];
         return nil;
     }
-    
-    /*
-     Setting creationDate to nil here intentionally as it is only needed for cpp code.
-     CreationDate will be initialized using lazy loading once it is queried for the first time on key pair object.
-     */
-    MSIDAssymetricKeyPair *keyPair = [[MSIDAssymetricKeyPair alloc] initWithPrivateKey:privateKeyRef publicKey:publicKeyRef creationDate:nil];
-    
-    if (privateKeyRef) CFRelease(privateKeyRef);
-    if (publicKeyRef) CFRelease(publicKeyRef);
-    
-    return keyPair;
 }
 
 #pragma mark - Platform

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyLookupAttributes.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyLookupAttributes.m
@@ -35,11 +35,11 @@
     keyPairAttr[(__bridge id)kSecAttrKeyType] = (__bridge id)kSecAttrKeyTypeRSA;
     keyPairAttr[(__bridge id)kSecAttrKeySizeInBits] = @2048;
     keyPairAttr[(__bridge id)kSecAttrLabel] = self.keyDisplayableLabel;
+    keyPairAttr[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
     
     NSMutableDictionary *privateKeyAttr = [NSMutableDictionary new];
     privateKeyAttr[(__bridge id)kSecAttrIsPermanent] = @YES;
     privateKeyAttr[(__bridge id)kSecAttrApplicationTag] = [self.privateKeyIdentifier dataUsingEncoding:NSUTF8StringEncoding];
-    privateKeyAttr[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
     privateKeyAttr[(__bridge id)kSecAttrIsSensitive] = @YES;
     privateKeyAttr[(__bridge id)kSecAttrIsExtractable] = @NO;
     

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.h
@@ -35,6 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
     
 }
 
+@property (nonatomic, readonly) NSString *keyExponent;
+@property (nonatomic, readonly) NSString *keyModulus;
+@property (nonatomic, readonly) NSData *keyData;
+
 @property (nonatomic, readonly) SecKeyRef privateKeyRef;
 @property (nonatomic, readonly) SecKeyRef publicKeyRef;
 @property (nonatomic, readonly) NSString *jsonWebKey;

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.m
@@ -23,6 +23,7 @@
 
 #import "MSIDAssymetricKeyPair.h"
 #import "NSData+MSIDExtensions.h"
+#import "NSData+JWT.h"
 
 static NSString *s_jwkTemplate = @"{\"e\":\"%@\",\"kty\":\"RSA\",\"n\":\"%@\"}";
 static NSString *s_kidTemplate = @"{\"kid\":\"%@\"}";
@@ -233,8 +234,15 @@ static NSString *s_kidTemplate = @"{\"kid\":\"%@\"}";
 
 - (NSString *)signData:(NSString *)message
 {
-    NSData *signedData = [[message dataUsingEncoding:NSUTF8StringEncoding] msidSignHashWithPrivateKey:self.privateKeyRef];
-    return [[NSString alloc] initWithData:signedData encoding:NSUTF8StringEncoding];
+    if ([message length] == 0)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Message to sign was empty");
+        return nil;
+    }
+    
+    NSData *hashedData = [[message dataUsingEncoding:NSUTF8StringEncoding] msidSHA256];
+    NSData *signedData = [hashedData msidSignHashWithPrivateKey:self.privateKeyRef];
+    return [signedData msidHexString];
 }
 
 - (NSDate *)creationDate

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.m
@@ -242,7 +242,8 @@ static NSString *s_kidTemplate = @"{\"kid\":\"%@\"}";
     
     NSData *hashedData = [[message dataUsingEncoding:NSUTF8StringEncoding] msidSHA256];
     NSData *signedData = [hashedData msidSignHashWithPrivateKey:self.privateKeyRef];
-    return [signedData msidHexString];
+    NSString *signedEncodedDataString = [NSString msidBase64UrlEncodedStringFromData:signedData];
+    return signedEncodedDataString;
 }
 
 - (NSDate *)creationDate

--- a/IdentityCore/src/util/MSIDJWTHelper.m
+++ b/IdentityCore/src/util/MSIDJWTHelper.m
@@ -27,6 +27,7 @@
 #import <Security/SecKey.h>
 #import "NSString+MSIDExtensions.h"
 #import "MSIDLogger+Internal.h"
+#import "NSData+JWT.h"
 #import "NSData+MSIDExtensions.h"
 
 @implementation MSIDJWTHelper
@@ -38,7 +39,8 @@
     NSString *headerJSON = [self JSONFromDictionary:header];
     NSString *payloadJSON = [self JSONFromDictionary:payload];
     NSString *signingInput = [NSString stringWithFormat:@"%@.%@", [headerJSON msidBase64UrlEncode], [payloadJSON msidBase64UrlEncode]];
-    NSData *signedData = [[signingInput dataUsingEncoding:NSUTF8StringEncoding] msidSignHashWithPrivateKey:signingKey];
+    NSData *signedData = [self sign:signingKey
+                               data:[signingInput dataUsingEncoding:NSUTF8StringEncoding]];
     NSString *signedEncodedDataString = [NSString msidBase64UrlEncodedStringFromData:signedData];
 
     return [NSString stringWithFormat:@"%@.%@", signingInput, signedEncodedDataString];
@@ -72,6 +74,14 @@
 
     [bits setLength:keyBufferSize];
     return [[NSString alloc] initWithData:bits encoding:NSUTF8StringEncoding];
+}
+
++ (NSData *)sign:(SecKeyRef)privateKey
+            data:(NSData *)plainData
+{
+
+    NSData *hashData = [plainData msidSHA256];
+    return [hashData msidSignHashWithPrivateKey:privateKey];
 }
 
 + (NSString *)JSONFromDictionary:(NSDictionary *)dictionary

--- a/IdentityCore/src/util/NSData+JWT.h
+++ b/IdentityCore/src/util/NSData+JWT.h
@@ -23,33 +23,8 @@
 
 #import <Foundation/Foundation.h>
 
-@interface NSData (MSIDExtensions)
+@interface NSData (JWT)
 
-/*!
- =============================================================================
- Hashing
- =============================================================================
- */
-- (NSData *)msidSHA256;
-
-/*!
- =============================================================================
- Constructors
- =============================================================================
- */
-+ (NSData *)msidDataFromBase64UrlEncodedString:(NSString *)encodedString;
-
-/*!
- =============================================================================
- Convenience methods
- =============================================================================
- */
-/*! Converts to hex string */
-- (NSString *)msidHexString;
-
-/*! Converts NSData to base64 String */
-- (NSString *)msidBase64UrlEncodedString;
-
-- (NSData *)msidDecryptedDataWithAlgorithm:(SecKeyAlgorithm)algorithm privateKey:(SecKeyRef)privateKey API_AVAILABLE(ios(10.0), macos(10.12));
+- (NSData *)msidSignHashWithPrivateKey:(SecKeyRef)privateKey;
 
 @end

--- a/IdentityCore/src/util/NSData+JWT.m
+++ b/IdentityCore/src/util/NSData+JWT.m
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "NSData+JWT.h"
+#import <CommonCrypto/CommonDigest.h>
+#import <Security/Security.h>
+#import <Security/SecKey.h>
+
+@implementation NSData (JWT)
+
+#if TARGET_OS_IPHONE
+
+- (NSData *)msidSignHashWithPrivateKey:(SecKeyRef)privateKey
+{
+    NSData *signedHash = nil;
+    size_t signedHashBytesSize = SecKeyGetBlockSize(privateKey);
+    uint8_t *signedHashBytes = calloc(signedHashBytesSize, 1);
+
+    if (!signedHashBytes)
+    {
+        return nil;
+    }
+
+    OSStatus status = errSecAuthFailed;
+
+    status = SecKeyRawSign(privateKey,
+                           kSecPaddingPKCS1SHA256,
+                           [self bytes],
+                           CC_SHA256_DIGEST_LENGTH,
+                           signedHashBytes,
+                           &signedHashBytesSize);
+
+    if (status != errSecSuccess)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to sign JWT %d", (int)status);
+        free(signedHashBytes);
+        return nil;
+    }
+
+    signedHash = [NSData dataWithBytes:signedHashBytes
+                                length:(NSUInteger)signedHashBytesSize];
+
+    free(signedHashBytes);
+    return signedHash;
+}
+
+#else
+
+- (NSData *)msidSignHashWithPrivateKey:(SecKeyRef)privateKey
+{
+    CFErrorRef error = nil;
+    // Create signer
+    SecTransformRef signer = SecSignTransformCreate(privateKey, &error);
+
+    if (!signer)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to sign JWT %@", error);
+        return nil;
+    }
+
+    BOOL result = YES;
+    // Set attributes
+    result &= [self msidSetAttributeOnSigner:signer attributeKey:kSecPaddingKey attributeValue:kSecPaddingPKCS1Key];
+    result &= [self msidSetAttributeOnSigner:signer attributeKey:kSecInputIsAttributeName attributeValue:kSecInputIsDigest];
+    result &= [self msidSetAttributeOnSigner:signer attributeKey:kSecTransformInputAttributeName attributeValue:(__bridge CFDataRef)self];
+    result &= [self msidSetAttributeOnSigner:signer attributeKey:kSecDigestTypeAttribute attributeValue:kSecDigestSHA2];
+    result &= [self msidSetAttributeOnSigner:signer attributeKey:kSecDigestLengthAttribute attributeValue:(__bridge CFNumberRef)@(256)];
+
+    if (!result)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to sign JWT %@", error);
+        CFRelease(signer);
+        return nil;
+    }
+
+    CFDataRef resultData = SecTransformExecute(signer, &error);
+    CFRelease(signer);
+
+    if (!resultData)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to sign JWT %@", error);
+        return nil;
+    }
+
+    return CFBridgingRelease(resultData);
+}
+
+- (BOOL)msidSetAttributeOnSigner:(SecTransformRef)signer attributeKey:(CFStringRef)key attributeValue:(CFTypeRef)value
+{
+    CFErrorRef error = nil;
+    BOOL result = SecTransformSetAttribute(signer, key, value, &error);
+
+    if (!result)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to set signing attribute with error %@", error);
+        return NO;
+    }
+
+    return YES;
+}
+
+#endif
+
+@end

--- a/IdentityCore/src/util/NSData+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSData+MSIDExtensions.m
@@ -120,25 +120,4 @@
     return decryptedMessage;
 }
 
-- (NSData *)msidSignHashWithPrivateKey:(SecKeyRef)privateKey
-{
-    if (!SecKeyIsAlgorithmSupported(privateKey, kSecKeyOperationTypeSign, kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256))
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Unable to use the requested crypto algorithm with the provided key.");
-        return nil;
-    }
-    
-    CFErrorRef error = nil;
-    NSData *signedData = CFBridgingRelease(SecKeyCreateSignature(privateKey, kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256, (__bridge CFDataRef )self,&error));
-    
-    if (error)
-    {
-        NSError *err = CFBridgingRelease(error);
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"%@", [@"Unable to sign data" stringByAppendingString:[NSString stringWithFormat:@"%ld", err.code]]);
-        return nil;
-    }
-    
-    return signedData;
-}
-
 @end

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -53,7 +53,11 @@ static WKWebViewConfiguration *s_webConfig;
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
     WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
-    webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    
+    if (@available(iOS 9.0, *))
+    {
+        webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    }
 
     if (@available(iOS 13.0, *))
     {

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -50,7 +50,11 @@ static WKWebViewConfiguration *s_webConfig;
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
     WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
-    webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    
+    if (@available(macOS 10.11, *))
+    {
+        webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    }
     
     if (@available(macOS 10.15, *))
     {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+* Update RSA signing code and add conditional check for supported iOS/osx platforms.
 Version 1.5.7
 * Enabled PKeyAuth via UserAgent String on MacOS 
 * Added an API for both iOS and MacOS for returning a WKWebView config setting with default recommended settings for developers. 


### PR DESCRIPTION
## Proposed changes

This PR reverts the signing code change I made which used SecKeyVerifySignature in my previous PR as it breaks cpp build. SecKeyVerifySignature was always using sha256 hashing and cpp was relying on this method to do sha1 hashing as well. 
The files NSData+JWT is the same code we had before which used SecKeyRawSign. Added these files back again unchanged. Deleting these files was breaking cpp build.
Also exposed the properties like, keyModulus and keyExponent of public key as it was before because cpp is relying on these properties being publicly exposed.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

