### PR TITLE
Fix redirect uri parsing in cba flow

### DIFF
--- a/IdentityCore/src/webview/response/MSIDCBAWebAADAuthResponse.m
+++ b/IdentityCore/src/webview/response/MSIDCBAWebAADAuthResponse.m
@@ -58,6 +58,7 @@
     {
         NSURLComponents *resultUrlComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
         resultUrlComponents.query = nil;
+        resultUrlComponents.fragment = nil;
         
         _redirectUri = resultUrlComponents.URL.absoluteString;
     }

--- a/IdentityCore/tests/MSIDCBAWebAADAuthResponseTests.m
+++ b/IdentityCore/tests/MSIDCBAWebAADAuthResponseTests.m
@@ -47,7 +47,6 @@
     XCTAssertFalse([MSIDCBAWebAADAuthResponse isCBAWebAADAuthResponse:url]);
 }
 
-
 - (void)testIsCBAWebAADAuthResponse_whenHostIncorrect_shouldReturnNO
 {
     NSURL *url = [NSURL URLWithString:@"msauth://somehost?querystring"];
@@ -60,11 +59,20 @@
     XCTAssertTrue([MSIDCBAWebAADAuthResponse isCBAWebAADAuthResponse:url]);
 }
 
-
-
 - (void)testInitWithURL_whenAllValid_shouldReturnResponseWithRedirect
 {
     NSURL *url = [NSURL URLWithString:@"msauth://code/redirect?code=somecode"];
+    NSError *error;
+    MSIDCBAWebAADAuthResponse *response = [[MSIDCBAWebAADAuthResponse alloc] initWithURL:url context:nil error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(response.authorizationCode, @"somecode");
+    XCTAssertEqualObjects(response.redirectUri, @"msauth://code/redirect");
+}
+
+- (void)testInitWithURL_whenValidUrlWithPound_shouldParseRedirectUriWithoutPound
+{
+    NSURL *url = [NSURL URLWithString:@"msauth://code/redirect?code=somecode#"];
     NSError *error;
     MSIDCBAWebAADAuthResponse *response = [[MSIDCBAWebAADAuthResponse alloc] initWithURL:url context:nil error:&error];
     

--- a/IdentityCore/tests/MSIDRedirectUriVerifierTests.m
+++ b/IdentityCore/tests/MSIDRedirectUriVerifierTests.m
@@ -87,6 +87,26 @@
     XCTAssertNil(error);
 }
 
+- (void)testMsidRedirectUriWithCustomUri_whenUriContainsFragment_shoulReturnError
+{
+    NSArray *urlTypes = @[@{@"CFBundleURLSchemes": @[@"msauth.test.bundle.identifier"]}];
+    [MSIDTestBundle overrideObject:urlTypes forKey:@"CFBundleURLTypes"];
+    [MSIDTestBundle overrideBundleId:@"test.bundle.identifier"];
+
+    NSString *redirectUri = @"msauth.test.bundle.identifier://auth#";
+    NSString *clientId = @"msidclient";
+
+    NSError *error = nil;
+    MSIDRedirectUri *result = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:redirectUri
+                                                                           clientId:clientId
+                                                           bypassRedirectValidation:NO
+                                                                              error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInternal);
+}
+
 - (void)testMSIDRedirectUri_whenCustomRedirectUri_andLegacyBrokerCapable_shouldReturnUriBrokerCapableYes
 {
     NSArray *urlTypes = @[@{@"CFBundleURLSchemes": @[@"myscheme"]}];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+TBD
+* Fix redirect uri parsing in cba flow (#972)
+
 Version 1.6.3
 * Add refresh_on field to access tokens (#964)
 * Improve logging for SSO extension and broker scenarios (#963)


### PR DESCRIPTION
## Proposed changes

Fix parsing of the redirect URI in CBA flow when the server returns URL with the hashtag.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

