### PR TITLE
Cross cloud support

### DIFF
--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -400,10 +400,10 @@
         }
         
         // Check if token endpoint (from open id metadata) is the same cloud as the RT issuer cloud
-        // If not the same cloud, we don't send RT
-        if (![self checkTokenEndpoint])
+        // If not the same cloud, we don't send RT to wrong cloud.
+        if (![self.requestParameters.authority checkTokenEndpointForRTRefresh:self.requestParameters.tokenEndpoint])
         {
-            NSError *interactionError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired, @"User interaction is required", nil, nil, nil, self.requestParameters.correlationId, nil, YES);
+            NSError *interactionError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired, @"User interaction is required (unable to use token from a different cloud).", nil, nil, nil, self.requestParameters.correlationId, nil, YES);
             completionBlock(nil, interactionError);
             return;
         }
@@ -483,18 +483,6 @@
             completionBlock(result, error);
         }];
     }];
-}
-
-- (BOOL)checkTokenEndpoint
-{
-    NSArray *environmentAliases = self.requestParameters.authority.defaultCacheEnvironmentAliases;
-    if ([environmentAliases count] &&
-        ![self.requestParameters.tokenEndpoint.host.msidNormalizedString msidIsEquivalentWithAnyAlias:environmentAliases])
-    {
-        return NO;
-    }
-    
-    return YES;
 }
 
 #pragma mark - Abstract

--- a/IdentityCore/src/validation/MSIDAADAuthority.m
+++ b/IdentityCore/src/validation/MSIDAADAuthority.m
@@ -234,6 +234,16 @@
     return YES;
 }
 
+- (BOOL)checkTokenEndpointForRTRefresh:(NSURL *)tokenEndpoint
+{
+    NSArray *environmentAliases = self.defaultCacheEnvironmentAliases;
+    
+    if (!tokenEndpoint || ![environmentAliases count])
+        return YES;
+    
+    return [tokenEndpoint.host.msidNormalizedString msidIsEquivalentWithAnyAlias:environmentAliases];
+}
+
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(NSZone *)zone

--- a/IdentityCore/src/validation/MSIDAuthority.h
+++ b/IdentityCore/src/validation/MSIDAuthority.h
@@ -92,6 +92,9 @@ typedef void(^MSIDOpenIdConfigurationInfoBlock)(MSIDOpenIdProviderMetadata * _Nu
 // Only certain authorities support MAM CA scenarios
 - (BOOL)supportsMAMScenarios;
 
+// Check if token endpoint is the same cloud as the authoirty
+- (BOOL)checkTokenEndpointForRTRefresh:(nullable NSURL *)tokenEndpoint;
+
 /* It is used in telemetry */
 - (nonnull NSString *)telemetryAuthorityType;
 

--- a/IdentityCore/src/validation/MSIDAuthority.h
+++ b/IdentityCore/src/validation/MSIDAuthority.h
@@ -92,7 +92,8 @@ typedef void(^MSIDOpenIdConfigurationInfoBlock)(MSIDOpenIdProviderMetadata * _Nu
 // Only certain authorities support MAM CA scenarios
 - (BOOL)supportsMAMScenarios;
 
-// Check if token endpoint is the same cloud as the authoirty
+// Check if token endpoint is consistent with the authoirty
+// E.g., currently AAD Authority checks if the host is the same, which requires resolving authority beforehand
 - (BOOL)checkTokenEndpointForRTRefresh:(nullable NSURL *)tokenEndpoint;
 
 /* It is used in telemetry */

--- a/IdentityCore/src/validation/MSIDAuthority.m
+++ b/IdentityCore/src/validation/MSIDAuthority.m
@@ -191,6 +191,11 @@ NSString *const MSID_AUTHORITY_TYPE_JSON_KEY = @"authority_type";
     return NO;
 }
 
+- (BOOL)checkTokenEndpointForRTRefresh:(NSURL *)tokenEndpoint
+{
+    return YES;
+}
+
 - (nonnull NSString *)telemetryAuthorityType
 {
     NSAssert(NO, @"Abstract method.");

--- a/IdentityCore/tests/MSIDAADAuthorityTests.m
+++ b/IdentityCore/tests/MSIDAADAuthorityTests.m
@@ -701,6 +701,19 @@
     XCTAssertNotEqualObjects(lhs, rhs);
 }
 
+- (void)testCheckTokenEndpointForRTRefresh_whenTokenEndpointNil_shouldReturnTrue
+{
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    XCTAssertTrue([authority checkTokenEndpointForRTRefresh:nil]);
+}
+
+- (void)testCheckTokenEndpointForRTRefresh_whenTokenEndpointInDifferentCloud_shouldReturnFalse
+{
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    NSURL *urlFromDifferentCloud = [NSURL URLWithString:@"https://login.partner.microsoftonline.cn/oauth2/v2.0/token"];
+    XCTAssertFalse([authority checkTokenEndpointForRTRefresh:urlFromDifferentCloud]);
+}
+
 #pragma mark - Private
 
 - (void)setupAADAuthorityCache

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+* Avoid sending RT to wrong cloud
 * Added logic to handle links that should open in new window in embedded webView.
 * Fix code in kDF function. Add test cases
 * Enabled various warnings (which we were mostly compliant with) (#814)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-* Avoid sending RT to wrong cloud. (#892)
+* Avoid sending RT to wrong cloud (#892)
 * Added logic to handle links that should open in new window in embedded webView.
 * Fix code in kDF function. Add test cases
 * Enabled various warnings (which we were mostly compliant with) (#814)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-* Avoid sending RT to wrong cloud
+* Avoid sending RT to wrong cloud. (#892)
 * Added logic to handle links that should open in new window in embedded webView.
 * Fix code in kDF function. Add test cases
 * Enabled various warnings (which we were mostly compliant with) (#814)


### PR DESCRIPTION
## Proposed changes

Most of the changes are in MSAL repo. Changes in common core here is to make sure we do not send RT to a wrong cloud.

The reason we could send RT to wrong cloud is:
server open id configuration endpoint supports url `login.microsoftonline.com/<CHINA_CLOUD_TENANT_ID>/v2.0/.well-known/openid-configuration`, where it will return the correct token endpoint, i.e. `login.partner.microsoftonline.cn`. In such a case, RT issued by WW cloud could be sent to China cloud.

Logic is added to handle such mismatch more actively (only for AADAuthority). UT will be added later.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

