### PR TITLE
[new PR] memorize certificate preference for macos

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
@@ -72,6 +72,18 @@
                  completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
                  return;
              }
+            
+            // If there is no preferred identity saved, we must set preferred identity certificate using hostname and key usage parameters: kSecAttrCanSign to create digital signature in Keychain and kSecAttrCanEn/Decrypt to specify certain attributes of identity to be stored in encrypted format
+            NSArray *arr = @[(__bridge NSString *)kSecAttrCanSign, (__bridge NSString *)kSecAttrCanEncrypt, (__bridge NSString *)kSecAttrCanDecrypt];
+            CFArrayRef arrayRef = (__bridge CFArrayRef)arr;
+            if (host)
+            {
+                OSStatus status = SecIdentitySetPreferred(selectedIdentity, (CFStringRef)host, arrayRef);
+                if (!status)
+                {
+                    MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Result of setting identity preference is %d", status);
+                }
+            }
              
              // Adding a retain count to match the retain count from SecIdentityCopyPreferred
              CFRetain(selectedIdentity);

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ TBD
 * Add support for nested auth protocol (#1175)
 * Return enrollmentId only if homeAccountId and legacyId are both empty (#1191)
 * Prevent crash when missing completionBlock on local interactive aquireToken (#1193)
+* Add support for memorizing certificate preference for CBA on MacOS (#1194)
 
 Version 1.7.15
 * Fix a crash when no identiy found during getting device registration information on iOS.


### PR DESCRIPTION
## Proposed changes

Linking original PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1192

The existing method of certificate-based authorization does not save the preferred identity certificate choice of the user on MacOS. This PR aims to resolve this issue by saving (memorizing) the certificate preference after the first login, which should be picked automatically for future logins. The goal of the PR is to prevent the user from being asked multiple times to choose the same certificate when trying to access Office applications.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Creating new PR to make it cleaner and remove unchanged files from previous PR
