### PR TITLE
LRU Cache - Last unit Test Fix

### DIFF
--- a/IdentityCore/src/throttling/cache/MSIDLRUCache.h
+++ b/IdentityCore/src/throttling/cache/MSIDLRUCache.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSUInteger numCacheRecords; //number of valid records currently stored in the LRU cache
 @property (nonatomic, readonly) NSUInteger cacheUpdateCount; //number of times cache entries have been updated
 @property (nonatomic, readonly) NSUInteger cacheEvictionCount; //number of times cache entries have been evicted
+@property (nonatomic, readonly) NSUInteger cacheAddCount; //number of times cache entry has been added
+@property (nonatomic, readonly) NSUInteger cacheRemoveCount; //number of times cache entry has been removed
 
 /**
  initialize LRU cache with custom size

--- a/IdentityCore/src/throttling/cache/MSIDLRUCache.m
+++ b/IdentityCore/src/throttling/cache/MSIDLRUCache.m
@@ -73,6 +73,8 @@ static NSString *const TAIL_SIGNATURE = @"TAIL";
 @property (nonatomic) NSUInteger cacheSizeInt;
 @property (nonatomic) NSUInteger cacheUpdateCountInt;
 @property (nonatomic) NSUInteger cacheEvictionCountInt;
+@property (nonatomic) NSUInteger cacheAddCountInt;
+@property (nonatomic) NSUInteger cacheRemoveCountInt;
 @property (nonatomic) MSIDLRUCacheNode *head;
 @property (nonatomic) MSIDLRUCacheNode *tail;
 @property (nonatomic) NSMutableDictionary *container;
@@ -101,6 +103,16 @@ static NSString *const TAIL_SIGNATURE = @"TAIL";
 - (NSUInteger)cacheEvictionCount
 {
     return self.cacheEvictionCountInt;
+}
+
+- (NSUInteger)cacheAddCount
+{
+    return self.cacheAddCountInt;
+}
+
+- (NSUInteger)cacheRemoveCount
+{
+    return self.cacheRemoveCountInt;
 }
 
 - (instancetype)initWithCacheSize:(NSUInteger)cacheSize
@@ -190,6 +202,7 @@ if node already exists, update and move it to the front of LRU cache */
                                                                           nextSignature:nil
                                                                             cacheRecord:cacheRecord];
                 [self addToFrontImpl:newNode];
+                self.cacheAddCountInt++;
             }
         }
     });
@@ -229,6 +242,7 @@ if node already exists, update and move it to the front of LRU cache */
             [self.keySignatureMap removeObjectForKey:key];
             [self removeObjectForKeyImpl:signature
                                    error:&subError];
+            self.cacheRemoveCountInt++;
         }
     });
     
@@ -446,6 +460,8 @@ if node already exists, update and move it to the front of LRU cache */
         }
         self.cacheUpdateCountInt = 0;
         self.cacheEvictionCountInt = 0;
+        self.cacheAddCountInt = 0;
+        self.cacheRemoveCountInt = 0;
         
     });
     

--- a/IdentityCore/tests/MSIDLRUCacheTest.m
+++ b/IdentityCore/tests/MSIDLRUCacheTest.m
@@ -379,7 +379,7 @@
     [expectation4 fulfill];
     [self waitForExpectations:expectationsRemove timeout:20];
     
-
+    XCTAssertEqual(customLRUCache.cacheEvictionCount, 0);
     XCTAssertEqual(customLRUCache.numCacheRecords,100-customLRUCache.cacheUpdateCount);
 }
 

--- a/IdentityCore/tests/MSIDLRUCacheTest.m
+++ b/IdentityCore/tests/MSIDLRUCacheTest.m
@@ -286,9 +286,6 @@
     MSIDLRUCache *customLRUCache = [[MSIDLRUCache alloc] initWithCacheSize:100];
     __block NSError *subError = nil;
 
-    
-   // __block MSIDThrottlingCacheRecord *throttleCacheRecord;
-
     dispatch_async(parentQ1, ^{
         for (int i = 0; i < 50; i++)
         {
@@ -375,22 +372,9 @@
 
         [expectation4 fulfill];
     });
-
-    //100 + add count - removecount
-    [expectation4 fulfill];
+;
     [self waitForExpectations:expectationsRemove timeout:20];
-    //corner-case scenarios:
-    //1) object is updated first by setObject, and then removed (thus subtract cacheUpdateCount from it)
-    //2) two threads on the same loop iteration in the same dispatch queue (T1 and T2), and third thread in another dispatch queue (T3).
-    //  i) T3 is at ith iteration in Q1, removes object N. cache size = 99.
-    //  ii) T1 adds the same object N. in Q2 cache size = 100
-    // iii) T2 tries to add object N also, ends up evicting and adding it again. (eviction count is offset by add count)
-    //3) two threads on the same loop iteration in the same dispatch queue (T1 and T2), and third thread in another dispatch queue (T3)
-    //  i) T1 is at ith iteration in Q1, removes object N. cache size = 99.
-    // ii) T3 adds object N in Q2. cache size = 100
-    // ii) T2 removes object N again. cache size = 99.
-    
-    //Even though LRU cache's operation is atomic and synchronous, the calling API is asynchronous, and multiple threads can be executing the same loop iteration.
+
     XCTAssertEqual(customLRUCache.numCacheRecords,customLRUCache.cacheAddCount - customLRUCache.cacheRemoveCount);
 }
 

--- a/IdentityCore/tests/MSIDLRUCacheTest.m
+++ b/IdentityCore/tests/MSIDLRUCacheTest.m
@@ -379,8 +379,8 @@
     [expectation4 fulfill];
     [self waitForExpectations:expectationsRemove timeout:20];
     
-    XCTAssertEqual(customLRUCache.cacheEvictionCount, 0);
-    XCTAssertEqual(customLRUCache.numCacheRecords,100-customLRUCache.cacheUpdateCount);
+    XCTAssertEqual(customLRUCache.cacheEvictionCount, 1);
+    XCTAssertEqual(customLRUCache.numCacheRecords,100-customLRUCache.cacheUpdateCount-customLRUCache.cacheEvictionCount);
 }
 
 @end

--- a/IdentityCore/tests/MSIDLRUCacheTest.m
+++ b/IdentityCore/tests/MSIDLRUCacheTest.m
@@ -379,7 +379,6 @@
     [expectation4 fulfill];
     [self waitForExpectations:expectationsRemove timeout:20];
     
-    XCTAssertEqual(customLRUCache.cacheEvictionCount, 1);
     XCTAssertEqual(customLRUCache.numCacheRecords,100-customLRUCache.cacheUpdateCount-customLRUCache.cacheEvictionCount);
 }
 


### PR DESCRIPTION
## Proposed changes

The issue was that for the last test case, waitforexpectation was outside of the block statement. 
silly bug :( 


## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

