### PR TITLE
Remove PKeyAuth from MacOS and add regression test.

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -729,6 +729,9 @@
 		D6D9A4BD1FBE712900EFA430 /* MSIDURLExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D6D9A4BA1FBE712900EFA430 /* MSIDURLExtensionsTests.m */; };
 		D6D9A4BE1FBE712900EFA430 /* MSIDStringExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D6D9A4BB1FBE712900EFA430 /* MSIDStringExtensionsTests.m */; };
 		D6D9A4BF1FBE712900EFA430 /* MSIDStringExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D6D9A4BB1FBE712900EFA430 /* MSIDStringExtensionsTests.m */; };
+		E7407A722575807B00C88199 /* MSIDWebviewDefaultConfigurationSettingsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7407A712575807B00C88199 /* MSIDWebviewDefaultConfigurationSettingsTest.m */; };
+		E7407A7C2575836700C88199 /* MSIDWebviewDefaultConfigurationSettingsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7407A712575807B00C88199 /* MSIDWebviewDefaultConfigurationSettingsTest.m */; };
+		E7407A9925758B3B00C88199 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7407A9825758B3B00C88199 /* CoreGraphics.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1381,6 +1384,8 @@
 		D6D9A4B91FBE6D1C00EFA430 /* IdentityCore.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IdentityCore.pch; sourceTree = "<group>"; };
 		D6D9A4BA1FBE712900EFA430 /* MSIDURLExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDURLExtensionsTests.m; sourceTree = "<group>"; };
 		D6D9A4BB1FBE712900EFA430 /* MSIDStringExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDStringExtensionsTests.m; sourceTree = "<group>"; };
+		E7407A712575807B00C88199 /* MSIDWebviewDefaultConfigurationSettingsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWebviewDefaultConfigurationSettingsTest.m; sourceTree = "<group>"; };
+		E7407A9825758B3B00C88199 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1409,6 +1414,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7407A9925758B3B00C88199 /* CoreGraphics.framework in Frameworks */,
 				B29DB0FC216C4367008F846C /* AuthenticationServices.framework in Frameworks */,
 				60D6ED0C20D9BB89002FCBBB /* Security.framework in Frameworks */,
 				60D6ED0A20D9BB79002FCBBB /* SafariServices.framework in Frameworks */,
@@ -2354,6 +2360,7 @@
 		D6D9A4C21FBE718C00EFA430 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E7407A9825758B3B00C88199 /* CoreGraphics.framework */,
 				963C898C214B98F10051AFEE /* AuthenticationServices.framework */,
 				60D6ED0B20D9BB89002FCBBB /* Security.framework */,
 				60D6ED0920D9BB79002FCBBB /* SafariServices.framework */,
@@ -2512,6 +2519,7 @@
 				23AE9DBA2148574F00B285F3 /* MSIDErrorExtensionsTests.m */,
 				B203197E217BF191006488D0 /* MSIDClientCapabilitiesTests.m */,
 				B2525C742330623E006FBA4B /* MSIDMainThreadUtilTests.m */,
+				E7407A712575807B00C88199 /* MSIDWebviewDefaultConfigurationSettingsTest.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -3090,6 +3098,7 @@
 				2338ECDA208A7CBD00809B9E /* MSIDAADRequestErrorHandlerTests.m in Sources */,
 				B2DD4B4220A934BC0047A66E /* MSIDTokenFilteringHelperTests.m in Sources */,
 				239DF9C320E04BC9002D428B /* MSIDADFSAuthorityTests.m in Sources */,
+				E7407A7C2575836700C88199 /* MSIDWebviewDefaultConfigurationSettingsTest.m in Sources */,
 				960F918A20CBECAE0055A162 /* MSIDAADWebviewFactoryTests.m in Sources */,
 				B2936F7320ABDEF40050C585 /* MSIDBaseTokenTests.m in Sources */,
 				B2C17AF41FC7A6BC0070A514 /* MSIDTestLogger.m in Sources */,
@@ -3331,6 +3340,7 @@
 				96CD652A20C885E2004813EE /* MSIDWebviewFactoryTests.m in Sources */,
 				239DF9C220E04BC9002D428B /* MSIDB2CAuthorityTests.m in Sources */,
 				B2808005204CB2A700944D89 /* MSIDAADV1TokenResponseTests.m in Sources */,
+				E7407A722575807B00C88199 /* MSIDWebviewDefaultConfigurationSettingsTest.m in Sources */,
 				D6D9A4BD1FBE712900EFA430 /* MSIDURLExtensionsTests.m in Sources */,
 				B2525C762330623E006FBA4B /* MSIDMainThreadUtilTests.m in Sources */,
 				960F918B20CBECAE0055A162 /* MSIDAADWebviewFactoryTests.m in Sources */,

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 
 #import "MSIDWebviewUIController.h"
-#import "MSIDWorkPlaceJoinConstants.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -52,11 +51,6 @@ static WKWebViewConfiguration *s_webConfig;
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
     WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
-
-    if (@available(macOS 10.11, *))
-    {
-        webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
-    }
     
     if (@available(macOS 10.15, *))
     {

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import "MSIDWebviewUIController.h"
+#import "MSIDWorkPlaceJoinConstants.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -51,7 +52,6 @@ static WKWebViewConfiguration *s_webConfig;
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
     WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
-    
     if (@available(macOS 10.15, *))
     {
         webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;

--- a/IdentityCore/tests/MSIDWebviewDefaultConfigurationSettingsTest.m
+++ b/IdentityCore/tests/MSIDWebviewDefaultConfigurationSettingsTest.m
@@ -1,0 +1,54 @@
+//
+//  MSIDWebviewDefaultConfigurationSettingsTest.m
+//  IdentityCoreTests Mac
+//
+//  Created by Peter Lee on 11/30/20.
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "MSIDWebviewUIController.h"
+#import <WebKit/WebKit.h>
+#import "MSIDWorkPlaceJoinConstants.h"
+
+@interface MSIDWebviewDefaultConfigurationSettingsTest : XCTestCase
+
+@end
+
+@implementation MSIDWebviewDefaultConfigurationSettingsTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+
+}
+
+- (void)testMSIDWebViewUIController_MSIDWebViewShouldBeInitializedWithValidDefaultConfigSettings{
+   
+    WKWebViewConfiguration *defaultConfig = [MSIDWebviewUIController defaultWKWebviewConfiguration];
+    WKWebView* webview = [[WKWebView alloc] initWithFrame:CGRectZero configuration:defaultConfig];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"retrieve userAgent String"];
+    [webview evaluateJavaScript:@"navigator.userAgent" completionHandler:^(id result, NSError *error) {
+        NSString *userAgent = result;
+        BOOL PKeyAuthNotFound = [userAgent rangeOfString:kMSIDPKeyAuthKeyWordForUserAgent].location == NSNotFound;
+        XCTAssertNil(error);
+#if TARGET_OS_IOS
+        XCTAssertEqual(PKeyAuthNotFound,NO);
+#else
+        XCTAssertEqual(PKeyAuthNotFound,YES);
+#endif
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:3 handler:nil];
+    
+}
+
+
+
+@end

--- a/IdentityCore/tests/MSIDWebviewDefaultConfigurationSettingsTest.m
+++ b/IdentityCore/tests/MSIDWebviewDefaultConfigurationSettingsTest.m
@@ -45,7 +45,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:3 handler:nil];
+    [self waitForExpectationsWithTimeout:10 handler:nil];
     
 }
 

--- a/IdentityCore/tests/MSIDWebviewDefaultConfigurationSettingsTest.m
+++ b/IdentityCore/tests/MSIDWebviewDefaultConfigurationSettingsTest.m
@@ -1,10 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
 //
-//  MSIDWebviewDefaultConfigurationSettingsTest.m
-//  IdentityCoreTests Mac
+// This code is licensed under the MIT License.
 //
-//  Created by Peter Lee on 11/30/20.
-//  Copyright © 2020 Microsoft. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
 #import "MSIDWebviewUIController.h"


### PR DESCRIPTION
## Proposed changes

Removed PKeyAuth from the UA string on MacOS, and also added a regression test.


## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

