### PR TITLE
Fix to show spinner on ADAL apps that are blocked from showing SSO UI…

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -62,6 +62,8 @@ static WKWebViewConfiguration *s_webConfig;
 {
     if (_webView)
     {
+        _loadingIndicator = [self prepareLoadingIndicator];
+        [_webView addSubview:_loadingIndicator];
         return YES;
     }
     


### PR DESCRIPTION

## Proposed changes

Fix to show spinner on ADAL apps that are blocked from showing SSO UI. Apps that use PassedIn view didnt have a spinner while waiting for SSO prompt to show.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

