### PR TITLE
Fix showing smart card's cert on macOS (ADAL hotfix).

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDClientTLSHandler.m
@@ -192,6 +192,7 @@
     [@{
        (id)kSecClass : (id)kSecClassIdentity,
        (id)kSecMatchLimit : (id)kSecMatchLimitAll,
+       (id)kSecReturnRef: @YES,
        } mutableCopy];
     
     if (issuers.count > 0)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.0.21
+-------------
+* Fix showing smart card's cert on macOS (ADAL hotfix). #1022
+
 Version 1.0.20 (12/01/2020)
 -------------
 * Updated Embedded webview to allow opening links that open in a new window to open with system browser. Used in MFA setup.


### PR DESCRIPTION
## Proposed changes

Fix showing smart card's cert on macOS (ADAL hotfix).

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

