### PR TITLE
Added logic for handling external links that open in new tab for embedded web view.

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -248,6 +248,8 @@
 		60D6ED0A20D9BB79002FCBBB /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60D6ED0920D9BB79002FCBBB /* SafariServices.framework */; };
 		60D6ED0C20D9BB89002FCBBB /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60D6ED0B20D9BB89002FCBBB /* Security.framework */; };
 		60D6ED0D20D9BBA0002FCBBB /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B20657D61FC92D2700412B7D /* IOKit.framework */; };
+		723DADA1255A344800E519BD /* MSIDAppExtensionUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 723DAD75255A330900E519BD /* MSIDAppExtensionUtil.m */; };
+		728D97BA255AF16500194881 /* MSIDAppExtensionUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F21B0420A4FB27002B87C3 /* MSIDAppExtensionUtil.m */; };
 		960196F9208E578900D962D3 /* MSIDAuthenticationSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 960196F8208E578900D962D3 /* MSIDAuthenticationSession.m */; };
 		960196FC208E579600D962D3 /* MSIDSafariViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 960196FB208E579600D962D3 /* MSIDSafariViewController.m */; };
 		96090D9820E59B2000E42B37 /* MSIDNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 96090D9620E59B2000E42B37 /* MSIDNotifications.h */; };
@@ -337,7 +339,6 @@
 		96DAC2CE21431DE30001FBF5 /* NSString+MSIDTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 96DAC2CC21431DE30001FBF5 /* NSString+MSIDTestUtil.m */; };
 		96F21AED20A4C6F2002B87C3 /* UIApplication+MSIDExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 96F21AEB20A4C6F2002B87C3 /* UIApplication+MSIDExtensions.h */; };
 		96F21AEE20A4C6F2002B87C3 /* UIApplication+MSIDExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F21AEC20A4C6F2002B87C3 /* UIApplication+MSIDExtensions.m */; };
-		96F21B0520A4FB27002B87C3 /* MSIDAppExtensionUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F21B0420A4FB27002B87C3 /* MSIDAppExtensionUtil.m */; };
 		96F21B1A20A65187002B87C3 /* MSIDWebviewInteracting.h in Headers */ = {isa = PBXBuildFile; fileRef = 96F21B1720A65187002B87C3 /* MSIDWebviewInteracting.h */; };
 		96F21B3120A65896002B87C3 /* MSIDWebviewAuthorization.h in Headers */ = {isa = PBXBuildFile; fileRef = 96F21B2F20A65896002B87C3 /* MSIDWebviewAuthorization.h */; };
 		96F21B3220A65896002B87C3 /* MSIDWebviewAuthorization.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F21B3020A65896002B87C3 /* MSIDWebviewAuthorization.m */; };
@@ -1002,6 +1003,7 @@
 		60D6ED0920D9BB79002FCBBB /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/SafariServices.framework; sourceTree = DEVELOPER_DIR; };
 		60D6ED0B20D9BB89002FCBBB /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		60E434262088F79200802D59 /* MSIDAppExtensionUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAppExtensionUtil.m; sourceTree = "<group>"; };
+		723DAD75255A330900E519BD /* MSIDAppExtensionUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAppExtensionUtil.m; sourceTree = "<group>"; };
 		960196F7208E578900D962D3 /* MSIDAuthenticationSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAuthenticationSession.h; sourceTree = "<group>"; };
 		960196F8208E578900D962D3 /* MSIDAuthenticationSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAuthenticationSession.m; sourceTree = "<group>"; };
 		960196FA208E579600D962D3 /* MSIDSafariViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSafariViewController.h; sourceTree = "<group>"; };
@@ -1749,6 +1751,14 @@
 			path = ui;
 			sourceTree = "<group>";
 		};
+		723DAD74255A330900E519BD /* mac */ = {
+			isa = PBXGroup;
+			children = (
+				723DAD75255A330900E519BD /* MSIDAppExtensionUtil.m */,
+			);
+			path = mac;
+			sourceTree = "<group>";
+		};
 		96235F8F207D7128007EAB36 /* webview */ = {
 			isa = PBXGroup;
 			children = (
@@ -1877,7 +1887,6 @@
 			children = (
 				96F21AEB20A4C6F2002B87C3 /* UIApplication+MSIDExtensions.h */,
 				96F21AEC20A4C6F2002B87C3 /* UIApplication+MSIDExtensions.m */,
-				96F21B0320A4FB27002B87C3 /* MSIDAppExtensionUtil.h */,
 				96F21B0420A4FB27002B87C3 /* MSIDAppExtensionUtil.m */,
 			);
 			path = ios;
@@ -2201,8 +2210,10 @@
 		D62600091FBD305800EE4487 /* util */ = {
 			isa = PBXGroup;
 			children = (
+				723DAD74255A330900E519BD /* mac */,
 				96F21AF020A4C895002B87C3 /* ios */,
 				237A6D61203269740084E15F /* MSIDJsonSerializable.h */,
+				96F21B0320A4FB27002B87C3 /* MSIDAppExtensionUtil.h */,
 				96CD69571FE84A0300D41938 /* MSIDJsonObject.h */,
 				96CD69581FE84A0300D41938 /* MSIDJsonObject.m */,
 				B27CCE1122A0AFCE00CAD565 /* NSJSONSerialization+MSIDExtensions.h */,
@@ -3109,6 +3120,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				723DADA1255A344800E519BD /* MSIDAppExtensionUtil.m in Sources */,
 				B251CC3A2041058D005E0179 /* MSIDLegacySingleResourceToken.m in Sources */,
 				B2A3C2812145D04E0082525C /* MSIDAuthorityCacheRecord.m in Sources */,
 				B2000C9B20EC64FE0092790A /* MSIDDefaultCredentialCacheKey.m in Sources */,
@@ -3405,6 +3417,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				728D97BA255AF16500194881 /* MSIDAppExtensionUtil.m in Sources */,
 				23B39AC2209BD901000AA905 /* MSIDAdfsAuthorityResolver.m in Sources */,
 				B2000C8E20EC62DF0092790A /* MSIDAADV1IdTokenClaims.m in Sources */,
 				B2000C9020EC633C0092790A /* MSIDConfiguration.m in Sources */,
@@ -3506,7 +3519,6 @@
 				B29A36C020B1289D00427B63 /* MSIDAccountIdentifier.m in Sources */,
 				96A3E9B9208941D700BE5262 /* MSIDSystemWebviewController.m in Sources */,
 				238E19CD2086FC87004DF483 /* MSIDUrlRequestSerializer.m in Sources */,
-				96F21B0520A4FB27002B87C3 /* MSIDAppExtensionUtil.m in Sources */,
 				238E19DE2086FE28004DF483 /* MSIDTokenRequest.m in Sources */,
 				96F94A3420817C1A0034676C /* MSIDNTLMHandler.m in Sources */,
 				6068303A20A3560F00CCA6AB /* MSIDPKeyAuthHandler.m in Sources */,

--- a/IdentityCore/src/IdentityCore.pch
+++ b/IdentityCore/src/IdentityCore.pch
@@ -32,6 +32,8 @@
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#else
+#import <AppKit/AppKit.h>
 #endif
 
 #endif /* IdentityCore_pch */

--- a/IdentityCore/src/util/MSIDAppExtensionUtil.h
+++ b/IdentityCore/src/util/MSIDAppExtensionUtil.h
@@ -28,9 +28,21 @@
 
 /// Determine whether or not the host app is an application extension based on the main bundle path
 + (BOOL)isExecutingInAppExtension;
-/// Application extension safe replacement for `[UIApplication sharedApplication]`. The caller should make sure `isExecutingInAppExtension == NO` before calling this method.
-+ (UIApplication *)sharedApplication;
-/// Application extension safe replacement for `[[UIApplication sharedApplication] openURL:]`. The caller should make sure `isExecutingInAppExtension == NO` before calling this method.
-+ (void)sharedApplicationOpenURL:(NSURL *)url;
 
+/// Application extension safe replacement for `openURL:`. The caller should make sure `isExecutingInAppExtension == NO` before calling this method.
++ (void)sharedApplicationOpenURL:(nonnull NSURL *)url;
+
+#if TARGET_OS_IPHONE
+/// Application extension safe replacement for `[UIApplication sharedApplication]`. The caller should make sure `isExecutingInAppExtension == NO` before calling this method.
++ (nullable UIApplication *)sharedApplication;
+
+#else
+/// Application extension safe replacement for `[NSWorkspace sharedWorkspace]`. The caller should make sure `isExecutingInAppExtension == NO` before calling this method.
++ (nullable NSWorkspace *)sharedApplication;
+
+/// Application extension safe replacement for `[[NSWorkspace sharedWorkspace] openURL:configuration:completionHandler:]`. The caller should make sure `isExecutingInAppExtension == NO` before calling this method.
++ (void)sharedApplicationOpenURL:(nonnull NSURL *)url
+                   configuration:(nullable NSWorkspaceOpenConfiguration *)options
+               completionHandler:(void (^ __nullable)(BOOL success))completionHandler API_AVAILABLE(macos(10.15));
+#endif
 @end

--- a/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
+++ b/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
@@ -32,7 +32,7 @@
     
     if (mainBundlePath.length == 0)
     {
-        MSID_LOG_ERROR(nil, @"Expected `[[NSBundle mainBundle] bundlePath]` to be non-nil. Defaulting to non-application-extension safe API.");
+        MSID_LOG_WARN(nil, @"Expected `[[NSBundle mainBundle] bundlePath]` to be non-nil. Defaulting to non-application-extension safe API.");
         
         return NO;
     }

--- a/IdentityCore/src/util/mac/MSIDAppExtensionUtil.m
+++ b/IdentityCore/src/util/mac/MSIDAppExtensionUtil.m
@@ -34,7 +34,7 @@
     
     if ([NSString msidIsStringNilOrBlank:mainBundlePath])
     {
-        MSID_LOG_ERROR(nil, @"Expected `[[NSBundle mainBundle] bundlePath]` to be non-nil. Defaulting to non-application-extension safe API.");
+        MSID_LOG_WARN(nil, @"Expected `[[NSBundle mainBundle] bundlePath]` to be non-nil. Defaulting to non-application-extension safe API.");
         
         return NO;
     }

--- a/IdentityCore/src/util/mac/MSIDAppExtensionUtil.m
+++ b/IdentityCore/src/util/mac/MSIDAppExtensionUtil.m
@@ -32,7 +32,7 @@
 {
     NSString *mainBundlePath = [[NSBundle mainBundle] bundlePath];
     
-    if (mainBundlePath.length == 0)
+    if ([NSString msidIsStringNilOrBlank:mainBundlePath])
     {
         MSID_LOG_ERROR(nil, @"Expected `[[NSBundle mainBundle] bundlePath]` to be non-nil. Defaulting to non-application-extension safe API.");
         

--- a/IdentityCore/src/util/mac/MSIDAppExtensionUtil.m
+++ b/IdentityCore/src/util/mac/MSIDAppExtensionUtil.m
@@ -1,0 +1,95 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#import "MSIDAppExtensionUtil.h"
+#import "MSIDMainThreadUtil.h"
+
+@implementation MSIDAppExtensionUtil
+
++ (BOOL)isExecutingInAppExtension
+{
+    NSString *mainBundlePath = [[NSBundle mainBundle] bundlePath];
+    
+    if (mainBundlePath.length == 0)
+    {
+        MSID_LOG_ERROR(nil, @"Expected `[[NSBundle mainBundle] bundlePath]` to be non-nil. Defaulting to non-application-extension safe API.");
+        
+        return NO;
+    }
+    
+    return [mainBundlePath hasSuffix:@"appex"];
+}
+
+#pragma mark - NSWorkspace
+
++ (NSWorkspace *)sharedApplication
+{
+    if ([self isExecutingInAppExtension])
+    {
+        // The caller should do this check but we will double check to fail safely
+        return nil;
+    }
+    
+    return [NSWorkspace performSelector:NSSelectorFromString(@"sharedWorkspace")];
+}
+
++ (void)sharedApplicationOpenURL:(NSURL*)url
+{
+    if ([self isExecutingInAppExtension])
+    {
+        // The caller should do this check but we will double check to fail safely
+        return;
+    }
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
+        [[self sharedApplication] performSelector:NSSelectorFromString(@"openURL:") withObject:url];
+    }];
+#pragma clang diagnostic pop
+}
+
++ (void)sharedApplicationOpenURL:(NSURL *)url
+                   configuration:(NSWorkspaceOpenConfiguration *)options
+               completionHandler:(void (^ __nullable)(BOOL success))completionHandler
+API_AVAILABLE(macos(10.15)){
+    if ([self isExecutingInAppExtension])
+    {
+        // The caller should do this check but we will double check to fail safely
+        return;
+    }
+    
+    [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
+        
+        SEL openURLSelector = @selector(openURL:configuration:completionHandler:);
+        NSWorkspace *application = [self sharedApplication];
+        id (*safeOpenURL)(id, SEL, id, id, id) = (void *)[application methodForSelector:openURLSelector];
+        
+        safeOpenURL(application, openURLSelector, url, options, completionHandler);
+    }];
+}
+
+@end

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -362,7 +362,7 @@
         //Open secure web links with target=new window in default browser or non-web links with URL schemes that can be opened by the application
         if (([requestURL.scheme.lowercaseString isEqualToString:@"https"] && !navigationAction.targetFrame.isMainFrame) || ![requestURL.scheme.lowercaseString hasPrefix:@"http"])
         {
-            MSID_LOG_INFO_PII(self.context, @"Opening URL outside embedded webview : %@",requestURLString);
+            MSID_LOG_INFO_PII(self.context, @"Opening URL outside embedded webview with scheme: %@ host: %@",requestURL.scheme,requestURL.host);
             [MSIDAppExtensionUtil sharedApplicationOpenURL:requestURL];
             decisionHandler(WKNavigationActionPolicyCancel);
             return;

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -37,6 +37,7 @@
 #import "MSIDTelemetryUIEvent.h"
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDMainThreadUtil.h"
+#import "MSIDAppExtensionUtil.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -353,6 +354,19 @@
     {
         decisionHandler(WKNavigationActionPolicyAllow);
         return;
+    }
+    
+    // Handle anchor links that were clicked
+    if ([navigationAction navigationType] == WKNavigationTypeLinkActivated)
+    {
+        //Open secure web links with target=new window in default browser or non-web links with URL schemes that can be opened by the application
+        if (([requestURL.scheme.lowercaseString isEqualToString:@"https"] && !navigationAction.targetFrame.isMainFrame) || ![requestURL.scheme.lowercaseString hasPrefix:@"http"])
+        {
+            MSID_LOG_INFO(self.context, @"Opening URL outside embedded webview : %@",requestURLString);
+            [MSIDAppExtensionUtil sharedApplicationOpenURL:requestURL];
+            decisionHandler(WKNavigationActionPolicyCancel);
+            return;
+        }
     }
     
     // redirecting to non-https url is not allowed

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -362,7 +362,7 @@
         //Open secure web links with target=new window in default browser or non-web links with URL schemes that can be opened by the application
         if (([requestURL.scheme.lowercaseString isEqualToString:@"https"] && !navigationAction.targetFrame.isMainFrame) || ![requestURL.scheme.lowercaseString hasPrefix:@"http"])
         {
-            MSID_LOG_INFO(self.context, @"Opening URL outside embedded webview : %@",requestURLString);
+            MSID_LOG_INFO_PII(self.context, @"Opening URL outside embedded webview : %@",requestURLString);
             [MSIDAppExtensionUtil sharedApplicationOpenURL:requestURL];
             decisionHandler(WKNavigationActionPolicyCancel);
             return;


### PR DESCRIPTION
## Proposed changes
Currently in embedded web view, links with target=_blank (web links that should open in a new window/tab) are ignored by WKWebView since it is an embedded web view. These links should be handled by opening in the default browser. Links that can be opened via URL schemes on the device need to also be handled. This is required during MFA setup since the link to activate MFA code looks like this : microsoft-authenticator://activateMFA?code=

This PR adds logic to handle these types of links in embedded web view by opening them in browser or application that supports the URL's scheme.

This is for ADAL common core update.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

