### PR TITLE
convert struct from mock files to class and prevent crashes when buil…

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -450,6 +450,14 @@
 		583BFCB624D908980035B901 /* MSIDTestBundle.m in Sources */ = {isa = PBXBuildFile; fileRef = 583BFCB324D908980035B901 /* MSIDTestBundle.m */; };
 		583BFCB724D908980035B901 /* MSIDTestBundle.m in Sources */ = {isa = PBXBuildFile; fileRef = 583BFCB324D908980035B901 /* MSIDTestBundle.m */; };
 		58543C8B24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h in Headers */ = {isa = PBXBuildFile; fileRef = 58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */; };
+		589842472525447B0075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898422025253FE00075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m */; };
+		58984254252544850075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898422025253FE00075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m */; };
+		5898426D2525448A0075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898421025253F050075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m */; };
+		5898427A2525448A0075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898421025253F050075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m */; };
+		5898429F252544900075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898420025253E9F0075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.m */; };
+		589842AC252544910075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898420025253E9F0075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.m */; };
+		589842B9252544940075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 589841F025253DF30075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m */; };
+		589842C6252544940075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 589841F025253DF30075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m */; };
 		58B81F7C24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 58B81F7A24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.h */; };
 		58B81F7D24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B81F7B24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.m */; };
 		58B81F7E24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B81F7B24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.m */; };
@@ -2046,6 +2054,14 @@
 		583BFCB224D908980035B901 /* MSIDTestBundle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTestBundle.h; sourceTree = "<group>"; };
 		583BFCB324D908980035B901 /* MSIDTestBundle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTestBundle.m; sourceTree = "<group>"; };
 		58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDMacKeychainTokenCache+Test.h"; sourceTree = "<group>"; };
+		589841EF25253DF30075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h; sourceTree = "<group>"; };
+		589841F025253DF30075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m; sourceTree = "<group>"; };
+		589841FF25253E9F0075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountMetadataCacheMockGetAuthorityParameters.h; sourceTree = "<group>"; };
+		5898420025253E9F0075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountMetadataCacheMockGetAuthorityParameters.m; sourceTree = "<group>"; };
+		5898420F25253F050075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.h; sourceTree = "<group>"; };
+		5898421025253F050075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m; sourceTree = "<group>"; };
+		5898421F25253FE00075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.h; sourceTree = "<group>"; };
+		5898422025253FE00075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m; sourceTree = "<group>"; };
 		58B81F7A24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDWebResponseOperationFactory.h; sourceTree = "<group>"; };
 		58B81F7B24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWebResponseOperationFactory.m; sourceTree = "<group>"; };
 		58B81F8024AD0F8B00E8799E /* MSIDWebResponseBaseOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDWebResponseBaseOperation.h; sourceTree = "<group>"; };
@@ -3181,6 +3197,14 @@
 				B216825F23AB09C300F4897A /* MSIDSSOExtensionGetAccountsRequestMock.m */,
 				B253154023DD75CE00432133 /* MSIDSSOExtensionGetDeviceInfoRequestMock.h */,
 				B253154123DD75CE00432133 /* MSIDSSOExtensionGetDeviceInfoRequestMock.m */,
+				589841EF25253DF30075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h */,
+				589841F025253DF30075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m */,
+				589841FF25253E9F0075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.h */,
+				5898420025253E9F0075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.m */,
+				5898420F25253F050075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.h */,
+				5898421025253F050075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m */,
+				5898421F25253FE00075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.h */,
+				5898422025253FE00075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m */,
 			);
 			path = mocks;
 			sourceTree = "<group>";
@@ -6598,6 +6622,7 @@
 				23F32F251FFDAF1900B2905E /* MSIDTestBrokerResponse.m in Sources */,
 				B2E4A07724DDE5CD007CE642 /* NSDate+MSIDTestUtil.m in Sources */,
 				B245C2FA2106ABDC00CD5A52 /* MSIDTestIdTokenUtil.m in Sources */,
+				589842472525447B0075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m in Sources */,
 				B2E4A06A24DDE54B007CE642 /* MSIDRegistrationInformationMock.m in Sources */,
 				B24DE9FD21A60F0E003A651D /* MSIDTestBrokerTokenRequest.m in Sources */,
 				B2968CA822F67B4C005AFC33 /* MSIDTestLocalInteractiveController.m in Sources */,
@@ -6608,12 +6633,15 @@
 				B2E4A07324DDE575007CE642 /* MSIDTestTelemetryEventsObserver.m in Sources */,
 				B217862A23A5839300839CE8 /* MSIDSSOExtensionSignoutRequestMock.m in Sources */,
 				D6D9A4571FBD40BF00EFA430 /* NSURL+MSIDTestUtil.m in Sources */,
+				589842B9252544940075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m in Sources */,
 				D626FFF11FBD200A00EE4487 /* MSIDTestURLResponse.m in Sources */,
 				963E68E721489A9500D7D0CC /* NSString+MSIDTestUtil.m in Sources */,
 				23185368206D8B1D0024DCA4 /* MSIDTestTokenResponse.m in Sources */,
 				961ACDFD22A1F60800B9266C /* NSData+MSIDTestUtil.m in Sources */,
 				607A788D23294D6F00A1F74D /* MSIDAccountMetadataCacheAccessorMock.m in Sources */,
+				5898427A2525448A0075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m in Sources */,
 				B216826123AB09C300F4897A /* MSIDSSOExtensionGetAccountsRequestMock.m in Sources */,
+				589842AC252544910075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.m in Sources */,
 				B2BE925421A24B8200F5AB8C /* MSIDTestTokenRequestProvider.m in Sources */,
 				23FB5C3A225588D0002BF1EB /* MSIDClaimsRequestMock.m in Sources */,
 				B217861A23A57EDC00839CE8 /* MSIDAuthorizationControllerMock.m in Sources */,
@@ -6657,12 +6685,14 @@
 				D626FFF51FBD200A00EE4487 /* MSIDTestURLSession.m in Sources */,
 				B216826223AB09C300F4897A /* MSIDSSOExtensionGetAccountsRequestMock.m in Sources */,
 				B2E4A07424DDE576007CE642 /* MSIDTestTelemetryEventsObserver.m in Sources */,
+				5898429F252544900075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.m in Sources */,
 				B2E2A94E239320B100BA2EA3 /* MSIDTestParametersProvider.m in Sources */,
 				969CCB5822A9EB7D00A55515 /* MSIDTestCacheDataSource.m in Sources */,
 				96290E5721489BB800FDD5C8 /* NSString+MSIDTestUtil.m in Sources */,
 				607A788E23294D6F00A1F74D /* MSIDAccountMetadataCacheAccessorMock.m in Sources */,
 				58D1514424A6888D001DD18A /* MSIDHttpRequest+OverrideCacheSave.m in Sources */,
 				D6D9A44E1FBD3EEA00EFA430 /* NSDictionary+MSIDTestUtil.m in Sources */,
+				589842C6252544940075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m in Sources */,
 				23FB5C39225588CF002BF1EB /* MSIDClaimsRequestMock.m in Sources */,
 				B2E4A06E24DDE559007CE642 /* MSIDTestContext.m in Sources */,
 				B245C2FB2106ABDC00CD5A52 /* MSIDTestIdTokenUtil.m in Sources */,
@@ -6676,11 +6706,13 @@
 				B217861923A57EDB00839CE8 /* MSIDAuthorizationControllerMock.m in Sources */,
 				B2E4A07624DDE5CD007CE642 /* NSDate+MSIDTestUtil.m in Sources */,
 				B24DE9FC21A60F0D003A651D /* MSIDTestBrokerTokenRequest.m in Sources */,
+				5898426D2525448A0075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m in Sources */,
 				23185369206D8B1E0024DCA4 /* MSIDTestTokenResponse.m in Sources */,
 				B2E4A06B24DDE54C007CE642 /* MSIDRegistrationInformationMock.m in Sources */,
 				1E0B145224CF5ADD00825143 /* MSIDAssymetricKeyPair+Test.m in Sources */,
 				964E669820AE97FD00857009 /* MSIDTestWebviewInteractingViewController.m in Sources */,
 				B28AC66621A0BB9D00A1FC4A /* MSIDTestBrokerResponseHelper.m in Sources */,
+				58984254252544850075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.h
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.h
@@ -23,44 +23,20 @@
 
 #import "MSIDAccountMetadataCacheAccessor.h"
 
+@class MSIDAccountMetadataCacheMockUpdateAuthorityParameters;
+@class MSIDAccountMetadataCacheMockGetAuthorityParameters;
+@class MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams;
+@class MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams;
+
 NS_ASSUME_NONNULL_BEGIN
-
-struct MSIDAccountMetadataCacheMockUpdateAuthorityParameters
-{
-    NSURL * _Nullable cacheAuthorityURL;
-    NSURL * _Nullable requestAuthorityURL;
-    NSString * _Nullable homeAccountId;
-    NSString *_Nullable clientId;
-    BOOL instanceAware;
-};
-
-struct MSIDAccountMetadataCacheMockGetAuthorityParameters
-{
-    NSURL * _Nullable requestAuthorityURL;
-    NSString * _Nullable homeAccountId;
-    NSString *_Nullable clientId;
-    BOOL instanceAware;
-};
-
-struct MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams
-{
-    MSIDAccountIdentifier * _Nullable principalAccountId;
-    NSString * _Nullable clientId;
-    NSString * _Nullable accountEnvironment;
-};
-
-struct MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams
-{
-    NSString * _Nullable homeAccountId;
-};
 
 @interface MSIDAccountMetadataCacheAccessorMock : MSIDAccountMetadataCacheAccessor
 
 @property (nonatomic) NSInteger updateAuthorityURLInvokedCount;
-@property (nonatomic) struct MSIDAccountMetadataCacheMockUpdateAuthorityParameters updateAuthorityProvidedParams;
+@property (nonatomic) MSIDAccountMetadataCacheMockUpdateAuthorityParameters *updateAuthorityProvidedParams;
 
 @property (nonatomic) NSInteger getAuthorityURLInvokedCount;
-@property (nonatomic) struct MSIDAccountMetadataCacheMockGetAuthorityParameters getAuthorityProvidedParams;
+@property (nonatomic) MSIDAccountMetadataCacheMockGetAuthorityParameters *getAuthorityProvidedParams;
 @property (nonatomic) NSURL *authorityURLToReturn;
 
 @property (nonatomic, nullable) MSIDAccountIdentifier *mockedPrincipalAccountId;
@@ -69,12 +45,12 @@ struct MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams
 @property (nonatomic) BOOL updatePrincipalAccountIdResult;
 @property (nonatomic) NSError *updatePrincipalAccountIdError;
 @property (nonatomic) NSInteger updatePrincipalAccountIdInvokedCount;
-@property (nonatomic) struct MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams updatePrincipalAccountIdParams;
+@property (nonatomic) MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams *updatePrincipalAccountIdParams;
 
 @property (nonatomic) BOOL removeAccountMetadataForHomeAccountIdResult;
 @property (nonatomic) NSError *removeAccountMetadataForHomeAccountIdError;
 @property (nonatomic) NSInteger removeAccountMetadataForHomeAccountIdInvokedCount;
-@property (nonatomic) struct MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams removeAccountMetadataForHomeAccountIdParams;
+@property (nonatomic) MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams *removeAccountMetadataForHomeAccountIdParams;
 
 
 @end

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
@@ -22,6 +22,10 @@
 // THE SOFTWARE.
 
 #import "MSIDAccountMetadataCacheAccessorMock.h"
+#import "MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h"
+#import "MSIDAccountMetadataCacheMockGetAuthorityParameters.h"
+#import "MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.h"
+#import "MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.h"
 
 @implementation MSIDAccountMetadataCacheAccessorMock
 
@@ -34,7 +38,7 @@
 {
     self.getAuthorityURLInvokedCount++;
     
-    struct MSIDAccountMetadataCacheMockGetAuthorityParameters s = self.getAuthorityProvidedParams;
+    MSIDAccountMetadataCacheMockGetAuthorityParameters *s = [MSIDAccountMetadataCacheMockGetAuthorityParameters new];
     s.requestAuthorityURL = requestAuthorityURL;
     s.homeAccountId = homeAccountId;
     s.clientId = clientId;
@@ -54,7 +58,7 @@
 {
     self.updateAuthorityURLInvokedCount++;
     
-    struct MSIDAccountMetadataCacheMockUpdateAuthorityParameters s = self.updateAuthorityProvidedParams;
+    MSIDAccountMetadataCacheMockUpdateAuthorityParameters *s = [MSIDAccountMetadataCacheMockUpdateAuthorityParameters new];
     s.cacheAuthorityURL = cacheAuthorityURL;
     s.requestAuthorityURL = requestAuthorityURL;
     s.homeAccountId = homeAccountId;
@@ -89,7 +93,7 @@
 {
     if (error) *error = self.updatePrincipalAccountIdError;
     
-    struct MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams s  = self.updatePrincipalAccountIdParams;
+    MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams *s  = [MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams new];
     s.principalAccountId = principalAccountId;
     s.clientId = clientId;
     s.accountEnvironment = principalAccountEnvironment;
@@ -106,7 +110,7 @@
 {
     if (error) *error = self.removeAccountMetadataForHomeAccountIdError;
     
-    struct MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams s  = self.removeAccountMetadataForHomeAccountIdParams;
+    MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams *s  = [MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams new];
     s.homeAccountId = homeAccountId;
     self.removeAccountMetadataForHomeAccountIdParams = s;
     

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockGetAuthorityParameters.h
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockGetAuthorityParameters.h
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAccountMetadataCacheMockGetAuthorityParameters : NSObject
+
+@property (nonatomic) NSURL * _Nullable requestAuthorityURL;
+@property (nonatomic) NSString * _Nullable homeAccountId;
+@property (nonatomic) NSString *_Nullable clientId;
+@property (nonatomic) BOOL instanceAware;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockGetAuthorityParameters.m
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockGetAuthorityParameters.m
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import "MSIDAccountMetadataCacheMockGetAuthorityParameters.h"
+
+@implementation MSIDAccountMetadataCacheMockGetAuthorityParameters
+
+@end

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.h
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.h
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams : NSObject
+
+@property(nonatomic) NSString * _Nullable homeAccountId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import "MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.h"
+
+@implementation MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams
+
+@end

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h
@@ -1,0 +1,40 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAccountMetadataCacheMockUpdateAuthorityParameters : NSObject
+
+@property (nonatomic) NSURL * _Nullable cacheAuthorityURL;
+@property (nonatomic) NSURL * _Nullable requestAuthorityURL;
+@property (nonatomic) NSString * _Nullable homeAccountId;
+@property (nonatomic) NSString *_Nullable clientId;
+@property (nonatomic) BOOL instanceAware;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import "MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h"
+
+@implementation MSIDAccountMetadataCacheMockUpdateAuthorityParameters
+
+@end

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.h
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.h
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import "MSIDAccountMetadataCacheAccessor.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams : NSObject
+
+@property (nonatomic) MSIDAccountIdentifier * _Nullable principalAccountId;
+@property (nonatomic) NSString * _Nullable clientId;
+@property (nonatomic) NSString * _Nullable accountEnvironment;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import "MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.h"
+
+@implementation MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams
+
+@end


### PR DESCRIPTION
…d on Xcode 12

## Proposed changes

In Xcode 12, if we declare as a struct within Objc, it will cause crashes

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

