### PR TITLE
temp remove federationprovider param in automation api

### DIFF
--- a/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDTestAutomationAccountConfigurationRequest.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDTestAutomationAccountConfigurationRequest.m
@@ -121,7 +121,7 @@ MSIDTestAccountTypeUserRoleType MSIDTestAccountTypeUserRoleTypeCloudAdministrato
     if (self.accountType) [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"usertype" value:self.accountType]];
     if (self.protectionPolicyType) [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"protectionpolicy" value:self.protectionPolicyType]];
     if (self.b2cProviderType) [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"b2cprovider" value:self.b2cProviderType]];
-    if (self.federationProviderType) [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"federationprovider" value:self.federationProviderType]];
+    if (self.federationProviderType && self.federationProviderType != MSIDTestAccountFederationProviderTypeNone) [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"federationprovider" value:self.federationProviderType]];
     if (self.environmentType) [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"azureenvironment" value:self.environmentType]];
     if (self.userRole) [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"userrole" value:self.userRole]];
     


### PR DESCRIPTION
## Proposed changes

/api/User from msidlab not returns the account if federationProviderType = none for truemamca account. tmp workaround by not sending that param if the value is none

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

