### PR TITLE
sso ext sanity check response

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -245,6 +245,9 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     
     MSIDErrorBrokerNotAvailable                    =   -51814,
     
+    // SSO Extension internal error
+    MSIDErrorSSOExtensionUnexpectedError           =   -51815,
+    
     // Throttling errors
     MSIDErrorThrottleCacheNoRecord = -51900,
     MSIDErrorThrottleCacheInvalidSignature = -51901,

--- a/IdentityCore/src/controllers/MSIDSilentController.m
+++ b/IdentityCore/src/controllers/MSIDSilentController.m
@@ -128,7 +128,20 @@
         }
 
         self.currentRequest = nil;
-        [self.fallbackController acquireToken:completionBlock];
+        MSIDRequestCompletionBlock completionBlockWrapper = ^(MSIDTokenResult *ssoResult, NSError *ssoError)
+        {
+            // We don't have any meaningful information from fallback controller (edge case of SSO error) so we use the local controller result earlier
+            if (!ssoResult && !ssoError)
+            {
+                completionBlock(result, error);
+            }
+            else
+            {
+                completionBlock(ssoResult, ssoError);
+            }
+        };
+
+        [self.fallbackController acquireToken:completionBlockWrapper];
     }];
 }
 

--- a/IdentityCore/src/controllers/MSIDSilentController.m
+++ b/IdentityCore/src/controllers/MSIDSilentController.m
@@ -131,7 +131,7 @@
         MSIDRequestCompletionBlock completionBlockWrapper = ^(MSIDTokenResult *ssoResult, NSError *ssoError)
         {
             // We don't have any meaningful information from fallback controller (edge case of SSO error) so we use the local controller result earlier
-            if (!ssoResult && !ssoError)
+            if (!ssoResult && (ssoError.code == MSIDErrorSSOExtensionUnexpectedError))
             {
                 completionBlock(result, error);
             }

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
@@ -85,6 +85,17 @@
 #if TARGET_OS_OSX
             strongSelf.ssoTokenResponseHandler.externalCacheSeeder = strongSelf.externalCacheSeeder;
 #endif
+            // Edge case: both response and error is nil. This happens if Apple SSO return the wrong callback.
+            // For normal scenario (we have response or error from SSO-Ext, keep the same logic)
+            if (!operationResponse && !error)
+            {
+                MSID_LOG_WITH_CTX(MSIDLogLevelError, strongSelf.requestParameters, @"Operation response is nil, exit early");
+                MSIDRequestCompletionBlock completionBlock = strongSelf.requestCompletionBlock;
+                strongSelf.requestCompletionBlock = nil;
+                if (completionBlock) completionBlock(nil, error);
+                return;
+            }
+            
             [strongSelf.ssoTokenResponseHandler handleOperationResponse:operationResponse
                                                       requestParameters:strongSelf.requestParameters
                                                  tokenResponseValidator:strongSelf.tokenResponseValidator

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
@@ -85,17 +85,7 @@
 #if TARGET_OS_OSX
             strongSelf.ssoTokenResponseHandler.externalCacheSeeder = strongSelf.externalCacheSeeder;
 #endif
-            // Edge case: both response and error is nil. This happens if Apple SSO return the wrong callback.
-            // For normal scenario (we have response or error from SSO-Ext, keep the same logic)
-            if (!operationResponse && !error)
-            {
-                MSID_LOG_WITH_CTX(MSIDLogLevelError, strongSelf.requestParameters, @"Operation response is nil, exit early");
-                MSIDRequestCompletionBlock completionBlock = strongSelf.requestCompletionBlock;
-                strongSelf.requestCompletionBlock = nil;
-                if (completionBlock) completionBlock(nil, error);
-                return;
-            }
-            
+                       
             [strongSelf.ssoTokenResponseHandler handleOperationResponse:operationResponse
                                                       requestParameters:strongSelf.requestParameters
                                                  tokenResponseValidator:strongSelf.tokenResponseValidator

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
@@ -34,13 +34,28 @@
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Receive response from SSO extension with authorization is nil: %@", authorization ? @"No" : @"Yes");
     
     if (!self.completionBlock) return;
+    MSIDSSOExtensionRequestDelegateCompletionBlock completionBlockWrapper = ^(id response, NSError  *error)
+    {
+        // 2 scenarios return MSIDErrorSSOExtensionUnexpectedError:
+        // 1. both response and either is nil (wrong callback is returned)
+        // 2. error when parsing data => This should be treated as internal (suberror)
+        if (!response)
+        {
+            NSError *wrapperError = MSIDCreateError(MSIDErrorDomain, MSIDErrorSSOExtensionUnexpectedError, @"Unexpected internal error from SSO", nil, error ? @"data parsing error" : nil, error ? error : nil, nil, nil, NO);
+            self.completionBlock(nil, wrapperError);
+        }
+        else
+        {
+            self.completionBlock(response, error);
+        }
+    };
     
     NSError *error;
     __auto_type ssoCredential = [self ssoCredentialFromCredential:authorization.credential error:&error];
     if (!ssoCredential)
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"ssoCredential is nill, error %@", error);
-        self.completionBlock(nil, error);
+        completionBlockWrapper(nil, error);
         return;
     }
     
@@ -48,7 +63,7 @@
     if (!json)
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"ssoCredential header is nill, error %@", error);
-        self.completionBlock(nil, error);
+        completionBlockWrapper(nil, error);
         return;
     }
     
@@ -57,11 +72,11 @@
     if (!operationResponse)
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"operationResponse is nill, error %@", error);
-        self.completionBlock(nil, error);
+        completionBlockWrapper(nil, error);
         return;
     }
     
-    self.completionBlock(operationResponse, nil);
+    completionBlockWrapper(operationResponse, nil);
 }
 
 @end

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
@@ -39,7 +39,7 @@
     __auto_type ssoCredential = [self ssoCredentialFromCredential:authorization.credential error:&error];
     if (!ssoCredential)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"This shouldn't happen: ssoCredential is nill");
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"ssoCredential is nill, error %@", error);
         self.completionBlock(nil, error);
         return;
     }
@@ -47,7 +47,7 @@
     __auto_type json = [self jsonPayloadFromSSOCredential:ssoCredential error:&error];
     if (!json)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"This shouldn't happen: ssoCredential header is nill");
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"ssoCredential header is nill, error %@", error);
         self.completionBlock(nil, error);
         return;
     }
@@ -56,7 +56,7 @@
 
     if (!operationResponse)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"This shouldn't happen: operationResponse is nill");
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"operationResponse is nill, error %@", error);
         self.completionBlock(nil, error);
         return;
     }

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
@@ -31,14 +31,15 @@
 
 - (void)authorizationController:(__unused ASAuthorizationController *)controller didCompleteWithAuthorization:(ASAuthorization *)authorization
 {
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.context, @"Received response from SSO extension with authorization is nil: %@", authorization ? @"No" : @"Yes");
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Receive response from SSO extension with authorization is nil: %@", authorization ? @"No" : @"Yes");
+    
     if (!self.completionBlock) return;
     
     NSError *error;
     __auto_type ssoCredential = [self ssoCredentialFromCredential:authorization.credential error:&error];
     if (!ssoCredential)
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.context, @"This shouldn't happen: ssoCredential is nill");
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"This shouldn't happen: ssoCredential is nill");
         self.completionBlock(nil, error);
         return;
     }
@@ -46,7 +47,7 @@
     __auto_type json = [self jsonPayloadFromSSOCredential:ssoCredential error:&error];
     if (!json)
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.context, @"This shouldn't happen: ssoCredential header is nill");
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"This shouldn't happen: ssoCredential header is nill");
         self.completionBlock(nil, error);
         return;
     }
@@ -55,7 +56,7 @@
 
     if (!operationResponse)
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.context, @"This shouldn't happen: operationResponse is nill");
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"This shouldn't happen: operationResponse is nill");
         self.completionBlock(nil, error);
         return;
     }

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
@@ -31,12 +31,14 @@
 
 - (void)authorizationController:(__unused ASAuthorizationController *)controller didCompleteWithAuthorization:(ASAuthorization *)authorization
 {
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.context, @"Received response from SSO extension with authorization is nil: %@", authorization ? @"No" : @"Yes");
     if (!self.completionBlock) return;
     
     NSError *error;
     __auto_type ssoCredential = [self ssoCredentialFromCredential:authorization.credential error:&error];
     if (!ssoCredential)
     {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.context, @"This shouldn't happen: ssoCredential is nill");
         self.completionBlock(nil, error);
         return;
     }
@@ -44,6 +46,7 @@
     __auto_type json = [self jsonPayloadFromSSOCredential:ssoCredential error:&error];
     if (!json)
     {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.context, @"This shouldn't happen: ssoCredential header is nill");
         self.completionBlock(nil, error);
         return;
     }
@@ -52,6 +55,7 @@
 
     if (!operationResponse)
     {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, self.context, @"This shouldn't happen: operationResponse is nill");
         self.completionBlock(nil, error);
         return;
     }

--- a/IdentityCore/tests/integration/MSIDSilentControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDSilentControllerIntegrationTests.m
@@ -36,6 +36,7 @@
 #import "MSIDTelemetryTestDispatcher.h"
 #import "MSIDTelemetry.h"
 #import "MSIDRefreshToken.h"
+#import "MSIDSSOExtensionSilentTokenRequestController.h"
 
 @interface MSIDSilentControllerIntegrationTests : XCTestCase
 
@@ -350,4 +351,39 @@
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
+- (void)testAcquireToken_WhenFallingLocalController_AndFallbackControllerReturnNilReponse_ShouldReturnLocalError API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    
+        // Setup test request providers
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+    parameters.telemetryApiId = @"api_prompt_auto_fail";
+    
+    NSError *localError = MSIDCreateError(MSIDErrorDomain, MSIDErrorServerInvalidGrant, @"Invalid grant", @"invalid_grant", @"consent_required", nil, parameters.correlationId, nil, YES);
+    
+    MSIDTestTokenRequestProvider *localSilentProvider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:localError testWebMSAuthResponse:nil];
+    MSIDTestTokenRequestProvider *brokerSilentProvider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil];
+
+    
+    NSError *error = nil;
+    MSIDSilentController *brokerController = [[MSIDSSOExtensionSilentTokenRequestController alloc] initWithRequestParameters:parameters forceRefresh:NO tokenRequestProvider:brokerSilentProvider error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(brokerController);
+    
+    MSIDSilentController *silentController = [[MSIDSilentController alloc] initWithRequestParameters:parameters forceRefresh:NO tokenRequestProvider:localSilentProvider fallbackInteractiveController:brokerController error:&error];
+    XCTAssertNotNil(silentController);
+    XCTAssertNil(error);
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+    [silentController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
+        
+        XCTAssertNil(result);
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error, localError);
+                
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+
+}
 @end

--- a/IdentityCore/tests/integration/MSIDSilentControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDSilentControllerIntegrationTests.m
@@ -351,7 +351,7 @@
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
-- (void)testAcquireToken_WhenFallingLocalController_AndFallbackControllerReturnNilReponse_ShouldReturnLocalError API_AVAILABLE(ios(13.0), macos(10.15))
+- (void)testAcquireToken_WhenFallingLocalController_AndFallbackControllerReturnSSOUnexpectedError_ShouldReturnLocalError API_AVAILABLE(ios(13.0), macos(10.15))
 {
     
         // Setup test request providers
@@ -361,10 +361,12 @@
     NSError *localError = MSIDCreateError(MSIDErrorDomain, MSIDErrorServerInvalidGrant, @"Invalid grant", @"invalid_grant", @"consent_required", nil, parameters.correlationId, nil, YES);
     
     MSIDTestTokenRequestProvider *localSilentProvider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:localError testWebMSAuthResponse:nil];
-    MSIDTestTokenRequestProvider *brokerSilentProvider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil];
 
     
     NSError *error = nil;
+    NSError *ssoUnexpectedError = MSIDCreateError(MSIDErrorDomain, MSIDErrorSSOExtensionUnexpectedError, @"unexpected error", @"unexpected error", @"unexpected error", nil, parameters.correlationId, nil, YES);
+    MSIDTestTokenRequestProvider *brokerSilentProvider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:ssoUnexpectedError testWebMSAuthResponse:nil];
+
     MSIDSilentController *brokerController = [[MSIDSSOExtensionSilentTokenRequestController alloc] initWithRequestParameters:parameters forceRefresh:NO tokenRequestProvider:brokerSilentProvider error:&error];
     XCTAssertNil(error);
     XCTAssertNotNil(brokerController);
@@ -386,4 +388,43 @@
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 
 }
+
+- (void)testAcquireToken_WhenFallingLocalController_AndFallbackControllerReturnSSOExpectedError_ShouldReturnSSOError API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    
+    // Setup test request providers
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+    parameters.telemetryApiId = @"api_prompt_auto_fail";
+    
+    NSError *localError = MSIDCreateError(MSIDErrorDomain, MSIDErrorServerInvalidGrant, @"Invalid grant", @"invalid_grant", @"consent_required", nil, parameters.correlationId, nil, YES);
+    
+    MSIDTestTokenRequestProvider *localSilentProvider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:localError testWebMSAuthResponse:nil];
+    
+    
+    NSError *error = nil;
+    NSError *ssoExpectedError = MSIDCreateError(MSIDErrorDomain, MSIDErrorServerInvalidGrant, @"Expected error", @"Expected error", @"Expected error", nil, parameters.correlationId, nil, YES);
+    MSIDTestTokenRequestProvider *brokerSilentProvider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:ssoExpectedError testWebMSAuthResponse:nil];
+    
+    MSIDSilentController *brokerController = [[MSIDSSOExtensionSilentTokenRequestController alloc] initWithRequestParameters:parameters forceRefresh:NO tokenRequestProvider:brokerSilentProvider error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(brokerController);
+    
+    MSIDSilentController *silentController = [[MSIDSilentController alloc] initWithRequestParameters:parameters forceRefresh:NO tokenRequestProvider:localSilentProvider fallbackInteractiveController:brokerController error:&error];
+    XCTAssertNotNil(silentController);
+    XCTAssertNil(error);
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+    [silentController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
+        
+        XCTAssertNil(result);
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error, ssoExpectedError);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    
+}
+
 @end

--- a/IdentityCore/tests/mocks/MSIDTestTokenRequestProvider.m
+++ b/IdentityCore/tests/mocks/MSIDTestTokenRequestProvider.m
@@ -115,7 +115,7 @@
 
 - (nullable MSIDSilentTokenRequest *)silentSSOExtensionTokenRequestWithParameters:(nonnull __unused MSIDRequestParameters *)parameters forceRefresh:(__unused BOOL)forceRefresh
 {
-    return nil;
+    return [[MSIDTestSilentTokenRequest alloc] initWithTestResponse:self.testTokenResult testError:self.testError];
 }
 
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 TBD
 * Enable additional warnings (#1042)
+* sanity check sso ext response. If no meaningful will use local result
 
 Version 1.7.2
 * Use base64URLEncoding for RSA modules (#1058)


### PR DESCRIPTION
## Proposed changes

- Add more log when we have response from sso ext for future debugging
- Exit the flow earlier if the response is invalid.
- If we don't have meaningful error from sso-ext, we choose the one from local controller

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

