### PR TITLE
Revert the look up and service call when trying with ART and FRT in s…

### DIFF
--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -236,53 +236,52 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"No completionHandler when fetch local refresh token");
         return;
     }
+    
+    NSError * rtError = nil;
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Looking for app refresh token...");
+    MSIDBaseToken<MSIDRefreshableToken> *refreshableToken = [self appRefreshTokenWithError:&rtError];
+    
+    if (rtError)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Failed to read app specific refresh token with error %@", MSID_PII_LOG_MASKABLE(rtError));
+        completionHandler(nil, MSIDAppRefreshTokenType, rtError);
+        return;
+    }
+    
+    if (!refreshableToken)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, self.requestParameters, @"Didn't find app refresh token");
+    }
     else
     {
-        NSError * rtError = nil;
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Looking for app refresh token...");
-        MSIDBaseToken<MSIDRefreshableToken> *refreshableToken = [self appRefreshTokenWithError:&rtError];
-        
-        if (rtError)
-        {
-            MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Failed to read app specific refresh token with error %@", MSID_PII_LOG_MASKABLE(rtError));
-            completionHandler(nil, MSIDAppRefreshTokenType, rtError);
-            return;
-        }
-        
-        if (!refreshableToken)
-        {
-            MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, self.requestParameters, @"Didn't find app refresh token");
-        }
-        else
-        {
-            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Found app refresh token.");
-            completionHandler(refreshableToken, MSIDAppRefreshTokenType, nil);
-            return;
-        }
-        
-        // If no ART, get family refresh token instead.
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Looking for family refresh token...");
-        refreshableToken = [self familyRefreshTokenWithError:&rtError];
-        
-        if (rtError)
-        {
-            MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Failed to read family refresh token with error %@", MSID_PII_LOG_MASKABLE(rtError));
-            completionHandler(nil, MSIDFamilyRefreshTokenType, rtError);
-            return;
-        }
-        
-        if (!refreshableToken)
-        {
-            MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, self.requestParameters, @"Didn't find family refresh token");
-            completionHandler(nil, MSIDFamilyRefreshTokenType, nil);
-        }
-        else
-        {
-            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Found family refresh token.");
-            completionHandler(refreshableToken, MSIDFamilyRefreshTokenType, nil);
-            return;
-        }
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Found app refresh token.");
+        completionHandler(refreshableToken, MSIDAppRefreshTokenType, nil);
+        return;
     }
+    
+    // If no ART, get family refresh token instead.
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Looking for family refresh token...");
+    refreshableToken = [self familyRefreshTokenWithError:&rtError];
+    
+    if (rtError)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Failed to read family refresh token with error %@", MSID_PII_LOG_MASKABLE(rtError));
+        completionHandler(nil, MSIDFamilyRefreshTokenType, rtError);
+        return;
+    }
+    
+    if (!refreshableToken)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, self.requestParameters, @"Didn't find family refresh token");
+        completionHandler(nil, MSIDFamilyRefreshTokenType, nil);
+    }
+    else
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Found family refresh token.");
+        completionHandler(refreshableToken, MSIDFamilyRefreshTokenType, nil);
+        return;
+    }
+
 }
 
 - (void)tryRefreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)refreshToken

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -238,7 +238,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
         return;
     }
     
-    NSError * rtError = nil;
+    NSError *rtError = nil;
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Looking for app refresh token...");
     MSIDBaseToken<MSIDRefreshableToken> *refreshableToken = [self appRefreshTokenWithError:&rtError];
     

--- a/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
@@ -182,10 +182,12 @@
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
-- (void)testAcquireTokenSilent_whenAccessAndFociRefreshTokensInCache_shouldReturnATAndFociRT
+- (void)testAcquireTokenSilent_whenAccessAndFociRefreshTokensInCache_andNoAppRefreshToken_shouldReturnATAndFociRT
 {
     MSIDRequestParameters *silentParameters = [self silentRequestParameters];
     MSIDDefaultTokenCacheAccessor *tokenCache = self.tokenCache;
+    
+    silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
     [self saveTokensInCache:tokenCache
               configuration:silentParameters.msidConfiguration
@@ -197,6 +199,17 @@
                  clientInfo:nil
                   expiresIn:nil
                extExpiresIn:nil];
+    
+    // Remove MRRT
+    MSIDRefreshToken *refreshToken = [tokenCache getRefreshTokenWithAccount:silentParameters.accountIdentifier
+                                                                   familyId:nil
+                                                              configuration:silentParameters.msidConfiguration
+                                                                    context:silentParameters
+                                                                      error:nil];
+    XCTAssertNotNil(refreshToken);
+    
+    BOOL result = [tokenCache removeToken:refreshToken context:silentParameters error:nil];
+    XCTAssertTrue(result);
     
     silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     
@@ -1480,97 +1493,7 @@
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
-- (void)testAcquireTokenSilent_whenRevokedFamilyRefreshTokenInCache_shouldFallbackToMRRTAndRefreshToken
-{
-    MSIDRequestParameters *silentParameters = [self silentRequestParameters];
-    MSIDDefaultTokenCacheAccessor *tokenCache = self.tokenCache;
-    
-    silentParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
-    
-    [self saveTokensInCache:tokenCache
-              configuration:silentParameters.msidConfiguration
-                      scope:nil
-                       foci:@"1"
-                accessToken:nil
-               refreshToken:nil
-                    idToken:nil
-                 clientInfo:nil
-                  expiresIn:@"1"
-               extExpiresIn:nil];
-    
-    // Update FRT
-    MSIDRefreshToken *refreshToken = [tokenCache getRefreshTokenWithAccount:silentParameters.accountIdentifier
-                                                                   familyId:@"1"
-                                                              configuration:silentParameters.msidConfiguration
-                                                                    context:silentParameters
-                                                                      error:nil];
-    
-    XCTAssertNotNil(refreshToken);
-    
-    refreshToken.refreshToken = @"family refresh token";
-    BOOL result = [[self accountCredentialCache] saveCredential:refreshToken.tokenCacheItem context:nil error:nil];
-    XCTAssertTrue(result);
-    
-    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
-    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
-    [MSIDTestURLSession addResponse:discoveryResponse];
-    
-    MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:authority];
-    [MSIDTestURLSession addResponse:oidcResponse];
-    
-    MSIDTestURLResponse *tokenResponse = [MSIDTestURLResponse errorRefreshTokenGrantResponseWithRT:@"family refresh token"
-                                                                                     requestClaims:nil
-                                                                                     requestScopes:@"user.read tasks.read openid profile offline_access"
-                                                                                     responseError:@"invalid_grant"
-                                                                                       description:nil
-                                                                                          subError:nil
-                                                                                               url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
-                                                                                      responseCode:200];
-    
-    [MSIDTestURLSession addResponse:tokenResponse];
-    
-    MSIDTestURLResponse *mrrtTokenResponse = [MSIDTestURLResponse refreshTokenGrantResponseWithRT:DEFAULT_TEST_REFRESH_TOKEN
-                                                                                    requestClaims:nil
-                                                                                    requestScopes:@"user.read tasks.read openid profile offline_access"
-                                                                                       responseAT:@"new at mrrt"
-                                                                                       responseRT:@"new rt"
-                                                                                       responseID:nil
-                                                                                    responseScope:@"user.read tasks.read"
-                                                                               responseClientInfo:nil
-                                                                                              url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
-                                                                                     responseCode:200
-                                                                                        expiresIn:nil];
-    
-    [MSIDTestURLSession addResponse:mrrtTokenResponse];
-    
-    MSIDDefaultSilentTokenRequest *silentRequest = [[MSIDDefaultSilentTokenRequest alloc] initWithRequestParameters:silentParameters
-                                                                                                       forceRefresh:NO
-                                                                                                       oauthFactory:[MSIDAADV2Oauth2Factory new]
-                                                                                             tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]
-                                                                                                         tokenCache:tokenCache
-                                                                                                      accountMetadataCache:self.accountMetadataCache];
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"silent request"];
-    
-    [silentRequest executeRequestWithCompletion:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
-        
-        XCTAssertNil(error);
-        XCTAssertNotNil(result);
-        XCTAssertEqualObjects(result.accessToken.accessToken, @"new at mrrt");
-        XCTAssertEqualObjects(result.accessToken.scopes, [NSOrderedSet msidOrderedSetFromString:@"user.read tasks.read"]);
-        XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
-        XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
-        XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:DEFAULT_TEST_AUTHORITY_GUID];
-        XCTAssertEqualObjects(result.authority.url, tenantURL);
-        XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
-        [expectation fulfill];
-    }];
-    
-    [self waitForExpectationsWithTimeout:1.0 handler:nil];
-}
-
-- (void)testAcquireTokenSilent_whenFamilyRefreshTokenInCache_andClientMismatch_shouldFallbackToMRRTAndRefreshToken_andNotUseFRTAnymore
+- (void)testAcquireTokenSilent_whenFamilyRefreshTokenInCache_andNoAppRefresh_ClientMismatch_shouldSkip
 {
     MSIDRequestParameters *silentParameters = [self silentRequestParameters];
     MSIDDefaultTokenCacheAccessor *tokenCache = self.tokenCache;
@@ -1589,8 +1512,19 @@
                   expiresIn:@"1"
                extExpiresIn:nil];
     
-    // Update FRT
+    // Remove MRRT
     MSIDRefreshToken *refreshToken = [tokenCache getRefreshTokenWithAccount:silentParameters.accountIdentifier
+                                                                   familyId:nil
+                                                              configuration:silentParameters.msidConfiguration
+                                                                    context:silentParameters
+                                                                      error:nil];
+    XCTAssertNotNil(refreshToken);
+    
+    BOOL result = [tokenCache removeToken:refreshToken context:silentParameters error:nil];
+    XCTAssertTrue(result);
+    
+    // Update FRT
+    refreshToken = [tokenCache getRefreshTokenWithAccount:silentParameters.accountIdentifier
                                                                    familyId:@"1"
                                                               configuration:silentParameters.msidConfiguration
                                                                     context:silentParameters
@@ -1599,7 +1533,7 @@
     XCTAssertNotNil(refreshToken);
     
     refreshToken.refreshToken = @"family refresh token";
-    BOOL result = [[self accountCredentialCache] saveCredential:refreshToken.tokenCacheItem context:nil error:nil];
+    result = [[self accountCredentialCache] saveCredential:refreshToken.tokenCacheItem context:nil error:nil];
     XCTAssertTrue(result);
     
     NSString *authority = @"https://login.windows.net/"DEFAULT_TEST_UTID;
@@ -1620,20 +1554,6 @@
     
     [MSIDTestURLSession addResponse:tokenResponse];
     
-    MSIDTestURLResponse *mrrtTokenResponse = [MSIDTestURLResponse refreshTokenGrantResponseWithRT:DEFAULT_TEST_REFRESH_TOKEN
-                                                                                    requestClaims:nil
-                                                                                    requestScopes:@"user.read tasks.read openid profile offline_access"
-                                                                                       responseAT:@"new at mrrt"
-                                                                                       responseRT:@"new mrrt"
-                                                                                       responseID:nil
-                                                                                    responseScope:@"user.read tasks.read"
-                                                                               responseClientInfo:nil
-                                                                                              url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
-                                                                                     responseCode:200
-                                                                                        expiresIn:@"1"];
-    
-    [MSIDTestURLSession addResponse:mrrtTokenResponse];
-    
     MSIDDefaultSilentTokenRequest *silentRequest = [[MSIDDefaultSilentTokenRequest alloc] initWithRequestParameters:silentParameters
                                                                                                        forceRefresh:NO
                                                                                                        oauthFactory:[MSIDAADV2Oauth2Factory new]
@@ -1645,23 +1565,15 @@
     
     [silentRequest executeRequestWithCompletion:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
         
-        XCTAssertNil(error);
-        XCTAssertNotNil(result);
-        XCTAssertEqualObjects(result.accessToken.accessToken, @"new at mrrt");
-        XCTAssertEqualObjects(result.accessToken.scopes, [NSOrderedSet msidOrderedSetFromString:@"user.read tasks.read"]);
-        XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
-        XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
-        XCTAssertFalse(result.extendedLifeTimeToken);
-        NSURL *tenantURL = [NSURL URLWithString:@"https://login.windows.net/"DEFAULT_TEST_UTID];
-        XCTAssertEqualObjects(result.authority.url, tenantURL);
-        XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new mrrt");
+        XCTAssertNil(result);
+        XCTAssertNotNil(error);
         
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:100.0 handler:nil];
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
     
-    // Next silent request shouldn't try to use FRT anymore
+    // Next silent request shouldn't try to use FRT anymore, but return error with not finding FRT in cache
     
     MSIDDefaultSilentTokenRequest *secondSilentRequest = [[MSIDDefaultSilentTokenRequest alloc] initWithRequestParameters:silentParameters
                                                                                                              forceRefresh:NO
@@ -1670,33 +1582,12 @@
                                                                                                                tokenCache:tokenCache
                                                                                                             accountMetadataCache:self.accountMetadataCache];
     
-    MSIDTestURLResponse *secondResponse = [MSIDTestURLResponse refreshTokenGrantResponseWithRT:@"new mrrt"
-                                                                                 requestClaims:nil
-                                                                                 requestScopes:@"user.read tasks.read openid profile offline_access"
-                                                                                    responseAT:@"new at mrrt"
-                                                                                    responseRT:@"new rt"
-                                                                                    responseID:nil
-                                                                                 responseScope:@"user.read tasks.read"
-                                                                            responseClientInfo:nil
-                                                                                           url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
-                                                                                  responseCode:200
-                                                                                     expiresIn:nil];
-    
-    [MSIDTestURLSession addResponse:secondResponse];
-    
     XCTestExpectation *secondExpecation = [self expectationWithDescription:@"silent request"];
     
     [secondSilentRequest executeRequestWithCompletion:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
-        
-        XCTAssertNil(error);
-        XCTAssertNotNil(result);
-        XCTAssertEqualObjects(result.accessToken.accessToken, @"new at mrrt");
-        XCTAssertEqualObjects(result.accessToken.scopes, [NSOrderedSet msidOrderedSetFromString:@"user.read tasks.read"]);
-        XCTAssertEqualObjects(result.account.accountIdentifier.homeAccountId, silentParameters.accountIdentifier.homeAccountId);
-        XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME subject:@"sub" givenName:@"Test" familyName:@"User" name:@"Test Name" version:@"2.0" tid:DEFAULT_TEST_UTID]);
-        XCTAssertFalse(result.extendedLifeTimeToken);
-        XCTAssertEqualObjects(result.authority.url, silentParameters.authority.url);
-        XCTAssertEqualObjects(result.refreshToken.refreshToken, @"new rt");
+        XCTAssertNil(result);
+        XCTAssertNotNil(error);
+        XCTAssertEqual(error.userInfo[MSIDErrorDescriptionKey], @"No token matching arguments found in the cache");
         
         [secondExpecation fulfill];
     }];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+* Revert FRT and ART lookup orders (#884)
 * Avoid sending RT to wrong cloud (#892)
 * Added logic to handle links that should open in new window in embedded webView.
 * Fix code in kDF function. Add test cases


### PR DESCRIPTION
…ilent flow

In the PR, I put a change of reverting the using the FRT and ART (MRRT) for redeeming the AT in order to trying to resolve an IcM issue where TOU claim is gone when access a different resource within the same app. The code change itself is straight forward but need more testing across different scenarios 

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

