### PR TITLE
Modify init method for keychain token cache so that developers can se…

### DIFF
--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.h
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.h
@@ -27,6 +27,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDMacACLKeychainAccessor : NSObject
 
+/*!
+ The queue which keychain will use to perform API actions
+
+ It can be set for only once, if getter was used ealier than setter, it will be set with default queue automatically
+ */
+@property (class, nullable) dispatch_queue_t s_synchronizationQueue;
+
 @property (readonly, nonnull) id accessControlForSharedItems;
 @property (readonly, nonnull) id accessControlForNonSharedItems;
 

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.h
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  It can be set for only once, if getter was used ealier than setter, it will be set with default queue automatically
  */
-@property (class, nullable) dispatch_queue_t s_synchronizationQueue;
+@property (class, nullable) dispatch_queue_t synchronizationQueue;
 
 @property (readonly, nonnull) id accessControlForSharedItems;
 @property (readonly, nonnull) id accessControlForNonSharedItems;

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -26,7 +26,7 @@
 #import "MSIDLogger+Internal.h"
 #import "MSIDKeychainUtil.h"
 
-static dispatch_queue_t s_defaultSynchronizationQueue;
+static dispatch_queue_t s_synchronizationQueue;
 
 @interface MSIDMacACLKeychainAccessor ()
 
@@ -77,15 +77,15 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
     return self;
 }
 
-+ (void)setSynchronizationQueue:(dispatch_queue_t)s_synchronizationQueue
++ (void)setSynchronizationQueue:(dispatch_queue_t)synchronizationQueue
 {
-    if (s_defaultSynchronizationQueue)
+    if (s_synchronizationQueue)
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Failed to set dispatch queue, The queue has been provided by default");
         return;
     }
     
-    s_defaultSynchronizationQueue = s_synchronizationQueue;
+    s_synchronizationQueue = synchronizationQueue;
 }
 
 + (dispatch_queue_t)synchronizationQueue
@@ -100,12 +100,12 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
     // To protect the underlying keychain API, a single queue is used even if multiple instances of this class are allocated.
     static dispatch_once_t s_once;
     dispatch_once(&s_once, ^{
-        if (!s_defaultSynchronizationQueue)
+        if (!s_synchronizationQueue)
         {
-            s_defaultSynchronizationQueue = dispatch_queue_create("com.microsoft.msidmackeychaintokencache", DISPATCH_QUEUE_CONCURRENT);
+            s_synchronizationQueue = dispatch_queue_create("com.microsoft.msidmackeychaintokencache", DISPATCH_QUEUE_CONCURRENT);
         }
     });
-    return s_defaultSynchronizationQueue;
+    return s_synchronizationQueue;
 }
 
 #pragma mark - Access Control Lists

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -234,7 +234,7 @@ static dispatch_queue_t s_synchronizationQueue;
     updateQuery[(id)kSecValueData] = data;
     
     __block OSStatus status;
-    dispatch_barrier_sync(MSIDMacACLKeychainAccessor.synchronizationQueue, ^{
+    dispatch_barrier_sync(self.class.synchronizationQueue, ^{
         status = SecItemUpdate((CFDictionaryRef)query, (CFDictionaryRef)updateQuery);
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Keychain update status: %d.", (int)status);
         

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -26,7 +26,8 @@
 #import "MSIDLogger+Internal.h"
 #import "MSIDKeychainUtil.h"
 
-static dispatch_queue_t s_synchronizationQueue;
+static dispatch_queue_t s_customizedSynchronizationQueue;
+static dispatch_queue_t s_defaultSynchronizationQueue;
 
 @interface MSIDMacACLKeychainAccessor ()
 
@@ -79,17 +80,21 @@ static dispatch_queue_t s_synchronizationQueue;
 
 + (void)setSynchronizationQueue:(dispatch_queue_t)synchronizationQueue
 {
-    if (s_synchronizationQueue)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Failed to set dispatch queue, The queue has been provided by default");
-        return;
-    }
+    static dispatch_once_t s_once;
     
-    s_synchronizationQueue = synchronizationQueue;
+    dispatch_once(&s_once, ^{
+        s_customizedSynchronizationQueue = synchronizationQueue;
+    });
 }
 
 + (dispatch_queue_t)synchronizationQueue
 {
+    
+    if (s_customizedSynchronizationQueue)
+    {
+        return s_customizedSynchronizationQueue;
+    }
+    
     // Note: Apple seems to recommend serializing keychain API calls on macOS in this document:
     // https://developer.apple.com/documentation/security/certificate_key_and_trust_services/working_with_concurrency?language=objc
     // However, it's not entirely clear if this applies to all keychain APIs.
@@ -99,13 +104,12 @@ static dispatch_queue_t s_synchronizationQueue;
     //
     // To protect the underlying keychain API, a single queue is used even if multiple instances of this class are allocated.
     static dispatch_once_t s_once;
+    
     dispatch_once(&s_once, ^{
-        if (!s_synchronizationQueue)
-        {
-            s_synchronizationQueue = dispatch_queue_create("com.microsoft.msidmackeychaintokencache", DISPATCH_QUEUE_CONCURRENT);
-        }
+        s_defaultSynchronizationQueue = dispatch_queue_create("com.microsoft.msidmackeychaintokencache", DISPATCH_QUEUE_CONCURRENT);
     });
-    return s_synchronizationQueue;
+    
+    return s_defaultSynchronizationQueue;
 }
 
 #pragma mark - Access Control Lists


### PR DESCRIPTION
…t their own dispatch queue

## Proposed changes

Expose ```s_synchronizationQueue``` from ```MSIDMacACLKeychainAccessor``` and  provide getter and setter method to avoid other changes. Also partners can set the queue as early as possible 

Currently when execute any keychain APIs on MAC, Common core provided a concurrent queue as default and there is no way to override the default queue by providing customized one.

There is a request from our partner to provide such ability so that the default queue can be overridden .

No impacts to existing logics rather than API changes 

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

