### PR TITLE
Add more detailed error codes for JIT WPJ - 2 [common]

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -272,6 +272,27 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     // JIT - Compliance Check - Device unknown
     MSIDErrorJITComplianceCheckResultUnknown       =   -51823,
     
+    // JIT - Compliance Check - Invalid linkPayload from SSO configuration
+    MSIDErrorJITComplianceCheckInvalidLinkPayload  =   -51824,
+
+    // JIT - Compliance Check - Could not create compliance check web view controller
+    MSIDErrorJITComplianceCheckCreateController    =   -51825,
+
+    // JIT - Link - LinkConfig not found
+    MSIDErrorJITLinkConfigNotFound                 =   -51826,
+
+    // JIT - Link - Invalid LinkTokenConfig
+    MSIDErrorJITInvalidLinkTokenConfig             =   -51827,
+
+    // JIT - WPJ - Device Registration Failed
+    MSIDErrorJITWPJDeviceRegistrationFailed        =   -51828,
+
+    // JIT - WPJ - AccountIdentifier is nil
+    MSIDErrorJITWPJAccountIdentifierNil            =   -51829,
+
+    // JIT - WPJ - Failed to acquire broker token
+    MSIDErrorJITWPJAcquireTokenError               =   -51830,
+    
     // Throttling errors
     MSIDErrorThrottleCacheNoRecord = -51900,
     MSIDErrorThrottleCacheInvalidSignature = -51901,

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -178,6 +178,12 @@ NSDictionary* MSIDErrorDomainsAndCodes()
                       @(MSIDErrorJITComplianceCheckResultNotCompliant),
                       @(MSIDErrorJITComplianceCheckResultTimeout),
                       @(MSIDErrorJITComplianceCheckResultUnknown),
+                      @(MSIDErrorJITComplianceCheckInvalidLinkPayload),
+                      @(MSIDErrorJITLinkConfigNotFound),
+                      @(MSIDErrorJITInvalidLinkTokenConfig),
+                      @(MSIDErrorJITWPJDeviceRegistrationFailed),
+                      @(MSIDErrorJITWPJAccountIdentifierNil),
+                      @(MSIDErrorJITWPJAcquireTokenError),
 
                       ],
               MSIDOAuthErrorDomain : @[// Server Errors

--- a/IdentityCore/src/util/NSError+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSError+MSIDExtensions.h
@@ -42,4 +42,6 @@ typedef NS_OPTIONS(NSUInteger, MSIDErrorFilteringOptions)
 
 - (nullable NSString *)msidSubError;
 
+- (nullable NSDictionary*)getStatusCodeUserInfoFromUnderlyingErrorCode;
+
 @end

--- a/IdentityCore/src/util/NSError+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSError+MSIDExtensions.h
@@ -42,6 +42,6 @@ typedef NS_OPTIONS(NSUInteger, MSIDErrorFilteringOptions)
 
 - (nullable NSString *)msidSubError;
 
-- (nullable NSDictionary*)getStatusCodeUserInfoFromUnderlyingErrorCode;
+- (nullable NSDictionary *)msidGetStatusCodeUserInfoFromUnderlyingErrorCode;
 
 @end

--- a/IdentityCore/src/util/NSError+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSError+MSIDExtensions.m
@@ -76,4 +76,17 @@
     return self.userInfo[self.msidErrorConverter.subErrorKey];
 }
 
+- (nullable NSDictionary*)getStatusCodeUserInfoFromUnderlyingErrorCode
+{
+    NSMutableDictionary *additionalUserInfo = nil;
+    if (self.userInfo[NSUnderlyingErrorKey] != nil)
+    {
+        additionalUserInfo = [NSMutableDictionary new];
+        NSError *underlyingError = self.userInfo[NSUnderlyingErrorKey];
+        [additionalUserInfo setValue:@(underlyingError.code) forKey:@"statusCode"];
+    }
+
+    return additionalUserInfo;
+}
+
 @end

--- a/IdentityCore/src/util/NSError+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSError+MSIDExtensions.m
@@ -76,7 +76,7 @@
     return self.userInfo[self.msidErrorConverter.subErrorKey];
 }
 
-- (nullable NSDictionary*)getStatusCodeUserInfoFromUnderlyingErrorCode
+- (nullable NSDictionary *)msidGetStatusCodeUserInfoFromUnderlyingErrorCode
 {
     NSMutableDictionary *additionalUserInfo = nil;
     if (self.userInfo[NSUnderlyingErrorKey] != nil)

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -72,13 +72,13 @@
 {
     if (!startURL)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"Attemped to start with nil URL");
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"Attempted to start with nil URL");
         return nil;
     }
     
     if (!endURL)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"Attemped to start with nil endURL");
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"Attempted to start with nil endURL");
         return nil;
     }
     
@@ -144,10 +144,10 @@
 
 - (void)cancelProgrammatically
 {
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Canceled web view contoller.");
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Canceled web view controller.");
     
     // End web auth with error
-    NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorSessionCanceledProgrammatically, @"Authorization session was cancelled programatically.", nil, nil, nil, self.context.correlationId, nil, NO);
+    NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorSessionCanceledProgrammatically, @"Authorization session was cancelled programmatically.", nil, nil, nil, self.context.correlationId, nil, NO);
     
     CONDITIONAL_UI_EVENT_SET_IS_CANCELLED(_telemetryEvent, YES);
     [self endWebAuthWithURL:nil error:error];
@@ -160,7 +160,7 @@
 
 - (void)userCancel
 {
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Canceled web view contoller by the user.");
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Canceled web view controller by the user.");
     
     // End web auth with error
     NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorUserCancel, @"User cancelled the authorization session.", nil, nil, nil, self.context.correlationId, nil, NO);
@@ -201,7 +201,7 @@
     CONDITIONAL_STOP_EVENT(CONDITIONAL_SHARED_INSTANCE, _telemetryRequestId, _telemetryEvent);
     
     [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Dismissed web view contoller.");
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Dismissed web view controller.");
         [self dismissWebview:^{[self dispatchCompletionBlock:endURL error:error];}];
     }];
     
@@ -236,7 +236,7 @@
 
 - (void)startRequest:(NSURLRequest *)request
 {
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Presenting web view contoller.");
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context, @"Presenting web view controller.");
     
     _telemetryRequestId = [_context telemetryRequestId];
     CONDITIONAL_START_EVENT(CONDITIONAL_SHARED_INSTANCE, _telemetryRequestId, MSID_TELEMETRY_EVENT_UI_EVENT);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+TBD
+* Add more detailed error codes for JIT (#1187)
+
 Version 1.7.15
 * Fix a crash when no identiy found during getting device registration information on iOS.
 


### PR DESCRIPTION
## Proposed changes

- Add additional error codes for a more detailed telemetry for JIT.
- Fix typos.

This PR replaces https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1180 which had some build errors.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

