### PR TITLE
Support for Universal cache in Login Keychain on macOS 10.15+ in Deve…

### DIFF
--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -364,6 +364,78 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 
 #pragma mark - init
 
+- (BOOL)isAppEntitled
+{
+    static dispatch_once_t once;
+    static BOOL appEntitled = NO;
+    
+    dispatch_once(&once, ^{
+        SecCodeRef selfCode = NULL;
+        SecCodeCopySelf(kSecCSDefaultFlags, &selfCode);
+        
+        if (selfCode)
+        {
+            CFDictionaryRef cfDic = NULL;
+            SecCodeCopySigningInformation(selfCode, kSecCSSigningInformation, &cfDic);
+            
+            if (!cfDic)
+            {
+                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to retrieve code signing information");
+            }
+            else
+            {
+                NSDictionary *signingDic = CFBridgingRelease(cfDic);
+                NSDictionary *entitlementsDictionary = [signingDic msidObjectForKey:(__bridge NSString*)kSecCodeInfoEntitlementsDict ofClass:[NSDictionary class]];
+                NSArray *keychainGroups = [entitlementsDictionary msidObjectForKey:@"keychain-access-groups" ofClass:[NSArray class]];
+                
+                for (id element in keychainGroups) {
+                    if ([element hasSuffix:@"com.microsoft.identity.universalstorage"])
+                    {
+                        appEntitled = YES;
+                        break;
+                    }
+                }
+            }
+            
+            CFRelease(selfCode);
+        }
+    });
+    
+    return appEntitled;
+}
+
+-(BOOL)shouldUseLoginKeychain
+{
+    if (@available(macOS 10.15, *))
+    {
+        
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:kLoginKeychainEmptyKey])
+        {
+#if MS_INTERNAL_BUILD
+            if ([self isAppEntitled])
+            {
+                return NO;
+            }
+            else
+            {
+                return YES;
+            }
+#else
+            return NO;
+#endif
+        }
+        else
+        {
+            // if kLoginKeychainEmptyKey is not set
+            return YES;
+        }
+    }
+    else
+    {
+        return YES;
+    }
+}
+
 // Initialize with defaultKeychainGroup
 - (nonnull instancetype)init
 {
@@ -386,10 +458,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     if (self)
     {
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
-        if (@available(macOS 10.15, *)) {
-            
-            if ([[NSUserDefaults standardUserDefaults] boolForKey:kLoginKeychainEmptyKey])
-            {
+        if (![self shouldUseLoginKeychain]) {
                 if (error)
                 {
                     *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Not creating login keychain for performance optimization on macOS 10.15, because no items where previously found in it", nil, nil, nil, nil, nil, NO);
@@ -398,7 +467,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
                 MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Not creating login keychain for performance optimization on macOS 10.15, because no items where previously found in it");
                 return nil;
             }
-        }
+        
 #endif
         
         self.appStorageItem = [MSIDMacCredentialStorageItem new];
@@ -804,12 +873,10 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     MSID_TRACE;
     
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
-    if (@available(macOS 10.15, *)) {
-        if ([[NSUserDefaults standardUserDefaults] boolForKey:kLoginKeychainEmptyKey])
-        {
-            MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"Skipping login keychain read because it has been previously marked as empty on 10.15");
-            return nil;
-        }
+    if (![self shouldUseLoginKeychain])
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"Skipping login keychain read because it has been previously marked as empty on 10.15");
+        return nil;
     }
 #endif
     

--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -404,7 +404,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     return appEntitled;
 }
 
--(BOOL)shouldUseLoginKeychain
+- (BOOL)shouldUseLoginKeychain
 {
     if (@available(macOS 10.15, *))
     {
@@ -412,14 +412,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
         if ([[NSUserDefaults standardUserDefaults] boolForKey:kLoginKeychainEmptyKey])
         {
 #if MS_INTERNAL_BUILD
-            if ([self isAppEntitled])
-            {
-                return NO;
-            }
-            else
-            {
-                return YES;
-            }
+            return ![self isAppEntitled];
 #else
             return NO;
 #endif

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ TBD
 Version 1.6.6
 * Fix telemetry enum value for refresh_in getting overwritten (#996)
 * Update automation for Xcode 12 UI
+* Support for Universal cache in Login Keychain on macOS 10.15+ in Developers (#1016)
 
 Version 1.6.5
 * Minimum Xcode version bumped to 12.2 (#981)

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@ Version 1.6.6
 * Update automation for Xcode 12 UI
 * Support for Universal cache in Login Keychain on macOS 10.15+ in Developers (#1016)
 * Fix issue with showing smart card's cert on macOS (#1015)
-
+ 
 Version 1.6.5
 * Minimum Xcode version bumped to 12.2 (#981)
 * Improve telemetry storage security (#981)


### PR DESCRIPTION
Following the recommendations of Apple, MSAL ObjC and OneAuth-MSAL shipped with Universal Storage in data protection keychain on macOS 10.15+. According to the [design], no application should ever write tokens into legacy keychain on macOS 10.15+. This implies that starting with macOS 10.15, all applications using OneAuth/MSAL SDK must have a `com.microsoft.identity.universalstorage` keaychain access group entitlement and must be signed with a provisioning profile. Applications that do not fulfill this requirement will not be able to acceess persistent token cache, i.e. perform silent token acquisition or SSO with other applications.

The requirements imposed on the applications shipping with OneAuth/MSAL imply that:

1. All developer builds of such applications that exercise authentication must be signed with [developer provisioning profiles](#provisioning-profiles) and entitled to `com.microsoft.identity.universalstorage` keychain access group
2. All macOS 10.15+ devices that need to run developer builds of such applications must be listed in the developer provisioning profile.

## The Problem

The requirement (2) has a hight cost on teams that manage large fleets of physical Apple devices, because the process of updating the device list in the developer provisioning profiles is manual, performed by a dedicated team, and requires some engineering work on top of that. 

Teams with smaller inventory of Apple devices - such as OneDrive, Edge, Teams - did not have a problem with requirement (2). **Office APEX team expressed that they cannot manage the list of their devices in the developer provisioning profile(s) due to the immense fleet (thousands) of physical Apple devices that they use**. The team requests temporary support for **Office developer builds** to store Universal Storage in the legacy keychain until they can build a sufficient infrastructure for developer profile management.

Fix:
Use login keychain for Office developer builds. If Office developer build is entitled to `com.microsoft.identity.universalstorage` keychain access group use Universal Storage in data protection keychain on macOS 10.15+.
