### PR TITLE
EnrollmentIds issue with empty home account and legacy id

### DIFF
--- a/IdentityCore/src/intune/MSIDIntuneEnrollmentIdsCache.m
+++ b/IdentityCore/src/intune/MSIDIntuneEnrollmentIdsCache.m
@@ -124,8 +124,8 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
     }
     
     // If we haven't found an exact match yet, fallback to any enrollment ID to support no userID or single userID scenarios
-    // only if homeAccountId or legacyId are not empty
-    if (![NSString msidIsStringNilOrBlank:homeAccountId] || ![NSString msidIsStringNilOrBlank:legacyUserId])
+    // only if homeAccountId and legacyId are both empty
+    if ([NSString msidIsStringNilOrBlank:homeAccountId] && [NSString msidIsStringNilOrBlank:legacyUserId])
     {
         return [self enrollmentIdIfAvailableWithContext:context error:error];
     }

--- a/IdentityCore/src/intune/MSIDIntuneEnrollmentIdsCache.m
+++ b/IdentityCore/src/intune/MSIDIntuneEnrollmentIdsCache.m
@@ -123,8 +123,14 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
         if (enrollmentId) return enrollmentId;
     }
     
-    // If we haven't found an exact match yet, fallback to any enrollment ID to support no userID or single userID scenarios.
-    return [self enrollmentIdIfAvailableWithContext:context error:error];
+    // If we haven't found an exact match yet, fallback to any enrollment ID to support no userID or single userID scenarios
+    // only if homeAccountId or legacyId are not empty
+    if (![NSString msidIsStringNilOrBlank:homeAccountId] || ![NSString msidIsStringNilOrBlank:legacyUserId])
+    {
+        return [self enrollmentIdIfAvailableWithContext:context error:error];
+    }
+    
+    return nil;
 }
 
 - (NSString *)enrollmentIdForHomeAccountId:(NSString *)homeAccountId
@@ -154,10 +160,11 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
                               context:(id<MSIDRequestContext>)context
                                 error:(NSError **)error
 {
+    validationId = [validationId msidNormalizedString];
     NSArray *enrollIds = [self fetchAllEnrollmentIdsWithContext:context error:error];
     for (NSDictionary *enrollIdDic in enrollIds)
     {
-        if ([enrollIdDic[key] isEqualToString:validationId])
+        if ([[enrollIdDic[key] msidNormalizedString] isEqualToString:validationId])
         {
             NSString *enrollmentId = enrollIdDic[MSID_INTUNE_ENROLL_ID];
             MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Queried by %@, enrollment id read from intune cache : %@.", key, enrollmentId ? MSID_PII_LOG_MASKABLE(enrollmentId) : enrollmentId);

--- a/IdentityCore/tests/MSIDAADAuthorityTests.m
+++ b/IdentityCore/tests/MSIDAADAuthorityTests.m
@@ -464,7 +464,7 @@
     XCTAssertNil(error);
 }
 
-- (void)testEnrollmentIdForHomeAccountId_whenUnenrolledHomeAccountIdAndUserId_shouldReturnFirstEnrollmentId
+- (void)testEnrollmentIdForHomeAccountId_whenUnenrolledHomeAccountIdAndUserId_shouldReturnNil
 {
     [self setUpEnrollmentIdsCache:NO];
     
@@ -472,11 +472,11 @@
     MSIDAADAuthority *authority = [[MSIDAADAuthority alloc] initWithURL:authorityUrl context:nil error:nil];
     NSError *error = nil;
     
-    XCTAssertEqual([authority enrollmentIdForHomeAccountId:@"homeAccountId" legacyUserId:@"user@contoso.com" context:nil error:&error], @"adf79e3f-mike-454d-9f0f-2299e76dbfd5");
+    XCTAssertNil([authority enrollmentIdForHomeAccountId:@"homeAccountId" legacyUserId:@"user@contoso.com" context:nil error:&error]);
     XCTAssertNil(error);
 }
 
-- (void)testEnrollmentIdForHomeAccountId_whenNilHomeAccountIdAndUserId_shouldReturnNil
+- (void)testEnrollmentIdForHomeAccountId_whenNilHomeAccountIdAndNilUserId_shouldReturnFirstEnrollmentId
 {
     [self setUpEnrollmentIdsCache:NO];
     
@@ -484,7 +484,7 @@
     MSIDAADAuthority *authority = [[MSIDAADAuthority alloc] initWithURL:authorityUrl context:nil error:nil];
     NSError* error = nil;
     
-    XCTAssertNil([authority enrollmentIdForHomeAccountId:nil legacyUserId:nil context:nil error:&error]);
+    XCTAssertEqual([authority enrollmentIdForHomeAccountId:nil legacyUserId:nil context:nil error:&error], @"adf79e3f-mike-454d-9f0f-2299e76dbfd5");
     XCTAssertNil(error);
 }
 

--- a/IdentityCore/tests/MSIDAADAuthorityTests.m
+++ b/IdentityCore/tests/MSIDAADAuthorityTests.m
@@ -476,7 +476,7 @@
     XCTAssertNil(error);
 }
 
-- (void)testEnrollmentIdForHomeAccountId_whenNilHomeAccountIdAndUserId_shouldReturnFirstEnrollmentId
+- (void)testEnrollmentIdForHomeAccountId_whenNilHomeAccountIdAndUserId_shouldReturnNil
 {
     [self setUpEnrollmentIdsCache:NO];
     
@@ -484,7 +484,7 @@
     MSIDAADAuthority *authority = [[MSIDAADAuthority alloc] initWithURL:authorityUrl context:nil error:nil];
     NSError* error = nil;
     
-    XCTAssertEqual([authority enrollmentIdForHomeAccountId:nil legacyUserId:nil context:nil error:&error], @"adf79e3f-mike-454d-9f0f-2299e76dbfd5");
+    XCTAssertNil([authority enrollmentIdForHomeAccountId:nil legacyUserId:nil context:nil error:&error]);
     XCTAssertNil(error);
 }
 

--- a/IdentityCore/tests/MSIDAADOauth2FactoryTests.m
+++ b/IdentityCore/tests/MSIDAADOauth2FactoryTests.m
@@ -263,7 +263,7 @@
     XCTAssertEqualObjects(token.resource, DEFAULT_TEST_RESOURCE);
     XCTAssertNotNil(token.expiresOn);
     XCTAssertNotNil(token.extendedExpiresOn);
-    XCTAssertEqualObjects(token.enrollmentId, @"enrollmentId");
+    XCTAssertNil(token.enrollmentId);
     
     [self setUpEnrollmentIdsCache:YES];
 }

--- a/IdentityCore/tests/MSIDIntuneEnrollmentIdsCacheTests.m
+++ b/IdentityCore/tests/MSIDIntuneEnrollmentIdsCacheTests.m
@@ -237,6 +237,42 @@
 
 #pragma mark - enrollmentIdForHomeAccountId:userId
 
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNotNil_shouldReturnId
+{
+    NSString *homeAccountId = @"60406d5d-mike-41e1-aa70-e97501076a22";
+    NSString *userId;
+    
+    NSError *error;
+    __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
+    
+    XCTAssertEqualObjects(@"adf79e3f-mike-454d-9f0f-2299e76dbfd5", enrollmentId);
+    XCTAssertNil(error);
+}
+
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNotNilCaseInsensitive_shouldReturnId
+{
+    NSString *homeAccountId = @"60406D5D-MIKE-41E1-AA70-E97501076A22";
+    NSString *userId;
+    
+    NSError *error;
+    __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
+    
+    XCTAssertEqualObjects(@"adf79e3f-mike-454d-9f0f-2299e76dbfd5", enrollmentId);
+    XCTAssertNil(error);
+}
+
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNotInCache_shouldReturnId
+{
+    NSString *homeAccountId = @"123-456-not-cached";
+    NSString *userId = @"mike@contoso.com";
+    
+    NSError *error;
+    __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
+    
+    XCTAssertEqualObjects(@"adf79e3f-mike-454d-9f0f-2299e76dbfd5", enrollmentId);
+    XCTAssertNil(error);
+}
+
 - (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNil_shouldReturnId
 {
     NSString *homeAccountId;
@@ -246,6 +282,30 @@
     __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
     
     XCTAssertEqualObjects(@"adf79e3f-mike-454d-9f0f-2299e76dbfd5", enrollmentId);
+    XCTAssertNil(error);
+}
+
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNilCaseInsensitive_shouldReturnId
+{
+    NSString *homeAccountId;
+    NSString *userId = @"MIKE@contoso.com";
+    
+    NSError *error;
+    __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
+    
+    XCTAssertEqualObjects(@"adf79e3f-mike-454d-9f0f-2299e76dbfd5", enrollmentId);
+    XCTAssertNil(error);
+}
+
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNotInCacheUserIdNotInCache_shouldReturnFirstAvailableId
+{
+    NSString *homeAccountId = @"123-456-not-cached";
+    NSString *userId = @"qwe@contoso.com";
+    
+    NSError *error;
+    __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
+    
+    XCTAssertEqualObjects(@"64d0557f-dave-4193-b630-8491ffd3b180", enrollmentId);
     XCTAssertNil(error);
 }
 
@@ -261,10 +321,47 @@
     XCTAssertNil(error);
 }
 
-- (void)testEnrollmentIdForHomeAccountIdUserId_whenCacheIsInvalid_shouldReturnNilAndError
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNilUserIdIsNil_shouldReturnNil
 {
     NSString *homeAccountId;
     NSString *userId;
+    
+    NSError *error;
+    __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
+    
+    XCTAssertNil(enrollmentId);
+    XCTAssertNil(error);
+}
+
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsEmptyUserIdIsEmpty_shouldReturnNil
+{
+    NSString *homeAccountId = @"";
+    NSString *userId = @"";
+    
+    NSError *error;
+    __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
+    
+    XCTAssertNil(enrollmentId);
+    XCTAssertNil(error);
+}
+
+- (void)testEnrollmentIdForHomeAccountIdUserId_HomeAccountIdIsNotInCacheAndCacheIsInvalid_shouldReturnNilAndError
+{
+    NSString *homeAccountId = @"123-456-not-cached";
+    NSString *userId;
+    [self corruptCache];
+    
+    NSError *error;
+    __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
+    
+    XCTAssertNil(enrollmentId);
+    XCTAssertNotNil(error);
+}
+
+- (void)testEnrollmentIdForHomeAccountIdUserId_UserIdIsNotInCacheAndCacheIsInvalid_shouldReturnNilAndError
+{
+    NSString *homeAccountId;
+    NSString *userId = @"qwe@contoso.com";
     [self corruptCache];
     
     NSError *error;

--- a/IdentityCore/tests/MSIDIntuneEnrollmentIdsCacheTests.m
+++ b/IdentityCore/tests/MSIDIntuneEnrollmentIdsCacheTests.m
@@ -297,7 +297,7 @@
     XCTAssertNil(error);
 }
 
-- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNotInCacheUserIdNotInCache_shouldReturnFirstAvailableId
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNotInCacheUserIdNotInCache_shouldReturnNil
 {
     NSString *homeAccountId = @"123-456-not-cached";
     NSString *userId = @"qwe@contoso.com";
@@ -305,11 +305,11 @@
     NSError *error;
     __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
     
-    XCTAssertEqualObjects(@"64d0557f-dave-4193-b630-8491ffd3b180", enrollmentId);
+    XCTAssertNil(enrollmentId);
     XCTAssertNil(error);
 }
 
-- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNilUserIdNotInCache_shouldReturnFirstAvailableId
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNilUserIdNotInCache_shouldReturnNil
 {
     NSString *homeAccountId;
     NSString *userId = @"qwe@contoso.com";
@@ -317,11 +317,11 @@
     NSError *error;
     __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
     
-    XCTAssertEqualObjects(@"64d0557f-dave-4193-b630-8491ffd3b180", enrollmentId);
+    XCTAssertNil(enrollmentId);
     XCTAssertNil(error);
 }
 
-- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNilUserIdIsNil_shouldReturnNil
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsNilUserIdIsNil_shouldReturnFirstAvailableId
 {
     NSString *homeAccountId;
     NSString *userId;
@@ -329,11 +329,11 @@
     NSError *error;
     __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
     
-    XCTAssertNil(enrollmentId);
+    XCTAssertEqualObjects(@"64d0557f-dave-4193-b630-8491ffd3b180", enrollmentId);
     XCTAssertNil(error);
 }
 
-- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsEmptyUserIdIsEmpty_shouldReturnNil
+- (void)testEnrollmentIdForHomeAccountIdUserId_whenHomeAccountIdIsEmptyUserIdIsEmpty_shouldReturnFirstAvailableId
 {
     NSString *homeAccountId = @"";
     NSString *userId = @"";
@@ -341,7 +341,7 @@
     NSError *error;
     __auto_type enrollmentId = [self.cache enrollmentIdForHomeAccountId:homeAccountId legacyUserId:userId context:nil error:&error];
     
-    XCTAssertNil(enrollmentId);
+    XCTAssertEqualObjects(@"64d0557f-dave-4193-b630-8491ffd3b180", enrollmentId);
     XCTAssertNil(error);
 }
 

--- a/IdentityCore/tests/MSIDThrottlingServiceIntegrationTests.m
+++ b/IdentityCore/tests/MSIDThrottlingServiceIntegrationTests.m
@@ -283,8 +283,7 @@
                                                                                                                      tokenCache:self.tokenCache
                                                                                                            accountMetadataCache:self.accountMetadataCache];
 
-    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
-   
+
     //refresh token
     MSIDRefreshToken *refreshToken = [[MSIDRefreshToken alloc] init];
     refreshToken.refreshToken = self.refreshToken;
@@ -398,7 +397,6 @@
                                                                                                                      tokenCache:self.tokenCache
                                                                                                            accountMetadataCache:self.accountMetadataCache];
 
-    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
     //refresh token
     MSIDRefreshToken *refreshToken = [[MSIDRefreshToken alloc] init];
@@ -522,7 +520,7 @@
                                                                                                            accountMetadataCache:self.accountMetadataCache];
     //add extended lifetime access token
     defaultSilentTokenRequest.extendedLifetimeAccessToken = [MSIDAccessToken new];
-    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
+
 
     //refresh token
     MSIDRefreshToken *refreshToken = [[MSIDRefreshToken alloc] init];
@@ -651,8 +649,6 @@
                                                                                                          tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]
                                                                                                                      tokenCache:self.tokenCache
                                                                                                            accountMetadataCache:self.accountMetadataCache];
-    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
-   
     //add extended lifetime access token
     defaultSilentTokenRequest.extendedLifetimeAccessToken = [MSIDAccessToken new];
 
@@ -796,8 +792,6 @@
                                                                                                          tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]
                                                                                                                      tokenCache:self.tokenCache
                                                                                                            accountMetadataCache:self.accountMetadataCache];
-    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
-   
     //add extended lifetime access token
     defaultSilentTokenRequest.extendedLifetimeAccessToken = [MSIDAccessToken new];
 
@@ -1592,7 +1586,6 @@
                                                                                                                     tokenCache:self.tokenCache
                                                                                                           accountMetadataCache:self.accountMetadataCache];
 
-   defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
    //refresh token
    MSIDRefreshToken *refreshToken = [[MSIDRefreshToken alloc] init];

--- a/IdentityCore/tests/MSIDThrottlingServiceIntegrationTests.m
+++ b/IdentityCore/tests/MSIDThrottlingServiceIntegrationTests.m
@@ -283,7 +283,8 @@
                                                                                                                      tokenCache:self.tokenCache
                                                                                                            accountMetadataCache:self.accountMetadataCache];
 
-
+    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
+   
     //refresh token
     MSIDRefreshToken *refreshToken = [[MSIDRefreshToken alloc] init];
     refreshToken.refreshToken = self.refreshToken;
@@ -397,6 +398,7 @@
                                                                                                                      tokenCache:self.tokenCache
                                                                                                            accountMetadataCache:self.accountMetadataCache];
 
+    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
     //refresh token
     MSIDRefreshToken *refreshToken = [[MSIDRefreshToken alloc] init];
@@ -520,7 +522,7 @@
                                                                                                            accountMetadataCache:self.accountMetadataCache];
     //add extended lifetime access token
     defaultSilentTokenRequest.extendedLifetimeAccessToken = [MSIDAccessToken new];
-
+    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
     //refresh token
     MSIDRefreshToken *refreshToken = [[MSIDRefreshToken alloc] init];
@@ -649,6 +651,8 @@
                                                                                                          tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]
                                                                                                                      tokenCache:self.tokenCache
                                                                                                            accountMetadataCache:self.accountMetadataCache];
+    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
+   
     //add extended lifetime access token
     defaultSilentTokenRequest.extendedLifetimeAccessToken = [MSIDAccessToken new];
 
@@ -792,6 +796,8 @@
                                                                                                          tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]
                                                                                                                      tokenCache:self.tokenCache
                                                                                                            accountMetadataCache:self.accountMetadataCache];
+    defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
+   
     //add extended lifetime access token
     defaultSilentTokenRequest.extendedLifetimeAccessToken = [MSIDAccessToken new];
 
@@ -1586,6 +1592,7 @@
                                                                                                                     tokenCache:self.tokenCache
                                                                                                           accountMetadataCache:self.accountMetadataCache];
 
+   defaultSilentTokenRequest.requestParameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
 
    //refresh token
    MSIDRefreshToken *refreshToken = [[MSIDRefreshToken alloc] init];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 TBD
 * Add more detailed error codes for JIT (#1187)
 * Add support for nested auth protocol (#1175)
+* Return enrollmentId only if homeAccountId and legacyId are both empty (#1191)
 
 Version 1.7.15
 * Fix a crash when no identiy found during getting device registration information on iOS.


### PR DESCRIPTION
## Proposed changes

- Return first enrollmentId from cache only if homeAccountId and legacyId are both empty. 
- Fetch enrollmentId by upn/oid with case insensitive checks. 
- Update/add unit tests.


## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

