### PR TITLE
revert the change on requetClaims lookup logic

### DIFF
--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -331,7 +331,7 @@
         return YES;
     }
     
-    if (!([NSString msidIsStringNilOrBlank:self.requestedClaims] || [NSString msidIsStringNilOrBlank:requestedClaims]) && !([self.requestedClaims isEqualToString:requestedClaims]))
+    if (!([NSString msidIsStringNilOrBlank:self.requestedClaims] && [NSString msidIsStringNilOrBlank:requestedClaims]) && !([self.requestedClaims isEqualToString:requestedClaims]))
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item did not have valid requestedClaims.", NSStringFromClass(self.class));
         return NO;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.6.4
+* Revert back the logic of checking requestedClaims
+
 Version 1.6.3
 * Add refresh_on field to access tokens (#964)
 * Improve logging for SSO extension and broker scenarios (#963)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 Version 1.6.4
-* Revert back the logic of checking requestedClaims
+* Revert back the logic of checking requestedClaims. (#974)
 
 Version 1.6.3
 * Add refresh_on field to access tokens (#964)


### PR DESCRIPTION
## Proposed changes

This is a hot-fix to revert a logic of comparing requestedClaims back to [this one](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/840#discussion_r486694061)

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

