### PR TITLE
Update telemetry string size limit to ESTS's new limits

### DIFF
--- a/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetrySerializedItem.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetrySerializedItem.m
@@ -64,7 +64,7 @@ static int telemetryStringSizeLimit = 100;
 {
     NSString *telemetryString = [NSString stringWithFormat:@"%@|%@|%@", self.schemaVersion, [self serializeFields: self.defaultFields], [self serializeFields: self.platformFields]];
     
-    if ([telemetryString lengthOfBytesUsingEncoding:NSUTF8StringEncoding] > telemetryStringSizeLimit)
+    if ((int)[telemetryString lengthOfBytesUsingEncoding:NSUTF8StringEncoding] > [MSIDCurrentRequestTelemetrySerializedItem telemetryStringSizeLimit])
     {
         return nil;
     }

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetrySerializedItem.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetrySerializedItem.m
@@ -33,8 +33,8 @@
 
 @implementation MSIDCurrentRequestTelemetrySerializedItem
 
-// Represents 4kB limit for size of telemetry string sent to server
-static int telemetryStringSizeLimit = 4000;
+// Represents 100 byte limit for size of current request telemetry string sent to server
+static int telemetryStringSizeLimit = 100;
 
 + (int)telemetryStringSizeLimit
 {
@@ -64,7 +64,7 @@ static int telemetryStringSizeLimit = 4000;
 {
     NSString *telemetryString = [NSString stringWithFormat:@"%@|%@|%@", self.schemaVersion, [self serializeFields: self.defaultFields], [self serializeFields: self.platformFields]];
     
-    if ([telemetryString lengthOfBytesUsingEncoding:NSUTF8StringEncoding] > 4000)
+    if ([telemetryString lengthOfBytesUsingEncoding:NSUTF8StringEncoding] > telemetryStringSizeLimit)
     {
         return nil;
     }

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetrySerializedItem.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetrySerializedItem.m
@@ -86,7 +86,7 @@ static int telemetryStringSizeLimit = 350;
         NSString *currentFailedRequest = [NSString stringWithFormat:@"%ld,%@", (long)self.errorsInfo[lastIndex].apiId, self.errorsInfo[lastIndex].correlationId ?: @""];
         NSString *currentErrorMessage = [NSString stringWithFormat:@"%@", self.errorsInfo[lastIndex].error ?: @""];
         
-        // Only add error info into string if the resulting string smaller than 4KB
+        // Only add error info into string if the resulting string smaller than size limit
         if ((int)([currentFailedRequest lengthOfBytesUsingEncoding:NSUTF8StringEncoding] +
                 [currentErrorMessage lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + startLength) < [MSIDLastRequestTelemetrySerializedItem telemetryStringSizeLimit])
         {
@@ -109,7 +109,7 @@ static int telemetryStringSizeLimit = 350;
             NSString *newFailedRequestsString = [currentFailedRequest stringByAppendingString:failedRequestsString];
             NSString *newErrorMessagesString = [currentErrorMessage stringByAppendingString:errorMessagesString];
             
-            // Only add next error into string if the resulting string smaller than 4KB, otherwise stop building
+            // Only add next error into string if the resulting string smaller than size limit, otherwise stop building
             // the string
             if ((int)([newFailedRequestsString lengthOfBytesUsingEncoding:NSUTF8StringEncoding] +
                     [newErrorMessagesString lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + startLength) < [MSIDLastRequestTelemetrySerializedItem telemetryStringSizeLimit])

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetrySerializedItem.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetrySerializedItem.m
@@ -33,6 +33,19 @@
 
 @implementation MSIDLastRequestTelemetrySerializedItem
 
+// // Represents 350 byte limit for size of last request telemetry string sent to server
+static int telemetryStringSizeLimit = 350;
+
++ (int)telemetryStringSizeLimit
+{
+    return telemetryStringSizeLimit;
+}
+
++ (void)setTelemetryStringSizeLimit:(int)newLimit
+{
+    telemetryStringSizeLimit = newLimit;
+}
+
 - (instancetype)initWithSchemaVersion:(NSNumber *)schemaVersion defaultFields:(NSArray *)defaultFields errorInfo:(NSArray *)errorsInfo platformFields:(NSArray *)platformFields
 {
     self = [super initWithSchemaVersion:schemaVersion defaultFields:defaultFields platformFields:platformFields];
@@ -75,7 +88,7 @@
         
         // Only add error info into string if the resulting string smaller than 4KB
         if ((int)([currentFailedRequest lengthOfBytesUsingEncoding:NSUTF8StringEncoding] +
-                [currentErrorMessage lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + startLength) < [MSIDCurrentRequestTelemetrySerializedItem telemetryStringSizeLimit])
+                [currentErrorMessage lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + startLength) < [MSIDLastRequestTelemetrySerializedItem telemetryStringSizeLimit])
         {
             failedRequestsString = [currentFailedRequest stringByAppendingString:failedRequestsString];
             errorMessagesString = [currentErrorMessage stringByAppendingString:errorMessagesString];
@@ -99,7 +112,7 @@
             // Only add next error into string if the resulting string smaller than 4KB, otherwise stop building
             // the string
             if ((int)([newFailedRequestsString lengthOfBytesUsingEncoding:NSUTF8StringEncoding] +
-                    [newErrorMessagesString lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + startLength) < [MSIDCurrentRequestTelemetrySerializedItem telemetryStringSizeLimit])
+                    [newErrorMessagesString lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + startLength) < [MSIDLastRequestTelemetrySerializedItem telemetryStringSizeLimit])
             {
                 failedRequestsString = newFailedRequestsString;
                 errorMessagesString = newErrorMessagesString;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.6.4
+* Added new limits to sizes of client telemetry strings sent to server
+
 Version 1.6.3
 * Add refresh_on field to access tokens (#964)
 * Improve logging for SSO extension and broker scenarios (#963)


### PR DESCRIPTION
## Proposed changes

ESTS has recently introduced a change to truncate telemetry strings in the "x-client-current-telemetry" and "x-client-last-telemetry" headers if they exceed 100 and 350 bytes respectively (the previous max limit for each string was 4kB). While we currently have nothing that will break if telemetry data is truncated on the server-side, it is useful to update the limits in our code so we are not sending excess data in our network requests. Also, we have code that sends telemetry data that has been cut off due to size during serialization in subsequent requests, so that can preserve the data that the server would truncate.

The last request serialization object will now override the telemetry string size methods in order to keep its own size limit value.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

