### PR TITLE
Fix for requested claims comparison function

### DIFF
--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -329,7 +329,6 @@
         if ((clientId && [self.clientId.msidNormalizedString isEqualToString:clientId.msidNormalizedString])
             || (familyId && [self.familyId.msidNormalizedString isEqualToString:familyId.msidNormalizedString]))
         {
-            
             return YES;       
         }
 

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -319,16 +319,18 @@
     {
         return YES;
     }
+    if (!([NSString msidIsStringNilOrBlank:self.requestedClaims] && [NSString msidIsStringNilOrBlank:requestedClaims]) && !([self.requestedClaims isEqualToString:requestedClaims]))
+    {
+        return NO;
+    }
 
     if (clientIDMatchingOptions == MSIDSuperSet)
     {
         if ((clientId && [self.clientId.msidNormalizedString isEqualToString:clientId.msidNormalizedString])
             || (familyId && [self.familyId.msidNormalizedString isEqualToString:familyId.msidNormalizedString]))
         {
-            if (([NSString msidIsStringNilOrBlank:self.requestedClaims] && [NSString msidIsStringNilOrBlank:requestedClaims]) || ([self.requestedClaims isEqualToString:requestedClaims]))
-            {
-                return YES;
-            }       
+            
+            return YES;       
         }
 
         return NO;


### PR DESCRIPTION
## Proposed changes

Fix an error in the comparison function for requested claims.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
This bug crept in due to a misunderstanding during the PR process of the original feature work PR. MSAL C++ doesn't specify a ClientIDMatching Option for AT lookups and thus default to exact string match, not SuperSet. As such, we never hit this codepath.

Nevertheless, claims are unrelated to client ID's so the current location doesn't make a lot of sense.