### PR TITLE
Remove input param to make the method reusable in CPP, added tests

### DIFF
--- a/IdentityCore/src/intune/MSIDIntuneApplicationStateManager.h
+++ b/IdentityCore/src/intune/MSIDIntuneApplicationStateManager.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDIntuneApplicationStateManager : NSObject
 
-+ (BOOL)isAppCapableForMAMCA:(MSIDAuthority *)authority;
++ (BOOL)isAppCapableForMAMCA;
 + (nullable NSString *)intuneApplicationIdentifierForAuthority:(MSIDAuthority *)authority
                                                  appIdentifier:(NSString *)appIdentifier;
 

--- a/IdentityCore/src/intune/MSIDIntuneApplicationStateManager.m
+++ b/IdentityCore/src/intune/MSIDIntuneApplicationStateManager.m
@@ -27,15 +27,9 @@
 
 @implementation MSIDIntuneApplicationStateManager
 
-+ (BOOL)isAppCapableForMAMCA:(__unused MSIDAuthority *)authority
++ (BOOL)isAppCapableForMAMCA
 {
 #if TARGET_OS_IPHONE
-    
-    if (!authority.supportsMAMScenarios)
-    {
-        return NO;
-    }
-    
     NSError *error = nil;
     NSDictionary *resourceCache = [[MSIDIntuneMAMResourcesCache sharedCache] resourcesJsonDictionaryWithContext:nil error:&error];
     
@@ -54,7 +48,12 @@
 + (nullable NSString *)intuneApplicationIdentifierForAuthority:(MSIDAuthority *)authority
                                                  appIdentifier:(NSString *)appIdentifier
 {
-    return [self isAppCapableForMAMCA:authority] ? appIdentifier : nil;
+    if (authority.supportsMAMScenarios && [self isAppCapableForMAMCA])
+    {
+        return appIdentifier;
+    }
+    
+    return nil;
 }
 
 @end

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -135,7 +135,8 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
         
         // If token is scoped down to a particular enrollmentId and app is capable for True MAM CA, verify that enrollmentIds match
         // EnrollmentID matching is done on the request layer to ensure that expired access tokens get removed even if valid enrollmentId is not presented
-        if ([MSIDIntuneApplicationStateManager isAppCapableForMAMCA:self.requestParameters.msidConfiguration.authority]
+        if (self.requestParameters.msidConfiguration.authority.supportsMAMScenarios
+            && [MSIDIntuneApplicationStateManager isAppCapableForMAMCA]
             && ![NSString msidIsStringNilOrBlank:accessToken.enrollmentId])
         {
             NSError *error = nil;

--- a/IdentityCore/src/validation/MSIDAADAuthority.m
+++ b/IdentityCore/src/validation/MSIDAADAuthority.m
@@ -231,7 +231,11 @@
 
 - (BOOL)supportsMAMScenarios
 {
+#if TARGET_OS_IPHONE
     return YES;
+#else
+    return NO;
+#endif
 }
 
 - (BOOL)checkTokenEndpointForRTRefresh:(NSURL *)tokenEndpoint

--- a/IdentityCore/tests/MSIDIntuneMAMResourcesCacheTests.m
+++ b/IdentityCore/tests/MSIDIntuneMAMResourcesCacheTests.m
@@ -26,6 +26,7 @@
 #import "MSIDIntuneInMemoryCacheDataSource.h"
 #import "MSIDAuthorityMock.h"
 #import "MSIDAuthority+Internal.h"
+#import "MSIDIntuneApplicationStateManager.h"
 
 @interface MSIDIntuneMAMResourcesCacheTests : XCTestCase
 
@@ -218,6 +219,26 @@
     
     XCTAssertNil(resource);
     XCTAssertNotNil(error);
+}
+
+- (void)testResourceInCache_intuneApplicationIdentifier_isAppCapableForMAMCA
+{
+    XCTAssertFalse([MSIDIntuneApplicationStateManager isAppCapableForMAMCA]);
+    XCTAssertNil([MSIDIntuneApplicationStateManager
+                  intuneApplicationIdentifierForAuthority:self.authority
+                  appIdentifier:@"com.contoso.identifier"]);
+    [MSIDIntuneMAMResourcesCache setSharedCache:self.cache];
+#if TARGET_OS_IPHONE
+    XCTAssertTrue([MSIDIntuneApplicationStateManager isAppCapableForMAMCA]);
+    XCTAssertEqualObjects([MSIDIntuneApplicationStateManager
+                           intuneApplicationIdentifierForAuthority:self.authority
+                           appIdentifier:@"com.contoso.identifier"], @"com.contoso.identifier");
+#else
+    XCTAssertFalse([MSIDIntuneApplicationStateManager isAppCapableForMAMCA]);
+    XCTAssertNil([MSIDIntuneApplicationStateManager
+                  intuneApplicationIdentifierForAuthority:self.authority
+                  appIdentifier:@"com.contoso.identifier"]);
+#endif
 }
 
 @end

--- a/IdentityCore/tests/MSIDIntuneMAMResourcesCacheTests.m
+++ b/IdentityCore/tests/MSIDIntuneMAMResourcesCacheTests.m
@@ -233,12 +233,24 @@
     XCTAssertEqualObjects([MSIDIntuneApplicationStateManager
                            intuneApplicationIdentifierForAuthority:self.authority
                            appIdentifier:@"com.contoso.identifier"], @"com.contoso.identifier");
+    [self resetResourceCache];
+    XCTAssertFalse([MSIDIntuneApplicationStateManager isAppCapableForMAMCA]);
+    XCTAssertNil([MSIDIntuneApplicationStateManager
+                  intuneApplicationIdentifierForAuthority:self.authority
+                  appIdentifier:@"com.contoso.identifier"]);
 #else
     XCTAssertFalse([MSIDIntuneApplicationStateManager isAppCapableForMAMCA]);
     XCTAssertNil([MSIDIntuneApplicationStateManager
                   intuneApplicationIdentifierForAuthority:self.authority
                   appIdentifier:@"com.contoso.identifier"]);
 #endif
+}
+
+#pragma mark - helpers
+
+- (void)resetResourceCache
+{
+    [MSIDIntuneMAMResourcesCache setSharedCache:[[MSIDIntuneMAMResourcesCache alloc] initWithDataSource:[[MSIDIntuneInMemoryCacheDataSource alloc] initWithCache:[MSIDCache new]]]];
 }
 
 @end

--- a/IdentityCore/tests/mocks/MSIDAuthorityMock.m
+++ b/IdentityCore/tests/mocks/MSIDAuthorityMock.m
@@ -31,4 +31,13 @@
     return self.environmentAliases;
 }
 
+- (BOOL)supportsMAMScenarios
+{
+#if TARGET_OS_IPHONE
+    return YES;
+#else
+    return NO;
+#endif
+}
+
 @end


### PR DESCRIPTION
## Proposed changes

Removed input param in isAppCapableForMAMCA to make it reusable in CPP later on

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

