### PR TITLE
Refresh_in telemetry changes

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -553,6 +553,9 @@
 		60F94D332210E8BD0035D956 /* MSIDV1IdToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 60F94D312210E8BD0035D956 /* MSIDV1IdToken.m */; };
 		60FDA9C521A18D3F001E09B8 /* MSIDDefaultBrokerRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FDA9C421A18D3F001E09B8 /* MSIDDefaultBrokerRequestTests.m */; };
 		60FDA9C721A19DA6001E09B8 /* MSIDDefaultBrokerResponseHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FDA9C621A19DA6001E09B8 /* MSIDDefaultBrokerResponseHandlerTests.m */; };
+		6599299D26296AA600830FD5 /* MSIDRequestTelemetryConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 6599299C26296AA600830FD5 /* MSIDRequestTelemetryConstants.h */; };
+		659929AB26296B0200830FD5 /* MSIDRequestTelemetryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 659929AA26296B0200830FD5 /* MSIDRequestTelemetryConstants.m */; };
+		659929AC26296B0200830FD5 /* MSIDRequestTelemetryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 659929AA26296B0200830FD5 /* MSIDRequestTelemetryConstants.m */; };
 		6E4F658C24D488010070CA36 /* MSIDSymmetricKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E4F658B24D488010070CA36 /* MSIDSymmetricKey.h */; };
 		6E4F658E24D4883A0070CA36 /* MSIDSymmetricKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E4F658D24D4883A0070CA36 /* MSIDSymmetricKey.m */; };
 		6E4F658F24D4883A0070CA36 /* MSIDSymmetricKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E4F658D24D4883A0070CA36 /* MSIDSymmetricKey.m */; };
@@ -2216,6 +2219,8 @@
 		60FDA9C621A19DA6001E09B8 /* MSIDDefaultBrokerResponseHandlerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDDefaultBrokerResponseHandlerTests.m; sourceTree = "<group>"; };
 		60FDA9D921A5EBBA001E09B8 /* MSIDTestCacheAccessorHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTestCacheAccessorHelper.h; sourceTree = "<group>"; };
 		60FDA9DA21A5EBCF001E09B8 /* MSIDTestCacheAccessorHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTestCacheAccessorHelper.m; sourceTree = "<group>"; };
+		6599299C26296AA600830FD5 /* MSIDRequestTelemetryConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDRequestTelemetryConstants.h; sourceTree = "<group>"; };
+		659929AA26296B0200830FD5 /* MSIDRequestTelemetryConstants.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDRequestTelemetryConstants.m; sourceTree = "<group>"; };
 		6E4F658B24D488010070CA36 /* MSIDSymmetricKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSymmetricKey.h; sourceTree = "<group>"; };
 		6E4F658D24D4883A0070CA36 /* MSIDSymmetricKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSymmetricKey.m; sourceTree = "<group>"; };
 		6E4F659024D48B120070CA36 /* MSIDSymmetricKeyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSymmetricKeyTests.m; sourceTree = "<group>"; };
@@ -3411,6 +3416,8 @@
 				74F04D48246C8AC000094017 /* MSIDLastRequestTelemetrySerializedItem.m */,
 				74F04D4C246CB5B100094017 /* MSIDCurrentRequestTelemetrySerializedItem+Internal.h */,
 				74D926C224B3EFC300AA4270 /* MSIDLastRequestTelemetry+Internal.h */,
+				6599299C26296AA600830FD5 /* MSIDRequestTelemetryConstants.h */,
+				659929AA26296B0200830FD5 /* MSIDRequestTelemetryConstants.m */,
 			);
 			path = request_telemetry;
 			sourceTree = "<group>";
@@ -5356,6 +5363,7 @@
 				B286B9A72389DD2E007833AD /* MSIDAADOAuthEmbeddedWebviewController.h in Headers */,
 				58B81F8224AD0F8B00E8799E /* MSIDWebResponseBaseOperation.h in Headers */,
 				23B5DF76234030B2002C530F /* MSIDRequestParameters+Broker.h in Headers */,
+				6599299D26296AA600830FD5 /* MSIDRequestTelemetryConstants.h in Headers */,
 				239D72D423625EF40008C76A /* MSIDJsonSerializableFactory.h in Headers */,
 				23B5DF7D234031EE002C530F /* MSIDSSOExtensionSilentTokenRequestController.h in Headers */,
 				B227035422A3633700030ADC /* MSIDMaskedLogParameter.h in Headers */,
@@ -6565,6 +6573,7 @@
 				B2C707F52192524700D917B8 /* MSIDDefaultTokenRequestProvider.m in Sources */,
 				B8DBEF652395CA6100A16651 /* MSIDKeychainTokenCache.m in Sources */,
 				600D19BE20964D9E0004CD43 /* MSIDWorkPlaceJoinUtil.m in Sources */,
+				659929AC26296B0200830FD5 /* MSIDRequestTelemetryConstants.m in Sources */,
 				58B81F8424AD0F8B00E8799E /* MSIDWebResponseBaseOperation.m in Sources */,
 				B214C3A01FE854FE0070C4F2 /* MSIDLegacyTokenCacheAccessor.m in Sources */,
 				1E62D0E5228B75E3000E2BBC /* MSIDKeychainUtil.m in Sources */,
@@ -7000,6 +7009,7 @@
 				B28BDA85217E9676003E5670 /* MSIDB2CIdTokenClaims.m in Sources */,
 				B26CEAFF2367ACFA009E6E54 /* MSIDSFAuthenticationSessionHandler.m in Sources */,
 				B2AF1D27218BCD900080C1A0 /* MSIDBrokerInteractiveController.m in Sources */,
+				659929AB26296B0200830FD5 /* MSIDRequestTelemetryConstants.m in Sources */,
 				23B018A023554B2B00207FEC /* MSIDBrokerOperationTokenRequest.m in Sources */,
 				B210F4381FDDEA23005A8F76 /* MSIDAADV1TokenResponse.m in Sources */,
 				A0C7DE7525D465CD00F5B5B6 /* MSIDThrottlingModelBase.m in Sources */,

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -132,8 +132,13 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
         if (accessTokenError)
         {
             completionBlock(nil, accessTokenError);
-            self.currentRequestTelemetry.tokenCacheRefresh = NoCachedAT;
             return;
+        }
+        
+        if (!accessToken)
+        {
+            self.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeNoCachedAT;
+            
         }
         
         BOOL enrollmentIdMatch = YES;
@@ -198,7 +203,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
             {
                 // unexpired token exists, but needs refresh. Store token to return if refresh attempt fails due to AAD being down
                 self.unexpiredRefreshNeededAccessToken = accessToken;
-                self.currentRequestTelemetry.tokenCacheRefresh = RefreshExpiredAT;
+                self.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeProactiveTokenRefresh;
                 MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Unexpired access token exists, but needs refresh, since refresh expired.");
             }
             
@@ -209,6 +214,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
             MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Access token has expired, but it is long-lived token.");
             
             self.extendedLifetimeAccessToken = accessToken;
+            self.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeExpiredAT;
         }
         else if (accessToken)
         {
@@ -223,7 +229,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
             else
             {
                 MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Access token has expired, removing it...");
-                self.currentRequestTelemetry.tokenCacheRefresh = ExpiredAT;
+                self.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeExpiredAT;
             }
             
             NSError *removalError = nil;

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -132,13 +132,12 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
         if (accessTokenError)
         {
             completionBlock(nil, accessTokenError);
-            self.currentRequestTelemetry.tokenCacheRefresh = NoCachedAT;
             return;
         }
         
         if (!accessToken)
         {
-            self.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeNoCachedAT;
+            self.currentRequestTelemetry.tokenCacheRefreshType = TokenCacheRefreshTypeNoCachedAT;
             
         }
         
@@ -204,7 +203,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
             {
                 // unexpired token exists, but needs refresh. Store token to return if refresh attempt fails due to AAD being down
                 self.unexpiredRefreshNeededAccessToken = accessToken;
-                self.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeProactiveTokenRefresh;
+                self.currentRequestTelemetry.tokenCacheRefreshType = TokenCacheRefreshTypeProactiveTokenRefresh;
                 MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Unexpired access token exists, but needs refresh, since refresh expired.");
             }
             
@@ -215,7 +214,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
             MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Access token has expired, but it is long-lived token.");
             
             self.extendedLifetimeAccessToken = accessToken;
-            self.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeExpiredAT;
+            self.currentRequestTelemetry.tokenCacheRefreshType = TokenCacheRefreshTypeExpiredAT;
         }
         else if (accessToken)
         {
@@ -230,7 +229,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
             else
             {
                 MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Access token has expired, removing it...");
-                self.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeExpiredAT;
+                self.currentRequestTelemetry.tokenCacheRefreshType = TokenCacheRefreshTypeExpiredAT;
             }
             
             NSError *removalError = nil;

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -132,6 +132,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
         if (accessTokenError)
         {
             completionBlock(nil, accessTokenError);
+            self.currentRequestTelemetry.tokenCacheRefresh = NoCachedAT;
             return;
         }
         

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.h
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.h
@@ -50,8 +50,7 @@ typedef NS_ENUM(NSInteger, TokenCacheRefreshType)
 
 @property (nonatomic) NSInteger schemaVersion;
 @property (nonatomic) NSInteger apiId;
-//@property (nonatomic) BOOL forceRefresh;
-@property (nonatomic) TokenCacheRefresh tokenCacheRefresh;
+@property (nonatomic) TokenCacheRefreshType tokenCacheRefreshType;
 
 
 @end

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.h
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.h
@@ -50,7 +50,9 @@ typedef NS_ENUM(NSInteger, TokenCacheRefreshType)
 
 @property (nonatomic) NSInteger schemaVersion;
 @property (nonatomic) NSInteger apiId;
+//@property (nonatomic) BOOL forceRefresh;
 @property (nonatomic) TokenCacheRefresh tokenCacheRefresh;
+
 
 @end
 

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.h
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.h
@@ -27,23 +27,23 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*
- •    InteractiveNoCacheLookupInvolved = 0, request goes to ESTS for interactive call for which there is no cache look-up involved (N/A for S2S).
- •    ForcedTokenRefresh = 1, request goes to ESTS because caller requested to forcefully refresh the cache.
- •    CacheMiss = 2, request goes to ESTS because cache entry for the requested token does NOT exist.
- •    CachedTokenExpired = 3, request goes to ESTS because cache entry for the requested token does exist but token has expired.
- •    ProactiveTokenRefresh = 4, request goes to ESTS because refresh_in was used and existing non-expired token needs to be refreshed proactively.
- •    CachingMechanismNotImplemented = 5, request goes to ESTS because client (for Non-MSAL client specifically for now) has not implemented any caching mechanism.
+ •    TokenCacheRefreshTypeNoCacheLookupInvolved = 0, request goes to ESTS for interactive call for which there is no cache look-up involved (N/A for S2S).
+ •    TokenCacheRefreshTypeForceRefresh = 1, request goes to ESTS because caller requested to forcefully refresh the cache.
+ •    TokenCacheRefreshTypeNoCachedAT = 2, request goes to ESTS because cache entry for the requested token does NOT exist.
+ •    TokenCacheRefreshTypeExpiredAT = 3, request goes to ESTS because cache entry for the requested token does exist but token has expired.
+ •    TokenCacheRefreshTypeProactiveTokenRefresh = 4, request goes to ESTS because refresh_in was used and existing non-expired token needs to be refreshed proactively.
+ •    TokenCacheRefreshTypeCachingMechanismNotImplemented = 5, request goes to ESTS because client (for Non-MSAL client specifically for now) has not implemented any caching mechanism.
  •    BLANK, if client is not aware of the LLT policy and its telemetry update and doesn’t update their code to send us this telemetry signal yet.
  */
 
-typedef NS_ENUM(NSInteger, TokenCacheRefresh)
+typedef NS_ENUM(NSInteger, TokenCacheRefreshType)
 {
-    NoCacheLookupInvolved,
-    ForceRefresh,
-    NoCachedAT,
-    ExpiredAT,
-    RefreshExpiredAT,
-    CachingMechanismNotImplemented,
+    TokenCacheRefreshTypeNoCacheLookupInvolved,
+    TokenCacheRefreshTypeForceRefresh,
+    TokenCacheRefreshTypeNoCachedAT,
+    TokenCacheRefreshTypeExpiredAT,
+    TokenCacheRefreshTypeProactiveTokenRefresh,
+    TokenCacheRefreshTypeCachingMechanismNotImplemented,
 };
 
 @interface MSIDCurrentRequestTelemetry : NSObject <MSIDTelemetryStringSerializable>

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.h
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.h
@@ -26,11 +26,31 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*
+ •    InteractiveNoCacheLookupInvolved = 0, request goes to ESTS for interactive call for which there is no cache look-up involved (N/A for S2S).
+ •    ForcedTokenRefresh = 1, request goes to ESTS because caller requested to forcefully refresh the cache.
+ •    CacheMiss = 2, request goes to ESTS because cache entry for the requested token does NOT exist.
+ •    CachedTokenExpired = 3, request goes to ESTS because cache entry for the requested token does exist but token has expired.
+ •    ProactiveTokenRefresh = 4, request goes to ESTS because refresh_in was used and existing non-expired token needs to be refreshed proactively.
+ •    CachingMechanismNotImplemented = 5, request goes to ESTS because client (for Non-MSAL client specifically for now) has not implemented any caching mechanism.
+ •    BLANK, if client is not aware of the LLT policy and its telemetry update and doesn’t update their code to send us this telemetry signal yet.
+ */
+
+typedef NS_ENUM(NSInteger, TokenCacheRefresh)
+{
+    NoCacheLookupInvolved,
+    ForceRefresh,
+    NoCachedAT,
+    ExpiredAT,
+    RefreshExpiredAT,
+    CachingMechanismNotImplemented,
+};
+
 @interface MSIDCurrentRequestTelemetry : NSObject <MSIDTelemetryStringSerializable>
 
 @property (nonatomic) NSInteger schemaVersion;
 @property (nonatomic) NSInteger apiId;
-@property (nonatomic) BOOL forceRefresh;
+@property (nonatomic) TokenCacheRefresh tokenCacheRefresh;
 
 @end
 

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.m
@@ -44,7 +44,7 @@
 
 - (MSIDCurrentRequestTelemetrySerializedItem *)createSerializedItem
 {
-    NSArray *defaultFields = @[[NSNumber numberWithInteger:self.apiId], [NSNumber numberWithBool:self.forceRefresh]];
+    NSArray *defaultFields = @[[NSNumber numberWithInteger:self.apiId], [NSNumber numberWithInteger:self.tokenCacheRefresh]];
     return [[MSIDCurrentRequestTelemetrySerializedItem alloc] initWithSchemaVersion:[NSNumber numberWithInteger:self.schemaVersion] defaultFields:defaultFields platformFields:nil];
 }
 

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDCurrentRequestTelemetry.m
@@ -44,7 +44,7 @@
 
 - (MSIDCurrentRequestTelemetrySerializedItem *)createSerializedItem
 {
-    NSArray *defaultFields = @[[NSNumber numberWithInteger:self.apiId], [NSNumber numberWithInteger:self.tokenCacheRefresh]];
+    NSArray *defaultFields = @[[NSNumber numberWithInteger:self.apiId], [NSNumber numberWithInteger:self.tokenCacheRefreshType]];
     return [[MSIDCurrentRequestTelemetrySerializedItem alloc] initWithSchemaVersion:[NSNumber numberWithInteger:self.schemaVersion] defaultFields:defaultFields platformFields:nil];
 }
 

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
@@ -25,6 +25,7 @@
 #import "MSIDLastRequestTelemetrySerializedItem.h"
 #import "NSKeyedArchiver+MSIDExtensions.h"
 #import "NSKeyedUnarchiver+MSIDExtensions.h"
+#import "MSIDRequestTelemetryConstants.h"
 
 @implementation MSIDRequestTelemetryErrorInfo
 
@@ -77,7 +78,6 @@
 @implementation MSIDLastRequestTelemetry
 
 static bool shouldReadFromDisk = YES;
-static const NSInteger currentSchemaVersion = 2;
 static int maxErrorCountToArchive = 75;
 
 + (int)telemetryStringSizeLimit
@@ -102,7 +102,7 @@ static int maxErrorCountToArchive = 75;
     self = [super init];
     if (self)
     {
-        _schemaVersion = currentSchemaVersion;
+        _schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
         _synchronizationQueue = [self initializeDispatchQueue];
         _platformFields = [NSMutableArray<NSString *> new];
     }
@@ -303,7 +303,7 @@ static int maxErrorCountToArchive = 75;
     self = [super init];
     if (self)
     {
-        if (schemaVersion == currentSchemaVersion)
+        if (schemaVersion == HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION)
         {
             _schemaVersion = schemaVersion;
             _silentSuccessfulCount = silentSuccessfulCount;

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDRequestTelemetryConstants.h
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDRequestTelemetryConstants.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+extern NSInteger const HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDRequestTelemetryConstants.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDRequestTelemetryConstants.m
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDRequestTelemetryConstants.h"
+
+NSInteger const HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION = 4;

--- a/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
+++ b/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
@@ -50,6 +50,16 @@
     NSString *result = [telemetryObject telemetryString];
     XCTAssertEqualObjects(result, @"2|30,0|");
 }
+-(void)testSerialization_whenRefreshReason_RefreshExpired_shouldCreateString
+{
+    MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
+    telemetryObject.schemaVersion = 2;
+    telemetryObject.tokenCacheRefresh = RefreshExpiredAT;
+    telemetryObject.apiId = 30;
+    
+    NSString *result = [telemetryObject telemetryString];
+    XCTAssertEqualObjects(result, @"2|30,4|");
+}
 
 -(void)testSerialization_whenRefreshReason_RefreshExpired_shouldCreateString
 {

--- a/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
+++ b/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
@@ -43,23 +43,23 @@
 -(void)testSerialization_whenValidProperties_shouldCreateString
 {
     MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
-    telemetryObject.schemaVersion = 2;
+    telemetryObject.schemaVersion = 4;
     telemetryObject.tokenCacheRefreshType = TokenCacheRefreshTypeNoCacheLookupInvolved;
     telemetryObject.apiId = 30;
     
     NSString *result = [telemetryObject telemetryString];
-    XCTAssertEqualObjects(result, @"2|30,0|");
+    XCTAssertEqualObjects(result, @"4|30,0|");
 }
 
 -(void)testSerialization_whenRefreshReason_RefreshExpired_shouldCreateString
 {
     MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
-    telemetryObject.schemaVersion = 2;
+    telemetryObject.schemaVersion = 4;
     telemetryObject.tokenCacheRefreshType = TokenCacheRefreshTypeProactiveTokenRefresh;
     telemetryObject.apiId = 30;
     
     NSString *result = [telemetryObject telemetryString];
-    XCTAssertEqualObjects(result, @"2|30,4|");
+    XCTAssertEqualObjects(result, @"4|30,4|");
 }
 
 

--- a/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
+++ b/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
@@ -44,33 +44,24 @@
 {
     MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
     telemetryObject.schemaVersion = 2;
-    telemetryObject.tokenCacheRefresh = NoCacheLookupInvolved;
+    telemetryObject.tokenCacheRefreshType = TokenCacheRefreshTypeNoCacheLookupInvolved;
     telemetryObject.apiId = 30;
     
     NSString *result = [telemetryObject telemetryString];
     XCTAssertEqualObjects(result, @"2|30,0|");
 }
+
 -(void)testSerialization_whenRefreshReason_RefreshExpired_shouldCreateString
 {
     MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
     telemetryObject.schemaVersion = 2;
-    telemetryObject.tokenCacheRefresh = RefreshExpiredAT;
+    telemetryObject.tokenCacheRefreshType = TokenCacheRefreshTypeProactiveTokenRefresh;
     telemetryObject.apiId = 30;
     
     NSString *result = [telemetryObject telemetryString];
     XCTAssertEqualObjects(result, @"2|30,4|");
 }
 
--(void)testSerialization_whenRefreshReason_RefreshExpired_shouldCreateString
-{
-    MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
-    telemetryObject.schemaVersion = 2;
-    telemetryObject.tokenCacheRefresh = RefreshExpiredAT;
-    telemetryObject.apiId = 30;
-
-    NSString *result = [telemetryObject telemetryString];
-    XCTAssertEqualObjects(result, @"2|30,4|");
-}
 
 -(void)testSerialization_whenNilProperties_shouldCreateString
 {

--- a/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
+++ b/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
@@ -23,6 +23,7 @@
 
 #import <XCTest/XCTest.h>
 #import "MSIDCurrentRequestTelemetry.h"
+#import "MSIDRequestTelemetryConstants.h"
 
 @interface MSIDCurrentRequestTelemetryTests : XCTestCase
 
@@ -43,7 +44,7 @@
 -(void)testSerialization_whenValidProperties_shouldCreateString
 {
     MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
-    telemetryObject.schemaVersion = 4;
+    telemetryObject.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
     telemetryObject.tokenCacheRefreshType = TokenCacheRefreshTypeNoCacheLookupInvolved;
     telemetryObject.apiId = 30;
     
@@ -54,7 +55,7 @@
 -(void)testSerialization_whenRefreshReason_RefreshExpired_shouldCreateString
 {
     MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
-    telemetryObject.schemaVersion = 4;
+    telemetryObject.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
     telemetryObject.tokenCacheRefreshType = TokenCacheRefreshTypeProactiveTokenRefresh;
     telemetryObject.apiId = 30;
     

--- a/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
+++ b/IdentityCore/tests/MSIDCurrentRequestTelemetryTests.m
@@ -44,11 +44,22 @@
 {
     MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
     telemetryObject.schemaVersion = 2;
-    telemetryObject.forceRefresh = NO;
+    telemetryObject.tokenCacheRefresh = NoCacheLookupInvolved;
     telemetryObject.apiId = 30;
     
     NSString *result = [telemetryObject telemetryString];
     XCTAssertEqualObjects(result, @"2|30,0|");
+}
+
+-(void)testSerialization_whenRefreshReason_RefreshExpired_shouldCreateString
+{
+    MSIDCurrentRequestTelemetry *telemetryObject = [MSIDCurrentRequestTelemetry new];
+    telemetryObject.schemaVersion = 2;
+    telemetryObject.tokenCacheRefresh = RefreshExpiredAT;
+    telemetryObject.apiId = 30;
+
+    NSString *result = [telemetryObject telemetryString];
+    XCTAssertEqualObjects(result, @"2|30,4|");
 }
 
 -(void)testSerialization_whenNilProperties_shouldCreateString

--- a/IdentityCore/tests/MSIDLastRequestTelemetryTests.m
+++ b/IdentityCore/tests/MSIDLastRequestTelemetryTests.m
@@ -96,7 +96,7 @@
     [telemetryObject updateWithApiId:30 errorString:@"error" context:self.context];
     NSString *result = [telemetryObject telemetryString];
     
-    XCTAssertEqualObjects(result, @"2|0|30,00000000-0000-0000-0000-000000000001|error|");
+    XCTAssertEqualObjects(result, @"4|0|30,00000000-0000-0000-0000-000000000001|error|");
 }
 
 - (void)testSerialization_whenValidProperties_shouldCreateString
@@ -110,7 +110,7 @@
     
     NSString *result = [telemetryObject telemetryString];
     
-    XCTAssertEqualObjects(result, @"2|0|30,00000000-0000-0000-0000-000000000001,40,00000000-0000-0000-0000-000000000001,50,00000000-0000-0000-0000-000000000001,60,00000000-0000-0000-0000-000000000001,70,00000000-0000-0000-0000-000000000001|error,error2,error3,error4,error5|");
+    XCTAssertEqualObjects(result, @"4|0|30,00000000-0000-0000-0000-000000000001,40,00000000-0000-0000-0000-000000000001,50,00000000-0000-0000-0000-000000000001,60,00000000-0000-0000-0000-000000000001,70,00000000-0000-0000-0000-000000000001|error,error2,error3,error4,error5|");
 }
 
 - (void)testSerialization_whenEmptyError_shouldCreateString
@@ -119,7 +119,7 @@
     [telemetryObject updateWithApiId:30 errorString:@"" context:nil];
     NSString *result = [telemetryObject telemetryString];
     
-    XCTAssertEqualObjects(result, @"2|0|30,||");
+    XCTAssertEqualObjects(result, @"4|0|30,||");
 }
 
 - (void)testSerialization_whenEmptyErrors_shouldCreateString
@@ -130,7 +130,7 @@
     [telemetryObject updateWithApiId:50 errorString:@"" context:nil];
     NSString *result = [telemetryObject telemetryString];
     
-    XCTAssertEqualObjects(result, @"2|0|30,,40,,50,|,,|");
+    XCTAssertEqualObjects(result, @"4|0|30,,40,,50,|,,|");
 }
 
 - (void)testSerialization_whenNilError_shouldCreateString
@@ -139,7 +139,7 @@
     [telemetryObject updateWithApiId:30 errorString:nil context:nil];
     NSString *result = [telemetryObject telemetryString];
     
-    XCTAssertEqualObjects(result, @"2|0|||");
+    XCTAssertEqualObjects(result, @"4|0|||");
 }
 
 - (void)testSerialization_whenNilErrors_shouldCreateString
@@ -153,7 +153,7 @@
     
     NSString *result = [telemetryObject telemetryString];
     
-    XCTAssertEqualObjects(result, @"2|0|||");
+    XCTAssertEqualObjects(result, @"4|0|||");
 }
 
 - (void)testSerialization_whenValidandNilProperties_shouldCreateString
@@ -174,7 +174,7 @@
     
     NSString *result = [telemetryObject telemetryString];
     
-    XCTAssertEqualObjects(result, @"2|0|70,00000000-0000-0000-0000-000000000001|error5|");
+    XCTAssertEqualObjects(result, @"4|0|70,00000000-0000-0000-0000-000000000001|error5|");
 }
  
 - (void)testSaveToDisk_whenSingleErrorSaved_shouldSaveAndRestoreToSameObject

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Added refresh_in telemetry changes and updated schema version to 4 (#983)
 * Added refresh_in changes for SilentTokenReuest flow (#975)
 * Fix redirect uri parsing in cba flow (#972)
 


### PR DESCRIPTION
## Proposed changes

Update server telemetry (Current Request Telemetry) to follow schema version 4. Replace existing field for force refresh with below values
 ->InteractiveNoCacheLookupInvolved = 0, request goes to ESTS for interactive call for which there is no cache look-up involved (N/A for S2S).
 -> ForcedTokenRefresh = 1, request goes to ESTS because caller requested to forcefully refresh the cache.
 -> CacheMiss = 2, request goes to ESTS because cache entry for the requested token does NOT exist.
 -> CachedTokenExpired = 3, request goes to ESTS because cache entry for the requested token does exist but token has expired.
 -> ProactiveTokenRefresh = 4, request goes to ESTS because refresh_in was used and existing non-expired token needs to be refreshed proactively.
 -> CachingMechanismNotImplemented = 5, request goes to ESTS because client (for Non-MSAL client specifically for now) has not implemented any caching mechanism.
 •    BLANK, if client is not aware of the LLT policy and its telemetry update and doesn’t update their code to send us this telemetry signal yet.
 
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

