### PR TITLE
Disable CBA automation

### DIFF
--- a/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.h
+++ b/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.h
@@ -65,6 +65,8 @@
 @property (nonatomic) NSUInteger ssoExtensionSharedDeviceMode;
 @property (nonatomic) NSUInteger ssoExtensionInteractiveMode;
 @property (nonatomic) NSString *tokenType;
+@property (nonatomic) BOOL disableCertBasedAuth;
+
 - (BOOL)usesEmbeddedWebView;
 
 @end

--- a/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.m
+++ b/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.m
@@ -90,6 +90,7 @@
         _ssoExtensionSharedDeviceMode = [json[@"ssoExtensionSharedDeviceMode"] integerValue];
         _ssoExtensionInteractiveMode = [json[@"ssoExtensionInteractiveMode"] integerValue];
         _tokenType = json[@"token_type"];
+        _disableCertBasedAuth = [json[@"disable_cert_based_auth"] boolValue];
     }
 
     return self;
@@ -154,6 +155,8 @@
     json[@"ssoExtensionSharedDeviceMode"] = @(_ssoExtensionSharedDeviceMode);
     json[@"ssoExtensionInteractiveMode"] = @(_ssoExtensionInteractiveMode);
     json[@"token_type"] = _tokenType;
+    json[@"disable_cert_based_auth"] = @(_disableCertBasedAuth);
+    
     return json;
 }
 


### PR DESCRIPTION
## Proposed changes

Some of federated msidlab4.com tests unexpectedly prompt for CBA, causing automation tests to be flaky.
This explicitly disables CBA for those tests to increase test stability.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

