### PR TITLE
Expose keychain error osstatus in errors returned by MSIDAssymetricKeyKeychainGenerator

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 TBD
 * Fixed logic to open links within iframe in embedded webiview in itself instead of Safari. (#1074)
+* Expose keychain error OSStatus in errors returned by MSIDAssymetricKeyKeychainGenerator (#1079)
 
 Version 1.7.3
 * Enable additional warnings (#1042)


### PR DESCRIPTION
Expose keychain error osstatus in errors returned by MSIDAssymetricKeyKeychainGenerator

## Proposed changes

This change fixes 2 issues:
1. MSIDAssymetricKeyKeychainGenerator generateKeyPainForAttributes:error: overwrites an error returned by deleteItemWithAttributes:error: today. The change updates generateKeyPainForAttributes:error to directly returns the error.

2. MSIDAssymetricKeyKeychainGenerator logAndFillError:status:error: does not expose the status parameter on the returned error today. This prevents the calling code (like OneAuth-MSAL) to report the error in telemetry. This change packs any non-trivial status into an underlying NSError and attaches it to the error created by  logAndFillError:status:error: .

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

ADO#1729972