### PR TITLE
Fix to show spinner on ADAL apps that are blocked from showing SSO UI

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -91,6 +91,8 @@ static WKWebViewConfiguration *s_webConfig;
 {
     if (_webView)
     {
+        _loadingIndicator = [self prepareLoadingIndicator];
+        [_webView addSubview:_loadingIndicator];
         return YES;
     }
     


### PR DESCRIPTION
## Proposed changes

Fix for ADAL apps that send passed In view to show spinner while blocked from showing SSO UI prompt on mac.

## Type of change

- [ ] Feature work
- [ x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

