### PR TITLE
Fix a logging crash

### DIFF
--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -123,7 +123,7 @@ static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privat
     identity = [self copyWPJIdentity:context sharedAccessGroup:sharedAccessGroup certificateIssuer:&certificateIssuer privateKeyDict:&keyDict];
     if (!identity || CFGetTypeID(identity) != SecIdentityGetTypeID())
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Failed to retrieve WPJ identity. Identity %@", @(!identity));
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Failed to retrieve WPJ identity. Identity is nil: %@", @(identity == nil));
         CFReleaseNull(identity);
         return nil;
     }

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -123,7 +123,7 @@ static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privat
     identity = [self copyWPJIdentity:context sharedAccessGroup:sharedAccessGroup certificateIssuer:&certificateIssuer privateKeyDict:&keyDict];
     if (!identity || CFGetTypeID(identity) != SecIdentityGetTypeID())
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Failed to retrieve WPJ identity. Identity %@, typeIdMismatch %@", @(!identity), @(CFGetTypeID(identity) != SecIdentityGetTypeID()));
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Failed to retrieve WPJ identity. Identity %@", @(!identity));
         CFReleaseNull(identity);
         return nil;
     }

--- a/IdentityCore/tests/MSIDWorkPlaceJoinUtilTests.m
+++ b/IdentityCore/tests/MSIDWorkPlaceJoinUtilTests.m
@@ -63,6 +63,12 @@ static NSString *kDummyTenant3CertIdentifier = @"NmFhNWYzM2ItOTc0OS00M2U3LTk1Njc
 #endif
 }
 
+- (void)testGetRegistrationInformation_withoutRegistrationInformation_andNoChallenge_shoudReturnNil
+{
+    MSIDRegistrationInformation *registrationInfo = [MSIDWorkPlaceJoinUtil getRegistrationInformation:nil workplacejoinChallenge:nil];
+    XCTAssertNil(registrationInfo);
+}
+
 - (void)testGetWPJStringDataForIdentifier_withKeychainItem_shouldReturnValidValue
 {
     NSString *dummyKeyIdentifierValue = @"dummyupn@dummytenant.com";

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.7.15
+* Fix a crash when no identiy found during getting device registration information on iOS.
+
 Version 1.7.14
 * Add skip local RT when creating silent controller
 


### PR DESCRIPTION
## Proposed changes

Fix a crash when identity is nil during getting device registration information on iOS

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

