### PR TITLE
Aherciya/device bound prt fix

### DIFF
--- a/IdentityCore/src/MSIDBrokerConstants.h
+++ b/IdentityCore/src/MSIDBrokerConstants.h
@@ -69,8 +69,10 @@ extern NSString * _Nonnull const MSID_BROKER_DEVICE_MODE_KEY;
 extern NSString * _Nonnull const MSID_BROKER_SSO_EXTENSION_MODE_KEY;
 extern NSString * _Nonnull const MSID_BROKER_WPJ_STATUS_KEY;
 extern NSString * _Nonnull const MSID_BROKER_BROKER_VERSION_KEY;
+extern NSString * _Nonnull const MSID_BROKER_IS_PERFORMING_CBA;
 extern NSString * _Nonnull const MSID_ADAL_BROKER_MESSAGE_VERSION;
 extern NSString * _Nonnull const MSID_MSAL_BROKER_MESSAGE_VERSION;
 extern NSString * _Nonnull const MSID_BROKER_SDK_CAPABILITIES_KEY;
 extern NSString * _Nonnull const MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY;
 extern NSString * _Nonnull const MSID_ADDITIONAL_EXTENSION_DATA_KEY;
+

--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -64,8 +64,10 @@ NSString *const MSID_BROKER_DEVICE_MODE_KEY        = @"device_mode";
 NSString *const MSID_BROKER_SSO_EXTENSION_MODE_KEY = @"sso_extension_mode";
 NSString *const MSID_BROKER_WPJ_STATUS_KEY         = @"wpj_status";
 NSString *const MSID_BROKER_BROKER_VERSION_KEY     = @"broker_version";
+NSString *const MSID_BROKER_IS_PERFORMING_CBA      = @"broker_is_performing_cba";
 NSString *const MSID_ADAL_BROKER_MESSAGE_VERSION   = @"2";
 NSString *const MSID_MSAL_BROKER_MESSAGE_VERSION   = @"3";
 NSString *const MSID_BROKER_SDK_CAPABILITIES_KEY   = @"sdk_broker_capabilities";
 NSString *const MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY = @"sso_extension";
+
 NSString *const MSID_ADDITIONAL_EXTENSION_DATA_KEY = @"additional_extension_data";

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -148,6 +148,7 @@ NSString *const MSID_DEVICE_ID_CACHE_KEY                 = @"device_id";
 NSString *const MSID_PRT_PROTOCOL_VERSION_CACHE_KEY      = @"prt_protocol_version";
 NSString *const MSID_KID_CACHE_KEY                       = @"kid";
 NSString *const MSID_REQUESTED_CLAIMS_CACHE_KEY          = @"requested_claims";
+NSString *const MSID_IS_CBA_FLOW                         = @"is_cba_flow";
 
 NSString *const MSID_OPENID_CONFIGURATION_SUFFIX         = @".well-known/openid-configuration";
 NSString *const MSID_PREFERRED_USERNAME_MISSING          = @"Missing from the token response";

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -148,7 +148,6 @@ NSString *const MSID_DEVICE_ID_CACHE_KEY                 = @"device_id";
 NSString *const MSID_PRT_PROTOCOL_VERSION_CACHE_KEY      = @"prt_protocol_version";
 NSString *const MSID_KID_CACHE_KEY                       = @"kid";
 NSString *const MSID_REQUESTED_CLAIMS_CACHE_KEY          = @"requested_claims";
-NSString *const MSID_IS_CBA_FLOW                         = @"is_cba_flow";
 
 NSString *const MSID_OPENID_CONFIGURATION_SUFFIX         = @".well-known/openid-configuration";
 NSString *const MSID_PREFERRED_USERNAME_MISSING          = @"Missing from the token response";

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
@@ -126,6 +126,7 @@ static BOOL s_useLastRequestURL = NO;
         NSMutableDictionary *newQueryItems = [NSMutableDictionary new];
         NSString *redirectSchemePrefix = [NSString stringWithFormat:@"%@://", s_redirectScheme];
         
+        newQueryItems[MSID_BROKER_IS_PERFORMING_CBA] = @"true";
         for (NSURLQueryItem *item in queryItems)
         {
             if ([item.name isEqualToString:MSID_OAUTH2_REDIRECT_URI]

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ TBD
 * Added thread-safe generic MSIDLRUCache (#922)
 * Fix possible deadlock caused by thread explosion
 * Revert FRT and ART lookup orders (#884)
+* Adding MSID contant to identify CBA flows in broker for SSO, to temporarily disable SSO with CBA flows. 
 
 Version 1.6.0
 * Avoid sending RT to wrong cloud (#892)


### PR DESCRIPTION
## Proposed changes

Adding MSID constant to identify CBA flows in Broker in order temporarily disable SSO for CBA flows. [Task](https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Apple/Backlog%20items/?workitem=1246590) is to avoid attaching device bound PRT's for device-less PRT flows.

## Type of change

- [ ] Feature work
- [ x ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ x ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

