### PR TITLE
fixed a minor bug in MSIDLRUCache last unit test

### DIFF
--- a/IdentityCore/src/throttling/cache/MSIDLRUCache.h
+++ b/IdentityCore/src/throttling/cache/MSIDLRUCache.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSUInteger numCacheRecords; //number of valid records currently stored in the LRU cache
 @property (nonatomic, readonly) NSUInteger cacheUpdateCount; //number of times cache entries have been updated
 @property (nonatomic, readonly) NSUInteger cacheEvictionCount; //number of times cache entries have been evicted
+@property (nonatomic, readonly) NSUInteger cacheAddCount; //number of times cache entry has been added
+@property (nonatomic, readonly) NSUInteger cacheRemoveCount; //number of times cache entry has been removed
 
 /**
  initialize LRU cache with custom size

--- a/IdentityCore/src/throttling/cache/MSIDLRUCache.m
+++ b/IdentityCore/src/throttling/cache/MSIDLRUCache.m
@@ -73,6 +73,8 @@ static NSString *const TAIL_SIGNATURE = @"TAIL";
 @property (nonatomic) NSUInteger cacheSizeInt;
 @property (nonatomic) NSUInteger cacheUpdateCountInt;
 @property (nonatomic) NSUInteger cacheEvictionCountInt;
+@property (nonatomic) NSUInteger cacheAddCountInt;
+@property (nonatomic) NSUInteger cacheRemoveCountInt;
 @property (nonatomic) MSIDLRUCacheNode *head;
 @property (nonatomic) MSIDLRUCacheNode *tail;
 @property (nonatomic) NSMutableDictionary *container;
@@ -101,6 +103,16 @@ static NSString *const TAIL_SIGNATURE = @"TAIL";
 - (NSUInteger)cacheEvictionCount
 {
     return self.cacheEvictionCountInt;
+}
+
+- (NSUInteger)cacheAddCount
+{
+    return self.cacheAddCountInt;
+}
+
+- (NSUInteger)cacheRemoveCount
+{
+    return self.cacheRemoveCountInt;
 }
 
 - (instancetype)initWithCacheSize:(NSUInteger)cacheSize
@@ -190,6 +202,7 @@ if node already exists, update and move it to the front of LRU cache */
                                                                           nextSignature:nil
                                                                             cacheRecord:cacheRecord];
                 [self addToFrontImpl:newNode];
+                self.cacheAddCountInt++;
             }
         }
     });
@@ -229,6 +242,7 @@ if node already exists, update and move it to the front of LRU cache */
             [self.keySignatureMap removeObjectForKey:key];
             [self removeObjectForKeyImpl:signature
                                    error:&subError];
+            self.cacheRemoveCountInt++;
         }
     });
     
@@ -446,6 +460,8 @@ if node already exists, update and move it to the front of LRU cache */
         }
         self.cacheUpdateCountInt = 0;
         self.cacheEvictionCountInt = 0;
+        self.cacheAddCountInt = 0;
+        self.cacheRemoveCountInt = 0;
         
     });
     

--- a/IdentityCore/tests/MSIDLRUCacheTest.m
+++ b/IdentityCore/tests/MSIDLRUCacheTest.m
@@ -376,11 +376,8 @@
         [expectation4 fulfill];
     });
 
-    [expectation4 fulfill];
     [self waitForExpectations:expectationsRemove timeout:20];
-    
-
-    XCTAssertEqual(customLRUCache.numCacheRecords,100-customLRUCache.cacheUpdateCount);
+    XCTAssertEqual(customLRUCache.numCacheRecords,customLRUCache.cacheAddCount - customLRUCache.cacheRemoveCount);
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

There was a minor bug in the last unit test case for the MSIDLRUCache class, where expectation fullfill was being done outside of the async block, resulting in intermittent test failures due to inaccurate synchronization. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

