### PR TITLE
Added additional errors to throttle

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -683,8 +683,8 @@
 		96F94A3B208184790034676C /* MSIDOAuth2EmbeddedWebviewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F94A38208184790034676C /* MSIDOAuth2EmbeddedWebviewController.m */; };
 		A0410E0825E81C5D004D80FD /* MSIDThrottlingModel429Test.m in Sources */ = {isa = PBXBuildFile; fileRef = A0410E0725E81C5D004D80FD /* MSIDThrottlingModel429Test.m */; };
 		A0410E0925E81C5D004D80FD /* MSIDThrottlingModel429Test.m in Sources */ = {isa = PBXBuildFile; fileRef = A0410E0725E81C5D004D80FD /* MSIDThrottlingModel429Test.m */; };
-		A0410E1A25E87E1A004D80FD /* MSIDThrottlingModelInteractionRequireTest.m in Sources */ = {isa = PBXBuildFile; fileRef = A0410E1925E87E1A004D80FD /* MSIDThrottlingModelInteractionRequireTest.m */; };
-		A0410E1B25E87E1A004D80FD /* MSIDThrottlingModelInteractionRequireTest.m in Sources */ = {isa = PBXBuildFile; fileRef = A0410E1925E87E1A004D80FD /* MSIDThrottlingModelInteractionRequireTest.m */; };
+		A0410E1A25E87E1A004D80FD /* MSIDThrottlingModelNonRecoverableServerError.m in Sources */ = {isa = PBXBuildFile; fileRef = A0410E1925E87E1A004D80FD /* MSIDThrottlingModelNonRecoverableServerError.m */; };
+		A0410E1B25E87E1A004D80FD /* MSIDThrottlingModelNonRecoverableServerError.m in Sources */ = {isa = PBXBuildFile; fileRef = A0410E1925E87E1A004D80FD /* MSIDThrottlingModelNonRecoverableServerError.m */; };
 		A0410E5025E88B5E004D80FD /* MSIDThrottlingMetaDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = A0410E4F25E88B5E004D80FD /* MSIDThrottlingMetaDataTest.m */; };
 		A0410E5125E88B5E004D80FD /* MSIDThrottlingMetaDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = A0410E4F25E88B5E004D80FD /* MSIDThrottlingMetaDataTest.m */; };
 		A057456225A669B90098E469 /* MSIDThrottlingCacheRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = E7B67215257EA84B0053773F /* MSIDThrottlingCacheRecord.h */; };
@@ -707,8 +707,8 @@
 		A0C7DE8525D46D7000F5B5B6 /* MSIDThrottlingModelFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = A0C7DE8325D46D7000F5B5B6 /* MSIDThrottlingModelFactory.m */; };
 		A0C7DEC325D4C8B600F5B5B6 /* MSIDThrottlingModel429.m in Sources */ = {isa = PBXBuildFile; fileRef = A0C7DEC225D4C8B600F5B5B6 /* MSIDThrottlingModel429.m */; };
 		A0C7DEC425D4C8B600F5B5B6 /* MSIDThrottlingModel429.m in Sources */ = {isa = PBXBuildFile; fileRef = A0C7DEC225D4C8B600F5B5B6 /* MSIDThrottlingModel429.m */; };
-		A0C7DED225D4CB2800F5B5B6 /* MSIDThrottlingModelInteractionRequire.m in Sources */ = {isa = PBXBuildFile; fileRef = A0C7DED125D4CB2800F5B5B6 /* MSIDThrottlingModelInteractionRequire.m */; };
-		A0C7DED325D4CB2800F5B5B6 /* MSIDThrottlingModelInteractionRequire.m in Sources */ = {isa = PBXBuildFile; fileRef = A0C7DED125D4CB2800F5B5B6 /* MSIDThrottlingModelInteractionRequire.m */; };
+		A0C7DED225D4CB2800F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.m in Sources */ = {isa = PBXBuildFile; fileRef = A0C7DED125D4CB2800F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.m */; };
+		A0C7DED325D4CB2800F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.m in Sources */ = {isa = PBXBuildFile; fileRef = A0C7DED125D4CB2800F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.m */; };
 		A0E540BD25CB62270016E167 /* MSIDThrottlingService.m in Sources */ = {isa = PBXBuildFile; fileRef = A057458325A789DC0098E469 /* MSIDThrottlingService.m */; };
 		A0E5419625CDC44B0016E167 /* MSIDThrottlingMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = A0E5419525CDC44B0016E167 /* MSIDThrottlingMetaData.h */; };
 		A0E541B025CDC5F10016E167 /* MSIDThrottlingMetaData.m in Sources */ = {isa = PBXBuildFile; fileRef = A0E541AF25CDC5F10016E167 /* MSIDThrottlingMetaData.m */; };
@@ -2327,7 +2327,7 @@
 		96F94A37208184790034676C /* MSIDOAuth2EmbeddedWebviewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDOAuth2EmbeddedWebviewController.h; sourceTree = "<group>"; };
 		96F94A38208184790034676C /* MSIDOAuth2EmbeddedWebviewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOAuth2EmbeddedWebviewController.m; sourceTree = "<group>"; };
 		A0410E0725E81C5D004D80FD /* MSIDThrottlingModel429Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MSIDThrottlingModel429Test.m; path = throttling/MSIDThrottlingModel429Test.m; sourceTree = "<group>"; };
-		A0410E1925E87E1A004D80FD /* MSIDThrottlingModelInteractionRequireTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MSIDThrottlingModelInteractionRequireTest.m; path = throttling/MSIDThrottlingModelInteractionRequireTest.m; sourceTree = "<group>"; };
+		A0410E1925E87E1A004D80FD /* MSIDThrottlingModelNonRecoverableServerError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MSIDThrottlingModelNonRecoverableServerError.m; path = throttling/MSIDThrottlingModelNonRecoverableServerError.m; sourceTree = "<group>"; };
 		A0410E4F25E88B5E004D80FD /* MSIDThrottlingMetaDataTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MSIDThrottlingMetaDataTest.m; path = throttling/MSIDThrottlingMetaDataTest.m; sourceTree = "<group>"; };
 		A057458325A789DC0098E469 /* MSIDThrottlingService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDThrottlingService.m; sourceTree = "<group>"; };
 		A07EB426259D0BF300783943 /* MSIDThrottlingService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingService.h; sourceTree = "<group>"; };
@@ -2349,11 +2349,11 @@
 		A0C7DE3425D451DF00F5B5B6 /* MSIDThrottlingModelBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingModelBase.h; sourceTree = "<group>"; };
 		A0C7DE4325D4522300F5B5B6 /* MSIDThrottlingModelFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingModelFactory.h; sourceTree = "<group>"; };
 		A0C7DE5D25D4523800F5B5B6 /* MSIDThrottlingModel429.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingModel429.h; sourceTree = "<group>"; };
-		A0C7DE5E25D4524D00F5B5B6 /* MSIDThrottlingModelInteractionRequire.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingModelInteractionRequire.h; sourceTree = "<group>"; };
+		A0C7DE5E25D4524D00F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingModelNonRecoverableServerError.h; sourceTree = "<group>"; };
 		A0C7DE7425D465CD00F5B5B6 /* MSIDThrottlingModelBase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDThrottlingModelBase.m; sourceTree = "<group>"; };
 		A0C7DE8325D46D7000F5B5B6 /* MSIDThrottlingModelFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDThrottlingModelFactory.m; sourceTree = "<group>"; };
 		A0C7DEC225D4C8B600F5B5B6 /* MSIDThrottlingModel429.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDThrottlingModel429.m; sourceTree = "<group>"; };
-		A0C7DED125D4CB2800F5B5B6 /* MSIDThrottlingModelInteractionRequire.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDThrottlingModelInteractionRequire.m; sourceTree = "<group>"; };
+		A0C7DED125D4CB2800F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDThrottlingModelNonRecoverableServerError.m; sourceTree = "<group>"; };
 		A0E5419525CDC44B0016E167 /* MSIDThrottlingMetaData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingMetaData.h; sourceTree = "<group>"; };
 		A0E541AF25CDC5F10016E167 /* MSIDThrottlingMetaData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDThrottlingMetaData.m; sourceTree = "<group>"; };
 		A0E541D325CDDAB30016E167 /* MSIDThrottlingMetaDataCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingMetaDataCache.h; sourceTree = "<group>"; };
@@ -3873,8 +3873,8 @@
 				A0C7DE8325D46D7000F5B5B6 /* MSIDThrottlingModelFactory.m */,
 				A0C7DE5D25D4523800F5B5B6 /* MSIDThrottlingModel429.h */,
 				A0C7DEC225D4C8B600F5B5B6 /* MSIDThrottlingModel429.m */,
-				A0C7DE5E25D4524D00F5B5B6 /* MSIDThrottlingModelInteractionRequire.h */,
-				A0C7DED125D4CB2800F5B5B6 /* MSIDThrottlingModelInteractionRequire.m */,
+				A0C7DE5E25D4524D00F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.h */,
+				A0C7DED125D4CB2800F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.m */,
 			);
 			path = model;
 			sourceTree = "<group>";
@@ -4965,7 +4965,7 @@
 			isa = PBXGroup;
 			children = (
 				A0410E4F25E88B5E004D80FD /* MSIDThrottlingMetaDataTest.m */,
-				A0410E1925E87E1A004D80FD /* MSIDThrottlingModelInteractionRequireTest.m */,
+				A0410E1925E87E1A004D80FD /* MSIDThrottlingModelNonRecoverableServerError.m */,
 				A0410E0725E81C5D004D80FD /* MSIDThrottlingModel429Test.m */,
 				A08D0A4724A8841400C9193D /* MSIDAuthenticationSchemeTest.m */,
 				A08D09DF24A85A1D00C9193D /* MSIDAADRefreshTokenGrantRequestTest.m */,
@@ -6300,7 +6300,7 @@
 				B27893732470BA5B00627C28 /* MSIDAssymetricKeychainGeneratorTests.m in Sources */,
 				23B3A4552187BA79009070B2 /* MSIDIntuneEnrollmentIdsCacheTests.m in Sources */,
 				B2936F7420ABEFC10050C585 /* MSIDAccessTokenTests.m in Sources */,
-				A0410E1A25E87E1A004D80FD /* MSIDThrottlingModelInteractionRequireTest.m in Sources */,
+				A0410E1A25E87E1A004D80FD /* MSIDThrottlingModelNonRecoverableServerError.m in Sources */,
 				B20657CF1FC92B8F00412B7D /* MSIDTelemetryUIEventTests.m in Sources */,
 				232C657621376755002A41FE /* MSIDDRSDiscoveryResponseSerializerTests.m in Sources */,
 				23419F5D23973AAD00EA78C5 /* MSIDBrokerOperationRequestTests.m in Sources */,
@@ -6629,7 +6629,7 @@
 				96C998F120B638F60053A2D9 /* MSIDWebviewSession.m in Sources */,
 				96891A982190F15E00D7F437 /* MSIDWPJChallengeHandler.m in Sources */,
 				B26CEADB23652795009E6E54 /* MSIDMacACLKeychainAccessor.m in Sources */,
-				A0C7DED325D4CB2800F5B5B6 /* MSIDThrottlingModelInteractionRequire.m in Sources */,
+				A0C7DED325D4CB2800F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.m in Sources */,
 				96090D9A20E59B2000E42B37 /* MSIDNotifications.m in Sources */,
 				23D2049521D1C274009B5975 /* MSIDTokenResponseSerializer.m in Sources */,
 				96F94A2920816B870034676C /* MSIDWebOAuth2AuthCodeResponse.m in Sources */,
@@ -6728,7 +6728,7 @@
 				A0410E0925E81C5D004D80FD /* MSIDThrottlingModel429Test.m in Sources */,
 				B2DD4B2F20A8D7DE0047A66E /* MSIDCacheKeyTests.m in Sources */,
 				B2DD5B7B20461F5E0084313F /* MSIDAccountCacheItemTests.m in Sources */,
-				A0410E1B25E87E1A004D80FD /* MSIDThrottlingModelInteractionRequireTest.m in Sources */,
+				A0410E1B25E87E1A004D80FD /* MSIDThrottlingModelNonRecoverableServerError.m in Sources */,
 				606B108C20D084B600B34224 /* MSIDAADV1WebviewFactoryTests.m in Sources */,
 				96CD652A20C885E2004813EE /* MSIDWebviewFactoryTests.m in Sources */,
 				239DF9C220E04BC9002D428B /* MSIDB2CAuthorityTests.m in Sources */,
@@ -7144,7 +7144,7 @@
 				B20657BE1FC9254800412B7D /* MSIDTelemetryCacheEvent.m in Sources */,
 				58B81F7D24AD0E7A00E8799E /* MSIDWebResponseOperationFactory.m in Sources */,
 				E70C49F1258D662F00A7A07E /* MSIDLRUCache.m in Sources */,
-				A0C7DED225D4CB2800F5B5B6 /* MSIDThrottlingModelInteractionRequire.m in Sources */,
+				A0C7DED225D4CB2800F5B5B6 /* MSIDThrottlingModelNonRecoverableServerError.m in Sources */,
 				A0E541EE25CDDAFD0016E167 /* MSIDThrottlingMetaDataCache.m in Sources */,
 				96F94A3A208184790034676C /* MSIDOAuth2EmbeddedWebviewController.m in Sources */,
 				B2E2A93E2392F91100BA2EA3 /* MSIDInteractiveTokenRequestParameters.m in Sources */,

--- a/IdentityCore/src/throttling/model/MSIDThrottlingModelFactory.m
+++ b/IdentityCore/src/throttling/model/MSIDThrottlingModelFactory.m
@@ -28,7 +28,7 @@
 #import "MSIDThrottlingCacheRecord.h"
 #import "MSIDLRUCache.h"
 #import "MSIDThrottlingModelBase.h"
-#import "MSIDThrottlingModelInteractionRequire.h"
+#import "MSIDThrottlingModelNonRecoverableServerError.h"
 #import "MSIDThrottlingModel429.h"
 
 @implementation MSIDThrottlingModelFactory
@@ -88,7 +88,7 @@
     }
     else
     {
-        return [[MSIDThrottlingModelInteractionRequire alloc] initWithRequest:request cacheRecord:cacheRecord errorResponse:errorResponse datasource:datasource];
+        return [[MSIDThrottlingModelNonRecoverableServerError alloc] initWithRequest:request cacheRecord:cacheRecord errorResponse:errorResponse datasource:datasource];
     }
 }
 
@@ -100,7 +100,7 @@
     {
         throttleType = MSIDThrottlingType429;
     }
-    else if ([MSIDThrottlingModelInteractionRequire isApplicableForTheThrottleModel:errorResponse])
+    else if ([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:errorResponse])
     {
         throttleType = MSIDThrottlingTypeInteractiveRequired;
     }

--- a/IdentityCore/src/throttling/model/MSIDThrottlingModelNonRecoverableServerError.h
+++ b/IdentityCore/src/throttling/model/MSIDThrottlingModelNonRecoverableServerError.h
@@ -26,6 +26,6 @@
 
 #import "MSIDThrottlingModelBase.h"
 
-@interface MSIDThrottlingModelInteractionRequire : MSIDThrottlingModelBase
+@interface MSIDThrottlingModelNonRecoverableServerError : MSIDThrottlingModelBase
 
 @end

--- a/IdentityCore/src/throttling/model/MSIDThrottlingModelNonRecoverableServerError.m
+++ b/IdentityCore/src/throttling/model/MSIDThrottlingModelNonRecoverableServerError.m
@@ -24,14 +24,14 @@
 
 
 #import <Foundation/Foundation.h>
-#import "MSIDThrottlingModelInteractionRequire.h"
+#import "MSIDThrottlingModelNonRecoverableServerError.h"
 #import "MSIDThrottlingMetaData.h"
 #import "MSIDThrottlingMetaDataCache.h"
 #import "NSDate+MSIDExtensions.h"
 #import "NSError+MSIDExtensions.h"
 static NSInteger const DefaultUIRequired = 120;
 
-@implementation MSIDThrottlingModelInteractionRequire
+@implementation MSIDThrottlingModelNonRecoverableServerError
 
 - (instancetype)initWithRequest:(id<MSIDThumbprintCalculatable>)request
                     cacheRecord:(MSIDThrottlingCacheRecord *)cacheRecord
@@ -57,21 +57,28 @@ static NSInteger const DefaultUIRequired = 120;
  */
 + (BOOL)isApplicableForTheThrottleModel:(NSError *)errorResponse
 {
-    // MSALErrorInteractionRequired = -50002
-    NSSet *uirequiredErrors = [[NSSet alloc] initWithArray:@[@(-50002)]];
     BOOL isMSIDError = [errorResponse msidIsMSIDError];
     
     if (isMSIDError)
     {
         NSString *errorString = errorResponse.msidOauthError;
         NSInteger errorCode = errorResponse.code;
-        if (![NSString msidIsStringNilOrBlank:errorString] || (errorCode == MSIDErrorInteractionRequired))
+        if (![NSString msidIsStringNilOrBlank:errorString]
+            || errorCode == MSIDErrorInteractionRequired
+            || errorCode == MSIDErrorServerDeclinedScopes
+            || errorCode == MSIDErrorServerProtectionPoliciesRequired)
         {
             return YES;
         }
     }
     else
     {
+        // MSALErrorInteractionRequired                 = -50002
+        // MSALErrorServerDeclinedScopes                = -50003
+        // MSALErrorServerProtectionPoliciesRequired    = -50004
+        
+        NSSet *uirequiredErrors = [[NSSet alloc] initWithArray:@[@(-50002),@(-50003),@(-50004)]];
+        
         if ([uirequiredErrors containsObject:[NSNumber numberWithLong:errorResponse.code]])
         {
             return YES;

--- a/IdentityCore/tests/throttling/MSIDThrottlingModelNonRecoverableServerError.m
+++ b/IdentityCore/tests/throttling/MSIDThrottlingModelNonRecoverableServerError.m
@@ -24,17 +24,17 @@
 
 
 #import <XCTest/XCTest.h>
-#import "MSIDThrottlingModelInteractionRequire.h"
+#import "MSIDThrottlingModelNonRecoverableServerError.h"
 #import "NSDate+MSIDExtensions.h"
 #import "NSError+MSIDExtensions.h"
 #import "MSIDTestSwizzle.h"
 #import "MSIDThrottlingMetaDataCache.h"
 
-@interface MSIDThrottlingModelInteractionRequireTest : XCTestCase
+@interface MSIDThrottlingModelNonRecoverableServerErrorTest : XCTestCase
 
 @end
 
-@implementation MSIDThrottlingModelInteractionRequireTest
+@implementation MSIDThrottlingModelNonRecoverableServerErrorTest
 
 - (NSMutableDictionary<NSString *, NSMutableArray<MSIDTestSwizzle *> *> *)swizzleStacks
 {
@@ -70,36 +70,60 @@
     //MSID error type
     //error is OAuth2 error
     NSError *error = [self createErrorWithDomain:YES errorCode:MSIDErrorInternal OAuthErrorString:@"oauth2_error"];
-    XCTAssertTrue([MSIDThrottlingModelInteractionRequire isApplicableForTheThrottleModel:error]);
+    XCTAssertTrue([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
     
     // error code is MSIDErrorInteractionRequired
     error = [self createErrorWithDomain:YES errorCode:MSIDErrorInteractionRequired OAuthErrorString:nil];
-    XCTAssertTrue([MSIDThrottlingModelInteractionRequire isApplicableForTheThrottleModel:error]);
+    XCTAssertTrue([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
     
     //MSAL error type
     // error code is -50002
     error = [self createErrorWithDomain:NO errorCode:-50002 OAuthErrorString:nil];
-    XCTAssertTrue([MSIDThrottlingModelInteractionRequire isApplicableForTheThrottleModel:error]);
+    XCTAssertTrue([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
 }
 
 - (void)test_IfTheErrorIsNotUIRequired_ThenIsApplicableForThrottleShouldBeNo
 {
     NSError *error = [self createErrorWithDomain:YES errorCode:MSIDErrorInternal OAuthErrorString:nil];
-    XCTAssertFalse([MSIDThrottlingModelInteractionRequire isApplicableForTheThrottleModel:error]);
+    XCTAssertFalse([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
     
     error = [self createErrorWithDomain:NO errorCode:MSIDErrorInternal OAuthErrorString:nil];
-    XCTAssertFalse([MSIDThrottlingModelInteractionRequire isApplicableForTheThrottleModel:error]);
+    XCTAssertFalse([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
     
     error = [self createErrorWithDomain:NO errorCode:MSIDErrorInternal OAuthErrorString:@"oauth2_error"];
-    XCTAssertFalse([MSIDThrottlingModelInteractionRequire isApplicableForTheThrottleModel:error]);
+    XCTAssertFalse([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
 
+}
+
+- (void)test_IfTheErrorIsIntuneAppProtectionPoliciesRequires_ThenIsApplicableForThrottleShouldBeYes
+{
+    // error code is MSIDErrorServerProtectionPoliciesRequired
+    NSError *error = [self createErrorWithDomain:YES errorCode:MSIDErrorServerProtectionPoliciesRequired OAuthErrorString:nil];
+    XCTAssertTrue([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
+    
+    //MSAL error type
+    // error code is -50004 (MSALErrorServerProtectionPoliciesRequired)
+    error = [self createErrorWithDomain:NO errorCode:-50004 OAuthErrorString:nil];
+    XCTAssertTrue([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
+}
+
+- (void)test_IfTheErrorIsServerDeclinedScopes_ThenIsApplicableForThrottleShouldBeYes
+{
+    // error code is MSIDErrorServerDeclinedScopes
+    NSError *error = [self createErrorWithDomain:YES errorCode:MSIDErrorServerDeclinedScopes OAuthErrorString:nil];
+    XCTAssertTrue([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
+    
+    //MSAL error type
+    // error code is -50003 (MSALErrorServerDeclinedScopes)
+    error = [self createErrorWithDomain:NO errorCode:-50003 OAuthErrorString:nil];
+    XCTAssertTrue([MSIDThrottlingModelNonRecoverableServerError isApplicableForTheThrottleModel:error]);
 }
 
 - (void)test_IfTheCacheIsNotExpired_AndNoLastRefreshTime_ThenshouldThrottleRequestShouldBeYes
 {
-    MSIDThrottlingModelInteractionRequire *model = [MSIDThrottlingModelInteractionRequire new];
+    MSIDThrottlingModelNonRecoverableServerError *model = [MSIDThrottlingModelNonRecoverableServerError new];
     MSIDTestSwizzle *swizzle = [MSIDTestSwizzle instanceMethod:@selector(cacheRecord)
-                              class:[MSIDThrottlingModelInteractionRequire class]
+                              class:[MSIDThrottlingModelNonRecoverableServerError class]
                               block:(id)^(void)
      {
         
@@ -123,9 +147,9 @@
 
 - (void)test_IfTheCacheIsNotExpired_AndLastRefreshTimeIsTooOld_ThenshouldThrottleRequestShouldBeYes
 {
-    MSIDThrottlingModelInteractionRequire *model = [MSIDThrottlingModelInteractionRequire new];
+    MSIDThrottlingModelNonRecoverableServerError *model = [MSIDThrottlingModelNonRecoverableServerError new];
     MSIDTestSwizzle *cacheSwizzle = [MSIDTestSwizzle instanceMethod:@selector(cacheRecord)
-                              class:[MSIDThrottlingModelInteractionRequire class]
+                              class:[MSIDThrottlingModelNonRecoverableServerError class]
                               block:(id)^(void)
      {
         
@@ -151,9 +175,9 @@
 
 - (void)test_IfTheCacheIsExpired_ThenShouldThrottleRequestShouldBeNo
 {
-    MSIDThrottlingModelInteractionRequire *model = [MSIDThrottlingModelInteractionRequire new];
+    MSIDThrottlingModelNonRecoverableServerError *model = [MSIDThrottlingModelNonRecoverableServerError new];
     MSIDTestSwizzle *cacheSwizzle = [MSIDTestSwizzle instanceMethod:@selector(cacheRecord)
-                              class:[MSIDThrottlingModelInteractionRequire class]
+                              class:[MSIDThrottlingModelNonRecoverableServerError class]
                               block:(id)^(void)
      {
         
@@ -179,9 +203,9 @@
 
 - (void)test_IfTheCacheIsNotExpired_AndLastRefreshTimeIsNew_ThenshouldThrottleRequestShouldBeNo
 {
-    MSIDThrottlingModelInteractionRequire *model = [MSIDThrottlingModelInteractionRequire new];
+    MSIDThrottlingModelNonRecoverableServerError *model = [MSIDThrottlingModelNonRecoverableServerError new];
     MSIDTestSwizzle *cacheSwizzle = [MSIDTestSwizzle instanceMethod:@selector(cacheRecord)
-                              class:[MSIDThrottlingModelInteractionRequire class]
+                              class:[MSIDThrottlingModelNonRecoverableServerError class]
                               block:(id)^(void)
      {
         


### PR DESCRIPTION
## Proposed changes

Adding a few additional error codes that should be throttled:

```
// MSALErrorServerDeclinedScopes                = -50003
// MSALErrorServerProtectionPoliciesRequired    = -50004
```

Since both of those are technically not "interaction required" errors, also renaming the model to MSIDThrottlingModelNonRecoverableServerError

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

