### PR TITLE
Basic SSO extension perf telemetry on MSAL side

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1597,6 +1597,8 @@
 		B2E4A07B24DDE5D7007CE642 /* NSUUID+MSIDTestUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 23CA0C66220A7B1700768729 /* NSUUID+MSIDTestUtil.h */; };
 		B2E7698E206096A7000F3F2B /* MSIDTelemetryCacheEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E7698D206096A7000F3F2B /* MSIDTelemetryCacheEventTests.m */; };
 		B2E7698F206096A7000F3F2B /* MSIDTelemetryCacheEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E7698D206096A7000F3F2B /* MSIDTelemetryCacheEventTests.m */; };
+		B2E97FB32914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E97FB22914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m */; };
+		B2E97FB42914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E97FB22914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m */; };
 		B2EB3ADF22F7C74000FA400E /* MSIDBrokerInvocationOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = B2968C8422F3C3E8005AFC33 /* MSIDBrokerInvocationOptions.m */; };
 		B2EB3AE022F7C74300FA400E /* MSIDBrokerInvocationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = B2968C8322F3C3E8005AFC33 /* MSIDBrokerInvocationOptions.h */; };
 		B2ED1BBC2204D29400A24E82 /* MSIDAutomationTestRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B25A437F21C3516B000B3DD4 /* MSIDAutomationTestRequest.h */; };
@@ -2948,6 +2950,7 @@
 		B2E2A93B2392F91100BA2EA3 /* MSIDInteractiveTokenRequestParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDInteractiveTokenRequestParameters.h; sourceTree = "<group>"; };
 		B2E2A93C2392F91100BA2EA3 /* MSIDInteractiveTokenRequestParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDInteractiveTokenRequestParameters.m; sourceTree = "<group>"; };
 		B2E7698D206096A7000F3F2B /* MSIDTelemetryCacheEventTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTelemetryCacheEventTests.m; sourceTree = "<group>"; };
+		B2E97FB22914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBrokerNativeAppOperationResponseTests.m; sourceTree = "<group>"; };
 		B2ED1BA62204D24700A24E82 /* libIdentityAutomationTestLib iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIdentityAutomationTestLib iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2ED1BB32204D26700A24E82 /* libIdentityAutomationTestLib Mac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIdentityAutomationTestLib Mac.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2ED904F24FDF3A900B6ED59 /* MSIDRedirectUriVerifierMacTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDRedirectUriVerifierMacTests.m; sourceTree = "<group>"; };
@@ -5177,6 +5180,7 @@
 				60747FFE23552ACF00C5308F /* MSIDBrokerOperationRemoveAccountRequestTests.m */,
 				23419F5C23973AAD00EA78C5 /* MSIDBrokerOperationRequestTests.m */,
 				23419F62239896E500EA78C5 /* MSIDBrokerOperationResponseTests.m */,
+				B2E97FB22914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m */,
 				B217860D23A578BE00839CE8 /* MSIDBrokerOperationSignoutFromDeviceRequestTests.m */,
 				23419F59239739AF00EA78C5 /* MSIDBrokerOperationSilentTokenRequestTests.m */,
 				23419F5F23974C0D00EA78C5 /* MSIDBrokerOperationTokenRequestTests.m */,
@@ -6394,6 +6398,7 @@
 				23419F82239B36F500EA78C5 /* MSIDAccountIdentifierTests.m in Sources */,
 				589BDB1D2718CD7D00BF3799 /* MSIDBrokerOperationGetSsoCookiesRequestTests.m in Sources */,
 				B210F42E1FDDE6A5005A8F76 /* MSIDJsonObjectTests.m in Sources */,
+				B2E97FB32914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m in Sources */,
 				B29F7805213DFA5600D61FC8 /* MSIDErrorTests.m in Sources */,
 				60747FF82354F73000C5308F /* MSIDBrokerOperationGetAccountsResponseTests.m in Sources */,
 				B2DD5B97204756580084313F /* MSIDAccountTypeTests.m in Sources */,
@@ -6918,6 +6923,7 @@
 				B2DD4B3E20A9270B0047A66E /* MSIDDefaultCredentialCacheQueryTests.m in Sources */,
 				B223B0A722ADEE5900FB8713 /* MSIDMaskedLogParameterTests.m in Sources */,
 				58EB18362729BAB800F4DD73 /* MSIDSSOExtensionGetSsoCookiesRequestMock.m in Sources */,
+				B2E97FB42914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m in Sources */,
 				B2BE923221A0EFB100F5AB8C /* MSIDDefaultTokenRequestProviderTests.m in Sources */,
 				23AE9D9E213A06EF00B285F3 /* MSIDAadAuthorityCacheTests.m in Sources */,
 				A0410E0925E81C5D004D80FD /* MSIDThrottlingModel429Test.m in Sources */,

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerNativeAppOperationResponse.h
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerNativeAppOperationResponse.h
@@ -26,6 +26,9 @@
 #import "MSIDBrokerOperationResponse.h"
 
 @class MSIDDeviceInfo;
+#if !EXCLUDE_FROM_MSALCPP
+@class MSIDLastRequestTelemetry;
+#endif
 
 extern NSString * _Nonnull const MSID_BROKER_OPERATION_RESPONSE_TYPE_JSON_KEY;
 
@@ -43,10 +46,20 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, class, readonly) NSNumber *defaultHttpStatusCode;
 @property (nonatomic, nullable) NSDictionary *httpHeaders;
 @property (nonatomic) NSString *httpVersion;
+@property (nonatomic) NSDate *responseGenerationTimeStamp;
+@property (nonatomic) NSDate *requestReceivedTimeStamp;
 
 - (instancetype)initWithDeviceInfo:(MSIDDeviceInfo *)deviceInfo;
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
+
+#if !EXCLUDE_FROM_MSALCPP
+
+- (void)trackPerfTelemetryWithLastRequest:(MSIDLastRequestTelemetry *)telemetry
+                         requestStartDate:(NSDate *)requestStartDate
+                                     type:(NSString *)type;
+
+#endif
 
 
 @end

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerNativeAppOperationResponse.h
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerNativeAppOperationResponse.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)trackPerfTelemetryWithLastRequest:(MSIDLastRequestTelemetry *)telemetry
                          requestStartDate:(NSDate *)requestStartDate
-                                     type:(NSString *)type;
+                            telemetryType:(NSString *)telemetryType;
 
 #endif
 

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerNativeAppOperationResponse.m
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerNativeAppOperationResponse.m
@@ -39,7 +39,6 @@
 #if !EXCLUDE_FROM_MSALCPP
 #import "MSIDLastRequestTelemetry.h"
 #endif
-#import "NSDate+MSIDExtensions.h"
 
 NSString *const MSID_BROKER_OPERATION_JSON_KEY = @"operation";
 NSString *const MSID_BROKER_OPERATION_RESULT_JSON_KEY = @"success";
@@ -139,14 +138,20 @@ NSString *const MSID_BROKER_REQUEST_RECEIVED_TIMESTAMP = @"request_received_time
 
 - (void)trackPerfTelemetryWithLastRequest:(MSIDLastRequestTelemetry *)telemetry
                          requestStartDate:(NSDate *)requestStartDate
-                                     type:(NSString *)type
+                            telemetryType:(NSString *)telemetryType
 {
+    if (!requestStartDate)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"trackPerfTelemetryWithLastRequest called with nil request start date");
+        return;
+    }
+    
     NSDate *responseDate = [NSDate date];
     NSTimeInterval totalTime = [responseDate timeIntervalSinceDate:requestStartDate];
-    NSTimeInterval ipcRequestTime = [self.requestReceivedTimeStamp timeIntervalSinceDate:requestStartDate];
-    NSTimeInterval ipcResponseTime = [responseDate timeIntervalSinceDate:self.responseGenerationTimeStamp];
+    NSTimeInterval ipcRequestTime = self.requestReceivedTimeStamp ? [self.requestReceivedTimeStamp timeIntervalSinceDate:requestStartDate] : 0;
+    NSTimeInterval ipcResponseTime = self.responseGenerationTimeStamp ? [responseDate timeIntervalSinceDate:self.responseGenerationTimeStamp] : 0;
     
-    [telemetry trackSSOExtensionPerformanceWithType:type
+    [telemetry trackSSOExtensionPerformanceWithType:telemetryType
                                     totalPerfNumber:totalTime
                                ipcRequestPerfNumber:ipcRequestTime
                               ipcResponsePerfNumber:ipcResponseTime];

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.h
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.h
@@ -34,6 +34,10 @@
 @class MSIDExternalAADCacheSeeder;
 #endif
 
+#if !EXCLUDE_FROM_MSALCPP
+@class MSIDLastRequestTelemetry;
+#endif
+
 @interface MSIDSilentTokenRequest : NSObject
 
 @property (nonatomic, readonly, nonnull) MSIDRequestParameters *requestParameters;
@@ -43,6 +47,10 @@
 
 #if TARGET_OS_OSX && !EXCLUDE_FROM_MSALCPP
 @property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;
+#endif
+
+#if !EXCLUDE_FROM_MSALCPP
+@property (nonatomic, readonly, nullable) MSIDLastRequestTelemetry *lastRequestTelemetry;
 #endif
 
 - (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
@@ -35,6 +35,10 @@
 #import "MSIDDeviceInfo.h"
 #import "ASAuthorizationController+MSIDExtensions.h"
 
+#if !EXCLUDE_FROM_MSALCPP
+#import "MSIDLastRequestTelemetry.h"
+#endif
+
 // TODO: 1656998 This file can be refactored and use MSIDSSOExtensionGetDataBaseRequest as super class
 @interface MSIDSSOExtensionGetAccountsRequest()
 
@@ -44,6 +48,10 @@
 @property (nonatomic) ASAuthorizationSingleSignOnProvider *ssoProvider;
 @property (nonatomic) MSIDRequestParameters *requestParameters;
 @property (nonatomic) BOOL returnOnlySignedInAccounts;
+@property (nonatomic) NSDate *requestSentDate;
+#if !EXCLUDE_FROM_MSALCPP
+@property (nonatomic) MSIDLastRequestTelemetry *lastRequestTelemetry;
+#endif
  
 @end
 
@@ -95,6 +103,12 @@
             
             __typeof__(self) strongSelf = weakSelf;
             
+#if !EXCLUDE_FROM_MSALCPP
+            [operationResponse trackPerfTelemetryWithLastRequest:strongSelf.lastRequestTelemetry
+                                                requestStartDate:strongSelf.requestSentDate
+                                                            type:MSID_PERF_TELEMETRY_GETACCOUNTS_TYPE];
+#endif
+            
             MSIDGetAccountsRequestCompletionBlock completionBlock = strongSelf.requestCompletionBlock;
             strongSelf.requestCompletionBlock = nil;
             
@@ -102,6 +116,9 @@
         };
         
         _ssoProvider = [ASAuthorizationSingleSignOnProvider msidSharedProvider];
+#if !EXCLUDE_FROM_MSALCPP
+        _lastRequestTelemetry = [MSIDLastRequestTelemetry sharedInstance];
+#endif
     }
     
     return self;
@@ -129,6 +146,8 @@
         
     self.authorizationController = [self controllerWithRequest:ssoRequest];
     self.authorizationController.delegate = self.extensionDelegate;
+    
+    self.requestSentDate = [NSDate date];
     [self.authorizationController msidPerformRequests];
     
     self.requestCompletionBlock = completionBlock;

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
@@ -106,7 +106,7 @@
 #if !EXCLUDE_FROM_MSALCPP
             [operationResponse trackPerfTelemetryWithLastRequest:strongSelf.lastRequestTelemetry
                                                 requestStartDate:strongSelf.requestSentDate
-                                                            type:MSID_PERF_TELEMETRY_GETACCOUNTS_TYPE];
+                                                   telemetryType:MSID_PERF_TELEMETRY_GETACCOUNTS_TYPE];
 #endif
             
             MSIDGetAccountsRequestCompletionBlock completionBlock = strongSelf.requestCompletionBlock;

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.m
@@ -32,6 +32,9 @@
 #import "MSIDBrokerOperationGetDeviceInfoRequest.h"
 #import "MSIDDeviceInfo.h"
 #import "ASAuthorizationController+MSIDExtensions.h"
+#if !EXCLUDE_FROM_MSALCPP
+#import "MSIDLastRequestTelemetry.h"
+#endif
 
 // TODO: 1656998 This file can be refactored and use MSIDSSOExtensionGetDataBaseRequest as super class
 @interface MSIDSSOExtensionGetDeviceInfoRequest()
@@ -41,6 +44,10 @@
 @property (nonatomic) MSIDSSOExtensionOperationRequestDelegate *extensionDelegate;
 @property (nonatomic) ASAuthorizationSingleSignOnProvider *ssoProvider;
 @property (nonatomic) MSIDRequestParameters *requestParameters;
+@property (nonatomic) NSDate *requestSentDate;
+#if !EXCLUDE_FROM_MSALCPP
+@property (nonatomic) MSIDLastRequestTelemetry *lastRequestTelemetry;
+#endif
 
 @end
 
@@ -84,6 +91,12 @@
             
             __typeof__(self) strongSelf = weakSelf;
             
+#if !EXCLUDE_FROM_MSALCPP
+            [operationResponse trackPerfTelemetryWithLastRequest:strongSelf.lastRequestTelemetry
+                                                requestStartDate:strongSelf.requestSentDate
+                                                            type:MSID_PERF_TELEMETRY_GETDEVICEINFO_TYPE];
+#endif
+            
             MSIDGetDeviceInfoRequestCompletionBlock completionBlock = strongSelf.requestCompletionBlock;
             strongSelf.requestCompletionBlock = nil;
             
@@ -91,6 +104,9 @@
         };
         
         _ssoProvider = [ASAuthorizationSingleSignOnProvider msidSharedProvider];
+#if !EXCLUDE_FROM_MSALCPP
+        _lastRequestTelemetry = [MSIDLastRequestTelemetry sharedInstance];
+#endif
     }
     
     return self;
@@ -114,6 +130,7 @@
         
     self.authorizationController = [self controllerWithRequest:ssoRequest];
     self.authorizationController.delegate = self.extensionDelegate;
+    self.requestSentDate = [NSDate date];
     [self.authorizationController msidPerformRequests];
     
     self.requestCompletionBlock = completionBlock;

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.m
@@ -94,7 +94,7 @@
 #if !EXCLUDE_FROM_MSALCPP
             [operationResponse trackPerfTelemetryWithLastRequest:strongSelf.lastRequestTelemetry
                                                 requestStartDate:strongSelf.requestSentDate
-                                                            type:MSID_PERF_TELEMETRY_GETDEVICEINFO_TYPE];
+                                                   telemetryType:MSID_PERF_TELEMETRY_GETDEVICEINFO_TYPE];
 #endif
             
             MSIDGetDeviceInfoRequestCompletionBlock completionBlock = strongSelf.requestCompletionBlock;

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
@@ -36,6 +36,10 @@
 #import "MSIDConfiguration.h"
 #import "ASAuthorizationController+MSIDExtensions.h"
 
+#if !EXCLUDE_FROM_MSALCPP
+#import "MSIDLastRequestTelemetry.h"
+#endif
+
 @interface MSIDSSOExtensionSignoutRequest() <ASAuthorizationControllerPresentationContextProviding, ASAuthorizationControllerDelegate>
 
 @property (nonatomic) ASAuthorizationController *authorizationController;
@@ -46,6 +50,10 @@
 @property (nonatomic) BOOL shouldSignoutFromBrowser;
 @property (nonatomic) BOOL clearSSOExtensionCookies;
 @property (nonatomic) BOOL shouldWipeCacheForAllAccounts;
+@property (nonatomic) NSDate *requestSentDate;
+#if !EXCLUDE_FROM_MSALCPP
+@property (nonatomic) MSIDLastRequestTelemetry *lastRequestTelemetry;
+#endif
 
 @end
 
@@ -89,6 +97,13 @@
             }
             
             __typeof__(self) strongSelf = weakSelf;
+            
+#if !EXCLUDE_FROM_MSALCPP
+            [operationResponse trackPerfTelemetryWithLastRequest:strongSelf.lastRequestTelemetry
+                                                requestStartDate:strongSelf.requestSentDate
+                                                            type:MSID_PERF_TELEMETRY_SIGNOUT_TYPE];
+#endif
+            
             MSIDSignoutRequestCompletionBlock completionBlock = strongSelf.requestCompletionBlock;
             strongSelf.requestCompletionBlock = nil;
             
@@ -98,6 +113,10 @@
         _ssoProvider = [ASAuthorizationSingleSignOnProvider msidSharedProvider];
         _providerType = [[oauthFactory class] providerType];
         _shouldSignoutFromBrowser = YES;
+        
+#if !EXCLUDE_FROM_MSALCPP
+        _lastRequestTelemetry = [MSIDLastRequestTelemetry sharedInstance];
+#endif
     }
     
     return self;
@@ -149,6 +168,7 @@
     self.authorizationController = [self controllerWithRequest:ssoRequest];
     self.authorizationController.delegate = self.extensionDelegate;
     self.authorizationController.presentationContextProvider = self;
+    self.requestSentDate = [NSDate date];
     [self.authorizationController msidPerformRequests];
     
     self.requestCompletionBlock = completionBlock;

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
@@ -101,7 +101,7 @@
 #if !EXCLUDE_FROM_MSALCPP
             [operationResponse trackPerfTelemetryWithLastRequest:strongSelf.lastRequestTelemetry
                                                 requestStartDate:strongSelf.requestSentDate
-                                                            type:MSID_PERF_TELEMETRY_SIGNOUT_TYPE];
+                                                   telemetryType:MSID_PERF_TELEMETRY_SIGNOUT_TYPE];
 #endif
             
             MSIDSignoutRequestCompletionBlock completionBlock = strongSelf.requestCompletionBlock;

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
@@ -96,7 +96,7 @@
 #if !EXCLUDE_FROM_MSALCPP
             [operationResponse trackPerfTelemetryWithLastRequest:strongSelf.lastRequestTelemetry
                                                 requestStartDate:strongSelf.requestSentDate
-                                                            type:MSID_PERF_TELEMETRY_SILENT_TYPE];
+                                                   telemetryType:MSID_PERF_TELEMETRY_SILENT_TYPE];
 #endif
             
             [strongSelf.ssoTokenResponseHandler handleOperationResponse:operationResponse

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSilentTokenRequest.m
@@ -43,6 +43,10 @@
 #import "MSIDDefaultTokenCacheAccessor.h"
 #import "ASAuthorizationController+MSIDExtensions.h"
 
+#if !EXCLUDE_FROM_MSALCPP
+#import "MSIDLastRequestTelemetry.h"
+#endif
+
 @interface MSIDSSOExtensionSilentTokenRequest () <ASAuthorizationControllerDelegate>
 
 @property (nonatomic) ASAuthorizationController *authorizationController;
@@ -56,6 +60,8 @@
 @property (nonatomic, readonly) MSIDIntuneMAMResourcesCache *mamResourcesCache;
 @property (nonatomic, readonly) MSIDSSOTokenResponseHandler *ssoTokenResponseHandler;
 @property (nonatomic) MSIDBrokerOperationSilentTokenRequest *operationRequest;
+@property (nonatomic) NSDate *requestSentDate;
+
 @end
 
 @implementation MSIDSSOExtensionSilentTokenRequest
@@ -86,7 +92,13 @@
 #if TARGET_OS_OSX && !EXCLUDE_FROM_MSALCPP
             strongSelf.ssoTokenResponseHandler.externalCacheSeeder = strongSelf.externalCacheSeeder;
 #endif
-
+            
+#if !EXCLUDE_FROM_MSALCPP
+            [operationResponse trackPerfTelemetryWithLastRequest:strongSelf.lastRequestTelemetry
+                                                requestStartDate:strongSelf.requestSentDate
+                                                            type:MSID_PERF_TELEMETRY_SILENT_TYPE];
+#endif
+            
             [strongSelf.ssoTokenResponseHandler handleOperationResponse:operationResponse
                                                       requestParameters:strongSelf.requestParameters
                                                  tokenResponseValidator:strongSelf.tokenResponseValidator
@@ -209,6 +221,8 @@
 
     self.authorizationController = [[ASAuthorizationController alloc] initWithAuthorizationRequests:@[ssoRequest]];
     self.authorizationController.delegate = self.extensionDelegate;
+    
+    self.requestSentDate = [NSDate date];
     [self.authorizationController msidPerformRequests];
 
     self.requestCompletionBlock = completionBlock;

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.h
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.h
@@ -34,7 +34,20 @@
 
 @end
 
+@interface MSIDRequestPerformanceInfo : NSObject <NSSecureCoding>
+
+@property (nonatomic, nullable) NSMutableArray<NSNumber *> *totalNumbers;
+@property (nonatomic, nullable) NSMutableArray<NSNumber *> *ipcRequestNumbers;
+@property (nonatomic, nullable) NSMutableArray<NSNumber *> *ipcResponseNumbers;
+
+@end
+
 NS_ASSUME_NONNULL_BEGIN
+
+extern NSString * _Nonnull const MSID_PERF_TELEMETRY_SILENT_TYPE;
+extern NSString * _Nonnull const MSID_PERF_TELEMETRY_SIGNOUT_TYPE;
+extern NSString * _Nonnull const MSID_PERF_TELEMETRY_GETACCOUNTS_TYPE;
+extern NSString * _Nonnull const MSID_PERF_TELEMETRY_GETDEVICEINFO_TYPE;
 
 @class MSIDCurrentRequestTelemetrySerializedItem;
 
@@ -55,6 +68,11 @@ NS_ASSUME_NONNULL_BEGIN
                 context:(nullable id<MSIDRequestContext>)context;
 
 - (void)increaseSilentSuccessfulCount;
+
+- (void)trackSSOExtensionPerformanceWithType:(NSString *)type
+                             totalPerfNumber:(NSTimeInterval)totalPerfNumber
+                        ipcRequestPerfNumber:(NSTimeInterval)ipcRequestPerfNumber
+                       ipcResponsePerfNumber:(NSTimeInterval)ipcResponsePerfNumber;
 
 @end
 

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
@@ -244,6 +244,11 @@ static int maxErrorCountToArchive = 75;
                             ipcRequestPerfNumber:(NSTimeInterval)ipcRequestPerfNumber
                            ipcResponsePerfNumber:(NSTimeInterval)ipcResponsePerfNumber
 {
+    if (!self.perfTelemetry)
+    {
+        self.perfTelemetry = [NSMutableDictionary new];
+    }
+    
     MSIDRequestPerformanceInfo *perfInfo = self.perfTelemetry[type];
     
     if (!perfInfo)
@@ -334,13 +339,24 @@ static int maxErrorCountToArchive = 75;
     
     NSMutableArray *platformFields = [NSMutableArray new];
     [platformFields addObjectsFromArray:self.platformFields];
-    [platformFields addObject:[self serializedPerfTelemetry]];
+    
+    NSString *serializedPerfTelemetry = [self serializedPerfTelemetry];
+    
+    if (![NSString msidIsStringNilOrBlank:serializedPerfTelemetry])
+    {
+        [platformFields addObject:[self serializedPerfTelemetry]];
+    }
     
     return [[MSIDLastRequestTelemetrySerializedItem alloc] initWithSchemaVersion:[NSNumber numberWithInteger:self.schemaVersion] defaultFields:defaultFields errorInfo:self->_errorsInfo platformFields:platformFields];
 }
 
 - (NSString *)serializedPerfTelemetry
 {
+    if (![self.perfTelemetry count])
+    {
+        return nil;
+    }
+    
     NSString *serializedPerfTelemetry = [NSString stringWithFormat:@"%@;%@;%@;%@;",
                                          [self serializedAverageForType:MSID_PERF_TELEMETRY_SILENT_TYPE],
                                          [self serializedAverageForType:MSID_PERF_TELEMETRY_SIGNOUT_TYPE],

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
@@ -29,6 +29,39 @@
 #import "NSKeyedUnarchiver+MSIDExtensions.h"
 #import "MSIDRequestTelemetryConstants.h"
 
+@implementation MSIDRequestPerformanceInfo
+
+#define kTotalNumbers              @"totalNumbers"
+#define kIpcRequestNumbers         @"ipcRequestNumbers"
+#define kIpcResponseNumbers        @"ipcResponseNumbers"
+
+- (void)encodeWithCoder:(NSCoder *)encoder
+{
+    [encoder encodeObject:self.totalNumbers forKey:kTotalNumbers];
+    [encoder encodeObject:self.ipcRequestNumbers forKey:kIpcRequestNumbers];
+    [encoder encodeObject:self.ipcResponseNumbers forKey:kIpcResponseNumbers];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder
+{
+    self = [super init];
+    if (self)
+    {
+        NSSet *classes = [NSSet setWithObjects:[NSMutableArray class], [NSNumber class], nil];
+        self.totalNumbers = [decoder decodeObjectOfClasses:classes forKey:kTotalNumbers];
+        self.ipcRequestNumbers = [decoder decodeObjectOfClasses:classes forKey:kIpcRequestNumbers];
+        self.ipcResponseNumbers = [decoder decodeObjectOfClasses:classes forKey:kIpcResponseNumbers];
+    }
+    return self;
+}
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
+@end
+
 @implementation MSIDRequestTelemetryErrorInfo
 
 #define kApiId              @"apiId"
@@ -66,11 +99,17 @@
 
 @end
 
+NSString * _Nonnull const MSID_PERF_TELEMETRY_SILENT_TYPE = @"silent";
+NSString * _Nonnull const MSID_PERF_TELEMETRY_SIGNOUT_TYPE = @"signout";
+NSString * _Nonnull const MSID_PERF_TELEMETRY_GETACCOUNTS_TYPE = @"accounts";
+NSString * _Nonnull const MSID_PERF_TELEMETRY_GETDEVICEINFO_TYPE = @"deviceinfo";
+
 @interface MSIDLastRequestTelemetry()
 
 @property (nonatomic) NSMutableArray<MSIDRequestTelemetryErrorInfo *> *errorsInfo;
 @property (nonatomic) NSInteger schemaVersion;
 @property (nonatomic) NSInteger silentSuccessfulCount;
+@property (nonatomic) NSMutableDictionary<NSString *, MSIDRequestPerformanceInfo *> *perfTelemetry;
 @property (nonatomic) NSMutableArray<NSString *> *platformFields;
 @property (nonatomic) dispatch_queue_t synchronizationQueue;
 @property (nonatomic) MSIDLastRequestTelemetrySerializedItem *telemetrySerializedItem;
@@ -184,6 +223,56 @@ static int maxErrorCountToArchive = 75;
     });
 }
 
+- (void)trackSSOExtensionPerformanceWithType:(NSString *)type
+                             totalPerfNumber:(NSTimeInterval)totalPerfNumber
+                        ipcRequestPerfNumber:(NSTimeInterval)ipcRequestPerfNumber
+                       ipcResponsePerfNumber:(NSTimeInterval)ipcResponsePerfNumber
+{
+    dispatch_barrier_async(self.synchronizationQueue, ^{
+        
+        [self trackSSOExtensionPerformanceWithTypeImpl:type
+                                       totalPerfNumber:totalPerfNumber
+                                  ipcRequestPerfNumber:ipcRequestPerfNumber
+                                 ipcResponsePerfNumber:ipcResponsePerfNumber];
+        
+        [self saveTelemetryToDisk];
+    });
+}
+
+- (void)trackSSOExtensionPerformanceWithTypeImpl:(NSString *)type
+                                 totalPerfNumber:(NSTimeInterval)totalPerfNumber
+                            ipcRequestPerfNumber:(NSTimeInterval)ipcRequestPerfNumber
+                           ipcResponsePerfNumber:(NSTimeInterval)ipcResponsePerfNumber
+{
+    MSIDRequestPerformanceInfo *perfInfo = self.perfTelemetry[type];
+    
+    if (!perfInfo)
+    {
+        perfInfo = [MSIDRequestPerformanceInfo new];
+    }
+    
+    if (!perfInfo.totalNumbers)
+    {
+        perfInfo.totalNumbers = [NSMutableArray new];
+    }
+    
+    if (!perfInfo.ipcRequestNumbers)
+    {
+        perfInfo.ipcRequestNumbers = [NSMutableArray new];
+    }
+    
+    if (!perfInfo.ipcResponseNumbers)
+    {
+        perfInfo.ipcResponseNumbers = [NSMutableArray new];
+    }
+    
+    [perfInfo.totalNumbers addObject:@(totalPerfNumber)];
+    [perfInfo.ipcRequestNumbers addObject:@(ipcRequestPerfNumber)];
+    [perfInfo.ipcResponseNumbers addObject:@(ipcResponsePerfNumber)];
+    
+    self.perfTelemetry[type] = perfInfo;
+}
+
 #pragma mark - MSIDTelemetryStringSerializable
 
 - (NSString *)telemetryString
@@ -201,12 +290,14 @@ static int maxErrorCountToArchive = 75;
 #define kSchemaVersion              @"schemaVersion"
 #define kSilentSuccessfulCount      @"silentSuccessfulCount"
 #define kErrorsInfo                 @"errorsInfo"
+#define kPerfTelemetry              @"perfTelemetry"
 
 - (void)encodeWithCoder:(NSCoder *)encoder
 {
     [encoder encodeInteger:_schemaVersion forKey:kSchemaVersion];
     [encoder encodeInteger:_silentSuccessfulCount forKey:kSilentSuccessfulCount];
     [encoder encodeObject:_errorsInfo forKey:kErrorsInfo];
+    [encoder encodeObject:_perfTelemetry forKey:kPerfTelemetry];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder
@@ -217,7 +308,10 @@ static int maxErrorCountToArchive = 75;
     NSSet *classes = [NSSet setWithObjects:[NSMutableArray class], [NSString class], [MSIDRequestTelemetryErrorInfo class], nil];
     NSMutableArray<MSIDRequestTelemetryErrorInfo *> *errorsInfo = [decoder decodeObjectOfClasses:classes forKey:kErrorsInfo];
     
-    return [self initFromDecodedObjectWithSchemaVersion:schemaVersion silentSuccessfulCount:silentSuccessfulCount errorsInfo:errorsInfo];
+    NSSet *perfClasses = [NSSet setWithObjects:[NSMutableDictionary class], [NSString class], [MSIDRequestPerformanceInfo class], nil];
+    NSDictionary *perfTelemetry = [decoder decodeObjectOfClasses:perfClasses forKey:kPerfTelemetry];
+    
+    return [self initFromDecodedObjectWithSchemaVersion:schemaVersion silentSuccessfulCount:silentSuccessfulCount errorsInfo:errorsInfo perfTelemetry:perfTelemetry];
 }
 
 + (BOOL)supportsSecureCoding
@@ -237,7 +331,38 @@ static int maxErrorCountToArchive = 75;
 - (MSIDLastRequestTelemetrySerializedItem *)createSerializedItem
 {
     NSArray *defaultFields = @[[NSNumber numberWithInteger:self->_silentSuccessfulCount]];
-    return [[MSIDLastRequestTelemetrySerializedItem alloc] initWithSchemaVersion:[NSNumber numberWithInteger:self.schemaVersion] defaultFields:defaultFields errorInfo:self->_errorsInfo platformFields:self.platformFields];
+    
+    NSMutableArray *platformFields = [NSMutableArray new];
+    [platformFields addObjectsFromArray:self.platformFields];
+    [platformFields addObject:[self serializedPerfTelemetry]];
+    
+    return [[MSIDLastRequestTelemetrySerializedItem alloc] initWithSchemaVersion:[NSNumber numberWithInteger:self.schemaVersion] defaultFields:defaultFields errorInfo:self->_errorsInfo platformFields:platformFields];
+}
+
+- (NSString *)serializedPerfTelemetry
+{
+    NSString *serializedPerfTelemetry = [NSString stringWithFormat:@"%@;%@;%@;%@;",
+                                         [self serializedAverageForType:MSID_PERF_TELEMETRY_SILENT_TYPE],
+                                         [self serializedAverageForType:MSID_PERF_TELEMETRY_SIGNOUT_TYPE],
+                                         [self serializedAverageForType:MSID_PERF_TELEMETRY_GETACCOUNTS_TYPE],
+                                         [self serializedAverageForType:MSID_PERF_TELEMETRY_GETDEVICEINFO_TYPE]];
+    return serializedPerfTelemetry;
+}
+
+- (NSString *)serializedAverageForType:(NSString *)type
+{
+    MSIDRequestPerformanceInfo *perfInfo = self.perfTelemetry[type];
+    
+    if (!perfInfo)
+    {
+        return [NSString stringWithFormat:@"%@:", type];
+    }
+ 
+    NSNumber *totalAverage = perfInfo.totalNumbers ? [perfInfo.totalNumbers valueForKeyPath:@"@avg.self"] : nil;
+    NSNumber *ipcRequestAverage = perfInfo.ipcRequestNumbers ? [perfInfo.ipcRequestNumbers valueForKeyPath:@"@avg.self"] : nil;
+    NSNumber *ipcResponseAverage = perfInfo.ipcResponseNumbers ? [perfInfo.ipcResponseNumbers valueForKeyPath:@"@avg.self"] : nil;
+    
+    return [NSString stringWithFormat:@"%@:%f:%f:%f", type, [totalAverage doubleValue], [ipcRequestAverage doubleValue], [ipcResponseAverage doubleValue]];
 }
 
 #pragma mark - Update object
@@ -271,6 +396,8 @@ static int maxErrorCountToArchive = 75;
         {
             self->_errorsInfo = nil;
         }
+        
+        self.perfTelemetry = [NSMutableDictionary new];
 
         [self saveTelemetryToDisk];
     });
@@ -304,7 +431,7 @@ static int maxErrorCountToArchive = 75;
     }
 }
 
-- (instancetype)initFromDecodedObjectWithSchemaVersion:(NSInteger)schemaVersion silentSuccessfulCount:(NSInteger)silentSuccessfulCount errorsInfo:(NSMutableArray<MSIDRequestTelemetryErrorInfo *>*) errorsInfo
+- (instancetype)initFromDecodedObjectWithSchemaVersion:(NSInteger)schemaVersion silentSuccessfulCount:(NSInteger)silentSuccessfulCount errorsInfo:(NSMutableArray<MSIDRequestTelemetryErrorInfo *>*) errorsInfo perfTelemetry:(NSDictionary *)perfTelemetry
 {
     self = [super init];
     if (self)
@@ -315,6 +442,7 @@ static int maxErrorCountToArchive = 75;
             _silentSuccessfulCount = silentSuccessfulCount;
             _errorsInfo = errorsInfo;
             _synchronizationQueue = [self initializeDispatchQueue];
+            _perfTelemetry = [[NSMutableDictionary alloc] initWithDictionary:perfTelemetry];
             _platformFields = [NSMutableArray<NSString *> new];
         }
         else

--- a/IdentityCore/src/util/NSDate+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSDate+MSIDExtensions.h
@@ -30,5 +30,4 @@
 - (NSString *)msidDateToFractionalTimestamp:(int)precision;
 + (NSDate *)msidDateFromTimeStamp:(NSString *)timeStamp;
 + (NSDate *)msidDateFromRetryHeader:(NSString *)retryHeaderString;
-
 @end

--- a/IdentityCore/src/util/NSDate+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSDate+MSIDExtensions.h
@@ -30,4 +30,5 @@
 - (NSString *)msidDateToFractionalTimestamp:(int)precision;
 + (NSDate *)msidDateFromTimeStamp:(NSString *)timeStamp;
 + (NSDate *)msidDateFromRetryHeader:(NSString *)retryHeaderString;
+
 @end

--- a/IdentityCore/tests/MSIDBrokerNativeAppOperationResponseTests.m
+++ b/IdentityCore/tests/MSIDBrokerNativeAppOperationResponseTests.m
@@ -1,0 +1,218 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <XCTest/XCTest.h>
+#import "MSIDBrokerNativeAppOperationResponse.h"
+#import "MSIDBrokerConstants.h"
+#import "MSIDDeviceInfo.h"
+#import "MSIDLastRequestTelemetry.h"
+#import "NSDate+MSIDTestUtil.h"
+
+@interface MSIDLastRequestTelemetry(Test)
+
+- (instancetype)initInternal;
+
+@end
+
+@interface MSIDLastRequestTelemetryMock : MSIDLastRequestTelemetry
+
+@property (nonatomic) NSString *telemetryType;
+@property (nonatomic) NSTimeInterval totalPerfNumber;
+@property (nonatomic) NSTimeInterval ipcRequestPerfNumber;
+@property (nonatomic) NSTimeInterval ipcResponsePerfNumber;
+
+@end
+
+@implementation MSIDLastRequestTelemetryMock
+
+- (void)trackSSOExtensionPerformanceWithType:(NSString *)type
+                             totalPerfNumber:(NSTimeInterval)totalPerfNumber
+                        ipcRequestPerfNumber:(NSTimeInterval)ipcRequestPerfNumber
+                       ipcResponsePerfNumber:(NSTimeInterval)ipcResponsePerfNumber
+{
+    self.telemetryType = type;
+    self.totalPerfNumber = totalPerfNumber;
+    self.ipcResponsePerfNumber = ipcResponsePerfNumber;
+    self.ipcRequestPerfNumber = ipcRequestPerfNumber;
+}
+
+@end
+
+@interface MSIDBrokerNativeAppOperationResponseTests : XCTestCase
+
+@end
+
+@implementation MSIDBrokerNativeAppOperationResponseTests
+
+- (void)tearDown
+{
+    [NSDate reset];
+    [super tearDown];
+}
+
+- (void)testJsonDictionary_whenAllPropertiesSet_shouldReturnJson
+{
+    __auto_type response = [[MSIDBrokerNativeAppOperationResponse alloc] initWithDeviceInfo:[MSIDDeviceInfo new]];
+    response.operation = @"login";
+    response.success = true;
+    response.clientAppVersion = @"1.0";
+    response.responseGenerationTimeStamp = [NSDate dateWithTimeIntervalSince1970:100];
+    response.requestReceivedTimeStamp = [NSDate dateWithTimeIntervalSince1970:50];
+    
+    NSDictionary *json = [response jsonDictionary];
+    
+    XCTAssertEqual(9, json.allKeys.count);
+    XCTAssertEqualObjects(json[@"client_app_version"], @"1.0");
+    XCTAssertEqualObjects(json[@"operation"], @"login");
+    XCTAssertEqualObjects(json[@"operation_response_type"], @"operation_generic_response");
+    XCTAssertEqualObjects(json[@"success"], @"1");
+    XCTAssertEqualObjects(json[MSID_BROKER_DEVICE_MODE_KEY], @"personal");
+    XCTAssertEqualObjects(json[MSID_BROKER_SSO_EXTENSION_MODE_KEY], @"full");
+    XCTAssertEqualObjects(json[MSID_BROKER_WPJ_STATUS_KEY], @"notJoined");
+    XCTAssertEqualObjects(json[@"response_gen_timestamp"], @"100.0000000000");
+    XCTAssertEqualObjects(json[@"request_received_timestamp"], @"50.0000000000");
+}
+
+- (void)testInitWithJSONDictionary_whenAllProperties_shouldInitResponse
+{
+    NSDictionary *json = @{
+        @"client_app_version": @"1.0",
+        @"operation_response_type": @"operation_generic_response",
+        @"success": @"1",
+        @"operation": @"login",
+        MSID_BROKER_DEVICE_MODE_KEY : @"shared",
+        MSID_BROKER_WPJ_STATUS_KEY : @"joined",
+        MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
+        @"response_gen_timestamp": @"100.0000000000",
+        @"request_received_timestamp": @"50.0000000000"
+    };
+    
+    NSError *error;
+    __auto_type response = [[MSIDBrokerNativeAppOperationResponse alloc] initWithJSONDictionary:json error:&error];
+    
+    XCTAssertNotNil(response);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(@"1.0", response.clientAppVersion);
+    XCTAssertEqualObjects(@"login", response.operation);
+    XCTAssertTrue(response.success);
+    XCTAssertEqual(response.deviceInfo.deviceMode, MSIDDeviceModeShared);
+    XCTAssertEqual(response.deviceInfo.wpjStatus, MSIDWorkPlaceJoinStatusJoined);
+    XCTAssertEqualObjects(response.deviceInfo.brokerVersion, @"1.2.3");
+    XCTAssertEqualObjects(response.responseGenerationTimeStamp, [NSDate dateWithTimeIntervalSince1970:100]);
+    XCTAssertEqualObjects(response.requestReceivedTimeStamp, [NSDate dateWithTimeIntervalSince1970:50]);
+}
+
+- (void)testInitWithJSONDictionary_whenDatesMissing_shouldInitResponseWithoutDates
+{
+    NSDictionary *json = @{
+        @"client_app_version": @"1.0",
+        @"operation_response_type": @"operation_generic_response",
+        @"success": @"1",
+        @"operation": @"login",
+        MSID_BROKER_DEVICE_MODE_KEY : @"shared",
+        MSID_BROKER_WPJ_STATUS_KEY : @"joined",
+        MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3"
+    };
+    
+    NSError *error;
+    __auto_type response = [[MSIDBrokerNativeAppOperationResponse alloc] initWithJSONDictionary:json error:&error];
+    
+    XCTAssertNotNil(response);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(@"1.0", response.clientAppVersion);
+    XCTAssertEqualObjects(@"login", response.operation);
+    XCTAssertTrue(response.success);
+    XCTAssertEqual(response.deviceInfo.deviceMode, MSIDDeviceModeShared);
+    XCTAssertEqual(response.deviceInfo.wpjStatus, MSIDWorkPlaceJoinStatusJoined);
+    XCTAssertEqualObjects(response.deviceInfo.brokerVersion, @"1.2.3");
+    XCTAssertNil(response.responseGenerationTimeStamp);
+    XCTAssertNil(response.requestReceivedTimeStamp);
+}
+
+- (void)testTrackPerfTelemetry_whenDatesAreAllSet_shouldCallTrackWithRightIntervals
+{
+    MSIDBrokerNativeAppOperationResponse *response = [[MSIDBrokerNativeAppOperationResponse alloc] initWithDeviceInfo:[MSIDDeviceInfo new]];
+    response.responseGenerationTimeStamp = [NSDate dateWithTimeIntervalSince1970:100];
+    response.requestReceivedTimeStamp = [NSDate dateWithTimeIntervalSince1970:50];
+    
+    MSIDLastRequestTelemetryMock *telemetryMock = [[MSIDLastRequestTelemetryMock alloc] initInternal];
+    
+    NSDate *requestStartDate = [NSDate dateWithTimeIntervalSince1970:20];
+    NSDate *responseReceivedDate = [NSDate dateWithTimeIntervalSince1970:150];
+    [NSDate mockCurrentDate:responseReceivedDate];
+    
+    [response trackPerfTelemetryWithLastRequest:telemetryMock
+                               requestStartDate:requestStartDate
+                                  telemetryType:@"type"];
+    
+    XCTAssertEqualObjects(telemetryMock.telemetryType, @"type");
+    XCTAssertEqualWithAccuracy(telemetryMock.totalPerfNumber, 130, 1.0);
+    XCTAssertEqualWithAccuracy(telemetryMock.ipcRequestPerfNumber, 30, 1.0);
+    XCTAssertEqualWithAccuracy(telemetryMock.ipcResponsePerfNumber, 50, 1.0);
+}
+
+- (void)testTrackPerfTelemetry_whenRequestReceivedDateIsNil_shouldCallTrackWithRightIntervals
+{
+    MSIDBrokerNativeAppOperationResponse *response = [[MSIDBrokerNativeAppOperationResponse alloc] initWithDeviceInfo:[MSIDDeviceInfo new]];
+    response.responseGenerationTimeStamp = [NSDate dateWithTimeIntervalSince1970:100];
+    
+    MSIDLastRequestTelemetryMock *telemetryMock = [[MSIDLastRequestTelemetryMock alloc] initInternal];
+    
+    NSDate *requestStartDate = [NSDate dateWithTimeIntervalSince1970:20];
+    NSDate *responseReceivedDate = [NSDate dateWithTimeIntervalSince1970:150];
+    [NSDate mockCurrentDate:responseReceivedDate];
+    
+    [response trackPerfTelemetryWithLastRequest:telemetryMock
+                               requestStartDate:requestStartDate
+                                  telemetryType:@"type"];
+    
+    XCTAssertEqualObjects(telemetryMock.telemetryType, @"type");
+    XCTAssertEqualWithAccuracy(telemetryMock.totalPerfNumber, 130, 1.0);
+    XCTAssertEqualWithAccuracy(telemetryMock.ipcRequestPerfNumber, 0, 1.0);
+    XCTAssertEqualWithAccuracy(telemetryMock.ipcResponsePerfNumber, 50, 1.0);
+}
+
+- (void)testTrackPerfTelemetry_whenResponseGenerationDateIsNil_shouldCallTrackWithRightIntervals
+{
+    MSIDBrokerNativeAppOperationResponse *response = [[MSIDBrokerNativeAppOperationResponse alloc] initWithDeviceInfo:[MSIDDeviceInfo new]];
+    response.requestReceivedTimeStamp = [NSDate dateWithTimeIntervalSince1970:50];
+    
+    MSIDLastRequestTelemetryMock *telemetryMock = [[MSIDLastRequestTelemetryMock alloc] initInternal];
+    
+    NSDate *requestStartDate = [NSDate dateWithTimeIntervalSince1970:20];
+    NSDate *responseReceivedDate = [NSDate dateWithTimeIntervalSince1970:150];
+    [NSDate mockCurrentDate:responseReceivedDate];
+    
+    [response trackPerfTelemetryWithLastRequest:telemetryMock
+                               requestStartDate:requestStartDate
+                                  telemetryType:@"type"];
+    
+    XCTAssertEqualObjects(telemetryMock.telemetryType, @"type");
+    XCTAssertEqualWithAccuracy(telemetryMock.totalPerfNumber, 130, 1.0);
+    XCTAssertEqualWithAccuracy(telemetryMock.ipcRequestPerfNumber, 30, 1.0);
+    XCTAssertEqualWithAccuracy(telemetryMock.ipcResponsePerfNumber, 0, 1.0);
+}
+
+@end


### PR DESCRIPTION
## Proposed changes

Adding basic SSO extension performance telemetry for MSAL.Objective C. Note, it doesn't measure any actual performance inside the broker, it only provides info on MSAL side and sends it to ESTS telemetry. 1DS nor MATS won't give us this insight.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

