### PR TITLE
remove test when running cpp pipeline

### DIFF
--- a/azure_pipelines/verify_msalcpp_per_pr_ios.yml
+++ b/azure_pipelines/verify_msalcpp_per_pr_ios.yml
@@ -53,9 +53,13 @@ jobs:
      arguments: '--skip-checkout --msal-common-repo $(Agent.BuildDirectory)/CommonCore'
 
   - template: azure_pipelines/templates/ios-setup.yml@microsoft-authentication-library-for-cpp
-
-  - template: azure_pipelines/templates/build-and-test.yml@microsoft-authentication-library-for-cpp
-    parameters:
-      configuration: Debug
-      platform: iOS
-      arch: x64
+  
+  - task: PythonScript@0
+    name: Build
+    displayName: 'Build x64 Debug iOS'
+    inputs:
+      scriptPath: build.py
+      arguments: '--clean --arch x64 --configuration Debug --platform iOS --djinni hashfail'
+    env:
+      MSAL_LAB_VAULT_ACCESS_CERT_LOCATION: $(Agent.TempDirectory)
+      MSAL_CERTIFICATE_PASSWORD: $(MSAL_CERTIFICATE_PASSWORD)

--- a/azure_pipelines/verify_msalcpp_per_pr_mac.yml
+++ b/azure_pipelines/verify_msalcpp_per_pr_mac.yml
@@ -54,8 +54,12 @@ jobs:
 
   - template: azure_pipelines/templates/macos-setup.yml@microsoft-authentication-library-for-cpp
 
-  - template: azure_pipelines/templates/build-and-test.yml@microsoft-authentication-library-for-cpp
-    parameters:
-      arch: x64
-      configuration: Debug
-      platform: macOS
+  - task: PythonScript@0
+    name: Build
+    displayName: 'Build x64 Debug macOS'
+    inputs:
+      scriptPath: build.py
+      arguments: '--clean --arch x64 --configuration Debug --platform macOS --djinni hashfail'
+    env:
+      MSAL_LAB_VAULT_ACCESS_CERT_LOCATION: $(Agent.TempDirectory)
+      MSAL_CERTIFICATE_PASSWORD: $(MSAL_CERTIFICATE_PASSWORD)


### PR DESCRIPTION
## Proposed changes

Disabled the Test running iOS and macOS on MSAL CPP. Our change in common core is just a subset of the whole Apple related test in MSAL C++ which is flaky for a while. Make compiling only just in case it will cause unnecessary blockers, and we can save some time as well

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

