### PR TITLE
add about:srcdoc into policy navigation in Oauth2Webview

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -367,7 +367,7 @@
         return;
     }
     
-    if ([requestURLString isEqualToString:@"about:blank"])
+    if ([requestURLString isEqualToString:@"about:blank"] || [requestURLString isEqualToString:@"about:srcdoc"])
     {
         decisionHandler(WKNavigationActionPolicyAllow);
         return;

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ TBD:
 * Enhanced logging in MSIDAccountCredentialCache. (#955) 
 * fix AT Pop sign request logic
 * Throttling feature (#945)
+* allow about:srcdoc in webview controller
 
 Version 1.6.2
 * Mask EUII in logs (#944)


### PR DESCRIPTION
## Proposed changes

add about:srcdoc into policy navigation in Oauth2Webview to fix Oauth2 flow in some providers (e.g facebook login).
## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

