### PR TITLE
Make a property public for MSAL CPP to overwrite -(void)presentView

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -46,7 +46,7 @@ NSWindowController
 #if TARGET_OS_IPHONE
 @property (nonatomic, weak) UIViewController *parentController;
 @property (nonatomic) UIModalPresentationStyle presentationType;
-@property (nonatomic) BOOL presentInParentController;
+@property (nonatomic, readonly) BOOL presentInParentController;
 #endif
 
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration;

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -46,6 +46,7 @@ NSWindowController
 #if TARGET_OS_IPHONE
 @property (nonatomic, weak) UIViewController *parentController;
 @property (nonatomic) UIModalPresentationStyle presentationType;
+@property (nonatomic) BOOL presentInParentController;
 #endif
 
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration;

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -36,8 +36,6 @@ static WKWebViewConfiguration *s_webConfig;
     UIActivityIndicatorView *_loadingIndicator;
 }
 
-@property (nonatomic) BOOL presentInParentController;
-
 @end
 
 @implementation MSIDWebviewUIController

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -36,6 +36,8 @@ static WKWebViewConfiguration *s_webConfig;
     UIActivityIndicatorView *_loadingIndicator;
 }
 
+@property (nonatomic) BOOL presentInParentController;
+
 @end
 
 @implementation MSIDWebviewUIController


### PR DESCRIPTION
## Proposed changes

MSAL CPP need to implement form sheet UI style on iPad. The only way is to overwrite -(void)presentView in MSIDWebviewUIController.m, but -(void)presentView is using a private property propertypresentInParentController.

Since MSIDOAuth2EmbeddedWebviewController which extends MSIDWebviewUIController is also used by MSAL CPP, adding a MSIDWebviewUIController+private will be not very applicable.

The easiest way is to make propertypresentInParentController a public property.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

