### PR TITLE
Validate if memory was successfully allocated before continuing.

### DIFF
--- a/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
+++ b/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
@@ -139,7 +139,7 @@
                                       fixedInput:(uint8_t*)mutData.bytes
                                 fixedInputLength:mutData.length];
     
-    if (pbDerivedKey == nil)
+    if (pbDerivedKey == NULL)
     {
         return nil;
     }
@@ -169,9 +169,9 @@
     ctr = 1;
     keyDerivated = (uint8_t *)malloc(outputSizeBit / 8); //output is 32 bytes
     
-    if (keyDerivated == nil)
+    if (keyDerivated == NULL)
     {
-        return nil;
+        return NULL;
     }
     
     do
@@ -181,9 +181,9 @@
                                fixedInput:fixedInput
                         fixedInput_length:fixedInputLength];
         
-        if (dataInput == nil)
+        if (dataInput == NULL)
         {
-            return nil;
+            return NULL;
         }
         
         CCHmac(kCCHmacAlgSHA256,
@@ -231,9 +231,9 @@
 {
     uint8_t *tmpFixedInput = (uint8_t *)malloc(fixedInput_length + 4); //+4 is caused from the ct
     
-    if (tmpFixedInput == nil)
+    if (tmpFixedInput == NULL)
     {
-        return nil;
+        return NULL;
     }
  
     tmpFixedInput[0] = (ctr >> 24);

--- a/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
+++ b/IdentityCore/src/cache/crypto/MSIDSymmetricKey.m
@@ -138,6 +138,12 @@
                           keyDerivationKeyLength:_symmetricKey.length
                                       fixedInput:(uint8_t*)mutData.bytes
                                 fixedInputLength:mutData.length];
+    
+    if (pbDerivedKey == nil)
+    {
+        return nil;
+    }
+    
     mutData = nil;
     NSData *dataToReturn = [NSData dataWithBytes:(const void *)pbDerivedKey length:32];
     free(pbDerivedKey);
@@ -163,12 +169,22 @@
     ctr = 1;
     keyDerivated = (uint8_t *)malloc(outputSizeBit / 8); //output is 32 bytes
     
+    if (keyDerivated == nil)
+    {
+        return nil;
+    }
+    
     do
     {
         //update data using "ctr"
         dataInput = [self updateDataInput:ctr
                                fixedInput:fixedInput
                         fixedInput_length:fixedInputLength];
+        
+        if (dataInput == nil)
+        {
+            return nil;
+        }
         
         CCHmac(kCCHmacAlgSHA256,
                keyDerivationKey,
@@ -215,6 +231,11 @@
 {
     uint8_t *tmpFixedInput = (uint8_t *)malloc(fixedInput_length + 4); //+4 is caused from the ct
     
+    if (tmpFixedInput == nil)
+    {
+        return nil;
+    }
+ 
     tmpFixedInput[0] = (ctr >> 24);
     tmpFixedInput[1] = (ctr >> 16);
     tmpFixedInput[2] = (ctr >> 8);

--- a/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.m
@@ -122,9 +122,15 @@
         NSString *key = [[NSString alloc] initWithData:self.encryptionKey encoding:NSASCIIStringEncoding];
         bzero(keyPtr, sizeof(keyPtr)); // fill with zeroes (for padding)
         // fetch key data
-        [key getCString:keyPtr maxLength:sizeof(keyPtr) encoding:NSUTF8StringEncoding];
-        keyBytes = keyPtr;
-        keySize = kCCKeySizeAES256;
+        if ([key getCString:keyPtr maxLength:sizeof(keyPtr) encoding:NSUTF8StringEncoding])
+        {
+            keyBytes = keyPtr;
+            keySize = kCCKeySizeAES256;
+        }
+        else
+        {
+            return nil;
+        }
     }
 
     return [response msidAES128DecryptedDataWithKey:keyBytes keySize:keySize];

--- a/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.m
@@ -122,15 +122,9 @@
         NSString *key = [[NSString alloc] initWithData:self.encryptionKey encoding:NSASCIIStringEncoding];
         bzero(keyPtr, sizeof(keyPtr)); // fill with zeroes (for padding)
         // fetch key data
-        if ([key getCString:keyPtr maxLength:sizeof(keyPtr) encoding:NSUTF8StringEncoding])
-        {
-            keyBytes = keyPtr;
-            keySize = kCCKeySizeAES256;
-        }
-        else
-        {
-            return nil;
-        }
+        [key getCString:keyPtr maxLength:sizeof(keyPtr) encoding:NSUTF8StringEncoding];
+        keyBytes = keyPtr;
+        keySize = kCCKeySizeAES256;
     }
 
     return [response msidAES128DecryptedDataWithKey:keyBytes keySize:keySize];


### PR DESCRIPTION
## Proposed changes

Add checks to make sure memory allocation is successful before continuing the process. 
Suggested in https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1497 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

