### PR TITLE
Use github3 version 2.0.0 to avoid Python 3.10 break

### DIFF
--- a/azure_pipelines/changelogs.yml
+++ b/azure_pipelines/changelogs.yml
@@ -29,7 +29,7 @@ jobs:
 
   - task: UsePythonVersion@0
     displayName: Use Python 3.x
-  - bash: python3 -m pip install github3.py==1.3.0
+  - bash: python3 -m pip install github3.py==2.0.0
     displayName: Install the github3.py REST API client for Python
 
   - task: PythonScript@0


### PR DESCRIPTION
## Proposed changes

Azure Pipelines agents have begun updating to Python 3.10 which is
incompatible with github3.py version 1.3.0. Update to 2.0.0 to fix the
break.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information


