### PR TITLE
Repetitive log when query account from cache

### DIFF
--- a/IdentityCore/src/cache/key/MSIDDefaultAccountCacheQuery.m
+++ b/IdentityCore/src/cache/key/MSIDDefaultAccountCacheQuery.m
@@ -35,16 +35,6 @@
     return nil;
 }
 
-- (NSNumber *)type
-{
-    if (self.accountType != MSIDAccountTypeOther)
-    {
-        return [super type];
-    }
-
-    return nil;
-}
-
 - (BOOL)exactMatch
 {
     return self.homeAccountId && self.environment && self.realm;

--- a/IdentityCore/src/cache/key/MSIDDefaultAccountCacheQuery.m
+++ b/IdentityCore/src/cache/key/MSIDDefaultAccountCacheQuery.m
@@ -25,6 +25,16 @@
 
 @implementation MSIDDefaultAccountCacheQuery
 
+- (id)init
+{
+    self = [super init];
+    if (self != nil)
+    {
+        self.accountType = MSIDAccountTypeMSSTS;
+    }
+    return self;
+}
+
 - (NSString *)account
 {
     if (self.homeAccountId && self.environment)

--- a/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
+++ b/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
@@ -2127,8 +2127,9 @@
     NSArray *allItems = [self.cache getAllItemsWithContext:nil error:&error];
     XCTAssertNil(error);
     XCTAssertTrue([allItems count] == 4);
-
-    NSArray *allAccounts = [self.cache getAccountsWithQuery:[MSIDDefaultAccountCacheQuery new] context:nil error:&error];
+    MSIDDefaultAccountCacheQuery *accountCacheQuery = [MSIDDefaultAccountCacheQuery new];
+    accountCacheQuery.accountType = MSIDAccountTypeMSSTS;
+    NSArray *allAccounts = [self.cache getAccountsWithQuery:accountCacheQuery context:nil error:&error];
     XCTAssertTrue([allAccounts count] == 1);
 
     BOOL result = [self.cache clearWithContext:nil error:&error];
@@ -2421,7 +2422,7 @@
 
     MSIDAccountCacheItem *account2 = [self createTestAccountCacheItem];
     account2.homeAccountId = @"uid.utid2";
-
+    
     [self saveAccount:account2];
 
     NSError *error = nil;
@@ -2430,6 +2431,7 @@
     query.homeAccountId = @"uid.utid2";
     query.environment = @"login.microsoftonline.com";
     query.realm = @"contoso.com";
+    query.accountType = MSIDAccountTypeMSSTS;
     XCTAssertTrue(query.exactMatch);
 
     NSArray *results = [self.cache getAccountsWithQuery:query context:nil error:&error];
@@ -2452,6 +2454,7 @@
 
     MSIDDefaultAccountCacheQuery *query = [MSIDDefaultAccountCacheQuery new];
     query.homeAccountId = @"uid.uTID2";
+    query.accountType = MSIDAccountTypeMSSTS;
     XCTAssertFalse(query.exactMatch);
 
     NSArray *results = [self.cache getAccountsWithQuery:query context:nil error:&error];
@@ -2474,6 +2477,8 @@
 
     MSIDDefaultAccountCacheQuery *query = [MSIDDefaultAccountCacheQuery new];
     query.environment = @"login.windows.net";
+    query.accountType = MSIDAccountTypeMSSTS;
+
     XCTAssertFalse(query.exactMatch);
 
     NSArray *results = [self.cache getAccountsWithQuery:query context:nil error:&error];
@@ -2496,6 +2501,8 @@
 
     MSIDDefaultAccountCacheQuery *query = [MSIDDefaultAccountCacheQuery new];
     query.environmentAliases = @[@"login.microsoftonline.us", @"login.windows.net"];
+    query.accountType = MSIDAccountTypeMSSTS;
+
     XCTAssertFalse(query.exactMatch);
 
     NSArray *results = [self.cache getAccountsWithQuery:query context:nil error:&error];
@@ -2518,6 +2525,8 @@
 
     MSIDDefaultAccountCacheQuery *query = [MSIDDefaultAccountCacheQuery new];
     query.realm = @"contoso2.com";
+    query.accountType = MSIDAccountTypeMSSTS;
+
     XCTAssertFalse(query.exactMatch);
 
     NSArray *results = [self.cache getAccountsWithQuery:query context:nil error:&error];
@@ -2544,6 +2553,8 @@
     query.homeAccountId = @"uid.utid2";
     query.environment = @"login.microsoftonline.com";
     query.realm = @"contoso.com";
+    query.accountType = MSIDAccountTypeMSSTS;
+
     XCTAssertTrue(query.exactMatch);
 
     BOOL result = [self.cache removeAccountsWithQuery:query context:nil error:&error];
@@ -2551,7 +2562,7 @@
     XCTAssertNil(error);
 
     MSIDDefaultAccountCacheQuery *allItemsQuery = [MSIDDefaultAccountCacheQuery new];
-
+    allItemsQuery.accountType = MSIDAccountTypeMSSTS;
     NSArray *results = [self.cache getAccountsWithQuery:allItemsQuery context:nil error:&error];
     XCTAssertNotNil(results);
     XCTAssertNil(error);
@@ -2574,6 +2585,8 @@
     MSIDDefaultAccountCacheQuery *query = [MSIDDefaultAccountCacheQuery new];
     query.environment = @"login.microsoftonline.com";
     query.realm = @"contoso.com";
+    query.accountType = MSIDAccountTypeMSSTS;
+
     XCTAssertFalse(query.exactMatch);
 
     BOOL result = [self.cache removeAccountsWithQuery:query context:nil error:&error];

--- a/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
+++ b/IdentityCore/tests/mac/MSIDMacKeychainTokenCacheTests.m
@@ -189,6 +189,7 @@
 
     _queryAll = [MSIDDefaultAccountCacheQuery new];
     _queryAll.realm = _accountA.realm;
+    _queryAll.accountType = MSIDAccountTypeMSSTS;
     // Ensure accounts don't already match the queryAll search key:
     NSArray<MSIDAccountCacheItem *> *accountList = [_cache getAccountsWithQuery:_queryAll context:nil error:&error];
     XCTAssertNil(error);
@@ -450,7 +451,7 @@
     NSError *error;
     NSArray<MSIDAccountCacheItem *> *foundAccounts = [_cache getAccountsWithQuery:_queryAll context:nil error:&error];
     XCTAssertNil(error);
-    NSArray<MSIDAccountCacheItem *> *expectedAccounts = [[NSArray alloc] initWithObjects:_accountA, _accountB, _accountC, nil];
+    NSArray<MSIDAccountCacheItem *> *expectedAccounts = [[NSArray alloc] initWithObjects:_accountA, _accountB, nil];
     BOOL isAccountListSame = [self arraysContainSameObjects:foundAccounts andOtherArray:expectedAccounts];
     XCTAssertTrue(isAccountListSame);
     [self multiAccountTestCleanup];
@@ -484,6 +485,7 @@
     MSIDAccountCacheItem *expectedAccount = _accountB;
     MSIDDefaultAccountCacheQuery *query = [MSIDDefaultAccountCacheQuery new];
     query.homeAccountId = _accountB.homeAccountId;
+    query.accountType = MSIDAccountTypeMSSTS;
     accountList = [_cache getAccountsWithQuery:query context:nil error:&error];
     XCTAssertNil(error);
     XCTAssertTrue(accountList.count == 1);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 TBD
 * Handle SSO Nonce response for interactive requests to authorize endpoint (#1005)
-
+* Update default account type to MSSTS in account cache query to avoid noise in cache query (#1010)
 Version 1.6.6
 * Fix telemetry enum value for refresh_in getting overwritten (#996)
 * Update automation for Xcode 12 UI


### PR DESCRIPTION
## Proposed changes

Report in this [link](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1449130)
These messages are repetitive written:
`2021-06-25T06:33:56.781Z kWarning [MSAL:0001] WARNING -[MSAIMSIDAccountCacheItem initWithJSONDictionary:error:]:284 No account type present in the JSON for credential`

`2021-06-25T06:33:56.781Z kVerbose [MSAL:0001] DEBUG   -[MSAIMSIDCacheItemJsonSerializer deserializeCacheItem:ofClass:]:96 TID=515301 (main thread) MSAL.xplat.iOS 1.0.0+bdeeb209 iOS 14.6 [2021-06-25 06:33:56] Failed to deserialize object (null) of expected class MSAIMSIDAccountCacheItem`

`2021-06-25T06:33:56.782Z kInfo [MSAL:0001] INFO   -[MSAIMSIDKeychainTokenCache cacheItemsWithKey:serializer:cacheItemClass:context:error:]:755 TID=515301 (main thread) MSAL.xplat.iOS 1.0.0+bdeeb209 iOS 14.6 [2021-06-25 06:33:56] Failed to deserialize item with class MSAIMSIDAccountCacheItem.`

I suspect the error is because kSecAttrType is nil in the query critirical.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

