### PR TITLE
Update Home accountId from clientInfo only if available

### DIFF
--- a/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
@@ -111,7 +111,11 @@
             {
                 errorCode = MSIDErrorServerProtectionPoliciesRequired;
                 additionalUserInfo[MSIDUserDisplayableIdkey] = response.additionalUserId;
-                additionalUserInfo[MSIDHomeAccountIdkey] = response.clientInfo.accountIdentifier;
+                if (response.clientInfo.accountIdentifier)
+                {
+                    additionalUserInfo[MSIDHomeAccountIdkey] = response.clientInfo.accountIdentifier;
+                }
+                
             }
             
             MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, context, @"Processing an AAD error with error code %ld, error %@, suberror %@, description %@", (long)errorCode, response.error, response.suberror, MSID_PII_LOG_MASKABLE(response.errorDescription));

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+#TBD
+* Added not nil check before updating homeAccountId from clientInfo(#1155)
+
 Version 1.7.11
 * Expose extra deviceInfo(#1131)
 


### PR DESCRIPTION
## Proposed changes

Update Home accountId from clientInfo only if available in response

## Type of change

- [ ] Feature work
- [ x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

