### PR TITLE
Increase PRT refresh frequency

### DIFF
--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
@@ -208,7 +208,7 @@ static NSUInteger kDefaultPRTRefreshInterval = 10800;
 {
     if (self.expiryInterval > 0)
     {
-        return self.expiryInterval / 20;
+        return self.expiryInterval / 30;
     }
     
     return kDefaultPRTRefreshInterval;

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
@@ -208,7 +208,7 @@ static NSUInteger kDefaultPRTRefreshInterval = 10800;
 {
     if (self.expiryInterval > 0)
     {
-        return self.expiryInterval / 10;
+        return self.expiryInterval / 20;
     }
     
     return kDefaultPRTRefreshInterval;


### PR DESCRIPTION
## Proposed changes

Latest broker that supports PRT refresh has reduced PRT expiry to 15%. However, we still have PRT expiry causing 15% of prompts. Adjusting the frequency to be a bit more aggressive (instead of expiry/10, expiry/30 - so if PRT expires in 14 days, we'll now try to refresh every 11 hours. This is still less aggressive than Windows (every 4 hours)). 

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

