### PR TITLE
Xcode 14: NSURLComponents percentEncodedHost will no longer throw an exception if invalid on iOS16+ & macOS13+

### DIFF
--- a/IdentityCore/src/util/NSURL+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSURL+MSIDExtensions.m
@@ -139,7 +139,11 @@
             // On iOS 16.0 or macOS 13.0 and above, NSURLComponents percentEncodedHost will no longer throw an exception if invalid.
             if ([NSString msidIsStringNilOrBlank:components.host])
             {
-                @throw MSIDException(MSIDGenericException, @"Host is not valid.", nil);
+                NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorServerInvalidResponse, @"Host is not valid.", nil, nil, nil, context.correlationId, nil, YES);
+                
+                if (error) *error = msidError;
+                
+                return nil;
             }
         }
 #endif

--- a/IdentityCore/src/util/NSURL+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSURL+MSIDExtensions.m
@@ -133,6 +133,17 @@
         // probably a good thing.
         components.percentEncodedHost = hostComponents[0];
         
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+        if (@available(iOS 16.0, macOS 13.0, *))
+        {
+            // On iOS 16.0 or macOS 13.0 and above, NSURLComponents percentEncodedHost will no longer throw an exception if invalid.
+            if ([NSString msidIsStringNilOrBlank:components.host])
+            {
+                @throw MSIDException(MSIDGenericException, @"Host is not valid.", nil);
+            }
+        }
+#endif
+        
         if (hostComponents.count > 1)
         {
             NSScanner *scanner = [NSScanner scannerWithString:hostComponents[1]];


### PR DESCRIPTION
## Proposed changes

On iOS 16.0 or macOS 13.0 and above, NSURLComponents percentEncodedHost will no longer throw an exception if invalid when building with Xcode 14, causing unit tests to fail to check an invalid host.

Note: There might be a better way to validate a host, specially since we are currently using the deprecated property `percentEncodedHost`.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

