### PR TITLE
Fix handling protection_policies_required in silent flow

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -3994,8 +3994,8 @@
 			isa = PBXGroup;
 			children = (
 				239222AC243D3791009736C4 /* request_telemetry */,
-				B20657981FC91BE000412B7D /* MSIDTelemetryEventInterface.h */,
 				B20657A41FC91C1600412B7D /* MSIDTelemetryDispatcher.h */,
+				B20657981FC91BE000412B7D /* MSIDTelemetryEventInterface.h */,
 				B20657A71FC91DA900412B7D /* MSIDTelemetry.h */,
 				B206578E1FC91BDF00412B7D /* MSIDTelemetry.m */,
 				B20657A01FC91BE100412B7D /* MSIDTelemetry+Internal.h */,

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -387,6 +387,12 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
 
 - (BOOL)isErrorRecoverableByUserInteraction:(NSError *)msidError
 {
+    // TODO: cover with UT
+    if ([msidError.domain isEqualToString:MSIDOAuthErrorDomain] && msidError.code == MSIDErrorServerProtectionPoliciesRequired)
+    {
+        return NO;
+    }
+    
     MSIDErrorCode oauthError = MSIDErrorCodeForOAuthError(msidError.msidOauthError, MSIDErrorServerInvalidGrant);
     
     if (oauthError == MSIDErrorServerInvalidScope

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -387,7 +387,6 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
 
 - (BOOL)isErrorRecoverableByUserInteraction:(NSError *)msidError
 {
-    // TODO: cover with UT
     if ([msidError.domain isEqualToString:MSIDOAuthErrorDomain] && msidError.code == MSIDErrorServerProtectionPoliciesRequired)
     {
         return NO;


### PR DESCRIPTION
## Proposed changes

Fix mapping unauthorized_client + protection_policy_required.
It was mapped to 50002 (MSALErrorInteractionRequired) instead of 50004 (MSALErrorServerProtectionPoliciesRequired) in silent flow.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

