### PR TITLE
Fix issue with showing smart card's cert on macOS.

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
@@ -106,6 +106,7 @@
     NSMutableDictionary *query =
     [@{
        (id)kSecClass : (id)kSecClassIdentity,
+       (id)kSecReturnRef: @YES,
        (id)kSecMatchLimit : (id)kSecMatchLimitAll,
        } mutableCopy];
     

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ TBD
 Version 1.6.6
 * Fix telemetry enum value for refresh_in getting overwritten (#996)
 * Update automation for Xcode 12 UI
+* Fix issue with showing smart card's cert on macOS (#1015)
 
 Version 1.6.5
 * Minimum Xcode version bumped to 12.2 (#981)


### PR DESCRIPTION
## Proposed changes

Fix issue with showing smart card's cert on macOS 11.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

