### PR TITLE
Change method of masking PII

### DIFF
--- a/IdentityCore/src/webview/operations/MSIDWebOpenBrowserResponseOperation.m
+++ b/IdentityCore/src/webview/operations/MSIDWebOpenBrowserResponseOperation.m
@@ -69,7 +69,7 @@
     #if TARGET_OS_IPHONE
     if (![MSIDAppExtensionUtil isExecutingInAppExtension])
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Opening a browser - %@", MSID_PII_LOG_MASKABLE(self.browserURL));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Opening a browser - %@", [self.browserURL msidPIINullifiedURL]);
         [MSIDAppExtensionUtil sharedApplicationOpenURL:self.browserURL];
     }
     else


### PR DESCRIPTION
## Proposed changes

The existing method  for masking PII : MSID_PII_LOG_MASKABLE(self.browserURL)); masks only when the masking level is set to 0 or 1. If, for some reason, it is changed to something else, masking isn't performed. See : https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/blob/8a4a62b74992d1bf21ca156605797f1ecda0e44a/IdentityCore/src/logger/MSIDMaskedLogParameter.m#L79

This PR aims to use a method to mask parts of the URL and does not depend on a masking level.


## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

