### PR TITLE
Fix a crash when UBSan validates

### DIFF
--- a/IdentityCore/src/throttling/model/MSIDThrottlingModel429.m
+++ b/IdentityCore/src/throttling/model/MSIDThrottlingModel429.m
@@ -66,6 +66,11 @@ NSInteger const MSID_THROTTLING_MAX_RETRY_AFTER = 3600;
     BOOL res = NO;
     
     NSString *httpResponseCode = [errorResponse msidGetUserInfoValueWithMSIDKey:MSIDHTTPResponseCodeKey orMSALKey:@"MSALHTTPResponseCodeKey"];
+    if ([NSString msidIsStringNilOrBlank:httpResponseCode])
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Throttling: httpResponseCode is not valid");
+    }
+    
     NSInteger responseCode = [httpResponseCode intValue];
     if (responseCode == 429) res = YES;
     if (responseCode >= 500 && responseCode <= 599) res = YES;

--- a/IdentityCore/src/util/NSError+MSIDThrottlingExtension.h
+++ b/IdentityCore/src/util/NSError+MSIDThrottlingExtension.h
@@ -35,5 +35,5 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 - (NSString *_Nullable)msidGetUserInfoValueWithMSIDKey:(NSString * _Nonnull)msidKey
-                                    orMSALKey:(NSString * _Nonnull)msalKey;
+                                             orMSALKey:(NSString * _Nonnull)msalKey;
 @end

--- a/IdentityCore/src/util/NSError+MSIDThrottlingExtension.h
+++ b/IdentityCore/src/util/NSError+MSIDThrottlingExtension.h
@@ -31,9 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDate *)msidGetRetryDateFromError;
 - (BOOL)msidIsMSIDError;
 - (NSString *)msidGetHTTPHeaderValue:(NSString *)headerKey;
-- (NSString *)msidGetUserInfoValueWithMSIDKey:(NSString *)msidKey
-                                    orMSALKey:(NSString *)msalKey;
-
-@end
 
 NS_ASSUME_NONNULL_END
+
+- (NSString *_Nullable)msidGetUserInfoValueWithMSIDKey:(NSString * _Nonnull)msidKey
+                                    orMSALKey:(NSString * _Nonnull)msalKey;
+@end


### PR DESCRIPTION
## Proposed changes

Copying per Office discoveries.

Crash happened when OneAuth SSO extension ran into error from -[ASAuthorizationController authorization:didCompleteWithError:], if this NSError has userInfo:
_userInfo __NSDictionaryI * [0](about:blanknull)x606000f03e60 0x0000606000f03e60
0 @"MSALErrorDescriptionKey" : @"Interaction is required to complete broker request, and interaction is not allowed in silent token acquisition."
[1](about:blanknull) @"MSALBrokerVersionKey" : @"5.2212.0"

IdentityCore code -[NSError(MSAIMSIDThrottlingExtension) msaimsidGetUserInfoValueWithMSIDKey:orMSALKey:] will try to parse httpStatus code from method:
(NSString *)msaimsidGetUserInfoValueWithMSIDKey:(NSString *)msidKey
orMSALKey:(NSString *)msalKey
{
return self.userInfo[[self msaimsidIsMSIDError] ? msidKey : msalKey];
}

with MSAIMSIDHTTPResponseCodeKey or MSALHTTPResponseCodeKey, yet none of them are found in userInfo, so msaimsidGetUserInfoValueWithMSIDKey will return nil.

Yet msaimsidGetUserInfoValueWithMSIDKey is defined inside NS_ASSUME_NONNULL_BEGIN, which has implicit nonnull return

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

