### PR TITLE
New internal throttle errors to distinguise error from cache

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -241,7 +241,12 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     
     MSIDErrorBrokerApplicationTokenReadFailed      =   -51813,
     
-    MSIDErrorBrokerNotAvailable                    =   -51814
+    MSIDErrorBrokerNotAvailable                    =   -51814,
+    
+    // Throttling errors
+    MSIDErrorThrottleCacheNoRecord = -51900,
+    MSIDErrorThrottleCacheInvalidSignature = -51901,
+
 };
 
 extern NSError * _Nonnull MSIDCreateError(NSString * _Nonnull domain, NSInteger code, NSString * _Nullable errorDescription, NSString * _Nullable oauthError, NSString * _Nullable subError, NSError * _Nullable underlyingError, NSUUID * _Nullable correlationId, NSDictionary * _Nullable additionalUserInfo, BOOL logErrorDescription);

--- a/IdentityCore/src/throttling/cache/MSIDLRUCache.m
+++ b/IdentityCore/src/throttling/cache/MSIDLRUCache.m
@@ -310,14 +310,14 @@ if node already exists, update and move it to the front of LRU cache */
     dispatch_barrier_sync(self.synchronizationQueue, ^{
         if (!key)
         {
-            subError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"MSIDLRUCache Error: invalid input during retrieval - key is nil.", nil, nil, nil, nil, nil, YES);
+            subError = MSIDCreateError(MSIDErrorDomain, MSIDErrorThrottleCacheInvalidSignature, @"MSIDLRUCache Error: invalid input during retrieval - key is nil.", nil, nil, nil, nil, nil, YES);
         }
         
         else if (![self.keySignatureMap objectForKey:key])
         {
-            subError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"MSIDLRUCache Error: Unable to find valid signature for the input key during retrieval", nil, nil, nil, nil, nil, YES);
+            subError = MSIDCreateError(MSIDErrorDomain, MSIDErrorThrottleCacheNoRecord, @"MSIDLRUCache Error: Unable to find valid signature for the input key during retrieval", nil, nil, nil, nil, nil, YES);
         }
-        
+        if (subError) return;
         cacheRecord = [self objectForKeyImpl:[self.keySignatureMap objectForKey:key]
                                        error:&subError];
     });
@@ -341,7 +341,7 @@ if node already exists, update and move it to the front of LRU cache */
     {
         if (error)
         {
-            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"MSIDLRUCache Error: invalid input during retrieval - signature is nil", nil, nil, nil, nil, nil, YES);
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorThrottleCacheInvalidSignature, @"MSIDLRUCache Error: invalid input during retrieval - signature is nil", nil, nil, nil, nil, nil, YES);
         }
         return nil;
     }
@@ -350,7 +350,7 @@ if node already exists, update and move it to the front of LRU cache */
     {
         if (error)
         {
-            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"MSIDLRUCache Error: Unable to find valid node for the input signature during retrieval", nil, nil, nil, nil, nil, YES);
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorThrottleCacheNoRecord, @"MSIDLRUCache Error: Unable to find valid node for the input signature during retrieval", nil, nil, nil, nil, nil, YES);
         }
         return nil;
     }

--- a/IdentityCore/src/throttling/model/MSIDThrottlingModelFactory.m
+++ b/IdentityCore/src/throttling/model/MSIDThrottlingModelFactory.m
@@ -30,6 +30,7 @@
 #import "MSIDThrottlingModelBase.h"
 #import "MSIDThrottlingModelInteractionRequire.h"
 #import "MSIDThrottlingModel429.h"
+#import "NSString+MSIDExtensions.h"
 
 @implementation MSIDThrottlingModelFactory
 
@@ -49,7 +50,14 @@
                                                                                                    error:&error];
     if (error)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Throttling: getting record from cache has returned error %@", error);
+        if (error.code != MSIDErrorThrottleCacheNoRecord && error.code != MSIDErrorThrottleCacheInvalidSignature)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Throttling: No record in throttle cache");
+        }
+        else
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Throttling: getting record from cache has returned error %@", error);
+        }
     }
     
     if(!cacheRecord) return nil;
@@ -120,10 +128,14 @@
                                                          error:(NSError **)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Query throttling database with thumbprint strict value: %@, full value: %@", strictThumbprint, fullThumbprint);
-
-    MSIDThrottlingCacheRecord *cacheRecord = [[MSIDLRUCache sharedInstance] objectForKey:strictThumbprint
-                                                                                   error:error];
-    if (!cacheRecord)
+    MSIDThrottlingCacheRecord *cacheRecord;
+    if (![NSString msidIsStringNilOrBlank:strictThumbprint])
+    {
+        cacheRecord = [[MSIDLRUCache sharedInstance] objectForKey:strictThumbprint
+                                                            error:error];
+    }
+     
+    if (!cacheRecord && ![NSString msidIsStringNilOrBlank:fullThumbprint])
     {
         cacheRecord = [[MSIDLRUCache sharedInstance] objectForKey:fullThumbprint error:error];
     }

--- a/IdentityCore/tests/MSIDLRUCacheTest.m
+++ b/IdentityCore/tests/MSIDLRUCacheTest.m
@@ -176,18 +176,22 @@
     XCTAssertNotNil(subError);
     
     //try to retrieve object using nil key
+    subError = nil;
     MSIDThrottlingCacheRecord *resObj = [self.lruCache objectForKey:cacheKey
                                                               error:&subError];
     
     XCTAssertNil(resObj);
     XCTAssertNotNil(subError);
+    XCTAssertEqual(subError.code, MSIDErrorThrottleCacheInvalidSignature);
     
     //try to retrieve object using key that does not exist in cache
+    subError = nil;
     resObj = [self.lruCache objectForKey:validKey
                                    error:&subError];
     XCTAssertNil(resObj);
     XCTAssertNotNil(subError);
-    
+    XCTAssertEqual(subError.code, MSIDErrorThrottleCacheNoRecord);
+
     throttleCacheRecord = [[MSIDThrottlingCacheRecord alloc] initWithErrorResponse:nil
                                                                       throttleType:1
                                                                   throttleDuration:100];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 TBD
 * Handle SSO Nonce response for interactive requests to authorize endpoint (#1005)
-
+* Internal throttle error code to distinguish cached server error (#1013)
 Version 1.6.6
 * Fix telemetry enum value for refresh_in getting overwritten (#996)
 * Update automation for Xcode 12 UI


### PR DESCRIPTION
## Proposed changes

Throttle internal logs confuse the reader. Add new throttle internal errors to help distinguish with cached error response from server.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

