### PR TITLE
Fix warning "allowed unarchiving safe plist type 'NSString'..."

### DIFF
--- a/IdentityCore/src/cache/MSIDMacTokenCache.m
+++ b/IdentityCore/src/cache/MSIDMacTokenCache.m
@@ -125,7 +125,7 @@ return NO; \
         [unarchiver setClass:MSIDLegacyTokenCacheKey.class forClassName:@"ADTokenCacheKey"];
         [unarchiver setClass:MSIDLegacyTokenCacheItem.class forClassName:@"ADTokenCacheStoreItem"];
         [unarchiver setClass:MSIDUserInformation.class forClassName:@"ADUserInformation"];
-        __auto_type allowedClasses = [NSSet setWithObjects:NSDictionary.class, MSIDLegacyTokenCacheKey.class, MSIDLegacyTokenCacheItem.class, MSIDUserInformation.class, nil];
+        __auto_type allowedClasses = [NSSet setWithObjects:NSDictionary.class, NSNumber.class, NSString.class, MSIDLegacyTokenCacheKey.class, MSIDLegacyTokenCacheItem.class, MSIDUserInformation.class, nil];
         cache = [unarchiver decodeObjectOfClasses:allowedClasses forKey:NSKeyedArchiveRootObjectKey];
         [unarchiver finishDecoding];
     }


### PR DESCRIPTION
## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] **Small** – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

Office reported seeing a lot of warnings when app is running, these warnings will be disallowed in the future:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1843056

The repro in OneAuthTestApp:
![32c665d2675f40f2f120e5a07af5f30](https://user-images.githubusercontent.com/62267180/165643795-9ee5ce17-8803-45f6-b053-0d75cdac2bde.jpg)

I believe the changes could eliminate the warnings.
