### PR TITLE
Fix Possible Deadlock caused by Thread Explosion

### DIFF
--- a/IdentityCore/src/MSIDCache.m
+++ b/IdentityCore/src/MSIDCache.m
@@ -79,21 +79,21 @@
 
 - (void)setObject:(id)obj forKey:(id)key
 {
-    dispatch_barrier_async(self.synchronizationQueue, ^{
+    dispatch_barrier_sync(self.synchronizationQueue, ^{
         self.container[key] = obj;
     });
 }
 
 - (void)removeObjectForKey:(id)key
 {
-    dispatch_barrier_async(self.synchronizationQueue, ^{
+    dispatch_barrier_sync(self.synchronizationQueue, ^{
         [self.container removeObjectForKey:key];
     });
 }
 
 - (void)removeAllObjects
 {
-    dispatch_barrier_async(self.synchronizationQueue, ^{
+    dispatch_barrier_sync(self.synchronizationQueue, ^{
         [self.container removeAllObjects];
     });
 }

--- a/IdentityCore/src/cache/mac/MSIDMacCredentialStorageItem.m
+++ b/IdentityCore/src/cache/mac/MSIDMacCredentialStorageItem.m
@@ -50,7 +50,7 @@ static NSString *keyDelimiter = @"-";
 
 - (void)storeItem:(id<MSIDJsonSerializable>)item forKey:(MSIDCacheKey *)key
 {
-    dispatch_barrier_async(self.queue, ^{
+    dispatch_barrier_sync(self.queue, ^{
         NSString *type = [self getItemTypeFromCacheKey:key];
         
         if (type)
@@ -70,7 +70,7 @@ static NSString *keyDelimiter = @"-";
 
 - (void)mergeStorageItem:(MSIDMacCredentialStorageItem *)storageItem
 {
-    dispatch_barrier_async(self.queue, ^{
+    dispatch_barrier_sync(self.queue, ^{
         
         for (NSString *typeKey in storageItem.cacheObjects)
         {
@@ -98,7 +98,7 @@ static NSString *keyDelimiter = @"-";
 
 - (void)removeStoredItemForKey:(MSIDCacheKey *)key
 {
-    dispatch_barrier_async(self.queue, ^{
+    dispatch_barrier_sync(self.queue, ^{
         NSString *type = [self getItemTypeFromCacheKey:key];
         
         if (type)

--- a/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
@@ -50,7 +50,7 @@
         _memoryCache = [NSMutableDictionary new];
         _dataSource = dataSource;
         NSString *queueName = [NSString stringWithFormat:@"com.microsoft.msidmetadatacache-%@", [NSUUID UUID].UUIDString];
-        _synchronizationQueue = dispatch_queue_create([queueName cStringUsingEncoding:NSASCIIStringEncoding], DISPATCH_QUEUE_CONCURRENT);
+        _synchronizationQueue = dispatch_queue_create([queueName cStringUsingEncoding:NSASCIIStringEncoding], DISPATCH_QUEUE_SERIAL);
         _jsonSerializer = [MSIDCacheItemJsonSerializer new];
     }
     

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
@@ -350,7 +350,7 @@ static int maxErrorCountToArchive = 75;
 - (dispatch_queue_t)initializeDispatchQueue
 {
     NSString *queueName = [NSString stringWithFormat:@"com.microsoft.msidlastrequesttelemetry-%@", [NSUUID UUID].UUIDString];
-    return dispatch_queue_create([queueName cStringUsingEncoding:NSASCIIStringEncoding], DISPATCH_QUEUE_CONCURRENT);
+    return dispatch_queue_create([queueName cStringUsingEncoding:NSASCIIStringEncoding], DISPATCH_QUEUE_SERIAL);
 }
 
 #pragma mark - MSIDLastRequestTelemetry+Internal

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+* Fix possible deadlock caused by thread explosion
 * Revert FRT and ART lookup orders (#884)
 
 Version 1.6.0


### PR DESCRIPTION
## Proposed changes

There are reports that deadlock could happen in MSAL if too many threads are calling MSAL APIs at the same time. 

After some investigation, we found that deadlock could happen if there are more than 64 threads calling MSAL APIs.
**Root cause:**
There is a limit regarding how many GCD threads we can create for an app (limit is 64 according to my testing, also found reference here https://www.oreilly.com/library/view/high-performance-ios/9781491910993/ch04.html). Such a limitation could cause deadlock in our code. E.g., if a `dispatch_barrier_async` block is at the front of a queue and waiting to be executed, it will block all other `dispatch_sync` blocks. Image there are 64 threads (limit is hit) waiting at `dispatch_sync`, then no more thread can be created to execute the `dispatch_barrier_async` block. In such a case, both `dispatch_barrier_async` and `dispatch_sync` cannot proceed further. Deadlock occurs.
 
Solutions:
1. According to Apple's suggestion (https://developer.apple.com/videos/play/wwdc2015/718/?time=2185), using serial queue instead of concurrent queue. But it will sacrifice some performance.
2. Change `dispatch_barrier_async` to `dispatch_barrier_sync`. The former requires a new thread to be created to execute the block, while the later tries to use the current thread to execute the block. In such a way we could avoid the "no more thread can be created" issue.

In this PR
- I adopted Num. 1 for those classes who don't strictly require data consistency. 
- I adopted Num. 2 for those classes who requires data consistency.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

