### PR TITLE
added more logging

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -410,8 +410,7 @@
                                           context:(id<MSIDRequestContext>)context
                                             error:(NSError **)error
 {
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(Default accessor) Get accounts.");
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default accessor) Get accounts with environment %@, clientId %@, familyId %@, account %@, username %@", authority.environment, clientId, familyId, accountIdentifier.maskedHomeAccountId, accountIdentifier.maskedDisplayableId);
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Default accessor) Get accounts with environment %@, clientId %@, familyId %@, account %@, username %@", authority.environment, clientId, familyId, accountIdentifier.maskedHomeAccountId, accountIdentifier.maskedDisplayableId);
 
     MSIDTelemetryCacheEvent *event = [MSIDTelemetry startCacheEventWithName:MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP context:context];
 
@@ -438,6 +437,7 @@
     NSError *localError;
     if (signedInAccountsOnly)
     {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(Default accessor) signedInAccountsOnly Enabled. retrieve account IDs from RT.");
         accountIdsFromRT = [self homeAccountIdsFromRTsWithAuthority:authority
                                                            clientId:clientId
                                                            familyId:familyId
@@ -461,6 +461,8 @@
                                                           clientId:clientId
                                                            context:context
                                                              error:nil];
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(Default accessor) %ld id tokens found with given authority.",idTokens.count);
     
     NSMutableSet<NSString *> *noReturnAccountUPNSet;
     NSMutableSet<MSIDAccount *> *returnAccountsSet = [self filterAndFillIdTokenClaimsForAccounts:allAccounts
@@ -563,6 +565,7 @@
          */
         if (realmHint && [account.realm isEqualToString:realmHint])
         {
+            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, context, @"(Default accessor) found an account that has matching realmHint: %@.", realmHint);
             return account;
         }
         
@@ -927,6 +930,7 @@
 
     if ([accountCacheItems count])
     {
+        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, context, @"(Default accessor) found %ld accounts with legacy account id. returning first account.",accountCacheItems.count);
         [MSIDTelemetry stopCacheEvent:event withItem:nil success:YES context:context];
         MSIDAccountCacheItem *accountCacheItem = accountCacheItems[0];
         return accountCacheItem.homeAccountId;
@@ -997,13 +1001,14 @@
     }
 
     NSMutableArray<MSIDBaseToken *> *resultTokens = [NSMutableArray new];
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(Default accessor) Found %lu cached credentials", (unsigned long)[cacheItems count]);
     for (MSIDCredentialCacheItem *cacheItem in cacheItems)
     {
         MSIDBaseToken *resultToken = [cacheItem tokenWithType:cacheQuery.credentialType];
 
         if (resultToken)
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(Default accessor) Found %lu tokens", (unsigned long)[cacheItems count]);
             resultToken.storageEnvironment = resultToken.environment;
             
             if (requestedEnvironment)
@@ -1014,6 +1019,7 @@
         }
     }
     
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(Default accessor) Found %lu tokens with environment", (unsigned long)[resultTokens count]);
     return resultTokens;
 }
 

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -315,25 +315,25 @@
 {
     if (realm && ![self.realm.msidNormalizedString isEqualToString:realm.msidNormalizedString])
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item did not have a valid realm. Actual: %@, expected: %@", NSStringFromClass(self.class), self.realm, realm);
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(%@) cached item did not have a valid realm. Actual: %@, expected: %@", NSStringFromClass(self.class), self.realm, realm);
         return NO;
     }
 
     if (![self matchesTarget:target comparisonOptions:matchingOptions])
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item did not have a valid target value. %@", NSStringFromClass(self.class), target);
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(%@) cached item did not have a valid target value. %@", NSStringFromClass(self.class), target);
         return NO;
     }
 
     if (!clientId && !familyId)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item had neither clientID nor family Id.", NSStringFromClass(self.class));
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(%@) cached item had neither clientID nor family Id.", NSStringFromClass(self.class));
         return YES;
     }
     
     if (!([NSString msidIsStringNilOrBlank:self.requestedClaims] && [NSString msidIsStringNilOrBlank:requestedClaims]) && !([self.requestedClaims isEqualToString:requestedClaims]))
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item did not have valid requestedClaims.", NSStringFromClass(self.class));
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(%@) cached item did not have valid requestedClaims.", NSStringFromClass(self.class));
         return NO;
     }
 
@@ -342,24 +342,24 @@
         if ((clientId && [self.clientId.msidNormalizedString isEqualToString:clientId.msidNormalizedString])
             || (familyId && [self.familyId.msidNormalizedString isEqualToString:familyId.msidNormalizedString]))
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item supserset match; actual client ID: %@, expected client ID: %@, actual family ID: %@, expected family ID: %@", NSStringFromClass(self.class), self.clientId, clientId, self.familyId, familyId);
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(%@) cached item supserset match; actual client ID: %@, expected client ID: %@, actual family ID: %@, expected family ID: %@", NSStringFromClass(self.class), self.clientId, clientId, self.familyId, familyId);
             return YES;       
         }
         
-            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item superset mismatch; cached item had both invalid clientID and familyID. actual client ID: %@, expected client ID: %@, actual family ID: %@, expected family ID: %@", NSStringFromClass(self.class), self.clientId, clientId, self.familyId, familyId);
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(%@) cached item superset mismatch; cached item had both invalid clientID and familyID. actual client ID: %@, expected client ID: %@, actual family ID: %@, expected family ID: %@", NSStringFromClass(self.class), self.clientId, clientId, self.familyId, familyId);
         return NO;
     }
     else
     {
         if (clientId && ![self.clientId.msidNormalizedString isEqualToString:clientId.msidNormalizedString])
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item clientID mismatch; actual client ID: %@, expected client ID: %@", NSStringFromClass(self.class), self.clientId, clientId);
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(%@) cached item clientID mismatch; actual client ID: %@, expected client ID: %@", NSStringFromClass(self.class), self.clientId, clientId);
             return NO;
         }
 
         if (familyId && ![self.familyId.msidNormalizedString isEqualToString:familyId.msidNormalizedString])
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item familyID mismatch; actual family ID: %@, expected family ID: %@", NSStringFromClass(self.class), self.familyId, familyId);
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(%@) cached item familyID mismatch; actual family ID: %@, expected family ID: %@", NSStringFromClass(self.class), self.familyId, familyId);
             return NO;
         }
     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 1.7.2
 * Use base64URLEncoding for RSA modules (#1058)
+* Added more logging
 
 Version 1.7.1
 * Add helper function used by cross cloud B2B support (#957)


### PR DESCRIPTION
## Proposed changes

Trying to add more logging in the default accessor logic as well as changing logging level from verbose to info for certain failure messages within the credential cache logic as well.
By doing so we can better identify how credentials get filtered out by the underlying logic.
Also there were a couple ares where logging was not placed in the correct place (ex: getTokenWithEnvironment). so also fixing that.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

