### PR TITLE
Stop extra background tasks in the system webview case

### DIFF
--- a/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
@@ -131,4 +131,11 @@
 #endif
 }
 
+- (void)dealloc
+{
+#if TARGET_OS_IPHONE
+    [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
+#endif
+}
+
 @end

--- a/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebviewController.m
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebviewController.m
@@ -132,10 +132,6 @@
 #endif
     void (^authCompletion)(NSURL *, NSError *) = ^void(NSURL *callbackURL, NSError *authError)
     {
-#if TARGET_OS_IPHONE
-        [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
-#endif
-        
         if (authError && authError.code == MSIDErrorUserCancel)
         {
             CONDITIONAL_UI_EVENT_SET_IS_CANCELLED(self.telemetryEvent, YES);
@@ -250,6 +246,12 @@
 - (void)notifyEndWebAuthWithURL:(NSURL *)url
                           error:(NSError *)error
 {
+    
+    // If the web auth session is ended, make sure that active background tasks started for the system webview session
+    // have been stopped.
+#if TARGET_OS_IPHONE
+        [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
+#endif
     
     if (error)
     {

--- a/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebviewController.m
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebviewController.m
@@ -132,6 +132,10 @@
 #endif
     void (^authCompletion)(NSURL *, NSError *) = ^void(NSURL *callbackURL, NSError *authError)
     {
+#if TARGET_OS_IPHONE
+        [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
+#endif
+        
         if (authError && authError.code == MSIDErrorUserCancel)
         {
             CONDITIONAL_UI_EVENT_SET_IS_CANCELLED(self.telemetryEvent, YES);


### PR DESCRIPTION
## Proposed changes

The issue is mentioned in this [GitHub issue](https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1526).

There are currently 2 small issues with the background task logic in the system webview case:

1. There are 2 tasks being spun up when doing a system webview request. Once in MSIDInteractiveTokenRequest (line 80), and once in MSIDSystemWebviewController (line 124).

2. If the user cancels the request before the auth code step, the existing "stop" call won't be reached.

This PR adds a "stop" call in the dealloc step of MSIDInteractiveTokenRequest to ensure tasks for cancelled requests are stopped, and a "stop" call in the completion handler of MSIDSystemWebviewController to ensure that all system webview background tasks are stopped.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

