### PR TITLE
ADAL fix for ADFS PKeyAuth issue. 

### DIFF
--- a/IdentityCore/src/util/NSDictionary+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSDictionary+MSIDExtensions.m
@@ -83,7 +83,6 @@
     return [NSString msidWWWFormURLEncodedStringFromDictionary:self];
 }
 
-
 - (NSDictionary *)dictionaryByRemovingFields:(NSArray *)fieldsToRemove
 {
     NSMutableDictionary *mutableDict = [self mutableCopy];

--- a/IdentityCore/src/util/NSString+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.h
@@ -44,6 +44,10 @@
  See https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4 for more details. */
 - (NSString *)msidWWWFormURLDecode;
 
+/*! URL decode (Percentage decode), in accordance to
+ https://tools.ietf.org/html/rfc3986 */
+- (NSString *)msidURLDecode;
+
 /*! Encodes the string to be application/x-www-form-urlencoded.
  See https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4 for more details.  */
 - (NSString *)msidWWWFormURLEncode;

--- a/IdentityCore/src/util/NSString+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.m
@@ -94,7 +94,6 @@ typedef unsigned char byte;
     return [self stringByTrimmingCharactersInSet:set];
 }
 
-
 - (NSString *)msidWWWFormURLDecode
 {
     // Two step decode: first replace + with a space, then percent unescape
@@ -109,6 +108,10 @@ typedef unsigned char byte;
     return CFBridgingRelease(unescapedString);
 }
 
+- (NSString *)msidURLDecode
+{
+    return CFBridgingRelease(CFURLCreateStringByReplacingPercentEscapes(kCFAllocatorDefault, (CFStringRef)self, CFSTR("")));
+}
 
 - (NSString *)msidWWWFormURLEncode
 {
@@ -224,6 +227,11 @@ typedef unsigned char byte;
          NSString *encodedValue = [[v msidTrimmedString] msidWWWFormURLEncode];
          
          if (![NSString msidIsStringNilOrBlank:encodedValue])
+         {
+             [encodedString appendFormat:@"=%@", encodedValue];
+         }
+        
+         else if ((encodedValue && ![encodedValue isKindOfClass:[NSNull class]]) && !encodedValue.length)
          {
              [encodedString appendFormat:@"=%@", encodedValue];
          }

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -58,6 +58,11 @@ static WKWebViewConfiguration *s_webConfig;
 {
     WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
 
+    if (@available(iOS 9.0, *))
+    {
+        webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    }
+    
     if (@available(iOS 13.0, *))
     {
         webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -52,6 +52,11 @@ static WKWebViewConfiguration *s_webConfig;
 {
     WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
 
+    if (@available(macOS 10.11, *))
+    {
+        webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    }
+    
     if (@available(macOS 10.15, *))
     {
         webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;

--- a/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
+++ b/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
@@ -110,7 +110,7 @@
 {
     NSString *regexString = @"OU=[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}";
     keychainCertIssuer = [keychainCertIssuer uppercaseString];
-    certAuths = [certAuths uppercaseString];
+    certAuths = [certAuths.msidURLDecode uppercaseString];
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexString options:0 error:NULL];
     
     for (NSTextCheckingResult *myMatch in [regex matchesInString:certAuths options:0 range:NSMakeRange(0, [certAuths length])]){


### PR DESCRIPTION
## Proposed changes

When PKeyAuth is enabled through UA string, Client-side PKeyAuth handler creates a PkeyAuth header and then responds to the server-side challenge.

There was a bug in the client-side code, specifically in the msidEncodeStringFromDictionary API in the MSID category method for the NSString object.

This API constructs a URL string from the key-value pairs contained in the input dictionary.
ex: https://fs.msidlab4.com/adfs/ls/?&key1=value1&key2=value2&......&keyn=valuen.

This input dictionary is constructed from the submitURL parameter contained within the PKeyAuth request URL returned by the server. this submitURL field contains the information about the endpoint to which the PKeyAuth response must be submitted.

This is how the flow goes:

Client submits PKeyAuth request through the UA string
Server sees the request, and returns the challenge request URL, upon which the client must respond with a valid PKeyAuth header to the endpoint stored in the challenge request URL's submitURL parameter.
Client first converts the submitURL field into a dictionary with different key value pairs, where each key-value is generated from the components separated by & field, and each component takes the following format: &key1=value1&key2=value2....&keyn=valuen.
Then, client adds the "x-client-Ver" key-value pair to the dictionary in the step 3.
Client converts the dictionary back into the URL format using msidEncodeStringFromDictionary API.
During the transition from liveID endpoint to OrgID endpoint, namely, between AAD and ADFS transition point, AAD's JS logic appends three additional parameters: cbctx, lc, and mkt to the ADFS endpoint URL string, and this also propagates to the SubmitURL field in the PKeyAuth request URL string. However, they do not contain any additional information, so the SubmitURL would have the following structure: &cbctx=&lc=&mkt=

When they are converted into key-value pairs & stored in a dictionary, this dictionary is then fed into msidEncodeStringFromDictionary API after "x-client-Ver" key-value pair is added.

However, this API does not add "=" after the key, if the value a non-null empty string.
So, the end result is a URL that will have &cbctx&lc&mkt in the string.
This breaks ADFS's input parser logic, since it also delimits the URL string based on '=' character, when not having that character would throw an exception.

The fix is to add "=" in the WWWFormURLEncode API, even if the value is an empty string, and this complies with the URL query string spec as well, and both AAD and ADFS also comply with this convention.

Additionally, ADAL first extracts certificate issuer from the WPJ keychain, and then tries to look for it in the list of certificate authorities embedded in the challenge data returned by the server using regex matching. That list of certificate authorities is stored in the string format, but it was not decoded properly in ADAL's latest release branch/master, while MSAL does. 


## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [x] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

