### PR TITLE
Fix bugs in MSIDAccountCacheItemTests from MSAL C++

### DIFF
--- a/IdentityCore/tests/MSIDAccountCacheItemTests.m
+++ b/IdentityCore/tests/MSIDAccountCacheItemTests.m
@@ -37,7 +37,7 @@
 
 - (void)testJSONDictionary_whenAccount_andAllFieldsSet_shouldReturnJSONDictionary
 {
-	NSString *base64String = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    NSString *base64String = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
     NSError *error = nil;
     MSIDClientInfo *clientInfo = [[MSIDClientInfo alloc] initWithRawClientInfo:base64String error:&error];
 	
@@ -47,16 +47,16 @@
                                          @"local_account_id": @"0000004-0000004-000004",
                                          @"given_name": @"First name",
                                          @"family_name": @"Last name",
-										 @"middle_name": @"Middle name",
+                                         @"middle_name": @"Middle name",
                                          @"test": @"test2",
                                          @"test3": @"test4",
                                          @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
                                          @"username": @"username",
                                          @"alternative_account_id": @"alt",
                                          @"name": @"test user",
-										 @"client_info": clientInfo.rawClientInfo,
-									     @"last_modification_app": @"",
-									     @"last_modification_time": @"0.000"
+                                         @"client_info": clientInfo.rawClientInfo,
+										 @"last_modification_app": @"",
+                                         @"last_modification_time": @"0.000"
                                          };
     MSIDAccountCacheItem *cacheItem = [[MSIDAccountCacheItem alloc] initWithJSONDictionary:expectedDictionary error:&error];
     XCTAssertEqualObjects(cacheItem.jsonDictionary, expectedDictionary);
@@ -110,14 +110,14 @@
                                         @"local_account_id": @"0000004-0000004-000004",
                                         @"given_name": @"First name",
                                         @"family_name": @"Last name",
-										@"middle_name": @"Middle name",
+                                        @"middle_name": @"Middle name",
                                         @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
                                         @"username": @"username",
                                         @"alternative_account_id": @"alt",
                                         @"name": @"test user",
-										@"client_info": clientInfo.rawClientInfo,
-										@"last_modification_app": @"",
-										@"last_modification_time": @"0.000"
+                                        @"client_info": clientInfo.rawClientInfo,
+                                        @"last_modification_app": @"",
+                                        @"last_modification_time": @"0.000"
                                         };
     NSMutableDictionary *firstDictionary = [accountDictionary mutableCopy];
     [firstDictionary addEntriesFromDictionary:@{@"field1": @"value1",
@@ -169,9 +169,9 @@
                                        @"environment": DEFAULT_TEST_ENVIRONMENT,
                                        @"realm": @"contoso.com",
                                        @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
-									   @"local_account_id": @"0000004-0000004-000004",
-									   @"realm": @"contoso.com",
-									   @"username": @"username"
+                                       @"local_account_id": @"0000004-0000004-000004",
+                                       @"realm": @"contoso.com",
+                                       @"username": @"username"
                                        };
     MSIDAccountCacheItem *secondAccount = [[MSIDAccountCacheItem alloc] initWithJSONDictionary:secondDictionary error:&error];
     XCTAssertNil(error);

--- a/IdentityCore/tests/MSIDAccountCacheItemTests.m
+++ b/IdentityCore/tests/MSIDAccountCacheItemTests.m
@@ -55,7 +55,7 @@
                                          @"alternative_account_id": @"alt",
                                          @"name": @"test user",
                                          @"client_info": clientInfo.rawClientInfo,
-										 @"last_modification_app": @"",
+                                         @"last_modification_app": @"",
                                          @"last_modification_time": @"0.000"
                                          };
     MSIDAccountCacheItem *cacheItem = [[MSIDAccountCacheItem alloc] initWithJSONDictionary:expectedDictionary error:&error];

--- a/IdentityCore/tests/MSIDAccountCacheItemTests.m
+++ b/IdentityCore/tests/MSIDAccountCacheItemTests.m
@@ -37,20 +37,28 @@
 
 - (void)testJSONDictionary_whenAccount_andAllFieldsSet_shouldReturnJSONDictionary
 {
+	NSString *base64String = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
+    NSError *error = nil;
+    MSIDClientInfo *clientInfo = [[MSIDClientInfo alloc] initWithRawClientInfo:base64String error:&error];
+	
     NSDictionary *expectedDictionary = @{@"authority_type": @"AAD",
                                          @"environment": DEFAULT_TEST_ENVIRONMENT,
                                          @"realm": @"contoso.com",
                                          @"local_account_id": @"0000004-0000004-000004",
                                          @"given_name": @"First name",
                                          @"family_name": @"Last name",
+										 @"middle_name": @"Middle name",
                                          @"test": @"test2",
                                          @"test3": @"test4",
-                                         @"home_account_id": @"uid.utid",
+                                         @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
                                          @"username": @"username",
                                          @"alternative_account_id": @"alt",
-                                         @"name": @"test user"
+                                         @"name": @"test user",
+										 @"client_info": clientInfo.rawClientInfo,
+									     @"last_modification_app": @"",
+									     @"last_modification_time": @"0.000"
                                          };
-    MSIDAccountCacheItem *cacheItem = [[MSIDAccountCacheItem alloc] initWithJSONDictionary:expectedDictionary error:nil];
+    MSIDAccountCacheItem *cacheItem = [[MSIDAccountCacheItem alloc] initWithJSONDictionary:expectedDictionary error:&error];
     XCTAssertEqualObjects(cacheItem.jsonDictionary, expectedDictionary);
 }
 
@@ -66,7 +74,7 @@
                                      @"family_name": @"Last name",
                                      @"test": @"test2",
                                      @"test3": @"test4",
-                                     @"home_account_id": @"uid.utid",
+                                     @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
                                      @"username": @"username",
                                      @"alternative_account_id": @"alt",
                                      @"name": @"test user"
@@ -84,7 +92,7 @@
     XCTAssertEqualObjects(cacheItem.familyName, @"Last name");
     XCTAssertEqualObjects(cacheItem.name, @"test user");
     XCTAssertEqualObjects(cacheItem.alternativeAccountId, @"alt");
-    XCTAssertEqualObjects(cacheItem.homeAccountId, @"uid.utid");
+    XCTAssertEqualObjects(cacheItem.homeAccountId, DEFAULT_TEST_HOME_ACCOUNT_ID);
     XCTAssertEqualObjects(cacheItem.username, @"username");
 }
 
@@ -92,17 +100,24 @@
 
 - (void)testAddAdditionalFields_whenSerializing_shouldCombineFields
 {
+    NSString *base64String = [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson];
     NSError *error = nil;
+    MSIDClientInfo *clientInfo = [[MSIDClientInfo alloc] initWithRawClientInfo:base64String error:&error];
+	
     NSDictionary *accountDictionary = @{@"authority_type": @"AAD",
                                         @"environment": DEFAULT_TEST_ENVIRONMENT,
                                         @"realm": @"contoso.com",
                                         @"local_account_id": @"0000004-0000004-000004",
                                         @"given_name": @"First name",
                                         @"family_name": @"Last name",
-                                        @"home_account_id": @"uid.utid",
+										@"middle_name": @"Middle name",
+                                        @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
                                         @"username": @"username",
                                         @"alternative_account_id": @"alt",
-                                        @"name": @"test user"
+                                        @"name": @"test user",
+										@"client_info": clientInfo.rawClientInfo,
+										@"last_modification_app": @"",
+										@"last_modification_time": @"0.000"
                                         };
     NSMutableDictionary *firstDictionary = [accountDictionary mutableCopy];
     [firstDictionary addEntriesFromDictionary:@{@"field1": @"value1",
@@ -139,7 +154,7 @@
                                       @"local_account_id": @"0000004-0000004-000004",
                                       @"given_name": @"First name",
                                       @"family_name": @"Last name",
-                                      @"home_account_id": @"uid.utid",
+                                      @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
                                       @"username": @"username",
                                       @"alternative_account_id": @"alternative_clientID",
                                       @"name": @"test user",
@@ -153,7 +168,10 @@
     NSDictionary* secondDictionary = @{@"authority_type": @"AAD",
                                        @"environment": DEFAULT_TEST_ENVIRONMENT,
                                        @"realm": @"contoso.com",
-                                       @"home_account_id": @"uid.utid"
+                                       @"home_account_id": DEFAULT_TEST_HOME_ACCOUNT_ID,
+									   @"local_account_id": @"0000004-0000004-000004",
+									   @"realm": @"contoso.com",
+									   @"username": @"username"
                                        };
     MSIDAccountCacheItem *secondAccount = [[MSIDAccountCacheItem alloc] initWithJSONDictionary:secondDictionary error:&error];
     XCTAssertNil(error);


### PR DESCRIPTION
## Proposed changes

In the past, we disabled these tests in MSAL C++ because of the account type discrepancy issue. Currently, after resolving that problem, we are willing to run these tests in our CI. 
And there are three bugs which will fail the tests on our side:

1. The home_account_id should be in UUID format.
2. MSAIAccountInternal requires nonnull values, so we need to add all of the values while comparing the accountCacheItem with expectedDictionary.
3. localAccountId, realm, and username cannot be nil while creating an account.

According to these bugs, I made this PR. If there is any problem, please let me know.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

