### PR TITLE
Fixing casting to unsigned ints

### DIFF
--- a/IdentityCore/src/throttling/cache/MSIDThrottlingCacheRecord.h
+++ b/IdentityCore/src/throttling/cache/MSIDThrottlingCacheRecord.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSDate *creationTime;
 @property (nonatomic, readonly) NSDate *expirationTime;
-@property (nonatomic) NSUInteger throttleType;
+@property (nonatomic) NSInteger throttleType;
 @property (nonatomic, readonly) NSError *cachedErrorResponse;
 @property (nonatomic) NSUInteger throttledCount;
 //number of times this request has been throttled - needs to be mutable 

--- a/IdentityCore/src/webview/background/ios/MSIDBackgroundTaskManager.m
+++ b/IdentityCore/src/webview/background/ios/MSIDBackgroundTaskManager.m
@@ -108,7 +108,7 @@
 
 - (UIBackgroundTaskIdentifier)backgroundTaskWithType:(MSIDBackgroundTaskType)type
 {
-    return [[self.taskCache objectForKey:@(type)] integerValue];
+    return [[self.taskCache objectForKey:@(type)] unsignedIntValue];
 }
 
 - (void)setBackgroundTask:(UIBackgroundTaskIdentifier)backgroundTask forType:(MSIDBackgroundTaskType)type

--- a/IdentityCore/tests/MSIDLRUCacheTest.m
+++ b/IdentityCore/tests/MSIDLRUCacheTest.m
@@ -254,7 +254,7 @@
     
     for (int i = 0; i < 100; i++)
     {
-        NSUInteger currentKey;
+        NSInteger currentKey;
         if (i < 100)
         {
             currentKey = 299 - i;


### PR DESCRIPTION
## Proposed changes

As pointed in following issues : 
https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/issues/993
https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/issues/991
there are some implicit casts performed.

I don't think existing code will cause any issues as : 
 - input param MSIDBackgroundTaskType is an enum with values 0 and 1 passed into MSIDBackgroundTaskManager setBackgroundTask: so the case should always work.
 - throttlingType is passed in as enum MSIDThrottlingType with values ranging 0 to 2

Please disregard PR if the changes are not necessary.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

