### PR TITLE
Mask EUII logs

### DIFF
--- a/IdentityCore/src/cache/MSIDKeychainTokenCache.m
+++ b/IdentityCore/src/cache/MSIDKeychainTokenCache.m
@@ -504,7 +504,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
     NSData *generic = key.generic;
     NSNumber *type = key.type;
     
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Remove keychain items, key info (account: %@ service: %@, keychainGroup: %@)", MSID_PII_LOG_MASKABLE(account), service, [self keychainGroupLoggingName]);
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Remove keychain items, key info (account: %@ service: %@, keychainGroup: %@)", MSID_EUII_ONLY_LOG_MASKABLE(account), service, [self keychainGroupLoggingName]);
     
     if (!key)
     {
@@ -763,7 +763,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
     NSData *generic = key.generic;
     NSNumber *type = key.type;
     
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Get keychain items, key info (account: %@ service: %@ generic: %@ type: %@, keychainGroup: %@)", MSID_PII_LOG_MASKABLE(account), service, generic, type, [self keychainGroupLoggingName]);
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Get keychain items, key info (account: %@ service: %@ generic: %@ type: %@, keychainGroup: %@)", MSID_EUII_ONLY_LOG_MASKABLE(account), service, generic, type, [self keychainGroupLoggingName]);
     
     NSMutableDictionary *query = [self.defaultKeychainQuery mutableCopy];
     if (service)
@@ -826,7 +826,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
     NSData *generic = key.generic;
     NSNumber *type = key.type;
     
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Set keychain item, key info (account: %@ service: %@, keychainGroup: %@)", MSID_PII_LOG_MASKABLE(account), service, [self keychainGroupLoggingName]);
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Set keychain item, key info (account: %@ service: %@, keychainGroup: %@)", MSID_EUII_ONLY_LOG_MASKABLE(account), service, [self keychainGroupLoggingName]);
     
     if (!service)
     {

--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
@@ -128,7 +128,7 @@
 {
     assert(key);
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Get credential for key %@, account %@", key.logDescription, MSID_PII_LOG_MASKABLE(key.account));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Get credential for key %@, account %@", key.logDescription, MSID_EUII_ONLY_LOG_MASKABLE(key.account));
 
     return [_dataSource tokenWithKey:key serializer:_serializer context:context error:error];
 }
@@ -152,7 +152,7 @@
 {
     assert(cacheQuery);
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Get accounts with environment %@, unique user id %@", cacheQuery.environment, MSID_PII_LOG_MASKABLE(cacheQuery.homeAccountId));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Get accounts with environment %@, unique user id %@", cacheQuery.environment, MSID_PII_LOG_TRACKABLE(cacheQuery.homeAccountId));
 
     NSArray<MSIDAccountCacheItem *> *cacheItems = [_dataSource accountsWithKey:cacheQuery serializer:_serializer context:context error:error];
 
@@ -187,7 +187,7 @@
 {
     assert(key);
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Get account for key %@, account %@", key.logDescription, MSID_PII_LOG_MASKABLE(key.account));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Get account for key %@, account %@", key.logDescription, MSID_EUII_ONLY_LOG_MASKABLE(key.account));
 
     return [_dataSource accountWithKey:key serializer:_serializer context:context error:error];
 }
@@ -221,7 +221,7 @@
 {
     assert(credential);
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Saving token %@ for userID %@ with environment %@, realm %@, clientID %@,", MSID_PII_LOG_MASKABLE(credential), MSID_PII_LOG_MASKABLE(credential.homeAccountId), credential.environment, credential.realm, credential.clientId);
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Saving token %@ for userID %@ with environment %@, realm %@, clientID %@,", MSID_PII_LOG_MASKABLE(credential), MSID_PII_LOG_TRACKABLE(credential.homeAccountId), credential.environment, credential.realm, credential.clientId);
     
     MSIDDefaultCredentialCacheKey *key = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:credential.homeAccountId
                                                                                           environment:credential.environment
@@ -250,7 +250,7 @@
 {
     assert(account);
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Saving account %@", MSID_PII_LOG_MASKABLE(account));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Saving account %@", MSID_EUII_ONLY_LOG_MASKABLE(account));
 
     MSIDDefaultAccountCacheKey *key = [[MSIDDefaultAccountCacheKey alloc] initWithHomeAccountId:account.homeAccountId
                                                                                     environment:account.environment
@@ -292,7 +292,7 @@
 {
     assert(cacheQuery);
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Default cache) Removing credentials with type %@, environment %@, realm %@, clientID %@, unique user ID %@, target %@", [MSIDCredentialTypeHelpers credentialTypeAsString:cacheQuery.credentialType], cacheQuery.environment, cacheQuery.realm, cacheQuery.clientId, MSID_PII_LOG_MASKABLE(cacheQuery.homeAccountId), cacheQuery.target);
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Default cache) Removing credentials with type %@, environment %@, realm %@, clientID %@, unique user ID %@, target %@", [MSIDCredentialTypeHelpers credentialTypeAsString:cacheQuery.credentialType], cacheQuery.environment, cacheQuery.realm, cacheQuery.clientId, MSID_PII_LOG_TRACKABLE(cacheQuery.homeAccountId), cacheQuery.target);
 
     if (cacheQuery.exactMatch)
     {
@@ -314,7 +314,7 @@
 {
     assert(credential);
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Default cache) Removing credential %@ for userID %@ with environment %@, realm %@, clientID %@,", MSID_PII_LOG_MASKABLE(credential), MSID_PII_LOG_MASKABLE(credential.homeAccountId), credential.environment, credential.realm, credential.clientId);
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Default cache) Removing credential %@ for userID %@ with environment %@, realm %@, clientID %@,", MSID_PII_LOG_MASKABLE(credential), MSID_PII_LOG_TRACKABLE(credential.homeAccountId), credential.environment, credential.realm, credential.clientId);
 
     MSIDDefaultCredentialCacheKey *key = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:credential.homeAccountId
                                                                                           environment:credential.environment
@@ -347,7 +347,7 @@
 {
     assert(cacheQuery);
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Removing accounts with environment %@, realm %@, unique user id %@", cacheQuery.environment, cacheQuery.realm, MSID_PII_LOG_MASKABLE(cacheQuery.homeAccountId));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Removing accounts with environment %@, realm %@, unique user id %@", cacheQuery.environment, cacheQuery.realm, MSID_PII_LOG_TRACKABLE(cacheQuery.homeAccountId));
 
     if (cacheQuery.exactMatch)
     {
@@ -365,7 +365,7 @@
 {
     assert(account);
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Removing account with environment %@, user ID %@, username %@", account.environment, MSID_PII_LOG_MASKABLE(account.homeAccountId), MSID_PII_LOG_EMAIL(account.username));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default cache) Removing account with environment %@, user ID %@, username %@", account.environment, MSID_PII_LOG_TRACKABLE(account.homeAccountId), MSID_PII_LOG_EMAIL(account.username));
 
     MSIDDefaultAccountCacheKey *key = [[MSIDDefaultAccountCacheKey alloc] initWithHomeAccountId:account.homeAccountId
                                                                                     environment:account.environment

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -349,7 +349,7 @@
     
     if (idToken)
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Found id token %@ for account %@:%@.", MSID_PII_LOG_MASKABLE(idToken), accountIdentifier.maskedHomeAccountId, accountIdentifier.maskedDisplayableId);
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Found id token %@ for account %@:%@.", MSID_EUII_ONLY_LOG_MASKABLE(idToken), accountIdentifier.maskedHomeAccountId, MSID_PII_LOG_MASKABLE(accountIdentifier.maskedDisplayableId));
     }
     else
     {
@@ -719,7 +719,7 @@
     
     NSString *environment = token.storageEnvironment ? token.storageEnvironment : token.environment;
     
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Removing refresh token with clientID %@, environment %@, realm %@, userId %@, token %@", token.clientId, environment, token.realm, token.accountIdentifier.maskedHomeAccountId, MSID_PII_LOG_MASKABLE(token));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Removing refresh token with clientID %@, environment %@, realm %@, userId %@, token %@", token.clientId, environment, token.realm, token.accountIdentifier.maskedHomeAccountId, MSID_EUII_ONLY_LOG_MASKABLE(token));
 
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
     query.homeAccountId = token.accountIdentifier.homeAccountId;
@@ -735,7 +735,7 @@
 
     if (tokenInCache && [tokenInCache.refreshToken isEqualToString:token.refreshToken])
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Found refresh token in cache and it's the latest version, removing token %@", MSID_PII_LOG_MASKABLE(tokenInCache));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Found refresh token in cache and it's the latest version, removing token %@", MSID_EUII_ONLY_LOG_MASKABLE(tokenInCache));
         return [self removeToken:tokenInCache context:context error:error];
     }
     
@@ -850,7 +850,7 @@
 
     if (![NSString msidIsStringNilOrBlank:refreshToken.familyId])
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default accessor) Saving family refresh token %@", MSID_PII_LOG_MASKABLE(refreshToken));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default accessor) Saving family refresh token %@", MSID_EUII_ONLY_LOG_MASKABLE(refreshToken));
 
         if (![self saveToken:refreshToken
                      context:context

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -409,7 +409,7 @@
         return NO;
     }
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Removing refresh token with clientID %@, environment %@, realm %@, userId %@, token %@", token.clientId, token.environment, token.realm, token.accountIdentifier.maskedHomeAccountId, MSID_PII_LOG_MASKABLE(token));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Removing refresh token with clientID %@, environment %@, realm %@, userId %@, token %@", token.clientId, token.environment, token.realm, token.accountIdentifier.maskedHomeAccountId, MSID_EUII_ONLY_LOG_MASKABLE(token));
 
     MSIDCredentialCacheItem *cacheItem = [token tokenCacheItem];
     
@@ -430,7 +430,7 @@
 
     if (tokenInCache && [tokenInCache.refreshToken isEqualToString:token.refreshToken])
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Found refresh token in cache and it's the latest version, removing token %@", MSID_PII_LOG_MASKABLE(token));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Found refresh token in cache and it's the latest version, removing token %@", MSID_EUII_ONLY_LOG_MASKABLE(token));
         
         return [self removeTokenEnvironment:storageEnvironment
                                       realm:token.realm
@@ -593,7 +593,7 @@
         return NO;
     }
     
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Legacy accessor) Saving access token in legacy accessor %@", MSID_PII_LOG_MASKABLE(accessToken));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Legacy accessor) Saving access token in legacy accessor %@", MSID_EUII_ONLY_LOG_MASKABLE(accessToken));
     
     return [self saveToken:accessToken
                    context:context
@@ -611,7 +611,7 @@
         return YES;
     }
     
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Legacy accessor) Saving multi resource refresh token in legacy accessor %@", MSID_PII_LOG_MASKABLE(refreshToken));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Legacy accessor) Saving multi resource refresh token in legacy accessor %@", MSID_EUII_ONLY_LOG_MASKABLE(refreshToken));
     
     BOOL result = [self saveToken:refreshToken
                           context:context
@@ -623,7 +623,7 @@
         return result;
     }
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Saving family refresh token in all caches %@", MSID_PII_LOG_MASKABLE(refreshToken));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Saving family refresh token in all caches %@", MSID_EUII_ONLY_LOG_MASKABLE(refreshToken));
 
     // If it's an FRT, save it separately and update the clientId of the token item
     MSIDLegacyRefreshToken *familyRefreshToken = [refreshToken copy];
@@ -665,7 +665,7 @@
         return NO;
     }
     
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Legacy accessor) Saving single resource tokens in legacy accessor %@", MSID_PII_LOG_MASKABLE(legacyToken));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Legacy accessor) Saving single resource tokens in legacy accessor %@", MSID_EUII_ONLY_LOG_MASKABLE(legacyToken));
 
     // Save token for legacy single resource token
     return [self saveToken:legacyToken
@@ -681,7 +681,7 @@
     
     MSIDCredentialCacheItem *tokenCacheItem = token.legacyTokenCacheItem;
 
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Legacy accessor) Saving token %@ for account %@ with environment %@, realm %@, clientID %@", MSID_PII_LOG_MASKABLE(tokenCacheItem), token.accountIdentifier.maskedDisplayableId, token.storageEnvironment, token.realm, tokenCacheItem.clientId);
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Legacy accessor) Saving token %@ for account %@ with environment %@, realm %@, clientID %@", MSID_EUII_ONLY_LOG_MASKABLE(tokenCacheItem), token.accountIdentifier.maskedDisplayableId, token.storageEnvironment, token.realm, tokenCacheItem.clientId);
     
     MSIDLegacyTokenCacheKey *key = [[MSIDLegacyTokenCacheKey alloc] initWithEnvironment:tokenCacheItem.environment
                                                                                   realm:tokenCacheItem.realm

--- a/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
+++ b/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
@@ -299,7 +299,7 @@
         return NO;
     }
     
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Remove account metadata for home account id: %@.", MSID_PII_LOG_MASKABLE(homeAccountId));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Remove account metadata for home account id: %@.", MSID_PII_LOG_TRACKABLE(homeAccountId));
     
     NSError *localError;
     NSArray<MSIDAccountMetadataCacheItem *> *cacheItems = [self allAccountMetadataCacheItemsWithContext:context error:&localError];

--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem.m
@@ -37,7 +37,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"MSIDAccountCacheItem: accountType: %@, homeAccountId: %@, environment: %@, localAccountId: %@, username: %@, name: %@, realm: %@, alternativeAccountId: %@", [MSIDAccountTypeHelpers accountTypeAsString:self.accountType], self.homeAccountId, self.environment, self.localAccountId, self.username, self.name, self.realm, self.alternativeAccountId];
+    return [NSString stringWithFormat:@"MSIDAccountCacheItem: accountType: %@, homeAccountId: %@, environment: %@, localAccountId: %@, username: %@, name: %@, realm: %@, alternativeAccountId: %@", [MSIDAccountTypeHelpers accountTypeAsString:self.accountType], self.homeAccountId, self.environment, self.localAccountId, MSID_PII_LOG_EMAIL(self.username), MSID_EUII_ONLY_LOG_MASKABLE(self.name), self.realm, self.alternativeAccountId];
 }
 
 #pragma mark - Equal

--- a/IdentityCore/src/logger/MSIDLogger+Internal.h
+++ b/IdentityCore/src/logger/MSIDLogger+Internal.h
@@ -50,6 +50,7 @@
 #define MSID_LOG_WITH_CORR_PII(_LVL, _CORRELATION_ID, _FMT, ...) MSID_LOG_COMMON(_LVL, nil, _CORRELATION_ID, YES, _FMT, ##__VA_ARGS__)
 
 #define MSID_PII_LOG_MASKABLE(_PARAMETER) [[MSIDMaskedLogParameter alloc] initWithParameterValue:_PARAMETER]
+#define MSID_EUII_ONLY_LOG_MASKABLE(_PARAMETER) [[MSIDMaskedLogParameter alloc] initWithParameterValue:_PARAMETER isEUII:YES]
 #define MSID_PII_LOG_TRACKABLE(_PARAMETER) [[MSIDMaskedHashableLogParameter alloc] initWithParameterValue:_PARAMETER]
 #define MSID_PII_LOG_EMAIL(_PARAMETER) [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:_PARAMETER]
 

--- a/IdentityCore/src/logger/MSIDLogger.h
+++ b/IdentityCore/src/logger/MSIDLogger.h
@@ -36,6 +36,20 @@ typedef NS_ENUM(NSInteger, MSIDLogLevel)
     MSIDLogLevelLast = MSIDLogLevelVerbose,
 };
 
+/*! Levels of log masking */
+typedef NS_ENUM(NSInteger, MSIDLogMaskingLevel)
+{
+    /** MSAL will not return any messages with any user or organizational information. This includes EUII and EUPI. */
+    MSIDLogMaskingSettingsMaskAllPII,
+    
+    /** MSAL logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs. */
+    
+    MSIDLogMaskingSettingsMaskEUIIOnly, //
+    
+    /** MSAL logs will still include OII (organization identifiable information),  EUPI (end user pseudonymous identifiers), and EUII (end user identifiable information) like UPN, username, email from its logs. MSAL will still hide all secrets like tokens from its logs */
+    MSIDLogMaskingSettingsMaskSecretsOnly
+};
+
 /*!
  The LogCallback block for the logger
  
@@ -62,12 +76,10 @@ typedef void (^MSIDLogCallback)(MSIDLogLevel level, NSString *message, BOOL cont
 @property (nonatomic, readwrite) MSIDLogLevel level;
 
 /*!
- Set to YES to allow messages possibly containing Personally Identifiable Information (PII) to be
- sent to the logging callback.
+    Provides a mechanism for a more granular log masking.
+    All PII will be masked by default.
  */
-@property (nonatomic, readwrite) BOOL piiLoggingEnabled;
-
-@property (nonatomic, readwrite) BOOL euiiMaskingEnabled;
+@property (nonatomic, readwrite) MSIDLogMaskingLevel logMaskingLevel;
 
 @property (nonatomic, readwrite) BOOL nsLoggingEnabled;
 

--- a/IdentityCore/src/logger/MSIDLogger.h
+++ b/IdentityCore/src/logger/MSIDLogger.h
@@ -67,6 +67,8 @@ typedef void (^MSIDLogCallback)(MSIDLogLevel level, NSString *message, BOOL cont
  */
 @property (nonatomic, readwrite) BOOL piiLoggingEnabled;
 
+@property (nonatomic, readwrite) BOOL euiiMaskingEnabled;
+
 @property (nonatomic, readwrite) BOOL nsLoggingEnabled;
 
 /*!

--- a/IdentityCore/src/logger/MSIDLogger.h
+++ b/IdentityCore/src/logger/MSIDLogger.h
@@ -39,14 +39,14 @@ typedef NS_ENUM(NSInteger, MSIDLogLevel)
 /*! Levels of log masking */
 typedef NS_ENUM(NSInteger, MSIDLogMaskingLevel)
 {
-    /** MSAL will not return any messages with any user or organizational information. This includes EUII and EUPI. */
+    /** Common core will not return any messages with any user or organizational information. This includes EUII and EUPI. */
     MSIDLogMaskingSettingsMaskAllPII,
     
-    /** MSAL logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs. */
+    /** Common core logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs. */
     
     MSIDLogMaskingSettingsMaskEUIIOnly, //
     
-    /** MSAL logs will still include OII (organization identifiable information),  EUPI (end user pseudonymous identifiers), and EUII (end user identifiable information) like UPN, username, email from its logs. MSAL will still hide all secrets like tokens from its logs */
+    /** Common core logs will still include OII (organization identifiable information),  EUPI (end user pseudonymous identifiers), and EUII (end user identifiable information) like UPN, username, email from its logs. MSAL will still hide all secrets like tokens from its logs */
     MSIDLogMaskingSettingsMaskSecretsOnly
 };
 

--- a/IdentityCore/src/logger/MSIDLogger.h
+++ b/IdentityCore/src/logger/MSIDLogger.h
@@ -43,8 +43,7 @@ typedef NS_ENUM(NSInteger, MSIDLogMaskingLevel)
     MSIDLogMaskingSettingsMaskAllPII,
     
     /** Common core logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs. */
-    
-    MSIDLogMaskingSettingsMaskEUIIOnly, //
+    MSIDLogMaskingSettingsMaskEUIIOnly,
     
     /** Common core logs will still include OII (organization identifiable information),  EUPI (end user pseudonymous identifiers), and EUII (end user identifiable information) like UPN, username, email from its logs. MSAL will still hide all secrets like tokens from its logs */
     MSIDLogMaskingSettingsMaskSecretsOnly

--- a/IdentityCore/src/logger/MSIDLogger.m
+++ b/IdentityCore/src/logger/MSIDLogger.m
@@ -107,6 +107,13 @@ static long s_maxQueueSize = 1000;
     return _nsLoggingEnabled;
 }
 
+- (BOOL)euiiMaskingEnabled
+{
+    if (self.loggerConnector) return self.loggerConnector.euiiMaskingEnabled;
+    
+    return _euiiMaskingEnabled;
+}
+
 - (BOOL)sourceLineLoggingEnabled
 {
     if (self.loggerConnector) return self.loggerConnector.sourceLineLoggingEnabled;

--- a/IdentityCore/src/logger/MSIDLogger.m
+++ b/IdentityCore/src/logger/MSIDLogger.m
@@ -51,7 +51,7 @@ static long s_maxQueueSize = 1000;
     // and we'll probably not have enough diagnostic information, however verbose
     // will most likely be too noisy for most usage.
     _level = MSIDLogLevelInfo;
-    _piiLoggingEnabled = NO;
+    _logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     _sourceLineLoggingEnabled = NO;
     
     NSString *queueName = [NSString stringWithFormat:@"com.microsoft.msidlogger-%@", [NSUUID UUID].UUIDString];
@@ -93,13 +93,6 @@ static long s_maxQueueSize = 1000;
     return _level;
 }
 
-- (BOOL)piiLoggingEnabled
-{
-    if (self.loggerConnector) return self.loggerConnector.piiLoggingEnabled;
-   
-    return _piiLoggingEnabled;
-}
-
 - (BOOL)nsLoggingEnabled
 {
     if (self.loggerConnector) return self.loggerConnector.nsLoggingEnabled;
@@ -107,11 +100,11 @@ static long s_maxQueueSize = 1000;
     return _nsLoggingEnabled;
 }
 
-- (BOOL)euiiMaskingEnabled
+- (MSIDLogMaskingLevel)logMaskingLevel
 {
-    if (self.loggerConnector) return self.loggerConnector.euiiMaskingEnabled;
+    if (self.loggerConnector) return self.loggerConnector.logMaskingLevel;
     
-    return _euiiMaskingEnabled;
+    return _logMaskingLevel;
 }
 
 - (BOOL)sourceLineLoggingEnabled
@@ -218,7 +211,8 @@ static NSDateFormatter *s_dateFormatter = nil;
         {
             NSString *log = [NSString stringWithFormat:@"%@ %@ %@ %@ [%@%@]%@%@ %@", threadInfo, sdkName, sdkVersion, [MSIDDeviceId deviceOSId], dateStr, correlationIdStr, componentStr, sourceInfo, message];
             
-            BOOL lineContainsPII = self.piiLoggingEnabled ? containsPII : NO;
+            BOOL piiAllowed = self.logMaskingLevel != MSIDLogMaskingSettingsMaskAllPII;
+            BOOL lineContainsPII = piiAllowed ? containsPII : NO;
             
             if (self.loggerConnector)
             {

--- a/IdentityCore/src/logger/MSIDLoggerConnecting.h
+++ b/IdentityCore/src/logger/MSIDLoggerConnecting.h
@@ -36,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)nsLoggingEnabled;
 
+- (BOOL)euiiMaskingEnabled;
+
 - (BOOL)sourceLineLoggingEnabled;
 
 - (BOOL)loggingQueueEnabled;

--- a/IdentityCore/src/logger/MSIDLoggerConnecting.h
+++ b/IdentityCore/src/logger/MSIDLoggerConnecting.h
@@ -32,11 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (MSIDLogLevel)level;
 
-- (BOOL)piiLoggingEnabled;
-
 - (BOOL)nsLoggingEnabled;
 
-- (BOOL)euiiMaskingEnabled;
+- (MSIDLogMaskingLevel)logMaskingLevel;
 
 - (BOOL)sourceLineLoggingEnabled;
 

--- a/IdentityCore/src/logger/MSIDMaskedHashableLogParameter.m
+++ b/IdentityCore/src/logger/MSIDMaskedHashableLogParameter.m
@@ -38,4 +38,9 @@
     return [self.parameterValue msidSecretLoggingHash];
 }
 
+- (BOOL)isEUII
+{
+    return NO;
+}
+
 @end

--- a/IdentityCore/src/logger/MSIDMaskedLogParameter.h
+++ b/IdentityCore/src/logger/MSIDMaskedLogParameter.h
@@ -28,10 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MSIDMaskedLogParameter : NSObject
 
 @property (nonatomic, readonly) id parameterValue;
+@property (nonatomic, readonly) BOOL isEUII;
 
 - (instancetype)initWithParameterValue:(id)parameter;
+- (instancetype)initWithParameterValue:(id)parameter isEUII:(BOOL)isEUII;
 
-- (NSString *)maskedDescription;
+- (NSString *)maskedDescription; // Masks any potential PII, including EUII, EUPI, OII
+- (NSString *)EUIIMaskedDescription; // Only masks EUII
 
 @end
 

--- a/IdentityCore/src/logger/MSIDMaskedLogParameter.m
+++ b/IdentityCore/src/logger/MSIDMaskedLogParameter.m
@@ -58,22 +58,27 @@
 
 - (NSString *)description
 {
-    if (![MSIDLogger sharedLogger].piiLoggingEnabled) // piiLoggingEnabled == NO
+    switch ([MSIDLogger sharedLogger].logMaskingLevel)
     {
-        if (self.maskedParameterValue) return self.maskedParameterValue;
-        
-        self.maskedParameterValue = [self maskedDescription];
-        return self.maskedParameterValue;
+        case MSIDLogMaskingSettingsMaskAllPII:
+        {
+            if (self.maskedParameterValue) return self.maskedParameterValue;
+            
+            self.maskedParameterValue = [self maskedDescription];
+            return self.maskedParameterValue;
+        }
+        case MSIDLogMaskingSettingsMaskEUIIOnly:
+        {
+            if (self.euiiMaskedParameterValue) return self.euiiMaskedParameterValue;
+            
+            self.euiiMaskedParameterValue = [self EUIIMaskedDescription];
+            return self.euiiMaskedParameterValue;
+        }
+        default:
+        {
+            return [NSString stringWithFormat:@"%@", self.parameterValue]; // no masking
+        }
     }
-    else if ([MSIDLogger sharedLogger].euiiMaskingEnabled) // piiLoggingEnabled == YES && euiiMaskingEnabled == YES
-    {
-        if (self.euiiMaskedParameterValue) return self.euiiMaskedParameterValue;
-        
-        self.euiiMaskedParameterValue = [self EUIIMaskedDescription];
-        return self.euiiMaskedParameterValue;
-    }
-    
-    return [NSString stringWithFormat:@"%@", self.parameterValue]; // piiLoggingEnabled == YES && euiiMaskingEnabled == NO
 }
  
 #pragma mark - Masking

--- a/IdentityCore/src/logger/MSIDMaskedLogParameter.m
+++ b/IdentityCore/src/logger/MSIDMaskedLogParameter.m
@@ -27,6 +27,8 @@
 
 @property (nonatomic, readwrite) id parameterValue;
 @property (nonatomic, readwrite) NSString *maskedParameterValue;
+@property (nonatomic, readwrite) NSString *euiiMaskedParameterValue;
+@property (nonatomic, readwrite) BOOL isEUII;
 
 @end
 
@@ -36,11 +38,17 @@
 
 - (instancetype)initWithParameterValue:(id)parameter
 {
+    return [self initWithParameterValue:parameter isEUII:NO];
+}
+
+- (instancetype)initWithParameterValue:(id)parameter isEUII:(BOOL)isEUII
+{
     self = [super init];
     
     if (self)
     {
         _parameterValue = parameter;
+        _isEUII = isEUII;
     }
     
     return self;
@@ -50,17 +58,24 @@
 
 - (NSString *)description
 {
-    if (![MSIDLogger sharedLogger].piiLoggingEnabled)
+    if (![MSIDLogger sharedLogger].piiLoggingEnabled) // piiLoggingEnabled == NO
     {
         if (self.maskedParameterValue) return self.maskedParameterValue;
         
         self.maskedParameterValue = [self maskedDescription];
         return self.maskedParameterValue;
     }
+    else if ([MSIDLogger sharedLogger].euiiMaskingEnabled) // piiLoggingEnabled == YES && euiiMaskingEnabled == YES
+    {
+        if (self.euiiMaskedParameterValue) return self.euiiMaskedParameterValue;
+        
+        self.euiiMaskedParameterValue = [self EUIIMaskedDescription];
+        return self.euiiMaskedParameterValue;
+    }
     
-    return [NSString stringWithFormat:@"%@", self.parameterValue];
+    return [NSString stringWithFormat:@"%@", self.parameterValue]; // piiLoggingEnabled == YES && euiiMaskingEnabled == NO
 }
-
+ 
 #pragma mark - Masking
 
 - (NSString *)maskedDescription
@@ -78,6 +93,16 @@
     }
     
     return [NSString stringWithFormat:@"Masked%@", _PII_NULLIFY(self.parameterValue)];
+}
+
+- (NSString *)EUIIMaskedDescription
+{
+    if (self.isEUII)
+    {
+        return [self maskedDescription];
+    }
+    
+    return [NSString stringWithFormat:@"%@", self.parameterValue]; // For a generic case, don't mask it
 }
 
 @end

--- a/IdentityCore/src/logger/MSIDMaskedUsernameLogParameter.m
+++ b/IdentityCore/src/logger/MSIDMaskedUsernameLogParameter.m
@@ -46,7 +46,7 @@
         
         if (emailIndex.location + 1 < stringValue.length)
         {
-            domain = [stringValue substringFromIndex:emailIndex.location+1];
+            domain = [stringValue substringFromIndex:emailIndex.location + 1];
         }
         
         return [NSString stringWithFormat:@"auth.placeholder-%@__%@", [username msidSecretLoggingHash], domain];

--- a/IdentityCore/src/logger/MSIDMaskedUsernameLogParameter.m
+++ b/IdentityCore/src/logger/MSIDMaskedUsernameLogParameter.m
@@ -42,11 +42,22 @@
     if (emailIndex.location != NSNotFound)
     {
         NSString *username = [stringValue substringToIndex:emailIndex.location];
-        NSString *domain = [stringValue substringFromIndex:emailIndex.location];
-        return [NSString stringWithFormat:@"auth.placeholder-%@%@", [username msidSecretLoggingHash], domain];
+        NSString *domain = @"";
+        
+        if (emailIndex.location + 1 < stringValue.length)
+        {
+            domain = [stringValue substringFromIndex:emailIndex.location+1];
+        }
+        
+        return [NSString stringWithFormat:@"auth.placeholder-%@__%@", [username msidSecretLoggingHash], domain];
     }
     
     return [self.parameterValue msidSecretLoggingHash];
+}
+
+- (BOOL)isEUII
+{
+    return YES;
 }
  
 @end

--- a/IdentityCore/src/oauth2/account/MSIDAccount.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccount.m
@@ -173,7 +173,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"MSIDAccount environment: %@ storage environment %@ realm: %@ username: %@ homeAccountId: %@ accountType: %@ localAccountId: %@", self.environment, self.storageEnvironment,  self.realm, MSID_PII_LOG_EMAIL(self.username), self.accountIdentifier.homeAccountId, [MSIDAccountTypeHelpers accountTypeAsString:self.accountType], self.localAccountId];
+    return [NSString stringWithFormat:@"MSIDAccount environment: %@ storage environment %@ realm: %@ username: %@ homeAccountId: %@ accountType: %@ localAccountId: %@", self.environment, self.storageEnvironment,  self.realm, MSID_PII_LOG_EMAIL(self.username), MSID_PII_LOG_TRACKABLE(self.accountIdentifier.homeAccountId), [MSIDAccountTypeHelpers accountTypeAsString:self.accountType], MSID_PII_LOG_TRACKABLE(self.localAccountId)];
 }
 
 #pragma mark - MSIDJsonSerializable

--- a/IdentityCore/src/oauth2/account/MSIDAccount.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccount.m
@@ -173,7 +173,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"MSIDAccount environment: %@ storage environment %@ realm: %@ username: %@ homeAccountId: %@ accountType: %@ localAccountId: %@", self.environment, self.storageEnvironment,  self.realm, self.username, self.accountIdentifier.homeAccountId, [MSIDAccountTypeHelpers accountTypeAsString:self.accountType], self.localAccountId];
+    return [NSString stringWithFormat:@"MSIDAccount environment: %@ storage environment %@ realm: %@ username: %@ homeAccountId: %@ accountType: %@ localAccountId: %@", self.environment, self.storageEnvironment,  self.realm, MSID_PII_LOG_EMAIL(self.username), self.accountIdentifier.homeAccountId, [MSIDAccountTypeHelpers accountTypeAsString:self.accountType], self.localAccountId];
 }
 
 #pragma mark - MSIDJsonSerializable

--- a/IdentityCore/src/oauth2/token/MSIDLegacyRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDLegacyRefreshToken.m
@@ -139,7 +139,7 @@
 - (NSString *)description
 {
     NSString *baseDescription = [super description];
-    return [baseDescription stringByAppendingFormat:@"(id token=%@, legacy user ID=%@)", [_idToken msidSecretLoggingHash], _accountIdentifier.displayableId];
+    return [baseDescription stringByAppendingFormat:@"(id token=%@, legacy user ID=%@)", [_idToken msidSecretLoggingHash], MSID_PII_LOG_EMAIL(_accountIdentifier.displayableId)];
 }
 
 @end

--- a/IdentityCore/src/requests/MSIDOIDCSignoutRequest.m
+++ b/IdentityCore/src/requests/MSIDOIDCSignoutRequest.m
@@ -119,7 +119,7 @@
             return;
         }
         
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.requestParameters, @"Completed logout request successfully with response %@", MSID_PII_LOG_MASKABLE(response));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.requestParameters, @"Completed logout request successfully with response %@", MSID_EUII_ONLY_LOG_MASKABLE(response));
         if (completionBlock) completionBlock(YES, nil);
     }];
 }

--- a/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
@@ -113,7 +113,7 @@
             *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Unable to create broker request URL", nil, nil, nil, self.requestParameters.correlationId, nil, YES);
         }
 
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Unable to create broker request URL with contents %@", MSID_PII_LOG_MASKABLE(contents));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.requestParameters, @"Unable to create broker request URL with contents %@", MSID_EUII_ONLY_LOG_MASKABLE(contents));
         return NO;
     }
 

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
@@ -82,7 +82,7 @@
           correlationID:(NSUUID *)correlationID
                   error:(NSError **)error
 {
-    MSID_LOG_WITH_CORR_PII(MSIDLogLevelVerbose, correlationID, @"Checking returned account, Input account id %@, returned account ID %@, local account ID %@", accountIdentifier.maskedDisplayableId, tokenResult.account.accountIdentifier.maskedDisplayableId, MSID_PII_LOG_MASKABLE(tokenResult.account.localAccountId));
+    MSID_LOG_WITH_CORR_PII(MSIDLogLevelVerbose, correlationID, @"Checking returned account, Input account id %@, returned account ID %@, local account ID %@", MSID_PII_LOG_MASKABLE(accountIdentifier.maskedDisplayableId), MSID_PII_LOG_MASKABLE(tokenResult.account.accountIdentifier.maskedDisplayableId), MSID_PII_LOG_TRACKABLE(tokenResult.account.localAccountId));
     
     switch (accountIdentifier.legacyAccountIdentifierType)
     {

--- a/IdentityCore/src/util/NSDictionary+MSIDLogging.m
+++ b/IdentityCore/src/util/NSDictionary+MSIDLogging.m
@@ -40,6 +40,25 @@
 {
     NSMutableDictionary *mutableRequestDict = [self mutableCopy];
     [mutableRequestDict removeObjectsForKeys:[[self class] msidSecretRequestKeys]];
+    
+    // Check for maskable request parameters
+    
+    // 1. Username
+    NSString *username = mutableRequestDict[@"username"];
+    
+    if (username)
+    {
+        mutableRequestDict[@"username"] = MSID_PII_LOG_EMAIL(mutableRequestDict[@"username"]);
+    }
+    
+    // 2. Login_hint
+    NSString *loginHint = mutableRequestDict[@"login_hint"];
+    
+    if (loginHint)
+    {
+        mutableRequestDict[@"login_hint"] = MSID_PII_LOG_EMAIL(mutableRequestDict[@"login_hint"]);
+    }
+
     return mutableRequestDict;
 }
 

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -85,7 +85,7 @@
     
     if (!authHeaderParams)
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, context, @"Unparseable wwwAuthHeader received %@", MSID_PII_LOG_MASKABLE(wwwAuthHeaderValue));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, context, @"Unparseable wwwAuthHeader received %@", MSID_EUII_ONLY_LOG_MASKABLE(wwwAuthHeaderValue));
     }
     
     NSError *error = nil;

--- a/IdentityCore/src/webview/operations/MSIDWebOpenBrowserResponseOperation.m
+++ b/IdentityCore/src/webview/operations/MSIDWebOpenBrowserResponseOperation.m
@@ -69,7 +69,7 @@
     #if TARGET_OS_IPHONE
     if (![MSIDAppExtensionUtil isExecutingInAppExtension])
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Opening a browser - %@", MSID_PII_LOG_MASKABLE(self.browserURL));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Opening a browser - %@", MSID_EUII_ONLY_LOG_MASKABLE(self.browserURL));
         [MSIDAppExtensionUtil sharedApplicationOpenURL:self.browserURL];
     }
     else

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -31,7 +31,7 @@
 @property (nonatomic) MSIDLogLevel levelValue;
 @property (nonatomic) BOOL nsLoggingEnabledValue;
 @property (nonatomic) BOOL piiLoggingEnabledValue;
-@property (nonatomic) BOOL euiiMaskingEnabledValue;
+@property (nonatomic) MSIDLogMaskingLevel logMaskingLevelValue;
 @property (nonatomic) BOOL shouldLogValue;
 @property (nonatomic) BOOL sourceLineLoggingEnabledValue;
 @property (nonatomic) BOOL loggingQueueEnabledValue;
@@ -76,11 +76,10 @@
     return self.loggingQueueEnabledValue;
 }
 
-- (BOOL)euiiMaskingEnabled
+- (MSIDLogMaskingLevel)logMaskingLevel
 {
-    return self.euiiMaskingEnabledValue;
+    return self.logMaskingLevelValue;
 }
-
 
 @end
 
@@ -95,7 +94,7 @@
     [super setUp];
     [[MSIDTestLogger sharedLogger] reset];
     [MSIDTestLogger sharedLogger].callbackInvoked = NO;
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
 }
 
 #pragma mark - Basic logging
@@ -118,8 +117,7 @@
 
 - (void)testLog_whenPiiEnabled_maskEUIINo_PiiMessage_shouldReturnMessageInCallback
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
-    [MSIDLogger sharedLogger].euiiMaskingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -133,8 +131,7 @@
 
 - (void)testLog_whenPiiEnabled_maskEUIIYes_PiiMessage_shouldReturnedMaskedMessageInCallback
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
-    [MSIDLogger sharedLogger].euiiMaskingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -149,8 +146,7 @@
 
 - (void)testLog_whenPiiEnabled_maskEUIINo_NonPiiMessage_shouldReturnSameMessageInCallback
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
-    [MSIDLogger sharedLogger].euiiMaskingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -165,8 +161,7 @@
 
 - (void)testLog_whenPiiEnabled_maskEUIIYes_NonPiiMessage_shouldReturnSameMessageInCallback
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
-    [MSIDLogger sharedLogger].euiiMaskingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -181,8 +176,7 @@
 
 - (void)testLog_whenPiiNotEnabled_maskEUIINo_NonPiiMessage_shouldReturnSameMessageInCallback
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
-    [MSIDLogger sharedLogger].euiiMaskingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -197,8 +191,7 @@
 
 - (void)testLog_whenPiiNotEnabled_maskEUIIYes_NonPiiMessage_shouldReturnSameMessageInCallback
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
-    [MSIDLogger sharedLogger].euiiMaskingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -213,8 +206,7 @@
 
 - (void)testLog_whenPiiNotEnabled_maskEUIINo_PiiMessage_shouldInvokeCallbackWithMaskedMessage
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
-    [MSIDLogger sharedLogger].euiiMaskingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -227,8 +219,7 @@
 
 - (void)testLog_whenPiiNotEnabled_maskEUIIYes_PiiMessage_shouldInvokeCallbackWithMaskedMessage
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
-    [MSIDLogger sharedLogger].euiiMaskingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -299,7 +290,7 @@
 
 - (void)testLogErrorPiiMacro_shouldReturnMessagePIITrueErrorLevel
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -314,7 +305,7 @@
 
 - (void)testLogWarningPiiMacro_shouldReturnMessagePIITrueWarningLevel
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -329,7 +320,7 @@
 
 - (void)testLogInfoPiiMacro_shouldReturnMessagePIITrueInfoLevel
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -344,7 +335,7 @@
 
 - (void)testLogVerbosePiiMacro_shouldReturnMessagePIITrueVerboseLevel
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -359,7 +350,7 @@
 
 - (void)testLogWithContextMacro_whenContainsPii_andPiiDisabled_shouldLogMessageWithMaskedPii
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -374,7 +365,7 @@
 
 - (void)testLogWithContextMacro_whenContainsPii_andPiiEnabled_shouldLogMessageWithRawPii
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
@@ -456,10 +447,9 @@
 {
     MSIDLoggerConnectorMock *connectorMock = [MSIDLoggerConnectorMock new];
     connectorMock.piiLoggingEnabledValue = YES;
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     [MSIDLogger sharedLogger].loggerConnector = connectorMock;
-    
-    XCTAssertTrue([MSIDLogger sharedLogger].piiLoggingEnabled);
+    XCTAssertEqual([MSIDLogger sharedLogger].logMaskingLevel, MSIDLogMaskingSettingsMaskAllPII);
 }
 
 - (void)testSourceLineLoggingEnabled_whenConnectorIsSet_shouldReturnValueFromConnector

--- a/IdentityCore/tests/MSIDMaskedLogParameterTests.m
+++ b/IdentityCore/tests/MSIDMaskedLogParameterTests.m
@@ -34,7 +34,7 @@
 
 - (void)testDescription_whenPIIDisabled_andParameterOfNSStringType_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDMaskedLogParameter *logParameter = [[MSIDMaskedLogParameter alloc] initWithParameterValue:@"secret-test"];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"Masked(not-null)");
@@ -42,7 +42,7 @@
 
 - (void)testDescription_whenPIIEnabled_andParameterOfNSStringType_shouldReturnRawValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     MSIDMaskedLogParameter *logParameter = [[MSIDMaskedLogParameter alloc] initWithParameterValue:@"secret-test"];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"secret-test");
@@ -50,7 +50,7 @@
 
 - (void)testDescription_whenPIIDisabled_andParameterOfArrayType_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     NSArray *param = @[@"1", @"2", @"3"];
     MSIDMaskedLogParameter *logParameter = [[MSIDMaskedLogParameter alloc] initWithParameterValue:param];
     NSString *description = [logParameter description];
@@ -59,7 +59,7 @@
 
 - (void)testDescription_whenPIIDisabled_andParameterOfErrorType_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     NSError *error = MSIDCreateError(MSIDErrorDomain, -10003, @"test", @"invalid_grant", @"bad_token", nil, nil, nil, NO);
     MSIDMaskedLogParameter *logParameter = [[MSIDMaskedLogParameter alloc] initWithParameterValue:error];
     NSString *description = [logParameter description];
@@ -68,7 +68,7 @@
 
 - (void)testDescription_whenPIIEnabled_andParameterOfErrorType_shouldReturnNonMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     NSError *error = MSIDCreateError(MSIDErrorDomain, -10003, @"test", @"invalid_grant", @"bad_token", nil, nil, nil, NO);
     MSIDMaskedLogParameter *logParameter = [[MSIDMaskedLogParameter alloc] initWithParameterValue:error];
     NSString *description = [logParameter description];
@@ -77,7 +77,7 @@
 
 - (void)testDescription_whenPIIDisabled_andParameterOfNSNullType_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDMaskedLogParameter *logParameter = [[MSIDMaskedLogParameter alloc] initWithParameterValue:[NSNull null]];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"Masked(not-null)");
@@ -85,7 +85,7 @@
 
 - (void)testDescription_whenPIIEnabled_andParameterOfNSNullType_shouldReturnNonMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     MSIDMaskedLogParameter *logParameter = [[MSIDMaskedLogParameter alloc] initWithParameterValue:[NSNull null]];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"<null>");
@@ -93,7 +93,7 @@
 
 - (void)testDescription_whenPIIEnabled_andNilParameter_shouldReturnNonMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     NSString *param = nil;
     MSIDMaskedLogParameter *logParameter = [[MSIDMaskedLogParameter alloc] initWithParameterValue:param];
     NSString *description = [logParameter description];
@@ -102,7 +102,7 @@
 
 - (void)testDescription_whenPIIEnabled_andNilParameter_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = YES;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
     NSString *param = nil;
     MSIDMaskedLogParameter *logParameter = [[MSIDMaskedLogParameter alloc] initWithParameterValue:param];
     NSString *description = [logParameter description];

--- a/IdentityCore/tests/MSIDMaskedUsernameLogParameterTests.m
+++ b/IdentityCore/tests/MSIDMaskedUsernameLogParameterTests.m
@@ -32,7 +32,7 @@
 
 - (void)testDescription_whenPIINotEnabled_andNilParameter_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     NSString *param = nil;
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:param];
     NSString *description = [logParameter description];
@@ -41,7 +41,7 @@
 
 - (void)testDescription_whenPIINotEnabled_andNsNullParameter_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:[NSNull null]];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"Masked(not-null)");
@@ -49,7 +49,7 @@
 
 - (void)testDescription_whenPIINotEnabled_andEmailParameter_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"test@email.com"];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"auth.placeholder-9f86d081__email.com");
@@ -57,7 +57,7 @@
 
 - (void)testDescription_whenPIINotEnabled_andEmailParameterWithoutUsername_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"@email.com"];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"auth.placeholder-e3b0c442__email.com");
@@ -66,7 +66,7 @@
 
 - (void)testDescription_whenPIINotEnabled_andEmailParameterWithoutEmailSign_shouldReturnHashedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"contoso.email.com"];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"2bf9fb0e");
@@ -74,7 +74,7 @@
 
 - (void)testDescription_whenPIINotEnabled_andEmailParameterWithNoDomain_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"test@"];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"auth.placeholder-9f86d081__");
@@ -82,7 +82,7 @@
 
 - (void)testDescription_whenPIINotEnabled_andEmailParameterWithNoDomain_andSpaceChar_shouldReturnMaskedValue
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"test@ "];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"auth.placeholder-9f86d081__ ");

--- a/IdentityCore/tests/MSIDMaskedUsernameLogParameterTests.m
+++ b/IdentityCore/tests/MSIDMaskedUsernameLogParameterTests.m
@@ -52,7 +52,7 @@
     [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"test@email.com"];
     NSString *description = [logParameter description];
-    XCTAssertEqualObjects(description, @"auth.placeholder-9f86d081@email.com");
+    XCTAssertEqualObjects(description, @"auth.placeholder-9f86d081__email.com");
 }
 
 - (void)testDescription_whenPIINotEnabled_andEmailParameterWithoutUsername_shouldReturnMaskedValue
@@ -60,7 +60,7 @@
     [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"@email.com"];
     NSString *description = [logParameter description];
-    XCTAssertEqualObjects(description, @"auth.placeholder-e3b0c442@email.com");
+    XCTAssertEqualObjects(description, @"auth.placeholder-e3b0c442__email.com");
 }
 
 
@@ -70,6 +70,22 @@
     MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"contoso.email.com"];
     NSString *description = [logParameter description];
     XCTAssertEqualObjects(description, @"2bf9fb0e");
+}
+
+- (void)testDescription_whenPIINotEnabled_andEmailParameterWithNoDomain_shouldReturnMaskedValue
+{
+    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"test@"];
+    NSString *description = [logParameter description];
+    XCTAssertEqualObjects(description, @"auth.placeholder-9f86d081__");
+}
+
+- (void)testDescription_whenPIINotEnabled_andEmailParameterWithNoDomain_andSpaceChar_shouldReturnMaskedValue
+{
+    [MSIDLogger sharedLogger].piiLoggingEnabled = NO;
+    MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"test@ "];
+    NSString *description = [logParameter description];
+    XCTAssertEqualObjects(description, @"auth.placeholder-9f86d081__ ");
 }
 
 @end

--- a/IdentityCore/tests/util/MSIDTestLogger.m
+++ b/IdentityCore/tests/util/MSIDTestLogger.m
@@ -70,7 +70,7 @@
     _lastLevel = -1;
     _containsPII = NO;
     [[MSIDLogger sharedLogger] setLevel:level];
-    [[MSIDLogger sharedLogger] setPiiLoggingEnabled:NO];
+    [[MSIDLogger sharedLogger] setLogMaskingLevel:MSIDLogMaskingSettingsMaskSecretsOnly];
 }
 
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+TBD
+* Mask EUII in logs (#944)
+
 Version 1.6.1
 * Extend iOS background tasks to silent and interactive requests (#923)
 * Added thread-safe generic MSIDLRUCache (#922)


### PR DESCRIPTION
## Proposed changes

MSAL and broker provide logging callbacks that assist in diagnostics. By default the library will not return any messages with any user or organizational information. However, this might make diagnosing issues difficult.

The most sensitive information is EUII (things like upn, name, email etc). 
This PR introduces a new logger flag and macro that allows masking only EUII, while keeping EUPI and OII intact. 

When both piiEnabled is set to YES, and maskEUII is set to YES, MSAL logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs.

This flag has no effect when piiEnabled is set to NO.
Default value is NO.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

