### PR TITLE
Return additional metadata about primary registration in SSO extension getDeviceInfo call

### DIFF
--- a/IdentityCore/src/MSIDBrokerConstants.h
+++ b/IdentityCore/src/MSIDBrokerConstants.h
@@ -82,4 +82,7 @@ extern NSString * _Nonnull const MSID_SSO_NONCE_QUERY_PARAM_KEY;
 extern NSString * _Nonnull const MSID_BROKER_MDM_ID_KEY;
 extern NSString * _Nonnull const MSID_ENROLLED_USER_OBJECT_ID_KEY;
 extern NSString * _Nonnull const MSID_EXTRA_DEVICE_INFO_KEY;
-
+extern NSString * _Nonnull const MSID_PRIMARY_REGISTRATION_UPN;
+extern NSString * _Nonnull const MSID_PRIMARY_REGISTRATION_DEVICE_ID;
+extern NSString * _Nonnull const MSID_PRIMARY_REGISTRATION_TENANT_ID;
+extern NSString * _Nonnull const MSID_PRIMARY_REGISTRATION_CLOUD;

--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -78,3 +78,7 @@ NSString *const MSID_SSO_NONCE_QUERY_PARAM_KEY = @"sso_nonce";
 NSString *const MSID_BROKER_MDM_ID_KEY = @"mdm_id";
 NSString *const MSID_ENROLLED_USER_OBJECT_ID_KEY = @"object_id";
 NSString *const MSID_EXTRA_DEVICE_INFO_KEY = @"extraDeviceInfo";
+NSString *const MSID_PRIMARY_REGISTRATION_UPN = @"primary_registration_metadata_upn";
+NSString *const MSID_PRIMARY_REGISTRATION_DEVICE_ID = @"primary_registration_metadata_device_id";
+NSString *const MSID_PRIMARY_REGISTRATION_TENANT_ID = @"primary_registration_metadata_tenant_id";
+NSString *const MSID_PRIMARY_REGISTRATION_CLOUD = @"primary_registration_metadata_cloud_host";


### PR DESCRIPTION
## Proposed changes

GetDeviceInfo API will now return additional metadata about primary AAD device registration.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

