### PR TITLE
Fix function declaration without prototype

### DIFF
--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -127,7 +127,7 @@ MSIDErrorCode MSIDErrorCodeForOAuthErrorWithSubErrorCode(NSString *oauthError, M
     return MSIDErrorCodeForOAuthError(oauthError, defaultCode);
 }
 
-NSDictionary* MSIDErrorDomainsAndCodes()
+NSDictionary* MSIDErrorDomainsAndCodes(void)
 {
     return @{ MSIDErrorDomain : @[// General Errors
                       @(MSIDErrorInternal),

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+[TBD]
+* Fix function declaration without prototype on Xcode 14.3 (#1200)
+
 Version 1.7.16
 * Add more detailed error codes for JIT (#1187)
 * Add support for nested auth protocol (#1175)


### PR DESCRIPTION
Fix `A function declaration without a prototype is deprecated in all versions of C` error when using the new Xcode 14.3 [beta]

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

