### PR TITLE
Handle missing bundle identifier when writing wipe data to keychain

### DIFF
--- a/IdentityCore/src/cache/MSIDKeychainTokenCache.m
+++ b/IdentityCore/src/cache/MSIDKeychainTokenCache.m
@@ -562,7 +562,14 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (BOOL)saveWipeInfoWithContext:(id<MSIDRequestContext>)context
                           error:(NSError **)error
 {
-    NSDictionary *wipeInfo = @{ @"bundleId" : [[NSBundle mainBundle] bundleIdentifier],
+    NSString *appIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+    
+    if (!appIdentifier)
+    {
+        appIdentifier = [NSProcessInfo processInfo].processName;
+    }
+    
+    NSDictionary *wipeInfo = @{ @"bundleId" : appIdentifier ?: @"",
                                 @"wipeTime" : [NSDate date]
                                 };
 


### PR DESCRIPTION
## Proposed changes

Current logic will crash the code if process is missing a bundle identifier. 
Applying a fix to fallback to process name, or empty string if it's missing.
Crash reported by Jamf on macOS. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

