### PR TITLE
Revert the cache look up logic if AT is still valid, will return FRT …

### DIFF
--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -166,7 +166,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
             MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Found valid access token.");
 
             __block MSIDBaseToken<MSIDRefreshableToken> *refreshableToken = nil;
-            [self fetchCachedRefreshTokenWithCompletionHandler:^(MSIDBaseToken<MSIDRefreshableToken> *token, __unused MSIDRefreshTokenTypes tokenType, __unused NSError *error) {
+            [self fetchCachedTokenAndCheckForFRTFirst:YES shouldComplete:NO completionHandler:^(MSIDBaseToken<MSIDRefreshableToken> *token, __unused MSIDRefreshTokenTypes tokenType, __unused NSError *error) {
                 refreshableToken = token;
             }];
             
@@ -216,8 +216,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
             }
         }
     }
-    
-    [self fetchCachedRefreshTokenWithCompletionHandler:^(MSIDBaseToken<MSIDRefreshableToken> *refreshToken, MSIDRefreshTokenTypes tokenType, NSError *error) {
+    [self fetchCachedTokenAndCheckForFRTFirst:NO shouldComplete:NO completionHandler:^(MSIDBaseToken<MSIDRefreshableToken> *refreshToken, MSIDRefreshTokenTypes tokenType, NSError *error) {
         if (!refreshToken)
         {
             NSError *interactionError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired, @"No token matching arguments found in the cache, user interaction is required", error.msidOauthError, error.msidSubError, error, self.requestParameters.correlationId, nil, YES);
@@ -227,10 +226,9 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
         
         [self tryRefreshToken:refreshToken tokenType:tokenType completionBlock:completionBlock];
     }];
-    
 }
 
-- (void)fetchCachedRefreshTokenWithCompletionHandler:(void (^)(MSIDBaseToken<MSIDRefreshableToken> *, MSIDRefreshTokenTypes, NSError *))completionHandler
+- (void)fetchCachedTokenAndCheckForFRTFirst:(BOOL)checkForFRT shouldComplete:(BOOL)shouldComplete completionHandler:(void (^)(MSIDBaseToken<MSIDRefreshableToken> *, MSIDRefreshTokenTypes, NSError *))completionHandler
 {
     if (!completionHandler)
     {
@@ -239,41 +237,46 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
     }
     
     NSError *rtError = nil;
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Looking for app refresh token...");
-    MSIDBaseToken<MSIDRefreshableToken> *refreshableToken = [self appRefreshTokenWithError:&rtError];
+    MSIDBaseToken<MSIDRefreshableToken> *refreshableToken = nil;
+    NSString *contextMsg = checkForFRT ? @"family refresh token" : @"app refresh token";
+    MSIDRefreshTokenTypes checkForTokenType = checkForFRT ? MSIDFamilyRefreshTokenType : MSIDAppRefreshTokenType;
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Looking for %@...", contextMsg);
+    if (checkForFRT)
+    {
+        refreshableToken = [self familyRefreshTokenWithError:&rtError];
+    }
+    else
+    {
+        refreshableToken = [self appRefreshTokenWithError:&rtError];
+    }
     
     if (rtError)
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Failed to read app specific refresh token with error %@", MSID_PII_LOG_MASKABLE(rtError));
-        completionHandler(nil, MSIDAppRefreshTokenType, rtError);
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Failed to read %@ token with error %@", contextMsg, MSID_PII_LOG_MASKABLE(rtError));
+        completionHandler(nil, checkForTokenType, rtError);
         return;
     }
     
     if (!refreshableToken)
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, self.requestParameters, @"Didn't find app refresh token");
+        // Handle to continue or complete
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, self.requestParameters, @"Didn't find %@", contextMsg);
+        if (!shouldComplete)
+        {
+            [self fetchCachedTokenAndCheckForFRTFirst:!checkForFRT shouldComplete:!shouldComplete completionHandler:completionHandler];
+        }
+        else
+        {
+            // If no refreshableToken was found, simply return nil as token and token type that the last one it tries to find
+            completionHandler(nil, checkForTokenType, nil);
+        }
     }
     else
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Found app refresh token.");
-        completionHandler(refreshableToken, MSIDAppRefreshTokenType, nil);
-        return;
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Found %@.", contextMsg);
+        completionHandler(refreshableToken, checkForTokenType, nil);
     }
-    
-    // If no ART, get family refresh token instead.
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Looking for family refresh token...");
-    refreshableToken = [self familyRefreshTokenWithError:&rtError];
-    
-    if (rtError)
-    {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Failed to read family refresh token with error %@", MSID_PII_LOG_MASKABLE(rtError));
-        completionHandler(nil, MSIDFamilyRefreshTokenType, rtError);
-        return;
-    }
-    
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Found family refresh token.");
-    completionHandler(refreshableToken, MSIDFamilyRefreshTokenType, nil);
-    return;
 }
 
 - (void)tryRefreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)refreshToken

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -251,7 +251,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
         refreshableToken = [self appRefreshTokenWithError:&rtError];
     }
     
-    if (rtError)
+    if (rtError && shouldComplete)
     {
         MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Failed to read %@ token with error %@", contextMsg, MSID_PII_LOG_MASKABLE(rtError));
         completionHandler(nil, checkForTokenType, rtError);


### PR DESCRIPTION
…first and then ART

## Proposed changes

Added a new param when fetching tokens from local cache, so that when fetching token while AT is still valid, we will use the same order as before (FRT and ART), and when we need to make a network call to redeem a new AT, we will use the new lookup order as ART and FRT

Describe what this PR is trying to do.

This PR is trying to fix a special case when broker is still holding a valid AT for the calling app and calling app acquires token through broker. Based on the new ART and FT lookup order, broker will return back an valid AT and RT without Foci. As result of that, it could cause some potential issues where other 1st party apps fail to sign in automatically for the first time.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

