### PR TITLE
Extend backgroud tasks for silent and interactive request

### DIFF
--- a/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
@@ -36,6 +36,7 @@
 
 #if TARGET_OS_IPHONE
 #import "MSIDAppExtensionUtil.h"
+#import "MSIDBackgroundTaskManager.h"
 #endif
 
 #if TARGET_OS_OSX
@@ -71,6 +72,10 @@
 
 - (void)executeRequestWithCompletion:(nonnull MSIDInteractiveRequestCompletionBlock)completionBlock
 {
+#if TARGET_OS_IPHONE
+    [[MSIDBackgroundTaskManager sharedInstance] startOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
+#endif
+    
     [super getAuthCodeWithCompletion:^(MSIDAuthorizationCodeResult * _Nullable result, NSError * _Nullable error, MSIDWebWPJResponse * _Nullable installBrokerResponse)
     {
         if (!result)
@@ -95,8 +100,10 @@
 
     [tokenRequest sendWithBlock:^(MSIDTokenResponse *tokenResponse, NSError *error)
     {
-#if TARGET_OS_OSX
-        self.tokenResponseHandler.externalCacheSeeder = self.externalCacheSeeder;
+#if TARGET_OS_IPHONE
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
+#elif TARGET_OS_OSX
+    self.tokenResponseHandler.externalCacheSeeder = self.externalCacheSeeder;
 #endif
         [self.tokenResponseHandler handleTokenResponse:tokenResponse
                                      requestParameters:self.requestParameters

--- a/IdentityCore/src/webview/background/ios/MSIDBackgroundTaskManager.h
+++ b/IdentityCore/src/webview/background/ios/MSIDBackgroundTaskManager.h
@@ -29,7 +29,8 @@
 
 typedef NS_ENUM(NSInteger, MSIDBackgroundTaskType)
 {
-    MSIDBackgroundTaskTypeInteractiveRequest = 0
+    MSIDBackgroundTaskTypeInteractiveRequest = 0,
+    MSIDBackgroundTaskTypeSilentRequest
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -164,8 +164,6 @@ static WKWebViewConfiguration *s_webConfig;
 
 - (void)dismissWebview:(void (^)(void))completion
 {
-    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
-    
     //if webview is created by us, dismiss and then complete and return;
     //otherwise just complete and return.
     if (_parentController && self.presentInParentController)

--- a/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebviewController.m
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebviewController.m
@@ -243,9 +243,6 @@
 - (void)notifyEndWebAuthWithURL:(NSURL *)url
                           error:(NSError *)error
 {
-#if TARGET_OS_IPHONE
-    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
-#endif
     
     if (error)
     {
@@ -255,15 +252,6 @@
     {
         [MSIDNotifications notifyWebAuthDidCompleteWithURL:url];
     }
-}
-
-#pragma mark - Dealloc
-
-- (void)dealloc
-{
-#if TARGET_OS_IPHONE
-    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
-#endif
 }
 
 @end


### PR DESCRIPTION
## Issue trying to resolve

We have customers reporting if they have MFA and put Authenticator app into background for 2FA, they are getting "The network connection was lost." or "The Internet connection appears to be offline." error from Authenticator app and cannot finish the whole authentication. 

When putting app into background, for interactive request, app will finish the authcode process first and then end the background task. At that moment, the app will be suspended. When reopen the app after 2nd FA is done, the AuthCode-token exchange flow will continue, however server drops the connection (not sure why) already and caused the network error.

## Proposed changes

Instead of closing the background task when the web view (both ASWebSession and WKWebView ) is dismissed, we will stop the task once the whole interactive/silent request is finished either in result or error state.

## Q&A

Why we need to call/use background tasks?
When your app moves to the background, the system calls your app delegate’s applicationDidEnterBackground(_:) method. That method has five seconds to perform any tasks and return. Shortly after that method returns, the system puts your app into the suspended state. 

What if we don't add proper code to stop the background task?
For each task before time expires, the system kills the app. If you provide a block object in the handler parameter, the system calls your handler before time expires to give you a chance to end the task. Current we will stop the current task in the handler

What type of background tasks we have?
Currently there are two, one for interactive request, and another for silent request. They are isolated.

What happens if same background task already happening?
We will check if the current background task is already in the cache based on background task id, and if there was already, we would simply return instead of adding it again

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

