### PR TITLE
Add/modify more level logs for CPP when Edge cannot find PkeyAuth in OneAuth but broker can

### DIFF
--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -179,6 +179,7 @@ static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privat
     
     if (status != errSecSuccess)
     {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Attempting to get registration information failed - %@ shared access Group - status %d", accessGroup, (int)status);
         return NULL;
     }
     

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -150,7 +150,10 @@ static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privat
                                                           privateKey:privateKey
                                                          certificate:certificate
                                                    certificateIssuer:certificateIssuer];
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Registration information failed to be created");
+        if (!info)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Registration information failed to be created");
+        }
     }
     
     CFReleaseNull(identity);

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -123,7 +123,7 @@ static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privat
     identity = [self copyWPJIdentity:context sharedAccessGroup:sharedAccessGroup certificateIssuer:&certificateIssuer privateKeyDict:&keyDict];
     if (!identity || CFGetTypeID(identity) != SecIdentityGetTypeID())
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Failed to retrieve WPJ identity. identity %@, typeIdMismatch %@", @(!identity), @(CFGetTypeID(identity) != SecIdentityGetTypeID()));
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Failed to retrieve WPJ identity. Identity %@, typeIdMismatch %@", @(!identity), @(CFGetTypeID(identity) != SecIdentityGetTypeID()));
         CFReleaseNull(identity);
         return nil;
     }

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -123,7 +123,7 @@ static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privat
     identity = [self copyWPJIdentity:context sharedAccessGroup:sharedAccessGroup certificateIssuer:&certificateIssuer privateKeyDict:&keyDict];
     if (!identity || CFGetTypeID(identity) != SecIdentityGetTypeID())
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, context, @"Failed to retrieve WPJ identity.");
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Failed to retrieve WPJ identity.identity %@, typeIdMismatch %@", @(!identity), @(CFGetTypeID(identity) != SecIdentityGetTypeID()));
         CFReleaseNull(identity);
         return nil;
     }
@@ -150,6 +150,7 @@ static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privat
                                                           privateKey:privateKey
                                                          certificate:certificate
                                                    certificateIssuer:certificateIssuer];
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Registration information failed to be created");
     }
     
     CFReleaseNull(identity);

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -123,7 +123,7 @@ static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privat
     identity = [self copyWPJIdentity:context sharedAccessGroup:sharedAccessGroup certificateIssuer:&certificateIssuer privateKeyDict:&keyDict];
     if (!identity || CFGetTypeID(identity) != SecIdentityGetTypeID())
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Failed to retrieve WPJ identity.identity %@, typeIdMismatch %@", @(!identity), @(CFGetTypeID(identity) != SecIdentityGetTypeID()));
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Failed to retrieve WPJ identity. identity %@, typeIdMismatch %@", @(!identity), @(CFGetTypeID(identity) != SecIdentityGetTypeID()));
         CFReleaseNull(identity);
         return nil;
     }


### PR DESCRIPTION
## Proposed changes

Edge is having issue when trying so handle PKeyAuth on iOS for ManBro. It cannot find device info, but broker can, and there is only single legacy device registration. Adding an error log to check the accessGroup and error Status

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

