### PR TITLE
Use base64URLEncoding for RSA modules

### DIFF
--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyPair.m
@@ -116,7 +116,7 @@ static NSString *s_kidTemplate = @"{\"kid\":\"%@\"}";
         iterator++; // TYPE - bit stream mod
         int mod_size = [self derEncodingGetSizeFrom:publicKeyBits at:&iterator];
         NSData *subData=[publicKeyBits subdataWithRange:NSMakeRange(iterator, mod_size)];
-        _keyModulus = [[subData subdataWithRange:NSMakeRange(1, subData.length-1)] base64EncodedStringWithOptions:0];
+        _keyModulus = [[subData subdataWithRange:NSMakeRange(1, subData.length-1)] msidBase64UrlEncodedString];
     }
     
     return _keyModulus;


### PR DESCRIPTION
## Proposed changes

Use base64URLEncoding for RSA modules in JWK.

See spec here: https://www.rfc-editor.org/rfc/rfc7517.txt

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

