### PR TITLE
typeof -> __typeof__

### DIFF
--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetSsoCookiesRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetSsoCookiesRequest.m
@@ -52,7 +52,7 @@
         __typeof__(self) __weak weakSelf = self;
         self.extensionDelegate.completionBlock = ^(MSIDBrokerNativeAppOperationResponse *operationResponse, NSError *error)
         {
-            __strong typeof(self) strongSelf = weakSelf;
+            __strong __typeof__(self) strongSelf = weakSelf;
             NSArray *prtHeaders = nil;
             NSArray *deviceHeaders = nil;
             NSError *resultError = error;


### PR DESCRIPTION
## Proposed changes

Fixing a build break in upstream consumer caused by `typeof` function unavailable with `-std` compiler option.  The fix here is just to switch to `__typeof__`. It looks like this already happened once in #728.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

