### PR TITLE
Broker save the session to local cache when in background state

### DIFF
--- a/IdentityCore/src/util/ios/MSIDAppExtensionUtil.h
+++ b/IdentityCore/src/util/ios/MSIDAppExtensionUtil.h
@@ -42,5 +42,6 @@
 + (void)sharedApplicationOpenURL:(nonnull NSURL *)url
                          options:(nullable NSDictionary<UIApplicationOpenExternalURLOptionsKey, id> *)options
                completionHandler:(void (^ __nullable)(BOOL success))completionHandler;
-
+// Helper method to check if the app state
++ (BOOL)runningInActiveState;
 @end

--- a/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
+++ b/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
@@ -102,4 +102,8 @@ static BOOL s_isRunningInCompliantExtension = NO;
     }];
 }
 
++ (BOOL)runningInActiveState
+{
+    return [[self sharedApplication] applicationState] == UIApplicationStateActive;
+}
 @end


### PR DESCRIPTION
## Proposed changes

Parent PR for context:
https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/645

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

