### PR TITLE
Updating logic to check if targetFrame is nil for new window

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -377,7 +377,8 @@
     if ([navigationAction navigationType] == WKNavigationTypeLinkActivated)
     {
         //Open secure web links with target=new window in default browser or non-web links with URL schemes that can be opened by the application
-        if (([requestURL.scheme.lowercaseString isEqualToString:@"https"] && !navigationAction.targetFrame.isMainFrame) || ![requestURL.scheme.lowercaseString hasPrefix:@"http"])
+        // If the target of the navigation is a new window, navigationAction.targetFrame is nil. (See discussions in : https://developer.apple.com/documentation/webkit/wknavigationaction/1401918-targetframe?language=objc)
+        if (([requestURL.scheme.lowercaseString isEqualToString:@"https"] && !navigationAction.targetFrame) || ![requestURL.scheme.lowercaseString hasPrefix:@"http"])
         {
             MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.context, @"Opening URL outside embedded webview with scheme: %@ host: %@", requestURL.scheme, MSID_PII_LOG_TRACKABLE(requestURL.host));
             [MSIDAppExtensionUtil sharedApplicationOpenURL:requestURL];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+TBD
+* Fixed logic to open links within iframe in embedded webiview in itself instead of Safari. (#1074)
+
 Version 1.7.3
 * Enable additional warnings (#1042)
 * sanity check sso ext response. If no meaningful will use local result (#1065)


### PR DESCRIPTION
## Proposed changes

In the sign in page, there is an option for user to create a MSA account via signup. 
During the sign up flow, there is a javascript game loaded in iframe to check if user is a robot/spammer. 
Clicking captcha image links in it causes them to open in safari instead of the same webview. This PR aims to update this logic so that links in iframes do not open in safari while keeping existing logic of opening links with target="_blank" in safari.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

