### PR TITLE
Fix a warning during telemetry decoding

### DIFF
--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
@@ -212,7 +212,7 @@ static int maxErrorCountToArchive = 75;
     NSInteger schemaVersion = [decoder decodeIntegerForKey:kSchemaVersion];
     NSInteger silentSuccessfulCount = [decoder decodeIntegerForKey:kSilentSuccessfulCount];
     
-    NSSet *classes = [NSSet setWithObjects:[NSMutableArray class], [MSIDRequestTelemetryErrorInfo class], nil];
+    NSSet *classes = [NSSet setWithObjects:[NSMutableArray class], [NSString class], [MSIDRequestTelemetryErrorInfo class], nil];
     NSMutableArray<MSIDRequestTelemetryErrorInfo *> *errorsInfo = [decoder decodeObjectOfClasses:classes forKey:kErrorsInfo];
     
     return [self initFromDecodedObjectWithSchemaVersion:schemaVersion silentSuccessfulCount:silentSuccessfulCount errorsInfo:errorsInfo];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 TBD
 * Add more utilities for test automation
+* Fix a warning during telemetry decoding
 
 Version 1.7.5
 * Multitenant PkeyAuth support (#1083)


### PR DESCRIPTION
## Proposed changes

The issue is reported in the MSAL repo: https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1455

The fix is to add the NSString type to when calling decode.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

