### PR TITLE
Support for scenarios where access_token is not returned

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -783,8 +783,7 @@
     MSIDAccessToken *accessToken = [factory accessTokenFromResponse:response configuration:configuration];
     if (!accessToken)
     {
-        MSIDFillAndLogError(error, MSIDErrorInternal, @"Response does not contain an access token", context.correlationId);
-        return NO;
+        return YES;
     }
 
     if (![self checkAccountIdentifier:accessToken.accountIdentifier.homeAccountId context:context error:error])

--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.m
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.m
@@ -97,11 +97,11 @@
         return NO;
     }
     
-    if (![self verifyAccessToken:response.accessToken])
+    if (![self verifyToken:response.accessToken] && ![self verifyToken:response.idToken])
     {
         if (error)
         {
-            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Authentication response received without expected accessToken", nil, nil, nil, context.correlationId, nil, YES);
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Authentication response received without expected accessToken and idToken", nil, nil, nil, context.correlationId, nil, YES);
         }
         return NO;
     }
@@ -109,9 +109,9 @@
     return YES;
 }
 
-- (BOOL)verifyAccessToken:(NSString *)accessToken
+- (BOOL)verifyToken:(NSString *)token
 {
-    return ![NSString msidIsStringNilOrBlank:accessToken];
+    return ![NSString msidIsStringNilOrBlank:token];
 }
 
 #pragma mark - Tokens

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
@@ -43,7 +43,7 @@
      we'd like to throw an error and specify which scopes were granted and which ones not
      */
     
-    if (!tokenRequest.accessToken)
+    if (tokenResult.accessToken == nil)
     {
         return YES;
     }

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
@@ -43,6 +43,11 @@
      we'd like to throw an error and specify which scopes were granted and which ones not
      */
     
+    if (!tokenRequest.accessToken)
+    {
+        return YES;
+    }
+
     NSOrderedSet *grantedScopes = tokenResult.accessToken.scopes;
     NSOrderedSet *normalizedGrantedScopes = grantedScopes.normalizedScopeSet;
 

--- a/IdentityCore/tests/MSIDOauth2FactoryTests.m
+++ b/IdentityCore/tests/MSIDOauth2FactoryTests.m
@@ -115,7 +115,7 @@
     XCTAssertEqualObjects(error.userInfo[MSIDOAuthErrorKey], @"invalid_grant");
 }
 
-- (void)testVerifyResponse_whenNoAccessToken_shouldReturnError
+- (void)testVerifyResponse_whenNoAccessTokenAndNoIdToken_shouldReturnError
 {
     MSIDOauth2Factory *factory = [MSIDOauth2Factory new];
     
@@ -129,10 +129,10 @@
     
     XCTAssertFalse(result);
     XCTAssertEqual(error.domain, MSIDErrorDomain);
-    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Authentication response received without expected accessToken");
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Authentication response received without expected accessToken and idToken");
 }
 
-- (void)testVerifyResponse_whenValidResponseWithTokens_shouldReturnNoError
+- (void)testVerifyResponse_whenValidResponseWithAccessTokens_shouldReturnNoError
 {
     MSIDOauth2Factory *factory = [MSIDOauth2Factory new];
     
@@ -145,6 +145,23 @@
     NSError *error = nil;
     BOOL result = [factory verifyResponse:response context:nil error:&error];
     
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+}
+
+- (void)testVerifyResponse_whenValidResponseWithIdTokens_shouldReturnNoError
+{
+    MSIDOauth2Factory *factory = [MSIDOauth2Factory new];
+
+    NSString *rawClientInfo = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    MSIDTokenResponse *response = [[MSIDTokenResponse alloc] initWithJSONDictionary:@{@"id_token":@"fake_id_token",
+                                                                                      @"refresh_token":@"fake_refresh_token",
+                                                                                      @"client_info":rawClientInfo
+                                                                                      }
+                                                                              error:nil];
+    NSError *error = nil;
+    BOOL result = [factory verifyResponse:response context:nil error:&error];
+
     XCTAssertTrue(result);
     XCTAssertNil(error);
 }

--- a/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
@@ -1022,7 +1022,7 @@
                                                                                 requestScopes:@"user.read tasks.read openid profile offline_access"
                                                                                    responseAT:@""
                                                                                    responseRT:@"new rt"
-                                                                                   responseID:nil
+                                                                                   responseID:@""
                                                                                 responseScope:@"user.read tasks.read"
                                                                            responseClientInfo:differentClientInfo
                                                                                           url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID


### PR DESCRIPTION
## Proposed changes

Support for scenarios where `access_token` is not returned (only `id_token` / `refresh_token` is returned). Changed to make it an error if both `access_token` and `id_token` are not returned.
https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/852

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

