### PR TITLE
Prevent logging PII in query to NSDictionary extension method

### DIFF
--- a/IdentityCore/src/util/NSDictionary+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSDictionary+MSIDExtensions.m
@@ -53,16 +53,17 @@
     for (NSString *query in queries)
     {
         NSArray *queryElements = [query componentsSeparatedByString:@"="];
-        if (queryElements.count > 2)
-        {
-            MSID_LOG_WITH_CTX(MSIDLogLevelWarning,nil, @"Query parameter must be a form key=value: %@", query);
-            continue;
-        }
         
         NSString *key = isFormEncoded ? [queryElements[0] msidTrimmedString].msidWWWFormURLDecode : [queryElements[0] msidTrimmedString].msidURLDecode;
         if ([NSString msidIsStringNilOrBlank:key])
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelWarning,nil, @"Query parameter must have a key");
+            MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Query parameter must have a key");
+            continue;
+        }
+        
+        if (queryElements.count > 2)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Query parameter contains more than one '=' for key: %@", key);
             continue;
         }
         

--- a/IdentityCore/tests/MSIDDictionaryExtensionsTests.m
+++ b/IdentityCore/tests/MSIDDictionaryExtensionsTests.m
@@ -53,24 +53,30 @@
 
 - (void)testmsidDictionaryFromWWWFormURLEncodedString_whenStringContainsQuery_shouldReturnDictWithDecoding
 {
-    NSString *string = @"key=Some+interesting+test%2F%2B-%29%28%2A%26%5E%25%24%23%40%21~%7C";
+    NSString *string = @"key=Some+interesting+test%2F%2B-%29%28%2A%26%5E%25%24%23%40%21~%7C%3D";
     NSDictionary *dict = [NSDictionary msidDictionaryFromWWWFormURLEncodedString:string];
     
     XCTAssertTrue([[dict allKeys] containsObject:@"key"]);
-    XCTAssertEqualObjects(dict[@"key"], @"Some interesting test/+-)(*&^%$#@!~|");
+    XCTAssertEqualObjects(dict[@"key"], @"Some interesting test/+-)(*&^%$#@!~|=");
 }
 
 - (void)testmsidDictionaryFromURLEncodedString_whenMalformedQuery_shouldReturnDictWithoutBadQuery
 {
-    NSString *string = @"key=val+val&malformed=v1=v2&=noval";
+    NSString *string = @"key=val+val&malformed=v1=v2&=nokey&noval&doubleEqualButEncoded=2%3D2&";
     NSDictionary *dict = [NSDictionary msidDictionaryFromURLEncodedString:string];
     
-    XCTAssertTrue(dict.count == 1);
+    XCTAssertTrue(dict.count == 3);
     XCTAssertTrue([dict.allKeys containsObject:@"key"]);
+    XCTAssertTrue([dict.allKeys containsObject:@"noval"]);
+    XCTAssertTrue([dict.allKeys containsObject:@"doubleEqualButEncoded"]);
+    
+    XCTAssertFalse([dict.allKeys containsObject:@"malformed"]);
+    XCTAssertFalse([dict.allKeys containsObject:@""]);
     
     XCTAssertEqualObjects(dict[@"key"], @"val+val");
+    XCTAssertEqualObjects(dict[@"noval"], @"");
+    XCTAssertEqualObjects(dict[@"doubleEqualButEncoded"], @"2=2");
 }
-
 
 - (void)testMsidDictionaryByRemovingFields_whenNilKeysArray_shouldNotRemoveFields
 {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 TBD
 * Fixed logic to open links within iframe in embedded webiview in itself instead of Safari. (#1074)
 * Expose keychain error OSStatus in errors returned by MSIDAssymetricKeyKeychainGenerator (#1079)
+* Prevent logging PII in query to NSDictionary extension method (#1084)
 
 Version 1.7.3
 * Enable additional warnings (#1042)


### PR DESCRIPTION
Add generic warning message when query contains more than one '=' before converting it to NSDictionary and prevent logging PII data. 
Update tests with additional cases.

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

