### PR TITLE
Add Darwin notification listener API for partners - underlying code in common core

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -613,6 +613,9 @@
 		74F04D4A246C8AC000094017 /* MSIDLastRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F04D48246C8AC000094017 /* MSIDLastRequestTelemetrySerializedItem.m */; };
 		74F04D4B246C8AC000094017 /* MSIDLastRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F04D48246C8AC000094017 /* MSIDLastRequestTelemetrySerializedItem.m */; };
 		74F04D4D246CB5B100094017 /* MSIDCurrentRequestTelemetrySerializedItem+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F04D4C246CB5B100094017 /* MSIDCurrentRequestTelemetrySerializedItem+Internal.h */; };
+		74FDE52D2864F8E500C25344 /* MSIDDarwinNotificationListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 74FDE52B2864F8E500C25344 /* MSIDDarwinNotificationListener.h */; };
+		74FDE52E2864F8E500C25344 /* MSIDDarwinNotificationListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FDE52C2864F8E500C25344 /* MSIDDarwinNotificationListener.m */; };
+		74FDE52F2864F8E500C25344 /* MSIDDarwinNotificationListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FDE52C2864F8E500C25344 /* MSIDDarwinNotificationListener.m */; };
 		80878AEF247A84C1000BC522 /* MSIDWorkPlaceJoinUtilBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 80878AEE247A84C1000BC522 /* MSIDWorkPlaceJoinUtilBase.m */; };
 		80878AF0247A9961000BC522 /* MSIDWorkPlaceJoinUtilBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 80878AEE247A84C1000BC522 /* MSIDWorkPlaceJoinUtilBase.m */; };
 		80B6BF3C2480A3E30031BFE8 /* MSIDWorkPlaceJoinUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 80B6BF3B2480A3E30031BFE8 /* MSIDWorkPlaceJoinUtilTests.m */; };
@@ -2305,6 +2308,8 @@
 		74F04D47246C8AC000094017 /* MSIDLastRequestTelemetrySerializedItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDLastRequestTelemetrySerializedItem.h; sourceTree = "<group>"; };
 		74F04D48246C8AC000094017 /* MSIDLastRequestTelemetrySerializedItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLastRequestTelemetrySerializedItem.m; sourceTree = "<group>"; };
 		74F04D4C246CB5B100094017 /* MSIDCurrentRequestTelemetrySerializedItem+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDCurrentRequestTelemetrySerializedItem+Internal.h"; sourceTree = "<group>"; };
+		74FDE52B2864F8E500C25344 /* MSIDDarwinNotificationListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDDarwinNotificationListener.h; sourceTree = "<group>"; };
+		74FDE52C2864F8E500C25344 /* MSIDDarwinNotificationListener.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDDarwinNotificationListener.m; sourceTree = "<group>"; };
 		80878AED247A7BBF000BC522 /* MSIDWorkPlaceJoinUtilBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDWorkPlaceJoinUtilBase.h; sourceTree = "<group>"; };
 		80878AEE247A84C1000BC522 /* MSIDWorkPlaceJoinUtilBase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWorkPlaceJoinUtilBase.m; sourceTree = "<group>"; };
 		809B38212480C3C8001DF9D4 /* MSIDWorkPlaceJoinUtilBase+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDWorkPlaceJoinUtilBase+Internal.h"; sourceTree = "<group>"; };
@@ -3775,6 +3780,15 @@
 			path = ui;
 			sourceTree = "<group>";
 		};
+		74FDE52A2864F87000C25344 /* shared_device */ = {
+			isa = PBXGroup;
+			children = (
+				74FDE52B2864F8E500C25344 /* MSIDDarwinNotificationListener.h */,
+				74FDE52C2864F8E500C25344 /* MSIDDarwinNotificationListener.m */,
+			);
+			path = shared_device;
+			sourceTree = "<group>";
+		};
 		96235F8F207D7128007EAB36 /* webview */ = {
 			isa = PBXGroup;
 			children = (
@@ -5047,6 +5061,7 @@
 				230847942082BB2A0024CE7C /* network */,
 				B210F4241FDDE12B005A8F76 /* oauth2 */,
 				9641B4FF1FCF3E1400AFA0EC /* cache */,
+				74FDE52A2864F87000C25344 /* shared_device */,
 				B206578A1FC917D900412B7D /* telemetry */,
 				B25A35681FC4D6B600C7FD43 /* logger */,
 				04930F821FEC8E3D00FC4DCD /* validation */,
@@ -5614,6 +5629,7 @@
 				B286B96223861852007833AD /* MSIDSignoutWebRequestConfiguration.h in Headers */,
 				B20657AB1FC91F6400412B7D /* MSIDTelemetry+Internal.h in Headers */,
 				B297E1EB20A1388E00F370EC /* MSIDDefaultAccountCacheQuery.h in Headers */,
+				74FDE52D2864F8E500C25344 /* MSIDDarwinNotificationListener.h in Headers */,
 				B2C0748B246B71300008D701 /* MSIDAssymetricKeyPairWithCert.h in Headers */,
 				B286B9562385F01A007833AD /* MSIDOIDCSignoutRequest.h in Headers */,
 				B2C708B0219A614C00D917B8 /* MSIDDefaultBrokerTokenRequest.h in Headers */,
@@ -6516,6 +6532,7 @@
 				1E7DC42A2405A95400740BAD /* MSIDBaseBrokerOperationRequest.m in Sources */,
 				B286B97F2389DC08007833AD /* MSIDBrokerOperationRequest.m in Sources */,
 				23FB5C3122551866002BF1EB /* MSIDClaimsRequest+ClientCapabilities.m in Sources */,
+				74FDE52F2864F8E500C25344 /* MSIDDarwinNotificationListener.m in Sources */,
 				23B39ACD209CF317000AA905 /* MSIDAADNetworkConfiguration.m in Sources */,
 				23FB5C462255A135002BF1EB /* MSIDIndividualClaimRequest.m in Sources */,
 				238F80A222C2BE1600437CB1 /* MSIDGetV1IdTokenHttpEvent.m in Sources */,
@@ -7361,6 +7378,7 @@
 				1E769E4723ECDC9600B7B7D2 /* MSIDBaseBrokerOperationRequest.m in Sources */,
 				B2C708A6219A593C00D917B8 /* MSIDLegacyTokenRequestProvider.m in Sources */,
 				B2C708AB219A5A3D00D917B8 /* MSIDLegacySilentTokenRequest.m in Sources */,
+				74FDE52E2864F8E500C25344 /* MSIDDarwinNotificationListener.m in Sources */,
 				96F21B3220A65896002B87C3 /* MSIDWebviewAuthorization.m in Sources */,
 				B286B9572385F01A007833AD /* MSIDOIDCSignoutRequest.m in Sources */,
 				B210F4561FDDFA7B005A8F76 /* MSIDBrokerResponse.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -615,7 +615,6 @@
 		74F04D4D246CB5B100094017 /* MSIDCurrentRequestTelemetrySerializedItem+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F04D4C246CB5B100094017 /* MSIDCurrentRequestTelemetrySerializedItem+Internal.h */; };
 		74FDE52D2864F8E500C25344 /* MSIDDarwinNotificationListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 74FDE52B2864F8E500C25344 /* MSIDDarwinNotificationListener.h */; };
 		74FDE52E2864F8E500C25344 /* MSIDDarwinNotificationListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FDE52C2864F8E500C25344 /* MSIDDarwinNotificationListener.m */; };
-		74FDE52F2864F8E500C25344 /* MSIDDarwinNotificationListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FDE52C2864F8E500C25344 /* MSIDDarwinNotificationListener.m */; };
 		80878AEF247A84C1000BC522 /* MSIDWorkPlaceJoinUtilBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 80878AEE247A84C1000BC522 /* MSIDWorkPlaceJoinUtilBase.m */; };
 		80878AF0247A9961000BC522 /* MSIDWorkPlaceJoinUtilBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 80878AEE247A84C1000BC522 /* MSIDWorkPlaceJoinUtilBase.m */; };
 		80B6BF3C2480A3E30031BFE8 /* MSIDWorkPlaceJoinUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 80B6BF3B2480A3E30031BFE8 /* MSIDWorkPlaceJoinUtilTests.m */; };

--- a/IdentityCore/src/shared_device/MSIDDarwinNotificationListener.h
+++ b/IdentityCore/src/shared_device/MSIDDarwinNotificationListener.h
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^MSIDDarwinNotificationCallback)(NSError * _Nullable error);
+
+@interface MSIDDarwinNotificationListener : NSObject
+
+@property (nonatomic) MSIDDarwinNotificationCallback passedInCallback;
+
+- (instancetype)initWithCallback:(MSIDDarwinNotificationCallback)passedInCallback;
+
+- (void)createSharedDeviceAccountChangeListener;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/shared_device/MSIDDarwinNotificationListener.m
+++ b/IdentityCore/src/shared_device/MSIDDarwinNotificationListener.m
@@ -1,0 +1,89 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import "MSIDDarwinNotificationListener.h"
+#import "MSIDConstants.h"
+
+static NSString *const kDarwinNotificationReceivedKey = @"DarwinNotificationReceived";
+
+static void sharedModeAccountChangedCallback(__unused CFNotificationCenterRef center,
+                                             __unused void * observer,
+                                             CFStringRef name,
+                                             __unused void const * object,
+                                             __unused CFDictionaryRef userInfo)
+{
+    if ([(__bridge NSString *)name isEqualToString: MSID_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY])
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,nil, @"Received shared device mode account change Darwin notification broadcast");
+
+        [[NSNotificationCenter defaultCenter] postNotificationName:kDarwinNotificationReceivedKey object:nil];
+    }
+}
+
+@implementation MSIDDarwinNotificationListener
+
+- (instancetype)initWithCallback:(MSIDDarwinNotificationCallback)passedInCallback
+{
+    if (!passedInCallback)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"No callback passed to MSIDDarwinNotificationListener");
+        return nil;
+    }
+    
+    self = [super init];
+    if (self)
+    {
+        _passedInCallback = passedInCallback;
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(receivedGlobalSignoutDarwinNotification:)
+                                                     name:kDarwinNotificationReceivedKey
+                                                   object:nil];
+    }
+    return self;
+}
+
+- (void)createSharedDeviceAccountChangeListener
+{
+    if (!self.passedInCallback)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"No callback available when creating Darwin notification listener");
+    }
+    
+    //Listens for Darwin notifcations coming from broker in the FLW global signout scenario
+    CFNotificationCenterRef center = CFNotificationCenterGetDarwinNotifyCenter();
+    CFNotificationCenterAddObserver(center, nil, sharedModeAccountChangedCallback, (CFStringRef)MSID_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY,
+                                    nil, CFNotificationSuspensionBehaviorDeliverImmediately);
+}
+
+- (void)receivedGlobalSignoutDarwinNotification:(NSNotification *)notification
+{
+    if (self.passedInCallback)
+    {
+        self.passedInCallback(nil);
+    }
+}
+
+@end

--- a/IdentityCore/src/shared_device/MSIDDarwinNotificationListener.m
+++ b/IdentityCore/src/shared_device/MSIDDarwinNotificationListener.m
@@ -34,7 +34,7 @@ static void sharedModeAccountChangedCallback(__unused CFNotificationCenterRef ce
                                              __unused void const * object,
                                              __unused CFDictionaryRef userInfo)
 {
-    if ([(__bridge NSString *)name isEqualToString: MSID_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY])
+    if ([(__bridge NSString *)name isEqualToString:MSID_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY])
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,nil, @"Received shared device mode account change Darwin notification broadcast");
 
@@ -67,11 +67,6 @@ static void sharedModeAccountChangedCallback(__unused CFNotificationCenterRef ce
 
 - (void)createSharedDeviceAccountChangeListener
 {
-    if (!self.passedInCallback)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"No callback available when creating Darwin notification listener");
-    }
-    
     //Listens for Darwin notifcations coming from broker in the FLW global signout scenario
     CFNotificationCenterRef center = CFNotificationCenterGetDarwinNotifyCenter();
     CFNotificationCenterAddObserver(center, nil, sharedModeAccountChangedCallback, (CFStringRef)MSID_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY,
@@ -84,6 +79,10 @@ static void sharedModeAccountChangedCallback(__unused CFNotificationCenterRef ce
     {
         self.passedInCallback(nil);
     }
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:kDarwinNotificationReceivedKey
+                                                  object:nil];
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

In order to make it simpler to use the basic Darwin notification system that we offer for shared device mode partners, we can create an API in MSAL that will setup the notification listener. That way, partners don't have to implement it themselves. Also, we can better control how to functionality is used this way, and can make changes under the hood if necessary.

A follow up PR will be made in MSAL that makes this using these API's publicly available. They are necessary in common core so OneAuth can create the same API's.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

