### PR TITLE
Revert PkeyAuth change

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -53,11 +53,6 @@ static WKWebViewConfiguration *s_webConfig;
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
     WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
-    
-    if (@available(iOS 9.0, *))
-    {
-        webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
-    }
 
     if (@available(iOS 13.0, *))
     {


### PR DESCRIPTION
## Proposed changes

PkeyAuth/1.0 in the user agent was causing ADFS v4 issues. Reverting it for now. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

