### PR TITLE
Add nil check for sourceApplication and do a early return if response…

### DIFF
--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -288,7 +288,7 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
            sourceApplication:(nullable NSString *)sourceApplication
        brokerResponseHandler:(nonnull MSIDBrokerResponseHandler *)responseHandler
 {
-    // sourceApplication could be nil, we want to return early if we know for sure response is not from broker
+    // sourceApplication could be nil or empty, we want to return early if we know for sure response is not from broker
     if (![NSString msidIsStringNilOrBlank:sourceApplication] && ![self isResponseFromBroker:sourceApplication])
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelWarning,nil, @"Asked to handle non broker response. Skipping request.");

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -288,7 +288,7 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
        brokerResponseHandler:(nonnull MSIDBrokerResponseHandler *)responseHandler
 {
     // sourceApplication could be nil, we want to return early if we know for sure response is not from broker
-    if (sourceApplication && ![self isResponseFromBroker:sourceApplication])
+    if (!sourceApplication || (sourceApplication && ![self isResponseFromBroker:sourceApplication]))
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelWarning,nil, @"Asked to handle non broker response. Skipping request.");
         return NO;

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -42,6 +42,7 @@
 #import "MSIDBrokerInvocationOptions.h"
 #import "MSIDBrokerKeyProvider.h"
 #import "MSIDMainThreadUtil.h"
+#import "NSString+MSIDExtensions.h"
 
 static MSIDBrokerInteractiveController *s_currentExecutingController;
 
@@ -288,7 +289,7 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
        brokerResponseHandler:(nonnull MSIDBrokerResponseHandler *)responseHandler
 {
     // sourceApplication could be nil, we want to return early if we know for sure response is not from broker
-    if (!sourceApplication || (sourceApplication && ![self isResponseFromBroker:sourceApplication]))
+    if (![NSString msidIsStringNilOrBlank:sourceApplication] && ![self isResponseFromBroker:sourceApplication])
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelWarning,nil, @"Asked to handle non broker response. Skipping request.");
         return NO;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+TBD
+
 Version 1.6.6
 * Fix telemetry enum value for refresh_in getting overwritten (#996)
 * Update automation for Xcode 12 UI


### PR DESCRIPTION
… is not from broker

The comment mentioned should return early when sourcerApplication, but looks like the logic is missing. Add a fix in

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

