### PR TITLE
Prevent crash on MSAL issue

### DIFF
--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
@@ -90,6 +90,12 @@
                                                                  error:nil];
         }
         
+        if (!completionBlock)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, self.requestParameters, @"Passed nil completionBlock. End local interactive acquire token.");
+            return;
+        }
+        
         completionBlock(result, error);
     };
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ TBD
 * Add more detailed error codes for JIT (#1187)
 * Add support for nested auth protocol (#1175)
 * Return enrollmentId only if homeAccountId and legacyId are both empty (#1191)
+* Prevent crash when missing completionBlock on local interactive aquireToken (#1193)
 
 Version 1.7.15
 * Fix a crash when no identiy found during getting device registration information on iOS.


### PR DESCRIPTION


## Proposed changes

Check if completionBlock is valid before calling it on local interactive aquireToken.
MSAL issue: https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1652

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

