### PR TITLE
Performance Improvement for StartUp API

### DIFF
--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -49,16 +49,20 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
     self = [super init];
     if (self)
     {
-        NSArray *appList = [self trustedAppListWithCurrentApp:error];
-        
-        if (![appList count])
-        {
-            return nil;
-        }
-        
         NSMutableArray *allTrustedApps = [NSMutableArray new];
-        [allTrustedApps addObjectsFromArray:trustedApplications];
-        [allTrustedApps addObjectsFromArray:appList];
+        if (![trustedApplications count])
+        {
+            NSArray *appList = [self trustedAppListWithCurrentApp:error];
+            if (![appList count])
+            {
+                return nil;
+            }
+            [allTrustedApps addObjectsFromArray:appList];
+        }
+        else
+        {
+             [allTrustedApps addObjectsFromArray:trustedApplications];
+        }
         
         self.accessControlForSharedItems = [self accessCreateWithChangeACL:allTrustedApps accessLabel:accessLabel error:error];
         if (!self.accessControlForSharedItems)

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -50,9 +50,10 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
     if (self)
     {
         NSMutableArray *allTrustedApps = [NSMutableArray new];
+        NSArray *appList;
         if (![trustedApplications count])
         {
-            NSArray *appList = [self trustedAppListWithCurrentApp:error];
+            appList = [self trustedAppListWithCurrentApp:error];
             if (![appList count])
             {
                 return nil;
@@ -69,13 +70,15 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
         {
             return nil;
         }
-        
-        self.accessControlForNonSharedItems = [self accessCreateWithChangeACL:appList accessLabel:accessLabel error:error];
-        if (!self.accessControlForNonSharedItems)
+
+        if ([appList count])
         {
-            return nil;
+            self.accessControlForNonSharedItems = [self accessCreateWithChangeACL:appList accessLabel:accessLabel error:error];
+            if (!self.accessControlForNonSharedItems)
+            {
+                return nil;
+            }
         }
-        
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Init MSIDMacACLPersistentTokenCache");
     }
 


### PR DESCRIPTION
## Proposed changes
If list of trusted applications is provided by caller then use it instead of making an OS call.

Describe what this PR is trying to do.
During OneAuth/MSAL Startup on Mac, multiple calls are made to Sec* APIs like SecTrustedApplicationCreateFromRequirement, SecTrustedApplicationCreateFromPath (file:MOAUtil.m) etc... These APIs are heavy on IO and impacts performance. In current changes, if list of trusted applications is sent by caller then use them instead of querying them again. This change improves the performance by appox 15% in local dev environment.

How to verify impact: accessCreateWithChangeACL API uses the trusted application list to make another OS call. If any error, it logs the error code. We can track the error code in production to see if any spike in error.
ADO#1852918

Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

