### PR TITLE
Add more utility to automation tests

### DIFF
--- a/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDTestAutomationAccount.h
+++ b/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDTestAutomationAccount.h
@@ -43,6 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Writable properties
 @property (nonatomic, nullable) NSString *password;
+@property (nonatomic, nullable) NSString *overriddenTargetTenantId;
+@property (nonatomic, nullable) NSString *overriddenKeyvaultName;
 
 @end
 

--- a/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDTestAutomationAccount.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDTestAutomationAccount.m
@@ -120,4 +120,18 @@ static NSDictionary *s_tenantMappingDictionary;
     return nil;
 }
 
+- (NSString *)targetTenantId
+{
+    if (![NSString msidIsStringNilOrBlank:self.overriddenTargetTenantId]) return self.overriddenTargetTenantId;
+    
+    return _targetTenantId;
+}
+
+- (NSString *)keyvaultName
+{
+    if (![NSString msidIsStringNilOrBlank:self.overriddenKeyvaultName]) return self.overriddenKeyvaultName;
+    
+    return _keyvaultName;
+}
+
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 TBD
+* Add more utilities for test automation
+
+Version 1.7.5
 * Multitenant PkeyAuth support (#1083)
 * Expose keychain error OSStatus in errors returned by MSIDAssymetricKeyKeychainGenerator (#1079)
 * Prevent logging PII in query to NSDictionary extension method (#1084)


### PR DESCRIPTION
## Proposed changes

Added overriddenKeyvaultName and  overriddenTargetTenantId to MSIDTestAutomationAccount. Lab team suggests to use `homeDomainName` to construct key vault URL for guest account:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1651300

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

