### PR TITLE
Add a new switch csae when returning MSIDErrorSSOExtensionUnexpectedE…

### DIFF
--- a/IdentityCore/src/controllers/broker/MSIDSSOExtensionInteractiveTokenRequestController.m
+++ b/IdentityCore/src/controllers/broker/MSIDSSOExtensionInteractiveTokenRequestController.m
@@ -99,7 +99,8 @@
         return NO;
     }
     
-    if (![error.domain isEqualToString:ASAuthorizationErrorDomain]) return NO;
+    // If it is MSIDErrorDomain and Sso Extension returns unexpected error, we should fall back to local controler and unblock user
+    if (![error.domain isEqualToString:ASAuthorizationErrorDomain] && ![error.domain isEqualToString:MSIDErrorDomain]) return NO;
     
     BOOL shouldFallback = NO;
     switch (error.code)
@@ -107,6 +108,7 @@
         case ASAuthorizationErrorNotHandled:
         case ASAuthorizationErrorUnknown:
         case ASAuthorizationErrorFailed:
+        case MSIDErrorSSOExtensionUnexpectedError:
             shouldFallback = YES;
     }
     


### PR DESCRIPTION
…rror, should fallback to local controller

## Proposed changes

When Sso extension throws back MSIDErrorSSOExtensionUnexpectedError, we should fall back to use local controler to unblock user

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

