### PR TITLE
Read navigation response on MSIDOAuth2EmbeddedWebviewController

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
@@ -34,6 +34,8 @@
 #import "MSIDAuthorizeWebRequestConfiguration.h"
 #import "MSIDWebViewPlatformParams.h"
 
+typedef void (^NavigationResponseBlock)(NSHTTPURLResponse *response);
+
 @interface MSIDOAuth2EmbeddedWebviewController :
 MSIDWebviewUIController <MSIDWebviewInteracting, WKNavigationDelegate>
 
@@ -53,6 +55,7 @@ MSIDWebviewUIController <MSIDWebviewInteracting, WKNavigationDelegate>
                         decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler;
 
 @property (atomic, readonly) NSURL *startURL;
+@property (nonatomic, copy) NavigationResponseBlock navigationResponseBlock;
 
 @end
 

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
@@ -34,7 +34,7 @@
 #import "MSIDAuthorizeWebRequestConfiguration.h"
 #import "MSIDWebViewPlatformParams.h"
 
-typedef void (^NavigationResponseBlock)(NSHTTPURLResponse *response);
+typedef void (^MSIDNavigationResponseBlock)(NSHTTPURLResponse *response);
 
 @interface MSIDOAuth2EmbeddedWebviewController :
 MSIDWebviewUIController <MSIDWebviewInteracting, WKNavigationDelegate>
@@ -55,7 +55,7 @@ MSIDWebviewUIController <MSIDWebviewInteracting, WKNavigationDelegate>
                         decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler;
 
 @property (atomic, readonly) NSURL *startURL;
-@property (nonatomic, copy) NavigationResponseBlock navigationResponseBlock;
+@property (nonatomic, copy) MSIDNavigationResponseBlock navigationResponseBlock;
 
 @end
 

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -315,6 +315,20 @@
                         completionHandler:completionHandler];
 }
 
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler
+{
+    if (_navigationResponseBlock && navigationResponse && navigationResponse.response)
+    {
+        NSHTTPURLResponse *response = (NSHTTPURLResponse *)navigationResponse.response;
+        if (response)
+        {
+            self.navigationResponseBlock(response);
+        }
+    }
+    
+    decisionHandler(WKNavigationResponsePolicyAllow);
+}
+
 - (void)completeWebAuthWithURL:(NSURL *)endURL
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.context, @"-completeWebAuthWithURL: %@", [endURL msidPIINullifiedURL]);

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -317,7 +317,7 @@
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler
 {
-    if (_navigationResponseBlock && navigationResponse && navigationResponse.response)
+    if (self.navigationResponseBlock && navigationResponse && navigationResponse.response)
     {
         NSHTTPURLResponse *response = (NSHTTPURLResponse *)navigationResponse.response;
         if (response)


### PR DESCRIPTION
## Proposed changes

Allow reading navigation response from MSIDOAuth2EmbeddedWebviewController.
This is required to extract request-id & session-id from the response headers, this information will help troubleshoot when doing compliance check fails.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

