### PR TITLE
Calling notifyWebAuthDidFinishLoad when external links are clicked

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -284,12 +284,7 @@
 - (void)webView:(WKWebView *)webView didFinishNavigation:(null_unspecified __unused WKNavigation *)navigation
 {
     NSURL *url = webView.URL;
-    
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, self.context, @"-didFinishNavigation host: %@", MSID_PII_LOG_TRACKABLE(url.host));
-    
-    [MSIDNotifications notifyWebAuthDidFinishLoad:url userInfo:webView ? @{@"webview": webView} : nil];
-    
-    [self stopSpinner];
+    [self notifyFinishedNavigation:url webView:webView];
 }
 
 - (void)webView:(__unused WKWebView *)webView didFailNavigation:(null_unspecified __unused WKNavigation *)navigation withError:(NSError *)error
@@ -386,6 +381,7 @@
         {
             MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.context, @"Opening URL outside embedded webview with scheme: %@ host: %@", requestURL.scheme, MSID_PII_LOG_TRACKABLE(requestURL.host));
             [MSIDAppExtensionUtil sharedApplicationOpenURL:requestURL];
+            [self notifyFinishedNavigation:requestURL webView:webView];
             decisionHandler(WKNavigationActionPolicyCancel);
             return;
         }
@@ -432,6 +428,15 @@
     }
     
     [self dismissLoadingIndicator];
+}
+
+-(void)notifyFinishedNavigation:(NSURL *)url webView:(WKWebView *)webView
+{
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, self.context, @"-didFinishNavigation host: %@", MSID_PII_LOG_TRACKABLE(url.host));
+    
+    [MSIDNotifications notifyWebAuthDidFinishLoad:url userInfo:webView ? @{@"webview": webView} : nil];
+    
+    [self stopSpinner];
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

When links with target=_blank ( anchor links that open in new tab) are clicked in an embedded webview, notifyWebAuthDidFinishLoad must be called so that any remaining actions that must be performed by observer are performed once navigation is complete.

Eg : ASDKBrokerViewController in Authenticator app initializes a UIActivityIndicator spinner on loading the web content. It relies on observing the notification mentioned to stop the spinner animation.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

