### PR TITLE
Rename the UIApplication Extensions

### DIFF
--- a/IdentityCore/src/util/ios/UIApplication+MSIDExtensions.h
+++ b/IdentityCore/src/util/ios/UIApplication+MSIDExtensions.h
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@interface UIApplication (internal)
+@interface UIApplication (MSIDExtensions)
 
 + (UIViewController *)msidCurrentViewController:(UIViewController *)parentController;
 

--- a/IdentityCore/src/util/ios/UIApplication+MSIDExtensions.m
+++ b/IdentityCore/src/util/ios/UIApplication+MSIDExtensions.m
@@ -25,7 +25,7 @@
 #import "MSIDAppExtensionUtil.h"
 #import "UIApplication+MSIDExtensions.h"
 
-@implementation UIApplication ( internal )
+@implementation UIApplication (MSIDExtensions)
 
 + (UIViewController *)msidCurrentViewController:(UIViewController *)parentController
 {


### PR DESCRIPTION
## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
OneAuth-MSAL did renaming from `MSID` prefix to `MSAIMSID` to avoid conflicts between OneAuth-MSAL and ADAL. This file used random word in the extensions which our automation script in under MSAL cpp didn't detect, and lead to compiling conflict for Outlook who consume both OneAuth-MSAL and ADAL. So rename to `MSIDExtensions` as other extension files.  See this [teams thread](https://teams.microsoft.com/l/message/19:79277c14b7314a308a29465e43d91b67@thread.skype/1623198298182?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=83a3ee91-d323-4a09-b01c-6ee0bae50992&parentMessageId=1623198298182&teamName=OneAuth&channelName=Outlook%20Collaboration%20(iOS)&createdTime=1623198298182) as reference.
