### PR TITLE
add option to pass in fallback anchor window

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -94,6 +94,14 @@ typedef void (^MSIDGetDeviceInfoRequestCompletionBlock)(MSIDDeviceInfo * _Nullab
 @compatibility_alias MSIDViewController NSViewController;
 #endif
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+@compatibility_alias MSIDWindow UIWindow;
+#else
+#import <AppKit/AppKit.h>
+@compatibility_alias MSIDWindow NSWindow;
+#endif
+
 extern NSString * _Nonnull const MSID_PLATFORM_KEY;//The SDK platform. iOS or OSX
 extern NSString * _Nonnull const MSID_SOURCE_PLATFORM_KEY;//The source SDK platform. iOS or OSX
 extern NSString * _Nonnull const MSID_VERSION_KEY;

--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -89,16 +89,10 @@ typedef void (^MSIDGetDeviceInfoRequestCompletionBlock)(MSIDDeviceInfo * _Nullab
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 @compatibility_alias MSIDViewController UIViewController;
-#else
-#import <AppKit/AppKit.h>
-@compatibility_alias MSIDViewController NSViewController;
-#endif
-
-#if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
 @compatibility_alias MSIDWindow UIWindow;
 #else
 #import <AppKit/AppKit.h>
+@compatibility_alias MSIDViewController NSViewController;
 @compatibility_alias MSIDWindow NSWindow;
 #endif
 

--- a/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDInteractiveRequestParameters.h
@@ -24,6 +24,7 @@
 #import "MSIDRequestParameters.h"
 #import "MSIDConstants.h"
 #import "MSIDBrokerInvocationOptions.h"
+#import "MSIDConstants.h"
 
 @class WKWebView;
 #if TARGET_OS_IPHONE
@@ -39,6 +40,10 @@
 #if TARGET_OS_IPHONE
 @property (nonatomic) UIModalPresentationStyle presentationType;
 #endif
+/* Use presentationAnchorWindow as a fallback if parentViewController is
+   not provided, so that Sso extension UI can attach to the provided window
+*/
+@property (nonatomic) MSIDWindow *presentationAnchorWindow;
 @property (nonatomic) BOOL prefersEphemeralWebBrowserSession;
 @property (nonatomic) NSString *telemetryWebviewType;
 

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionInteractiveTokenRequest.m
@@ -196,7 +196,7 @@
         return anchor;
     }
     
-    return self.requestParameters.parentViewController.view.window;
+    return self.requestParameters.parentViewController ? self.requestParameters.parentViewController.view.window : self.requestParameters.presentationAnchorWindow;
 }
 
 #pragma mark - Dealloc


### PR DESCRIPTION
## Proposed changes

During OneAuth-MSAL integration, there are chance that partners are not passing in a parentViewController. 

When presenting Sso extenion UI on Mac, the window will be placed randomly without an anchor. 

Current OneAuth can pass in a default Window, and we can use it in CommonCore as an anchor window.

The change is only applied to acquire token interactively.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

