### PR TITLE
[WIP] Force legacy broker fallback for ZTP + add "userless registration needed" as a request param

### DIFF
--- a/IdentityCore/src/MSIDBrokerConstants.h
+++ b/IdentityCore/src/MSIDBrokerConstants.h
@@ -80,3 +80,4 @@ extern NSString * _Nonnull const MSID_BROKER_TYPES_OF_HEADER;
 extern NSString * _Nonnull const MSID_ADDITIONAL_EXTENSION_DATA_KEY;
 extern NSString * _Nonnull const MSID_SSO_NONCE_QUERY_PARAM_KEY;
 extern NSString * _Nonnull const MSID_BROKER_MDM_ID_KEY;
+extern NSString * _Nonnull const MSID_BROKER_USERLESS_REGISTRATION_NEEDED;

--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -72,6 +72,7 @@ NSString *const MSID_BROKER_SDK_SSO_EXTENSION_CAPABILITY = @"sso_extension";
 NSString *const MSID_BROKER_SSO_URL = @"sso_url";
 NSString *const MSID_BROKER_ACCOUNT_IDENTIFIER = @"account_identifier";
 NSString *const MSID_BROKER_TYPES_OF_HEADER = @"types_of_header";
+NSString *const MSID_BROKER_USERLESS_REGISTRATION_NEEDED = @"userless_reg";
 
 NSString *const MSID_ADDITIONAL_EXTENSION_DATA_KEY = @"additional_extension_data";
 NSString *const MSID_SSO_NONCE_QUERY_PARAM_KEY = @"sso_nonce";

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.h
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSDictionary *mamResources;
 @property (nonatomic, nullable) NSArray *clientCapabilities;
 @property (nonatomic, nullable) MSIDClaimsRequest *claimsRequest;
+@property (nonatomic) BOOL isUserlessRegistrationNeeded;
 
 + (BOOL)fillRequest:(MSIDBrokerOperationTokenRequest *)request
      withParameters:(MSIDRequestParameters *)parameters

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
@@ -56,6 +56,7 @@
     request.mamResources = mamResources;
     request.clientCapabilities = parameters.clientCapabilities;
     request.claimsRequest = parameters.claimsRequest;
+    request.isUserlessRegistrationNeeded = parameters.isUserlessRegistrationNeeded;
         
     return YES;
 }

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -81,6 +81,9 @@
 #pragma mark - Cache
 @property (nonatomic) NSString *keychainAccessGroup;
 
+#pragma mark - Shared devices
+@property (nonatomic) BOOL isUserlessRegistrationNeeded;
+
 - (NSURL *)tokenEndpoint;
 
 #pragma mark Methods

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -338,6 +338,7 @@
     parameters->_clientCapabilities = [_clientCapabilities copyWithZone:zone];
     parameters->_msidConfiguration = [_msidConfiguration copyWithZone:zone];
     parameters->_keychainAccessGroup = [_keychainAccessGroup copyWithZone:zone];
+    parameters->_isUserlessRegistrationNeeded = _isUserlessRegistrationNeeded;
 
     return parameters;
 }

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
@@ -43,6 +43,11 @@
     {
         extraQueryParameters[MSID_BROKER_INSTANCE_AWARE_KEY] = @"true";
     }
+    
+    if (self.requestParameters.isUserlessRegistrationNeeded)
+    {
+        extraQueryParameters[MSID_BROKER_USERLESS_REGISTRATION_NEEDED] = @"true";
+    }
 
     NSString *extraQueryParametersString = [extraQueryParameters count] ? [extraQueryParameters msidWWWFormURLEncode] : @"";
     
@@ -70,6 +75,7 @@
     [protocolResumeDictionary msidSetNonEmptyString:MSID_MSAL_SDK_NAME forKey:MSID_SDK_NAME_KEY];
     [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.providedAuthority.url.absoluteString forKey:@"provided_authority_url"];
     [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.instanceAware ? @"YES" : @"NO" forKey:@"instance_aware"];
+    [protocolResumeDictionary msidSetNonEmptyString:self.requestParameters.isUserlessRegistrationNeeded ? @"YES" : @"" forKey:@"userless_reg"];
     
     return protocolResumeDictionary;
 }


### PR DESCRIPTION
## Proposed changes

In the Zero-Touch Provisioning public preview flow, users will expect to sign in from any shared device-participating app, and have the SSO extension automatically handle shared device registration. In order to do that, we need to force an automatic UI flip to the Authenticator app, which will automatically trigger userless registration when the Authenticator app is opened. A good way to achieve this is to force a fallback to the legacy broker flow when userless registration is needed - the SSO extension will detect if userless registration is needed, and return an "expected" error to MSAL. MSAL will recognize this error as a trigger for the userless registration flow, and trigger a fallback to the legacy broker flow.

Later on, the Authenticator app will be notified in the openURL request that userless registration is needed through the use of a new extra query param: "userless_reg". This will trigger any necessary UI actions on the Authenticator app side.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [x] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

