### PR TITLE
Multitenant PkeyAuth support

### DIFF
--- a/IdentityCore/MSIDTestsHostApp/MSIDTestsHostApp.entitlements
+++ b/IdentityCore/MSIDTestsHostApp/MSIDTestsHostApp.entitlements
@@ -8,6 +8,7 @@
 		<string>$(AppIdentifierPrefix)com.microsoft.MSIDTestsHostApp</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.intune.mam</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.workplacejoin.v2</string>
 	</array>
 </dict>
 </plist>

--- a/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
+++ b/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.m
@@ -39,10 +39,12 @@
                                   challengeData:(nullable NSDictionary *)challengeData
                                         context:(nullable id<MSIDRequestContext>)context
 {
-    MSIDAssymetricKeyPairWithCert *info = [MSIDWorkPlaceJoinUtil getWPJKeysWithContext:context];
     NSString *authToken = @"";
     NSString *challengeContext = challengeData ? [challengeData valueForKey:@"Context"] : @"";
     NSString *challengeVersion = challengeData ? [challengeData valueForKey:@"Version"] : @"";
+    NSString *challengeTenantId = challengeData ? [challengeData valueForKey:@"TenantId"] : @"";
+    
+    MSIDAssymetricKeyPairWithCert *info = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:challengeTenantId context:context];
     
     if (!info)
     {

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
@@ -33,7 +33,8 @@
 + (nullable MSIDRegistrationInformation *)getRegistrationInformation:(nullable id<MSIDRequestContext>)context
                                               workplacejoinChallenge:(nullable MSIDWorkplaceJoinChallenge *)workplacejoinChallenge;
 
-+ (nullable MSIDAssymetricKeyPairWithCert *)getWPJKeysWithContext:(nullable id<MSIDRequestContext>)context;
++ (nullable MSIDAssymetricKeyPairWithCert *)getWPJKeysWithTenantId:(nullable NSString *)tenantId
+                                                           context:(nullable id<MSIDRequestContext>)context;
 
 + (nullable NSString *)getWPJStringDataForIdentifier:(nonnull NSString *)identifier
                                              context:(nullable id<MSIDRequestContext>)context

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
@@ -33,6 +33,8 @@
 + (nullable MSIDRegistrationInformation *)getRegistrationInformation:(nullable id<MSIDRequestContext>)context
                                               workplacejoinChallenge:(nullable MSIDWorkplaceJoinChallenge *)workplacejoinChallenge;
 
++ (nullable MSIDAssymetricKeyPairWithCert *)getWPJKeysWithContext:(nullable id<MSIDRequestContext>)context;
+
 + (nullable MSIDAssymetricKeyPairWithCert *)getWPJKeysWithTenantId:(nullable NSString *)tenantId
                                                            context:(nullable id<MSIDRequestContext>)context;
 

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtilBase.m
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtilBase.m
@@ -78,7 +78,7 @@ NSString *const MSID_DEVICE_INFORMATION_AAD_TENANT_ID_KEY = @"aadTenantIdentifie
 
 + (nullable NSDictionary *)getRegisteredDeviceMetadataInformation:(nullable id<MSIDRequestContext>)context
 {
-    MSIDAssymetricKeyPairWithCert *wpjCerts = [MSIDWorkPlaceJoinUtil getWPJKeysWithContext:context];
+    MSIDAssymetricKeyPairWithCert *wpjCerts = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:nil context:context];
 
     if (wpjCerts)
     {

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -33,6 +33,11 @@ static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privat
 
 @implementation MSIDWorkPlaceJoinUtil
 
++ (nullable MSIDAssymetricKeyPairWithCert *)getWPJKeysWithContext:(nullable id<MSIDRequestContext>)context
+{
+    return [self getWPJKeysWithTenantId:nil context:context];
+}
+
 + (MSIDAssymetricKeyPairWithCert *)getWPJKeysWithTenantId:(NSString *)tenantId context:(id<MSIDRequestContext>)context
 {
     return [self getRegistrationInformation:context tenantId:tenantId workplacejoinChallenge:nil];

--- a/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
@@ -185,7 +185,12 @@
 
 #pragma mark - Lookup by private key
 
-+ (MSIDAssymetricKeyPairWithCert *)getWPJKeysWithTenantId:(NSString *)tenantId context:(__unused id<MSIDRequestContext>)context
++ (nullable MSIDAssymetricKeyPairWithCert *)getWPJKeysWithContext:(nullable id<MSIDRequestContext>)context
+{
+    return [self getWPJKeysWithTenantId:nil context:context];
+}
+
++ (MSIDAssymetricKeyPairWithCert *)getWPJKeysWithTenantId:(__unused NSString *)tenantId context:(__unused id<MSIDRequestContext>)context
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"No cert authorities provided in the request. Looking up default WPJ certificate");
     return [self findDefaultWPJRegistrationInfoWithContext:context];

--- a/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
@@ -185,7 +185,7 @@
 
 #pragma mark - Lookup by private key
 
-+ (MSIDAssymetricKeyPairWithCert *)getWPJKeysWithContext:(id<MSIDRequestContext>)context
++ (MSIDAssymetricKeyPairWithCert *)getWPJKeysWithTenantId:(NSString *)tenantId context:(__unused id<MSIDRequestContext>)context
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"No cert authorities provided in the request. Looking up default WPJ certificate");
     return [self findDefaultWPJRegistrationInfoWithContext:context];

--- a/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
+++ b/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
@@ -41,9 +41,9 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
 
 - (void)setUp
 {
-    [self swizzleMethod:@selector(getWPJKeysWithContext:)
+    [self swizzleMethod:@selector(getWPJKeysWithTenantId:context:)
                 inClass:[MSIDWorkPlaceJoinUtil class]
-             withMethod:@selector(getWPJKeysWithContext:)
+             withMethod:@selector(swizzled_getWPJKeysWithTenantId:context:)
               fromClass:[self class]
      ];
     
@@ -52,9 +52,9 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
 
 - (void)tearDown
 {
-    [self swizzleMethod:@selector(getWPJKeysWithContext:)
+    [self swizzleMethod:@selector(getWPJKeysWithTenantId:context:)
                 inClass:[MSIDWorkPlaceJoinUtil class]
-             withMethod:@selector(getWPJKeysWithContext:)
+             withMethod:@selector(swizzled_getWPJKeysWithTenantId:context:)
               fromClass:[self class]
      ];
     
@@ -246,7 +246,7 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
     method_exchangeImplementations(originalMethod, mockMethod);
 }
 
-+ (MSIDAssymetricKeyPairWithCert *)getWPJKeysWithContext:(__unused id<MSIDRequestContext>)context
++ (MSIDAssymetricKeyPairWithCert *)swizzled_getWPJKeysWithTenantId:(NSString *)tenantId context:(id<MSIDRequestContext>)context
 {
     return s_registrationInformationToReturn;
 }

--- a/IdentityCore/tests/MSIDWorkPlaceJoinUtilTests.m
+++ b/IdentityCore/tests/MSIDWorkPlaceJoinUtilTests.m
@@ -25,11 +25,17 @@
 #import "MSIDKeychainUtil.h"
 #import "MSIDWorkPlaceJoinUtil.h"
 #import "MSIDWorkPlaceJoinConstants.h"
+#import "NSData+MSIDExtensions.h"
+#import "MSIDAssymetricKeyPairWithCert.h"
 
 @interface MSIDWorkPlaceJoinUtilTests : XCTestCase
 @end
 
 NSString * const dummyKeyIdendetifier = @"com.microsoft.workplacejoin.dummyKeyIdentifier";
+static NSString *kDummyTenant1CertIdentifier = @"OWVlNWYzM2ItOTc0OS00M2U3LTk1NjctODMxOGVhNDEyNTRi";
+static NSString *kDummyTenant2CertIdentifier = @"OWZmNWYzM2ItOTc0OS00M2U3LTk1NjctODMxOGVhNDEyNTRi";
+static NSString *kDummyTenant3CertIdentifier = @"NmFhNWYzM2ItOTc0OS00M2U3LTk1NjctODMxOGVhNDEyNTRi";
+
 
 @implementation MSIDWorkPlaceJoinUtilTests
 
@@ -37,23 +43,18 @@ NSString * const dummyKeyIdendetifier = @"com.microsoft.workplacejoin.dummyKeyId
     // Put setup code here. This method is called before the invocation of each test method in the class.
 }
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+- (void)tearDown
+{
+#if TARGET_OS_IPHONE
+    [self cleanWPJ:[self keychainGroup:YES]];
+    [self cleanWPJ:[self keychainGroup:NO]];
+#endif
 }
 
 - (void)testGetWPJStringDataForIdentifier_withKeychainItem_shouldReturnValidValue
 {
     NSString *dummyKeyIdentifierValue = @"dummyupn@dummytenant.com";
-
-    NSString *sharedAccessGroup = nil;
-    #if TARGET_OS_IPHONE
-    NSString *teamId = [[MSIDKeychainUtil sharedInstance] teamId];
-
-    if (teamId)
-    {
-        sharedAccessGroup = [NSString stringWithFormat:@"%@.com.microsoft.workplacejoin", teamId];
-    }
-    #endif
+    NSString *sharedAccessGroup = [self keychainGroup:YES];
 
     // Insert dummy UPN value.
     [MSIDWorkPlaceJoinUtilTests insertDummyStringDataIntoKeychain:dummyKeyIdentifierValue dataIdentifier:dummyKeyIdendetifier accessGroup:sharedAccessGroup];
@@ -68,15 +69,7 @@ NSString * const dummyKeyIdendetifier = @"com.microsoft.workplacejoin.dummyKeyId
 
 - (void)testGetWPJStringDataForIdentifier_withoutKeychainItem_shouldReturnNil
 {
-    NSString *sharedAccessGroup = nil;
-    #if TARGET_OS_IPHONE
-    NSString *teamId = [[MSIDKeychainUtil sharedInstance] teamId];
-
-    if (teamId)
-    {
-        sharedAccessGroup = [NSString stringWithFormat:@"%@.com.microsoft.workplacejoin", teamId];
-    }
-    #endif
+    NSString *sharedAccessGroup = [self keychainGroup:YES];
 
     // Delete dummy key-value, if any exists before
     [MSIDWorkPlaceJoinUtilTests deleteDummyStringDataIntoKeychain:dummyKeyIdendetifier accessGroup:sharedAccessGroup];
@@ -85,7 +78,227 @@ NSString * const dummyKeyIdendetifier = @"com.microsoft.workplacejoin.dummyKeyId
     XCTAssertNil(keyData);
 }
 
+#pragma mark - iOS WPJ tests
+
+#if TARGET_OS_IPHONE
+- (void)testGetWPJKeysWithTenantId_whenWPJMissing_shouldReturnNil
+{
+    MSIDAssymetricKeyPairWithCert *result = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:@"tenantId" context:nil];
+    XCTAssertNil(result);
+}
+
+- (void)testGetWPJKeysWithTenantId_whenWPJInLegacyFormat_andTenantIdMatches_shouldReturnRegistration
+{
+    [self insertDummyWPJInLegacyFormat:YES tenantIdentifier:@"tenantId" writeTenantMetadata:YES certIdentifier:kDummyTenant1CertIdentifier];
+    
+    MSIDAssymetricKeyPairWithCert *result = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:@"tenantId" context:nil];
+    XCTAssertNotNil(result);
+}
+
+- (void)testGetWPJKeysWithTenantId_whenWPJInLegacyFormat_andTenantIdMismatches_shouldReturnRegistration
+{
+    [self insertDummyWPJInLegacyFormat:YES tenantIdentifier:@"tenantId2" writeTenantMetadata:YES certIdentifier:kDummyTenant2CertIdentifier];
+    
+    MSIDAssymetricKeyPairWithCert *result = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:@"tenantId" context:nil];
+    XCTAssertNotNil(result);
+}
+
+- (void)testGetWPJKeysWithTenantId_whenWPJInLegacyFormat_andNoTenantIdWritten_shouldReturnRegistration
+{
+    [self insertDummyWPJInLegacyFormat:YES tenantIdentifier:@"tenantId2" writeTenantMetadata:NO certIdentifier:kDummyTenant2CertIdentifier];
+    
+    MSIDAssymetricKeyPairWithCert *result = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:@"tenantId" context:nil];
+    XCTAssertNotNil(result);
+}
+
+- (void)testGetWPJKeysWithTenantId_whenWPJInLegacyFormat_andNoTenantIdRequested_shouldReturnRegistration
+{
+    [self insertDummyWPJInLegacyFormat:YES tenantIdentifier:nil writeTenantMetadata:YES certIdentifier:kDummyTenant1CertIdentifier];
+    
+    MSIDAssymetricKeyPairWithCert *result = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:@"tenantId" context:nil];
+    XCTAssertNotNil(result);
+}
+
+- (void)testGetWPJKeysWithTenantId_whenWPJInLegacyFormat_andNoTenantIdRequestedNotWritten_shouldReturnRegistration
+{
+    [self insertDummyWPJInLegacyFormat:YES tenantIdentifier:nil writeTenantMetadata:NO certIdentifier:kDummyTenant1CertIdentifier];
+    
+    MSIDAssymetricKeyPairWithCert *result = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:@"tenantId" context:nil];
+    XCTAssertNotNil(result);
+}
+
+- (void)testGetWPJKeysWithTenantId_whenMultipleWPJInLegacyAndDefaultFormat_andMatchingDefaultOne_shouldReturnDefaultRegistration
+{
+    [self insertDummyWPJInLegacyFormat:YES tenantIdentifier:@"tenantId1" writeTenantMetadata:YES certIdentifier:kDummyTenant1CertIdentifier];
+    [self insertDummyWPJInLegacyFormat:NO tenantIdentifier:@"tenantId2" writeTenantMetadata:NO certIdentifier:kDummyTenant3CertIdentifier];
+    
+    MSIDAssymetricKeyPairWithCert *result = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:@"tenantId2" context:nil];
+    XCTAssertNotNil(result);
+    
+    NSString *expectedIssuer = [kDummyTenant3CertIdentifier msidBase64UrlDecode];
+    XCTAssertEqualObjects(expectedIssuer, result.certificateSubject);
+}
+
+- (void)testGetWPJKeysWithTenantId_whenMultipleWPJInDefaultFormat_andLegacyRegistration_withMismatchingTenant_shouldReturnLegacyRegistration
+{
+    [self insertDummyWPJInLegacyFormat:YES tenantIdentifier:@"contoso" writeTenantMetadata:NO certIdentifier:kDummyTenant3CertIdentifier];
+    [self insertDummyWPJInLegacyFormat:NO tenantIdentifier:@"tenantId1" writeTenantMetadata:NO certIdentifier:kDummyTenant1CertIdentifier];
+    [self insertDummyWPJInLegacyFormat:NO tenantIdentifier:@"tenantId2" writeTenantMetadata:NO certIdentifier:kDummyTenant2CertIdentifier];
+    
+    MSIDAssymetricKeyPairWithCert *result = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:@"tenantId3" context:nil];
+    XCTAssertNotNil(result);
+    NSString *expectedIssuer = [kDummyTenant3CertIdentifier msidBase64UrlDecode];
+    XCTAssertEqualObjects(expectedIssuer, result.certificateSubject);
+}
+#endif
+
 #pragma mark - Helpers
+
+- (void)cleanWPJ:(NSString *)keychainGroup
+{
+    NSArray *deleteClasses = @[(__bridge id)(kSecClassKey), (__bridge id)(kSecClassCertificate), (__bridge id)(kSecClassGenericPassword)];
+    
+    for (NSString *deleteClass in deleteClasses)
+    {
+        NSMutableDictionary *deleteQuery = [[NSMutableDictionary alloc] init];
+        [deleteQuery setObject:deleteClass forKey:(__bridge id)kSecClass];
+    #if TARGET_OS_IOS
+        [deleteQuery setObject:keychainGroup forKey:(__bridge id)kSecAttrAccessGroup];
+    #endif
+        OSStatus result = SecItemDelete((__bridge CFDictionaryRef)deleteQuery);
+        XCTAssertTrue(result == errSecSuccess || result == errSecItemNotFound);
+    }
+}
+
+- (OSStatus)insertDummyWPJInLegacyFormat:(BOOL)useLegacyFormat
+                        tenantIdentifier:(NSString *)tenantIdentifier
+                     writeTenantMetadata:(BOOL)writeTenantMetadata
+                          certIdentifier:(NSString *)certIdentifier
+{
+    SecCertificateRef certRef = [self dummyCertRef:certIdentifier];
+    SecKeyRef keyRef = [self dummyPrivateKeyForCertRef];
+    
+    NSString *keychainGroup = [self keychainGroup:useLegacyFormat];
+    
+    NSString *tag = nil;
+    
+    if (useLegacyFormat)
+    {
+        tag = [NSString stringWithFormat:@"%@", kMSIDPrivateKeyIdentifier];
+        
+        if (writeTenantMetadata && tenantIdentifier)
+        {
+            [self.class insertDummyStringDataIntoKeychain:tenantIdentifier
+                                           dataIdentifier:kMSIDTenantKeyIdentifier
+                                              accessGroup:keychainGroup];
+        }
+    }
+    else
+    {
+        tag = [NSString stringWithFormat:@"%@#%@", kMSIDPrivateKeyIdentifier, tenantIdentifier];
+    }
+    
+    return [self insertDummyDRSIdentityIntoKeychain:certRef
+                                      privateKeyRef:keyRef
+                                      privateKeyTag:tag
+                                        accessGroup:keychainGroup];
+
+}
+
+- (OSStatus)insertDummyDRSIdentityIntoKeychain:(SecCertificateRef)certRef
+                                 privateKeyRef:(SecKeyRef)privateKeyRef
+                                 privateKeyTag:(NSString *)privateKeyTag
+                                   accessGroup:(NSString *)accessGroup
+{
+    OSStatus status = noErr;
+    
+    status = [self insertKeyIntoKeychain:privateKeyRef
+                           privateKeyTag:privateKeyTag
+                             accessGroup:accessGroup];
+    if (status != noErr)
+    {
+        return status;
+    }
+    
+    return [self insertCertIntoKeychain:certRef
+                            accessGroup:accessGroup
+                          publicKeyHash:nil];
+}
+
+- (OSStatus)insertKeyIntoKeychain:(SecKeyRef)keyRef
+                    privateKeyTag:(NSString *)keyTag
+                      accessGroup:(NSString *)accessGroup
+{
+    NSMutableDictionary *keyInsertQuery = [[NSMutableDictionary alloc] init];
+    [keyInsertQuery setObject:(__bridge id)(kSecClassKey) forKey:(__bridge id)kSecClass];
+    [keyInsertQuery setObject:(__bridge id)(keyRef) forKey:(__bridge id)kSecValueRef];
+    [keyInsertQuery setObject:[NSData dataWithBytes:[keyTag UTF8String] length:keyTag.length] forKey:(__bridge id)kSecAttrApplicationTag];
+
+#if TARGET_OS_IOS
+    [keyInsertQuery setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+#endif
+    return SecItemAdd((__bridge CFDictionaryRef)keyInsertQuery, nil);
+}
+
+- (OSStatus)insertCertIntoKeychain:(SecCertificateRef)certRef
+                       accessGroup:(NSString *)accessGroup
+                     publicKeyHash:(NSData *)publicKeyHash
+{
+    NSMutableDictionary *certInsertQuery = [[NSMutableDictionary alloc] init];
+    [certInsertQuery setObject:(__bridge id)(kSecClassCertificate) forKey:(__bridge id)kSecClass];
+    [certInsertQuery setObject:(__bridge id)(certRef) forKey:(__bridge id)kSecValueRef];
+#if TARGET_OS_IOS
+    [certInsertQuery setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+#else
+    //For MacOS new getWorkPlaceJoinKeyObj queries certificate reference using publicKeyHash (applicationLabel) retrieved from the private key dictionary
+    [certInsertQuery setObject:publicKeyHash forKey:(__bridge id)kSecAttrPublicKeyHash];
+#endif
+    return SecItemAdd((__bridge CFDictionaryRef)certInsertQuery, NULL);
+}
+
+- (SecCertificateRef)dummyCertRef:(NSString *)certIdentifier
+{
+    NSString *drsIssuedCertificate = [self dummyCertificate:certIdentifier];
+    NSData *certData = [NSData msidDataFromBase64UrlEncodedString:drsIssuedCertificate];
+    return SecCertificateCreateWithData(NULL, (__bridge CFDataRef)(certData));
+}
+
+- (NSString *)dummyCertificate:(NSString *)certIdentifier
+{
+    return [NSString stringWithFormat: @"MIIEAjCCAuqgAwIBAgIQFc8t8z6QDoBGW1z8UDN+0zANBgkqhkiG9w0BAQsFADB4MXYwEQYKCZImiZPyLGQBGRYDbmV0MBUGCgmSJomT8ixkARkWB3dpbmRvd3MwHQYDVQQDExZNUy1Pcmdhbml6YXRpb24tQWNjZXNzMCsGA1UECxMkODJkYmFjYTQtM2U4MS00NmNhLTljNzMtMDk1MGMxZWFjYTk3MB4XDTE5MDgyOTIwMjU1NloXDTI5MDgyOTIwNTU1NlowLzEtMCsGA1UEAxMk%@MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1H1ZmEe+OrXboN63oF8i+H649IHZaPySEnjQYF61TXS6vg0j2EC5e43xql3AG43NgDVW7ZrwtFvm5xIvXKCnN3BoQCi6JtUN6K7eZCnFdQIdrAV2Pyq5zkl9RItziKKFg+Gf92Bz5TQVgP3i/mb2xZe5fabNa0Jdj9tMSlq1QppDTyV01NOqk+AfPNwJsFlMZegGFdjLC3thGIgJEywmCaJacg+SBx2Vp3DawnuFMhWp1WRHJweZWZScCTCApiE5HJY4zMI44NJPOLUkUnN6zc7Yzw0AXKIZBid99OWlhJ6jQ92ayQEzmfNZM0IRRtl1VeU5TOQ1NcvKSyQFQ5uyvQIDAQABo4HQMIHNMAwGA1UdEwEB/wQCMAAwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwIwDgYDVR0PAQH/BAQDAgeAMCIGCyqGSIb3FAEFghwCBBMEgRA78+WeSZfnQ5VngxjqQSVLMCIGCyqGSIb3FAEFghwDBBMEgRBP+CztBI6eSJZu39covAlhMCIGCyqGSIb3FAEFghwFBBMEgRCS4qJehkWISIVqoGYSGf2rMBQGCyqGSIb3FAEFghwIBAUEgQJOQTATBgsqhkiG9xQBBYIcBwQEBIEBMDANBgkqhkiG9w0BAQsFAAOCAQEAn6nzvuRd1moZ78aNfaZwFlxJx9ycNQNHRVljw4/Asqc9X2ySq4vE+f3zpqq2Q0c6lZ/yykb0KmZXeqWgyRK82uR48gWNAVvbPJr4l6B2cnTHAwkc+PLmADr7sE2WgBGH3uSqMcDKSbE/VpH3zOAnxeC8RByy/EEvGdC3YasjR9IGL4sSkyLHrZNO6Pz7oApL/BA713xJcp+EkzDIFF09JILuP1IANz8uW26GyNLBtBfdulKbbzv1i0tWMukN+s8upm9mWJyn8hXmz/LUa5NQtP0mBrRbw1d7NXPOgO54dr+DPpKZxrQw6zpwCJ/waeKIJjHAIDAF6h1BjFCaAulhJA==", certIdentifier];
+}
+
+- (NSString *)dummyPrivateKeyForCert
+{
+    return @"MIIEowIBAAKCAQEA1H1ZmEe+OrXboN63oF8i+H649IHZaPySEnjQYF61TXS6vg0j2EC5e43xql3AG43NgDVW7ZrwtFvm5xIvXKCnN3BoQCi6JtUN6K7eZCnFdQIdrAV2Pyq5zkl9RItziKKFg+Gf92Bz5TQVgP3i/mb2xZe5fabNa0Jdj9tMSlq1QppDTyV01NOqk+AfPNwJsFlMZegGFdjLC3thGIgJEywmCaJacg+SBx2Vp3DawnuFMhWp1WRHJweZWZScCTCApiE5HJY4zMI44NJPOLUkUnN6zc7Yzw0AXKIZBid99OWlhJ6jQ92ayQEzmfNZM0IRRtl1VeU5TOQ1NcvKSyQFQ5uyvQIDAQABAoIBAEmRRI3GeQQWpn2h3m11wsPKC/sLYdxJZcFjdrGG2LqCaY0XO4vJjO5MDJlxb+uaQsXascf91sx67QyfbSpirMIy9sUP1LNRHEmtEW4YUDbcjq1aDsB76GyVYPt0VIG/0v4ABcQ97qIyUCeivw5ZU6LBjwUD1ScHiSEfSeCMWyk9YgRUozM3yZOpvugwjOF7efEjVlWvGvIfh9U/Xyeuj+NJ3r8zW87K+ySzGwrPwEmfBBfyd5LOqZzPJAKGJ3og8oaMDf4IWV7iSicCcPCbq6psj+B/i4HZc9u3MqE7YjKVbNG2S6qDsLUxpWfct72ZeKtfZcb3Kqa1nh0RximqUoECgYEA6UfzvsHg283KOTxQqX3v2IDbtwv73wKd/+V8sq8mhtjJhv5SpyJe99L/cuoxTu2ELUPmKIP++b7oyMvdRNyJaLIMRYDGGAKeLXXtWht//tCmHXyOZDhs9oHC3EMNHmqXBDSObL/CbN5puAQbCjofUX5zTNMdmq0qTOPYUezxjHECgYEA6S8JXstQ5RL+pmonoFlPWfuwXL8chpGJH1iOab1WYwjAbszSy1LJBQu5dWhKcqLl3EFywJgWRUKGFlQ/099XRVTHl4YhjEN054GEBxsTkZUhwXh0l0v6lPnsG6daWcTZ44gh4FXtqfPD/5/RcWUfhYQW0NoeIzviWt8MqZ6NIQ0CgYEA1TDpg/qBOb9vQTFq8grix7Szlyx/iYZFyNf8RvwktHWobxM7i/ywV8HfrDB00ZHlCs0TqRFAUxNygBc3Zzg455JX/qi54LV7w0YTnRamucQLG8V6CAM9KWbbIxqwAY0d6DzzsFTrJT151i8CWy1U89AhJSOG2ZXJo61SQ0TMVzECgYA6w8PUw+BLGpJaVf5OhrNctfUoKnGB6ENqRuL8+t4+bwIv6iZlXyORxfajA/lfEnZjH4tPxgQ2yCEKl4jOWEaiDk+OfBsQQh/AB//B2qz/z1mGbFjVmCw6RxGdlntKjDVtBe2jn4QZhHksfpZFwXpEJ5moYI+fyYOt6vBB/tcKMQKBgD7q4f036ad5TeX14vsFSSkGeOJrbUw0UqYeUit9B8DICwrV42/z60kTXxGg+2Wo8gL5Fo2tKCUe34BvvpMP92EKB/qbjoIirbZVnEDP9K1rCdGdEaYzDlRXsQ/p/bM6Tz3X++wpnqcDQhJp6lTDVLaX4faSQjWuVVIHVn1zpvIr";
+}
+
+- (SecKeyRef)dummyPrivateKeyForCertRef
+{
+    NSDictionary *keyAttr = @{(__bridge NSString*) kSecAttrKeyType : (__bridge NSString*)kSecAttrKeyTypeRSA,
+                              (__bridge NSString*) kSecAttrKeyClass : (__bridge NSString*)kSecAttrKeyClassPrivate};
+    
+    NSString *privateKeyForCert = [self dummyPrivateKeyForCert];
+    NSData *keyData = [NSData msidDataFromBase64UrlEncodedString:privateKeyForCert];
+    return SecKeyCreateWithData((__bridge CFDataRef)keyData, (__bridge CFDictionaryRef) keyAttr, NULL);
+}
+
+- (NSString *)keychainGroup:(BOOL)useLegacyFormat
+{
+#if TARGET_OS_IPHONE
+    NSString *teamId = [[MSIDKeychainUtil sharedInstance] teamId];
+    XCTAssertNotNil(teamId);
+
+    if (useLegacyFormat)
+    {
+        return [NSString stringWithFormat:@"%@.com.microsoft.workplacejoin", teamId];
+    }
+    
+    return [NSString stringWithFormat:@"%@.com.microsoft.workplacejoin.v2", teamId];
+#else
+    return nil;
+#endif
+}
 
 + (OSStatus) insertDummyStringDataIntoKeychain: (NSString *) stringData
                                 dataIdentifier: (NSString *) dataIdentifier

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Multitenant PkeyAuth support (#1081)
 * Fixed logic to open links within iframe in embedded webiview in itself instead of Safari. (#1074)
 * Expose keychain error OSStatus in errors returned by MSIDAssymetricKeyKeychainGenerator (#1079)
 


### PR DESCRIPTION
## Proposed changes

Allows handling PkeyAuth challenges for multiple tenant registrations. Note that MSAL version bump to 1.2 is a requirement to get tenantId from ESTS.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

