### PR TITLE
Adding warning checks on pipelines only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
   - set -o pipefail
 
 script:  
+  - python ./scripts/update_xcode_config_cpp_checks.py
   - ./build.py --no-clean --show-build-settings
 
 after_failure:

--- a/IdentityCore/tests/MSIDLastRequestTelemetryTests.m
+++ b/IdentityCore/tests/MSIDLastRequestTelemetryTests.m
@@ -282,7 +282,7 @@
     // Simulates a successful request to server, string up to limit size is sent to server
     [restoredTelemetryObject updateWithApiId:0 errorString:nil context:self.context];
     
-    NSUInteger afterFirstCutoff = restoredTelemetryObject.errorsInfo.count;
+    NSInteger afterFirstCutoff = restoredTelemetryObject.errorsInfo.count;
     XCTAssertTrue(afterFirstCutoff > 0);
     XCTAssertTrue(afterFirstCutoff < errorNum);
     
@@ -297,7 +297,7 @@
     // Simulates a successful request to server, string up to limit size is sent to server
     [restoredTelemetryObject updateWithApiId:1 errorString:nil context:self.context];
     
-    NSUInteger afterSecondCutoff = restoredTelemetryObject.errorsInfo.count;
+    NSInteger afterSecondCutoff = restoredTelemetryObject.errorsInfo.count;
     XCTAssertTrue(afterSecondCutoff > 0);
     XCTAssertTrue(afterSecondCutoff < afterFirstCutoff);
     
@@ -325,9 +325,9 @@
     
     dispatch_queue_t queue = [telemetryObject valueForKey:@"synchronizationQueue"];
     MSIDLastRequestTelemetry *restoredTelemetryObject = [[MSIDLastRequestTelemetry alloc] initTelemetryFromDiskWithQueue:queue];
-    
-    XCTAssertTrue(restoredTelemetryObject.errorsInfo.count < errorNum);
-    for (int i = 0; i < restoredTelemetryObject.errorsInfo.count; i++)
+    NSInteger afterSecondCutoff = restoredTelemetryObject.errorsInfo.count;
+    XCTAssertTrue(afterSecondCutoff < errorNum);
+    for (int i = 0; i < afterSecondCutoff; i++)
     {
         XCTAssertEqualObjects([restoredTelemetryObject.errorsInfo objectAtIndex:i].error, [allErrors objectAtIndex:i + (errorNum - maxErrors)]);
     }

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -421,7 +421,7 @@
     connectorMock.loggingQueueEnabledValue = NO;
     [MSIDLogger sharedLogger].level = MSIDLogLevelNothing;
     [MSIDLogger sharedLogger].loggerConnector = connectorMock;
-    [self keyValueObservingExpectationForObject:connectorMock keyPath:@"logMessageValue" handler:^BOOL(id observedObject, NSDictionary *change)
+    [self keyValueObservingExpectationForObject:connectorMock keyPath:@"logMessageValue" handler:^BOOL(id observedObject, __unused NSDictionary *change)
     {
         return [((MSIDLoggerConnectorMock *)observedObject).logMessageValue containsString:@"some message"];
     }];

--- a/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
@@ -397,7 +397,7 @@
 
     }];
 
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
 - (void)testInteractiveRequestFlow_whenProtectionPolicyRequired_shouldReturnNilResultWithError

--- a/scripts/update_xcode_config_cpp_checks.py
+++ b/scripts/update_xcode_config_cpp_checks.py
@@ -1,27 +1,58 @@
 import os
 
-prefixConfigurationFlags="OTHER_CFLAGS=$(OTHER_CFLAGS) -"
-configurations=["Wall", "Werror", "Wextra", "Wassign-enum", "Wblock-capture-autoreleasing", "Wbool-conversion", "Wcomma", "Wconditional-uninitialized", "Wconstant-conversion", "Wdeprecated-declarations", "Wdeprecated-implementations", "Wdeprecated-objc-isa-usage", "Wduplicate-method-match", "Wdocumentation", "Wempty-body", "Wenum-conversion", "Wfatal-errors", "Wfloat-conversion", "Wheader-hygiene", "Wincompatible-pointer-types", "Wint-conversion", "Winvalid-offsetof", "Wnewline-eof", "Wno-unknown-pragmas", "Wnon-literal-null-conversion", "Wnon-modular-include-in-framework-module", "Wnon-virtual-dtor", "Wobjc-literal-conversion", "Wobjc-root-class", "Wprotocol", "Wshorten-64-to-32", "Wstrict-prototypes", "Wundeclared-selector", "Wunreachable-code", "Wunused-parameter"]
+configurations = [
+    "Wall",
+    "Werror",
+    "Wextra",
+    "Wassign-enum",
+    "Wblock-capture-autoreleasing",
+    "Wbool-conversion",
+    "Wcomma",
+    "Wconditional-uninitialized",
+    "Wconstant-conversion",
+    "Wdeprecated-declarations",
+    "Wdeprecated-implementations",
+    "Wdeprecated-objc-isa-usage",
+    "Wduplicate-method-match",
+    "Wdocumentation",
+    "Wempty-body",
+    "Wenum-conversion",
+    "Wfatal-errors",
+    "Wfloat-conversion",
+    "Wheader-hygiene",
+    "Wincompatible-pointer-types",
+    "Wint-conversion",
+    "Winvalid-offsetof",
+    "Wnewline-eof",
+    "Wno-unknown-pragmas",
+    "Wnon-literal-null-conversion",
+    "Wnon-modular-include-in-framework-module",
+    "Wnon-virtual-dtor",
+    "Wobjc-literal-conversion",
+    "Wobjc-root-class",
+    "Wprotocol",
+    "Wshorten-64-to-32",
+    "Wstrict-prototypes",
+    "Wundeclared-selector",
+    "Wunreachable-code",
+    "Wunused-parameter",
+]
 
-# get current directory
-filePath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))+"/IdentityCore/xcconfig/identitycore__common.xcconfig"
-f=open(filePath, 'r')
-counter = 0
-# find the first line where to put extra configurations
-lines=f.readlines()
-for line in lines:
-    counter+=1
-    if line=="OTHER_CFLAGS=$(inherited) -fstack-protector-strong\n":
-        break
-configurationInStr = ""
+current_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+file_path = current_directory + "/IdentityCore/xcconfig/identitycore__common.xcconfig"
 
-# read lines and append configurations
-for configuration in configurations:
-    configurationInStr+=(prefixConfigurationFlags+configuration+"\n")
-lines[counter]=(lines[counter]+configurationInStr)
-f.close()
+
+contents = []
+with open(file_path, "r") as f:
+    contents = f.read().split("\n")
+
+for i in range(len(contents)):
+    if contents[i] == "OTHER_CFLAGS=$(inherited) -fstack-protector-strong":
+        new_lines = []
+        for configuration in configurations:
+            new_lines.append("OTHER_CFLAGS=$(OTHER_CFLAGS) -" + configuration)
+        contents = contents[:i] + new_lines + contents[i:]
 
 # write into file
-f=open(filePath, 'w')
-f.writelines(lines)
-f.close()
+with open(file_path, "w") as f:
+    f.write("\n".join(contents))

--- a/scripts/update_xcode_config_cpp_checks.py
+++ b/scripts/update_xcode_config_cpp_checks.py
@@ -52,6 +52,7 @@ for i in range(len(contents)):
         for configuration in configurations:
             new_lines.append("OTHER_CFLAGS=$(OTHER_CFLAGS) -" + configuration)
         contents = contents[:i] + new_lines + contents[i:]
+        break
 
 # write into file
 with open(file_path, "w") as f:

--- a/scripts/update_xcode_config_cpp_checks.py
+++ b/scripts/update_xcode_config_cpp_checks.py
@@ -1,0 +1,27 @@
+import os
+
+prefixConfigurationFlags="OTHER_CFLAGS=$(OTHER_CFLAGS) -"
+configurations=["Wall", "Werror", "Wextra", "Wassign-enum", "Wblock-capture-autoreleasing", "Wbool-conversion", "Wcomma", "Wconditional-uninitialized", "Wconstant-conversion", "Wdeprecated-declarations", "Wdeprecated-implementations", "Wdeprecated-objc-isa-usage", "Wduplicate-method-match", "Wdocumentation", "Wempty-body", "Wenum-conversion", "Wfatal-errors", "Wfloat-conversion", "Wheader-hygiene", "Wincompatible-pointer-types", "Wint-conversion", "Winvalid-offsetof", "Wnewline-eof", "Wno-unknown-pragmas", "Wnon-literal-null-conversion", "Wnon-modular-include-in-framework-module", "Wnon-virtual-dtor", "Wobjc-literal-conversion", "Wobjc-root-class", "Wprotocol", "Wshorten-64-to-32", "Wstrict-prototypes", "Wundeclared-selector", "Wunreachable-code", "Wunused-parameter"]
+
+# get current directory
+filePath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))+"/IdentityCore/xcconfig/identitycore__common.xcconfig"
+f=open(filePath, 'r')
+counter = 0
+# find the first line where to put extra configurations
+lines=f.readlines()
+for line in lines:
+    counter+=1
+    if line=="OTHER_CFLAGS=$(inherited) -fstack-protector-strong\n":
+        break
+configurationInStr = ""
+
+# read lines and append configurations
+for configuration in configurations:
+    configurationInStr+=(prefixConfigurationFlags+configuration+"\n")
+lines[counter]=(lines[counter]+configurationInStr)
+f.close()
+
+# write into file
+f=open(filePath, 'w')
+f.writelines(lines)
+f.close()


### PR DESCRIPTION
## Proposed changes

Added a new script to insert warning configurations per [this PR](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/814) and prevent warnings been introduced into cpp layer. The configuration changes only happens in pipelines (Travis) and will not propagate into broker or MSAL Objc

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

