### PR TITLE
Adding a BOOL property in request parameters

### DIFF
--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -60,6 +60,8 @@
 @property (nonatomic) NSString *intuneApplicationIdentifier;
 @property (nonatomic) MSIDRequestType requestType;
 @property (nonatomic) MSIDCurrentRequestTelemetry *currentRequestTelemetry;
+// indicates if current process is SSO extension
+@property (nonatomic,readonly) BOOL isFromSSOExtension;
 
 #pragma mark MSIDRequestContext properties
 @property (nonatomic) NSUUID *correlationId;

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -123,7 +123,7 @@
                             MSID_APP_VER_KEY: appVer ? appVer : @""};
     
     _authScheme = [MSIDAuthenticationScheme new];
-    _isFromSSOExtension = metadata[@"IsSSOExtension"];
+    _isFromSSOExtension = [metadata[@"IsSSOExtension"] boolValue];
 }
 
 #pragma mark - Helpers

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -123,6 +123,7 @@
                             MSID_APP_VER_KEY: appVer ? appVer : @""};
     
     _authScheme = [MSIDAuthenticationScheme new];
+    _isFromSSOExtension = metadata[@"IsSSOExtension"];
 }
 
 #pragma mark - Helpers

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 TBD: 
 * Minimum Xcode version bumped to 12.2 (#981)
 * Improve telemetry storage security (#981)
+* Added property in request parameter to indicate if it was initialized from SSO extension. (#989)
 
 Version 1.6.4
 * Added refresh_in telemetry changes and updated schema version to 4 (#983)


### PR DESCRIPTION
## Proposed changes

Adding a BOOL property in request parameters that will indicate if the request was initiated from within SSO extension.
Since the parameters are initially read from info plist, this property will read as true only from targets in broker project which are for SSO extension. Related broker PR : https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/726 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

