### PR TITLE
Notify observer for WebAuthDidFinishLoad when opening external links in embedded webview

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -263,11 +263,7 @@
     NSURL *url = webView.URL;
     __auto_type isKnown = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:url.host];
     MSID_LOG_VERBOSE(self.context, @"-didFinishNavigation host: %@", isKnown ? url.host : @"unknown host");
-    MSID_LOG_VERBOSE_PII(self.context, @"-didFinishNavigation host: %@", url.host);
-    
-    [MSIDNotifications notifyWebAuthDidFinishLoad:url userInfo:webView ? @{@"webview": webView} : nil];
-    
-    [self stopSpinner];
+    [self notifyFinishedNavigation:url webView:webView];
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(null_unspecified WKNavigation *)navigation withError:(NSError *)error
@@ -364,6 +360,7 @@
         {
             MSID_LOG_INFO_PII(self.context, @"Opening URL outside embedded webview with scheme: %@ host: %@",requestURL.scheme,requestURL.host);
             [MSIDAppExtensionUtil sharedApplicationOpenURL:requestURL];
+            [self notifyFinishedNavigation:requestURL webView:webView];
             decisionHandler(WKNavigationActionPolicyCancel);
             return;
         }
@@ -410,6 +407,15 @@
     }
     
     [self dismissLoadingIndicator];
+}
+
+-(void)notifyFinishedNavigation:(NSURL *)url webView:(WKWebView *)webView
+{
+    MSID_LOG_VERBOSE_PII(self.context, @"-didFinishNavigation host: %@", url.host);
+    
+    [MSIDNotifications notifyWebAuthDidFinishLoad:url userInfo:webView ? @{@"webview": webView} : nil];
+    
+    [self stopSpinner];
 }
 
 @end


### PR DESCRIPTION
## Proposed changes
For ADAL embedded webview,

When links with target=_blank ( anchor links that open in new tab) are clicked in an embedded webview, notifyWebAuthDidFinishLoad must be called so that any remaining actions that must be performed by observer are performed once navigation is complete.

Eg : ASDKBrokerViewController in Authenticator app initializes a UIActivityIndicator spinner on loading the web content. It relies on observing the notification mentioned to stop the spinner animation.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

