### PR TITLE
Support external SSO keys in PkeyAuth handling

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -818,6 +818,7 @@
 		B208854A29ADB86200A50B88 /* MSIDExternalSSOContextMock.m in Sources */ = {isa = PBXBuildFile; fileRef = B208854829ADB86100A50B88 /* MSIDExternalSSOContextMock.m */; };
 		B208854B29ADB86200A50B88 /* MSIDExternalSSOContextMock.m in Sources */ = {isa = PBXBuildFile; fileRef = B208854829ADB86100A50B88 /* MSIDExternalSSOContextMock.m */; };
 		B208854C29ADC0FD00A50B88 /* MSIDPkeyAuthHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23CA0C5E220A68D400768729 /* MSIDPkeyAuthHelperTests.m */; };
+		B208854D29AEE75D00A50B88 /* MSIDExternalSSOContext.m in Sources */ = {isa = PBXBuildFile; fileRef = B229841429A9C2930005F83D /* MSIDExternalSSOContext.m */; };
 		B20E3CAE1FC4F14B0029C097 /* MSIDDeviceId.m in Sources */ = {isa = PBXBuildFile; fileRef = B20E3CAD1FC4F14B0029C097 /* MSIDDeviceId.m */; };
 		B20E3CB21FC4FA550029C097 /* MSIDVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = B20E3CB11FC4FA550029C097 /* MSIDVersion.m */; };
 		B20E3CB31FC4FA550029C097 /* MSIDVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = B20E3CB11FC4FA550029C097 /* MSIDVersion.m */; };
@@ -7261,6 +7262,7 @@
 				600D19B220964CE70004CD43 /* MSIDPkeyAuthHelper.m in Sources */,
 				B2E2A924239221A000BA2EA3 /* MSIDBrokerOperationSignoutFromDeviceRequest.m in Sources */,
 				B217863923A5994300839CE8 /* MSIDSSOExtensionSignoutController.m in Sources */,
+				B208854D29AEE75D00A50B88 /* MSIDExternalSSOContext.m in Sources */,
 				602CD4E223739B3C00A4D7F3 /* MSIDBrokerOperationGetAccountsRequest.m in Sources */,
 				235480CB20DDF81000246F72 /* MSIDB2CAuthority.m in Sources */,
 				B214C3A41FE855290070C4F2 /* MSIDDefaultTokenCacheAccessor.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -814,6 +814,10 @@
 		B20657DF1FCA208C00412B7D /* NSDate+MSIDExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = B20657DD1FCA208C00412B7D /* NSDate+MSIDExtensions.h */; };
 		B20657E01FCA208C00412B7D /* NSDate+MSIDExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B20657DE1FCA208C00412B7D /* NSDate+MSIDExtensions.m */; };
 		B20657E11FCA208C00412B7D /* NSDate+MSIDExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B20657DE1FCA208C00412B7D /* NSDate+MSIDExtensions.m */; };
+		B208854929ADB86200A50B88 /* MSIDExternalSSOContextMock.h in Headers */ = {isa = PBXBuildFile; fileRef = B208854729ADB86100A50B88 /* MSIDExternalSSOContextMock.h */; };
+		B208854A29ADB86200A50B88 /* MSIDExternalSSOContextMock.m in Sources */ = {isa = PBXBuildFile; fileRef = B208854829ADB86100A50B88 /* MSIDExternalSSOContextMock.m */; };
+		B208854B29ADB86200A50B88 /* MSIDExternalSSOContextMock.m in Sources */ = {isa = PBXBuildFile; fileRef = B208854829ADB86100A50B88 /* MSIDExternalSSOContextMock.m */; };
+		B208854C29ADC0FD00A50B88 /* MSIDPkeyAuthHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23CA0C5E220A68D400768729 /* MSIDPkeyAuthHelperTests.m */; };
 		B20E3CAE1FC4F14B0029C097 /* MSIDDeviceId.m in Sources */ = {isa = PBXBuildFile; fileRef = B20E3CAD1FC4F14B0029C097 /* MSIDDeviceId.m */; };
 		B20E3CB21FC4FA550029C097 /* MSIDVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = B20E3CB11FC4FA550029C097 /* MSIDVersion.m */; };
 		B20E3CB31FC4FA550029C097 /* MSIDVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = B20E3CB11FC4FA550029C097 /* MSIDVersion.m */; };
@@ -2486,6 +2490,8 @@
 		B20657D81FC92D7600412B7D /* libswiftIOKit.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libswiftIOKit.tbd; path = System/Library/PrivateFrameworks/Swift/libswiftIOKit.tbd; sourceTree = SDKROOT; };
 		B20657DD1FCA208C00412B7D /* NSDate+MSIDExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDate+MSIDExtensions.h"; sourceTree = "<group>"; };
 		B20657DE1FCA208C00412B7D /* NSDate+MSIDExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDate+MSIDExtensions.m"; sourceTree = "<group>"; };
+		B208854729ADB86100A50B88 /* MSIDExternalSSOContextMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDExternalSSOContextMock.h; sourceTree = "<group>"; };
+		B208854829ADB86100A50B88 /* MSIDExternalSSOContextMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDExternalSSOContextMock.m; sourceTree = "<group>"; };
 		B20E3CAD1FC4F14B0029C097 /* MSIDDeviceId.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDDeviceId.m; sourceTree = "<group>"; };
 		B20E3CAF1FC4F1540029C097 /* MSIDVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDVersion.h; sourceTree = "<group>"; };
 		B20E3CB11FC4FA550029C097 /* MSIDVersion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDVersion.m; sourceTree = "<group>"; };
@@ -3411,6 +3417,8 @@
 				58EB18342729BAB800F4DD73 /* MSIDSSOExtensionGetSsoCookiesRequestMock.m */,
 				5837A7DA28F4977C007B3F4E /* MSIDLegacyTokenCacheKey+UTest.h */,
 				5837A7DB28F4977C007B3F4E /* MSIDLegacyTokenCacheKey+UTest.m */,
+				B208854729ADB86100A50B88 /* MSIDExternalSSOContextMock.h */,
+				B208854829ADB86100A50B88 /* MSIDExternalSSOContextMock.m */,
 			);
 			path = mocks;
 			sourceTree = "<group>";
@@ -5558,6 +5566,7 @@
 				B286B9CD2389DEB3007833AD /* MSIDUserInformation.h in Headers */,
 				23D2048921D1B2E4009B5975 /* MSIDJsonResponsePreprocessor.h in Headers */,
 				B20657A61FC91C9A00412B7D /* MSIDTelemetryEventInterface.h in Headers */,
+				B208854929ADB86200A50B88 /* MSIDExternalSSOContextMock.h in Headers */,
 				B28D90BF218FEA0700E230D6 /* MSIDTokenResult.h in Headers */,
 				B286B9D02389DF06007833AD /* MSIDLogger+Internal.h in Headers */,
 				B2D5625820CCD50E00FFF59C /* MSIDTelemetry+Cache.h in Headers */,
@@ -6797,6 +6806,7 @@
 				238EF044208FE88C0035ABE6 /* MSIDAADAuthorizationCodeGrantRequest.m in Sources */,
 				B286B98B2389DC2F007833AD /* MSIDBrokerOperationResponse.m in Sources */,
 				238E19C52086FC38004DF483 /* MSIDHttpResponseSerializer.m in Sources */,
+				B208854B29ADB86200A50B88 /* MSIDExternalSSOContextMock.m in Sources */,
 				B286B96423861852007833AD /* MSIDSignoutWebRequestConfiguration.m in Sources */,
 				B25D495F21B3649500502BE5 /* MSIDPromptType.m in Sources */,
 				B28BDA86217E9676003E5670 /* MSIDB2CIdTokenClaims.m in Sources */,
@@ -7023,6 +7033,7 @@
 				B20657D01FC92B8F00412B7D /* MSIDTelemetryUIEventTests.m in Sources */,
 				B2AE0FDB2427E96800B8FAF1 /* MSIDKeychainUtilTests.m in Sources */,
 				B26A0B972072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m in Sources */,
+				B208854C29ADC0FD00A50B88 /* MSIDPkeyAuthHelperTests.m in Sources */,
 				5837A7DD28F4977C007B3F4E /* MSIDLegacyTokenCacheKey+UTest.m in Sources */,
 				B2DD5BA2204761660084313F /* MSIDLegacySingleResourceTokenTests.m in Sources */,
 				239DF9C020E04BC9002D428B /* MSIDAADAuthorityTests.m in Sources */,
@@ -7463,6 +7474,7 @@
 				B239A43D209E8170000A3268 /* MSIDAccountCredentialCache.m in Sources */,
 				23B018822355481800207FEC /* MSIDSSOExtensionInteractiveTokenRequest.m in Sources */,
 				239E8F88233D951D00251373 /* MSIDBrokerOperationTokenResponse.m in Sources */,
+				B208854A29ADB86200A50B88 /* MSIDExternalSSOContextMock.m in Sources */,
 				B2B1D57320425DFD00DD81F0 /* MSIDAccountCacheItem.m in Sources */,
 				589BDB282718F18800BF3799 /* MSIDCredentialHeader.m in Sources */,
 				23B5DF7F234031EE002C530F /* MSIDSSOExtensionSilentTokenRequestController.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -913,6 +913,9 @@
 		B227036022A367A000030ADC /* MSIDMaskedHashableLogParameter.m in Sources */ = {isa = PBXBuildFile; fileRef = B227035D22A367A000030ADC /* MSIDMaskedHashableLogParameter.m */; };
 		B227037622A4C29800030ADC /* MSIDExtendedTokenCacheDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = B227037522A4C29800030ADC /* MSIDExtendedTokenCacheDataSource.h */; };
 		B227F28D2056264F00F7B822 /* MSIDMacTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 9641B5231FCF3EEF00AFA0EC /* MSIDMacTokenCache.m */; };
+		B229841529A9C2930005F83D /* MSIDExternalSSOContext.h in Headers */ = {isa = PBXBuildFile; fileRef = B229841329A9C2930005F83D /* MSIDExternalSSOContext.h */; };
+		B229841629A9C2930005F83D /* MSIDExternalSSOContext.m in Sources */ = {isa = PBXBuildFile; fileRef = B229841429A9C2930005F83D /* MSIDExternalSSOContext.m */; };
+		B229841829AA8C2F0005F83D /* MSIDWebViewPlatformParams.m in Sources */ = {isa = PBXBuildFile; fileRef = B229841729AA8C2F0005F83D /* MSIDWebViewPlatformParams.m */; };
 		B233F8BC219CE03F00DC90E3 /* MSIDTestURLResponse+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = B233F8B1219CDF5B00DC90E3 /* MSIDTestURLResponse+Util.m */; };
 		B233F8BD219CE04000DC90E3 /* MSIDTestURLResponse+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = B233F8B1219CDF5B00DC90E3 /* MSIDTestURLResponse+Util.m */; };
 		B233F8BE219CE04200DC90E3 /* MSIDTestURLResponse+Util.h in Headers */ = {isa = PBXBuildFile; fileRef = B233F8B0219CDF5B00DC90E3 /* MSIDTestURLResponse+Util.h */; };
@@ -2539,6 +2542,9 @@
 		B227035C22A367A000030ADC /* MSIDMaskedHashableLogParameter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDMaskedHashableLogParameter.h; sourceTree = "<group>"; };
 		B227035D22A367A000030ADC /* MSIDMaskedHashableLogParameter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMaskedHashableLogParameter.m; sourceTree = "<group>"; };
 		B227037522A4C29800030ADC /* MSIDExtendedTokenCacheDataSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDExtendedTokenCacheDataSource.h; sourceTree = "<group>"; };
+		B229841329A9C2930005F83D /* MSIDExternalSSOContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDExternalSSOContext.h; sourceTree = "<group>"; };
+		B229841429A9C2930005F83D /* MSIDExternalSSOContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDExternalSSOContext.m; sourceTree = "<group>"; };
+		B229841729AA8C2F0005F83D /* MSIDWebViewPlatformParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWebViewPlatformParams.m; sourceTree = "<group>"; };
 		B233F8B0219CDF5B00DC90E3 /* MSIDTestURLResponse+Util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDTestURLResponse+Util.h"; sourceTree = "<group>"; };
 		B233F8B1219CDF5B00DC90E3 /* MSIDTestURLResponse+Util.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDTestURLResponse+Util.m"; sourceTree = "<group>"; };
 		B233F8C7219E409C00DC90E3 /* MSIDBrokerCryptoProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBrokerCryptoProviderTests.m; sourceTree = "<group>"; };
@@ -3702,6 +3708,7 @@
 			children = (
 				60B3855D20A96E0600D546D0 /* MSIDWebviewUIController.m */,
 				600D199D20963B020004CD43 /* MSIDNTLMUIPrompt.m */,
+				B229841729AA8C2F0005F83D /* MSIDWebViewPlatformParams.m */,
 			);
 			path = ios;
 			sourceTree = "<group>";
@@ -4097,6 +4104,8 @@
 				B23ECEE71FF2F3F30015FC1D /* aad_base */,
 				B29CB6D11FEC9B4D00F880ED /* aad_v2 */,
 				B210F4341FDDEA0D005A8F76 /* aad_v1 */,
+				B229841329A9C2930005F83D /* MSIDExternalSSOContext.h */,
+				B229841429A9C2930005F83D /* MSIDExternalSSOContext.m */,
 			);
 			path = oauth2;
 			sourceTree = "<group>";
@@ -5529,6 +5538,7 @@
 				238EF03D208FE4730035ABE6 /* MSIDRefreshTokenGrantRequest.h in Headers */,
 				B2C707F02192516700D917B8 /* MSIDTokenRequestProviding.h in Headers */,
 				B20657A81FC91EC900412B7D /* MSIDTelemetry.h in Headers */,
+				B229841529A9C2930005F83D /* MSIDExternalSSOContext.h in Headers */,
 				233E96F622652D3A007FCE2A /* MSIDAggregatedDispatcher.h in Headers */,
 				B286B9D62389DF32007833AD /* MSIDPkeyAuthHelper.h in Headers */,
 				A057456225A669B90098E469 /* MSIDThrottlingCacheRecord.h in Headers */,
@@ -6584,6 +6594,7 @@
 				B28D90AC218FD1F800E230D6 /* MSIDDefaultTokenResponseValidator.m in Sources */,
 				23F9FD4D22EC097600DAB65D /* NSKeyedArchiver+MSIDExtensions.m in Sources */,
 				B2C7089421991CED00D917B8 /* MSIDAADV1BrokerResponse.m in Sources */,
+				B229841629A9C2930005F83D /* MSIDExternalSSOContext.m in Sources */,
 				B2C07483246B70F70008D701 /* MSIDAssymetricKeyPair.m in Sources */,
 				B266903F243706DB00FB0117 /* MSIDBrokerBrowserOperationResponse.m in Sources */,
 				B2AF1D3A218BCF140080C1A0 /* MSIDRequestControllerFactory.m in Sources */,
@@ -7145,6 +7156,7 @@
 				B2F671E42467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.m in Sources */,
 				2308476C207D6D500024CE7C /* NSData+MSIDExtensions.m in Sources */,
 				A0C7DE8425D46D7000F5B5B6 /* MSIDThrottlingModelFactory.m in Sources */,
+				B229841829AA8C2F0005F83D /* MSIDWebViewPlatformParams.m in Sources */,
 				B2BE924721A2279A00F5AB8C /* MSIDTelemetryBrokerEvent.m in Sources */,
 				9641B52A1FCF3F3A00AFA0EC /* MSIDKeyedArchiverSerializer.m in Sources */,
 				B2E2A934239239F800BA2EA3 /* MSIDSSOExtensionOperationRequestDelegate.m in Sources */,

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.h
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.h
@@ -28,6 +28,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class MSIDAADAuthority;
+@class MSIDExternalSSOContext;
 
 @interface MSIDBrokerOperationBrowserTokenRequest : MSIDBaseBrokerOperationRequest
 
@@ -37,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSDictionary *headers;
 @property (nonatomic, readonly) NSData *httpBody;
 @property (nonatomic, readonly) BOOL useSSOCookieFallback;
+@property (nonatomic, readonly) MSIDExternalSSOContext *ssoContext;
 
 - (instancetype)initWithRequest:(NSURL *)requestURL
                         headers:(NSDictionary *)headers
@@ -44,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
                bundleIdentifier:(NSString *)bundleIdentifier
                requestValidator:(id<MSIDBrowserRequestValidating>)requestValidator
            useSSOCookieFallback:(BOOL)useSSOCookieFallback
+                     ssoContext:(MSIDExternalSSOContext *)ssoContext
                           error:(NSError **)error;
 
 @end

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.m
@@ -37,6 +37,7 @@
                bundleIdentifier:(NSString *)bundleIdentifier
                requestValidator:(id<MSIDBrowserRequestValidating>)requestValidator
            useSSOCookieFallback:(BOOL)useSSOCookieFallback
+                     ssoContext:(MSIDExternalSSOContext *)ssoContext
                           error:(NSError **)error
 {
     self = [super init];
@@ -87,6 +88,7 @@
         authority.metadata.tokenEndpoint = tokenEndpoint;
         
         _correlationId = [NSUUID UUID];
+        _ssoContext = ssoContext;
     }
     
     return self;

--- a/IdentityCore/src/configuration/webview/MSIDAuthorizeWebRequestConfiguration.h
+++ b/IdentityCore/src/configuration/webview/MSIDAuthorizeWebRequestConfiguration.h
@@ -29,6 +29,7 @@
 #import "MSIDBaseWebRequestConfiguration.h"
 
 @class MSIDPkce;
+@class MSIDExternalSSOContext;
 
 @interface MSIDAuthorizeWebRequestConfiguration : MSIDBaseWebRequestConfiguration
 
@@ -39,6 +40,7 @@
                   endRedirectUri:(NSString *)endRedirectUri
                             pkce:(MSIDPkce *)pkce
                            state:(NSString *)state
-              ignoreInvalidState:(BOOL)ignoreInvalidState;
+              ignoreInvalidState:(BOOL)ignoreInvalidState
+                      ssoContext:(MSIDExternalSSOContext *)ssoContext;
 
 @end

--- a/IdentityCore/src/configuration/webview/MSIDAuthorizeWebRequestConfiguration.m
+++ b/IdentityCore/src/configuration/webview/MSIDAuthorizeWebRequestConfiguration.m
@@ -36,11 +36,13 @@
                             pkce:(MSIDPkce *)pkce
                            state:(NSString *)state
               ignoreInvalidState:(BOOL)ignoreInvalidState
+                      ssoContext:(MSIDExternalSSOContext *)ssoContext
 {
     self = [super initWithStartURL:startURL
                     endRedirectUri:endRedirectUri
                              state:state
-                ignoreInvalidState:ignoreInvalidState];
+                ignoreInvalidState:ignoreInvalidState
+                        ssoContext:ssoContext];
     
     if (self)
     {

--- a/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.h
+++ b/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class MSIDWebviewResponse;
 @class MSIDWebviewFactory;
+@class MSIDExternalSSOContext;
 
 @interface MSIDBaseWebRequestConfiguration : NSObject
 
@@ -53,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 @property (nonatomic, readonly) NSString *state;
+@property (nonatomic, readonly) MSIDExternalSSOContext *ssoContext;
 
 // State verification
 // Set this to YES to have the request continue even at state verification failure.
@@ -65,6 +67,11 @@ NS_ASSUME_NONNULL_BEGIN
                            state:(NSString *)state
               ignoreInvalidState:(BOOL)ignoreInvalidState;
 
+- (instancetype)initWithStartURL:(NSURL *)startURL
+                  endRedirectUri:(NSString *)endRedirectUri
+                           state:(NSString *)state
+              ignoreInvalidState:(BOOL)ignoreInvalidState
+                      ssoContext:(nullable MSIDExternalSSOContext *)ssoContext;
 
 - (nullable MSIDWebviewResponse *)responseWithResultURL:(NSURL *)url
                                                 factory:(MSIDWebviewFactory *)factory

--- a/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.m
+++ b/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.m
@@ -33,6 +33,7 @@
                   endRedirectUri:(NSString *)endRedirectUri
                            state:(NSString *)state
               ignoreInvalidState:(BOOL)ignoreInvalidState
+                      ssoContext:(MSIDExternalSSOContext *)ssoContext
 {
     self = [super init];
     
@@ -42,9 +43,22 @@
         _endRedirectUrl = endRedirectUri;
         _state = state;
         _ignoreInvalidState = ignoreInvalidState;
+        _ssoContext = ssoContext;
     }
     
     return self;
+}
+
+- (instancetype)initWithStartURL:(NSURL *)startURL
+                  endRedirectUri:(NSString *)endRedirectUri
+                           state:(NSString *)state
+              ignoreInvalidState:(BOOL)ignoreInvalidState
+{
+    return [self initWithStartURL:startURL
+                   endRedirectUri:endRedirectUri
+                            state:state
+               ignoreInvalidState:ignoreInvalidState
+                       ssoContext:nil];
 }
 
 - (MSIDWebviewResponse *)responseWithResultURL:(__unused NSURL *)url

--- a/IdentityCore/src/network/MSIDHttpRequest.h
+++ b/IdentityCore/src/network/MSIDHttpRequest.h
@@ -33,6 +33,7 @@
 @protocol MSIDHttpRequestErrorHandling;
 @protocol MSIDHttpRequestServerTelemetryHandling;
 @class MSIDURLSessionManager;
+@class MSIDExternalSSOContext;
 
 @interface MSIDHttpRequest : NSObject <MSIDHttpRequestProtocol>
 {
@@ -75,6 +76,8 @@
 @property (nonatomic, nullable) id<MSIDHttpRequestErrorHandling> errorHandler;
 
 @property (nonatomic, nullable) id<MSIDRequestContext> context;
+
+@property (nonatomic, nullable) MSIDExternalSSOContext *externalSSOContext;
 
 @property (nonatomic) NSInteger retryCounter;
 @property (nonatomic) NSTimeInterval retryInterval;

--- a/IdentityCore/src/network/MSIDHttpRequest.m
+++ b/IdentityCore/src/network/MSIDHttpRequest.m
@@ -150,6 +150,7 @@ static NSTimeInterval s_requestTimeoutInterval = 300;
                                             data:data
                                      httpRequest:self
                               responseSerializer:responseSerializer
+                              externalSSOContext:self.externalSSOContext
                                          context:self.context
                                  completionBlock:completeBlockWrapper];
               }

--- a/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
+++ b/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
@@ -37,6 +37,7 @@
                data:(NSData *)data
         httpRequest:(NSObject<MSIDHttpRequestProtocol> *)httpRequest
  responseSerializer:(id<MSIDResponseSerialization>)responseSerializer
+ externalSSOContext:(MSIDExternalSSOContext *)ssoContext
             context:(id<MSIDRequestContext>)context
     completionBlock:(MSIDHttpRequestDidCompleteBlock)completionBlock
 {
@@ -73,6 +74,7 @@
         {
             [MSIDPKeyAuthHandler handleWwwAuthenticateHeader:wwwAuthValue
                                                   requestUrl:httpRequest.urlRequest.URL
+                                          externalSSOContext:ssoContext
                                                      context:context
                                            completionHandler:^void (NSString *authHeader, NSError *completionError){
                                                if (![NSString msidIsStringNilOrBlank:authHeader])

--- a/IdentityCore/src/network/error_handler/MSIDHttpRequestErrorHandling.h
+++ b/IdentityCore/src/network/error_handler/MSIDHttpRequestErrorHandling.h
@@ -25,6 +25,8 @@
 #import "MSIDHttpRequestProtocol.h"
 #import "MSIDResponseSerialization.h"
 
+@class MSIDExternalSSOContext;
+
 @protocol MSIDHttpRequestErrorHandling <NSObject>
 
 - (void)handleError:(NSError * )error
@@ -32,6 +34,7 @@
                data:(NSData *)data
         httpRequest:(NSObject<MSIDHttpRequestProtocol> *)httpRequest
  responseSerializer:(id<MSIDResponseSerialization>)responseSerializer
+ externalSSOContext:(MSIDExternalSSOContext *)ssoContext
             context:(id<MSIDRequestContext>)context
     completionBlock:(MSIDHttpRequestDidCompleteBlock)completionBlock;
 

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.h
@@ -42,6 +42,7 @@
                                      claims:(nullable NSString *)claims
                                codeVerifier:(nullable NSString *)codeVerifier
                             extraParameters:(nullable NSDictionary *)extraParameters
+                                 ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                     context:(nullable id<MSIDRequestContext>)context;
 
 @end

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeGrantRequest.m
@@ -38,6 +38,7 @@
                           claims:(NSString *)claims
                     codeVerifier:(NSString *)codeVerifier
                  extraParameters:(NSDictionary *)extraParameters
+                      ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                          context:(nullable id<MSIDRequestContext>)context
 {
     self = [super initWithEndpoint:endpoint
@@ -49,6 +50,7 @@
                             claims:claims
                       codeVerifier:codeVerifier
                    extraParameters:extraParameters
+                        ssoContext:ssoContext
                            context:context];
     if (self)
     {

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeRequest.h
@@ -38,6 +38,7 @@
                                 redirectUri:(nonnull NSString *)redirectUri
                                       scope:(nullable NSString *)scope
                                   loginHint:(nullable NSString *)loginHint
+                                 ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                     context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable )init NS_UNAVAILABLE;

--- a/IdentityCore/src/network/request/MSIDAADAuthorizationCodeRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorizationCodeRequest.m
@@ -34,6 +34,7 @@
                      redirectUri:(NSString *)redirectUri
                            scope:(NSString *)scope
                        loginHint:(NSString *)loginHint
+                      ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                          context:(nullable id<MSIDRequestContext>)context
 {
     self = [super init];
@@ -44,6 +45,7 @@
         NSParameterAssert(redirectUri);
         
         self.context =  context;
+        self.externalSSOContext = ssoContext;
         
         NSMutableDictionary *parameters = [NSMutableDictionary new];
         parameters[MSID_OAUTH2_CLIENT_ID] = clientId;

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.h
@@ -40,6 +40,7 @@
                               refreshToken:(nonnull NSString *)refreshToken
                                     claims:(nullable NSString *)claims
                            extraParameters:(nullable NSDictionary *)extraParameters
+                                ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                    context:(nullable id<MSIDRequestContext>)context;
 
 @end

--- a/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADRefreshTokenGrantRequest.m
@@ -44,9 +44,10 @@
                     refreshToken:(NSString *)refreshToken
                           claims:(NSString *)claims
                  extraParameters:(NSDictionary *)extraParameters
+                      ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                          context:(nullable id<MSIDRequestContext>)context
 {
-    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope refreshToken:refreshToken redirectUri:redirectUri extraParameters:extraParameters context:context];
+    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope refreshToken:refreshToken redirectUri:redirectUri extraParameters:extraParameters ssoContext:ssoContext context:context];
     if (self)
     {
         __auto_type requestConfigurator = [MSIDAADRequestConfigurator new];

--- a/IdentityCore/src/network/request/MSIDAADV1AuthorizationCodeRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADV1AuthorizationCodeRequest.h
@@ -22,6 +22,8 @@
 
 #if !EXCLUDE_FROM_MSALCPP
 
+@class MSIDExternalSSOContext;
+
 #import "MSIDAADAuthorizationCodeRequest.h"
 
 @interface MSIDAADV1AuthorizationCodeRequest : MSIDAADAuthorizationCodeRequest
@@ -32,6 +34,7 @@
                                       scope:(nullable NSString *)scope
                                   loginHint:(nullable NSString *)loginHint
                                    resource:(nonnull NSString *)resource
+                                 ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                     context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable )initWithEndpoint:(nonnull NSURL *)endpoint
@@ -39,6 +42,7 @@
                                 redirectUri:(nonnull NSString *)redirectUri
                                       scope:(nullable NSString *)scope
                                   loginHint:(nullable NSString *)loginHint
+                                 ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                     context:(nullable id<MSIDRequestContext>)context NS_UNAVAILABLE;
 
 @end

--- a/IdentityCore/src/network/request/MSIDAADV1AuthorizationCodeRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADV1AuthorizationCodeRequest.m
@@ -32,6 +32,7 @@
                            scope:(NSString *)scope
                        loginHint:(NSString *)loginHint
                         resource:(NSString *)resource
+                      ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                          context:(nullable id<MSIDRequestContext>)context
 {
     self = [super initWithEndpoint:endpoint
@@ -39,6 +40,7 @@
                        redirectUri:redirectUri
                              scope:scope
                          loginHint:loginHint
+                        ssoContext:ssoContext
                            context:context];
     if (self)
     {

--- a/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.h
@@ -23,6 +23,8 @@
 
 #if !EXCLUDE_FROM_MSALCPP
 
+@class MSIDExternalSSOContext;
+
 #import <Foundation/Foundation.h>
 #import "MSIDAADRefreshTokenGrantRequest.h"
 
@@ -36,12 +38,14 @@
                                 redirectUri:(nonnull NSString *)redirectUri
                                    resource:(nonnull NSString *)resource
                             extraParameters:(nullable NSDictionary *)extraParameters
+                                 ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                     context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable )initWithEndpoint:(nonnull NSURL *)endpoint
                                    clientId:(nonnull NSString *)clientId
                                       scope:(nullable NSString *)scope
                                refreshToken:(nonnull NSString *)refreshToken
+                                 ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                     context:(nullable id<MSIDRequestContext>)context NS_UNAVAILABLE;
 
 @end

--- a/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAADV1RefreshTokenGrantRequest.m
@@ -42,9 +42,10 @@
                      redirectUri:(NSString *)redirectUri
                         resource:(NSString *)resource
                  extraParameters:(NSDictionary *)extraParameters
+                      ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                          context:(nullable id<MSIDRequestContext>)context
 {
-    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope refreshToken:refreshToken redirectUri:redirectUri extraParameters:extraParameters context:context];
+    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope refreshToken:refreshToken redirectUri:redirectUri extraParameters:extraParameters ssoContext:ssoContext context:context];
     if (self)
     {
         NSParameterAssert(resource);

--- a/IdentityCore/src/network/request/MSIDAuthorizationCodeGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDAuthorizationCodeGrantRequest.h
@@ -25,6 +25,8 @@
 
 #import "MSIDTokenRequest.h"
 
+@class MSIDExternalSSOContext;
+
 @interface MSIDAuthorizationCodeGrantRequest : MSIDTokenRequest
 
 - (instancetype _Nullable )initWithEndpoint:(nonnull NSURL *)endpoint
@@ -36,12 +38,14 @@
                                      claims:(nullable NSString *)claims
                                codeVerifier:(nullable NSString *)codeVerifier
                             extraParameters:(nullable NSDictionary *)extraParameters
+                                 ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                     context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable )initWithEndpoint:(nonnull NSURL *)endpoint
                                  authScheme:(nonnull MSIDAuthenticationScheme *)authScheme
                                    clientId:(nonnull NSString *)clientId
                                       scope:(nullable NSString *)scope
+                                 ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                     context:(nullable id<MSIDRequestContext>)context NS_UNAVAILABLE;
 
 @end

--- a/IdentityCore/src/network/request/MSIDAuthorizationCodeGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDAuthorizationCodeGrantRequest.m
@@ -36,9 +36,10 @@
                           claims:(NSString *)claims
                     codeVerifier:(NSString *)codeVerifier
                  extraParameters:(NSDictionary *)extraParameters
+                      ssoContext:(MSIDExternalSSOContext *)ssoContext
                          context:(nullable id<MSIDRequestContext>)context
 {
-    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope context:context];
+    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope ssoContext:ssoContext context:context];
     if (self)
     {
         NSParameterAssert(redirectUri);

--- a/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.h
+++ b/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.h
@@ -37,12 +37,14 @@
                               refreshToken:(nonnull NSString *)refreshToken
                                redirectUri:(nullable NSString *)redirectUri
                            extraParameters:(nullable NSDictionary *)extraParameters
+                                ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                    context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable)initWithEndpoint:(nonnull NSURL *)endpoint
                                 authScheme:(nonnull MSIDAuthenticationScheme *)authScheme
                                   clientId:(nonnull NSString *)clientId
                                      scope:(nullable NSString *)scope
+                                ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                    context:(nullable id<MSIDRequestContext>)context NS_UNAVAILABLE;
 
 @end

--- a/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.m
+++ b/IdentityCore/src/network/request/MSIDRefreshTokenGrantRequest.m
@@ -41,9 +41,10 @@
                               refreshToken:(nonnull NSString *)refreshToken
                                redirectUri:(NSString *)redirectUri
                            extraParameters:(nullable NSDictionary *)extraParameters
+                                ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                    context:(nullable id<MSIDRequestContext>)context
 {
-    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope context:context];
+    self = [super initWithEndpoint:endpoint authScheme:authScheme clientId:clientId scope:scope ssoContext:ssoContext context:context];
     if (self)
     {
         NSParameterAssert(refreshToken);

--- a/IdentityCore/src/network/request/MSIDTokenRequest.h
+++ b/IdentityCore/src/network/request/MSIDTokenRequest.h
@@ -26,6 +26,7 @@
 #import <Foundation/Foundation.h>
 #import "MSIDHttpRequest.h"
 @class MSIDAuthenticationScheme;
+@class MSIDExternalSSOContext;
 /**
  @abstract Represents abstract request to oauth 2.0 '/token' endpoint.
  */
@@ -35,6 +36,7 @@
                                 authScheme:(nonnull MSIDAuthenticationScheme *)authScheme
                                   clientId:(nonnull NSString *)clientId
                                      scope:(nullable NSString *)scope
+                                ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
                                    context:(nullable id<MSIDRequestContext>)context NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable)init NS_UNAVAILABLE;

--- a/IdentityCore/src/network/request/MSIDTokenRequest.m
+++ b/IdentityCore/src/network/request/MSIDTokenRequest.m
@@ -32,6 +32,7 @@
                       authScheme:(MSIDAuthenticationScheme *)authScheme
                         clientId:(NSString *)clientId
                            scope:(NSString *)scope
+                      ssoContext:(MSIDExternalSSOContext *)ssoContext
                          context:(nullable id<MSIDRequestContext>)context
 {
     self = [super init];
@@ -41,6 +42,7 @@
         NSParameterAssert(endpoint);
         
         self.context = context;
+        self.externalSSOContext = ssoContext;
         
         NSMutableDictionary *parameters = [NSMutableDictionary new];
         parameters[MSID_OAUTH2_CLIENT_ID] = clientId;

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
@@ -24,10 +24,15 @@
 
 
 #import <Foundation/Foundation.h>
+#import <AuthenticationServices/AuthenticationServices.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDExternalSSOContext : NSObject
+
+#if TARGET_OS_OSX
+@property (nonatomic, nullable, strong) ASAuthorizationProviderExtensionLoginManager *loginManager API_AVAILABLE(macos(13.0));
+#endif
 
 @end
 

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
@@ -33,7 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MSIDExternalSSOContext : NSObject
 
 #if TARGET_OS_OSX
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
 @property (nonatomic, nullable, strong) ASAuthorizationProviderExtensionLoginManager *loginManager API_AVAILABLE(macos(13.0));
+#endif
 #endif
 
 - (nullable MSIDWPJKeyPairWithCert *)wpjKeyPairWithCertWithContext:(nullable id<MSIDRequestContext>)context;

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
@@ -1,3 +1,4 @@
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -19,36 +20,15 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
+
 
 #import <Foundation/Foundation.h>
 
-#include <sys/types.h>
-#include <sys/sysctl.h>
-#include <mach/machine.h>
+NS_ASSUME_NONNULL_BEGIN
 
-@interface MSIDDeviceId : NSObject
-
-/*! Returns diagnostic trace data to be sent to the Azure Active Directory servers. */
-+ (NSDictionary *)deviceId;
-
-/*! Returns a short device identifier string containing device type and OS version. */
-+ (NSString *)deviceOSId;
-
-/*! Returns a unique device identifier for telemetry purposes. */
-+ (NSString *)deviceTelemetryId;
-
-/*! Returns application name for telemetry purposes. */
-+ (NSString *)applicationName;
-
-/*! Returns application version for telemetry purposes. */
-+ (NSString *)applicationVersion;
-
-/*! Used by Broker SDK */
-+ (void)setIdValue:(NSString*)value
-            forKey:(NSString*)key;
-
-/*! Returns OS version number */
-+ (NSString *)deviceOSVersion;
+@interface MSIDExternalSSOContext : NSObject
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
@@ -95,6 +95,11 @@
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
     if (@available(macOS 13.0, *))
     {
+        if (!self.loginManager)
+        {
+            return nil;
+        }
+        
         return self.loginManager.loginConfiguration.tokenEndpointURL;
     }
 #endif

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
@@ -1,3 +1,4 @@
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -19,36 +20,11 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-#import <Foundation/Foundation.h>
 
-#include <sys/types.h>
-#include <sys/sysctl.h>
-#include <mach/machine.h>
+#import "MSIDExternalSSOContext.h"
 
-@interface MSIDDeviceId : NSObject
-
-/*! Returns diagnostic trace data to be sent to the Azure Active Directory servers. */
-+ (NSDictionary *)deviceId;
-
-/*! Returns a short device identifier string containing device type and OS version. */
-+ (NSString *)deviceOSId;
-
-/*! Returns a unique device identifier for telemetry purposes. */
-+ (NSString *)deviceTelemetryId;
-
-/*! Returns application name for telemetry purposes. */
-+ (NSString *)applicationName;
-
-/*! Returns application version for telemetry purposes. */
-+ (NSString *)applicationVersion;
-
-/*! Used by Broker SDK */
-+ (void)setIdValue:(NSString*)value
-            forKey:(NSString*)key;
-
-/*! Returns OS version number */
-+ (NSString *)deviceOSVersion;
+@implementation MSIDExternalSSOContext
 
 @end

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
@@ -32,6 +32,7 @@
 - (MSIDWPJKeyPairWithCert *)wpjKeyPairWithCertWithContext:(id<MSIDRequestContext>)context
 {
 #if TARGET_OS_OSX
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
     if (@available(macOS 13.0, *))
     {
         SecIdentityRef identityRef = [self.loginManager copyIdentityForKeyType:ASAuthorizationProviderExtensionKeyTypeUserDeviceSigning]; // +1
@@ -77,6 +78,7 @@
         return keypair;
     }
 #endif
+#endif
 
     return nil;
 }
@@ -84,10 +86,12 @@
 - (nullable NSURL *)tokenEndpointURL
 {
 #if TARGET_OS_OSX
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
     if (@available(macOS 13.0, *))
     {
         return self.loginManager.loginConfiguration.tokenEndpointURL;
     }
+#endif
 #endif
     
     return nil;

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
@@ -83,10 +83,12 @@
 
 - (nullable NSURL *)tokenEndpointURL
 {
+#if TARGET_OS_OSX
     if (@available(macOS 13.0, *))
     {
         return self.loginManager.loginConfiguration.tokenEndpointURL;
     }
+#endif
     
     return nil;
 }

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
@@ -35,6 +35,12 @@
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
     if (@available(macOS 13.0, *))
     {
+        if (!self.loginManager)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Loginmanager not present, returning early");
+            return nil;
+        }
+        
         SecIdentityRef identityRef = [self.loginManager copyIdentityForKeyType:ASAuthorizationProviderExtensionKeyTypeUserDeviceSigning]; // +1
         
         if (!identityRef)

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
@@ -76,7 +76,7 @@
                                                                                  certificate:certificateRef
                                                                            certificateIssuer:nil];
         
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Successfully created MSIDWPJKeyPairWithCert from external SSO context for identity %@", identityRef);
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Successfully created MSIDWPJKeyPairWithCert from external SSO context for identity %@", identityRef ? @"not-null" : @"null");
         
         CFReleaseNull(identityRef);
         CFReleaseNull(certificateRef);

--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.m
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.m
@@ -438,6 +438,7 @@
                                                                                                            claims:claims
                                                                                                      codeVerifier:pkceCodeVerifier
                                                                                                   extraParameters:parameters.extraTokenRequestParameters
+                                                                                                       ssoContext:parameters.ssoContext
                                                                                                           context:parameters];
     tokenRequest.responseSerializer = [[MSIDTokenResponseSerializer alloc] initWithOauth2Factory:self];
     
@@ -456,6 +457,7 @@
                                                                                            refreshToken:refreshToken
                                                                                             redirectUri:parameters.redirectUri
                                                                                         extraParameters:parameters.extraTokenRequestParameters
+                                                                                             ssoContext:parameters.ssoContext
                                                                                                 context:parameters];
     tokenRequest.responseSerializer = [[MSIDTokenResponseSerializer alloc] initWithOauth2Factory:self];
     

--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.m
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.m
@@ -263,10 +263,11 @@
     }
 
     MSIDAuthorizeWebRequestConfiguration *configuration = [[MSIDAuthorizeWebRequestConfiguration alloc] initWithStartURL:startURL
-                                                                                  endRedirectUri:endRedirectUri
-                                                                                            pkce:pkce
-                                                                                           state:oauthState
-                                                                              ignoreInvalidState:NO];
+                                                                                                          endRedirectUri:endRedirectUri
+                                                                                                                    pkce:pkce
+                                                                                                                   state:oauthState
+                                                                                                      ignoreInvalidState:NO
+                                                                                                              ssoContext:parameters.ssoContext];
     configuration.customHeaders = parameters.customWebviewHeaders;
     configuration.parentController = parameters.parentViewController;
     configuration.prefersEphemeralWebBrowserSession = parameters.prefersEphemeralWebBrowserSession;

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
@@ -95,12 +95,19 @@
         return session;
     }
     
+    MSIDWebViewPlatformParams *platformParams = nil;
+    
+    if (configuration.ssoContext)
+    {
+        platformParams = [[MSIDWebViewPlatformParams alloc] initWithExternalSSOContext:configuration.ssoContext];
+    }
+    
      MSIDAADOAuthEmbeddedWebviewController *embeddedWebviewController
        = [[MSIDAADOAuthEmbeddedWebviewController alloc] initWithStartURL:configuration.startURL
                                                                   endURL:[NSURL URLWithString:configuration.endRedirectUrl]
                                                                  webview:webview
                                                            customHeaders:configuration.customHeaders
-                                                          platfromParams:nil
+                                                          platfromParams:platformParams
                                                                  context:context];
     
 #if TARGET_OS_IPHONE

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -204,6 +204,7 @@
                                                                                                                  claims:claims
                                                                                                            codeVerifier:pkceCodeVerifier
                                                                                                         extraParameters:parameters.extraTokenRequestParameters
+                                                                                                             ssoContext:parameters.ssoContext
                                                                                                                 context:parameters];
 
     if ([parameters isNestedAuthProtocol])
@@ -252,6 +253,7 @@
                                                                                                  refreshToken:refreshToken
                                                                                                        claims:claims
                                                                                               extraParameters:parameters.extraTokenRequestParameters
+                                                                                                   ssoContext:parameters.ssoContext
                                                                                                       context:parameters];
 
     if ([parameters isNestedAuthProtocol])

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -36,6 +36,7 @@
 #if !EXCLUDE_FROM_MSALCPP
 @class MSIDCurrentRequestTelemetry;
 #endif
+@class MSIDExternalSSOContext;
 
 @interface MSIDRequestParameters : NSObject <NSCopying, MSIDRequestContext>
 
@@ -89,6 +90,9 @@
 
 #pragma mark - Cache
 @property (nonatomic) NSString *keychainAccessGroup;
+
+#pragma mark - SSO context
+@property (nonatomic) MSIDExternalSSOContext *ssoContext;
 
 - (NSURL *)tokenEndpoint;
 

--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -83,6 +83,7 @@
         [MSIDPKeyAuthHandler handleChallenge:requestURL.absoluteString
                                      context:self.context
                                customHeaders:self.customHeaders
+                          externalSSOContext:self.platformParams.externalSSOContext
                            completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
                                if (!challengeResponse)
                                {

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.h
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.h
@@ -24,15 +24,19 @@
 #import <Foundation/Foundation.h>
 #import "MSIDChallengeHandling.h"
 
+@class MSIDExternalSSOContext;
+
 @interface MSIDPKeyAuthHandler : NSObject
 
 + (BOOL)handleChallenge:(NSString *)challengeUrl
                 context:(id<MSIDRequestContext>)context
           customHeaders:(NSDictionary<NSString *, NSString *> *)customHeaders
+     externalSSOContext:(MSIDExternalSSOContext *)externalSSOContext
       completionHandler:(void (^)(NSURLRequest *challengeResponse, NSError *error))completionHandler;
 
 + (void)handleWwwAuthenticateHeader:(NSString *)wwwAuthHeaderValue
                          requestUrl:(NSURL *)requestUrl
+                 externalSSOContext:(MSIDExternalSSOContext *)externalSSOContext
                             context:(id<MSIDRequestContext>)context
                   completionHandler:(void (^)(NSString *authHeader, NSError *error))completionHandler;
 

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -36,6 +36,7 @@
 + (BOOL)handleChallenge:(NSString *)challengeUrl
                 context:(id<MSIDRequestContext>)context
           customHeaders:(NSDictionary<NSString *, NSString *> *)customHeaders
+     externalSSOContext:(MSIDExternalSSOContext *)externalSSOContext
       completionHandler:(void (^)(NSURLRequest *challengeResponse, NSError *error))completionHandler
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Handling PKeyAuth Challenge.");
@@ -57,6 +58,7 @@
     // Extract authority from submit url    
     NSString *authHeader = [MSIDPkeyAuthHelper createDeviceAuthResponse:[NSURL URLWithString:submitUrl]
                                                           challengeData:queryParamsMap
+                                                     externalSSOContext:externalSSOContext
                                                                 context:context];
     
     // Attach client version to response url
@@ -92,6 +94,7 @@
 
 + (void)handleWwwAuthenticateHeader:(NSString *)wwwAuthHeaderValue
                          requestUrl:(NSURL *)requestUrl
+                 externalSSOContext:(MSIDExternalSSOContext *)externalSSOContext
                             context:(id<MSIDRequestContext>)context
                   completionHandler:(void (^)(NSString *authHeader, NSError *error))completionHandler
 {
@@ -105,6 +108,7 @@
     NSError *error = nil;
     NSString *authHeader = [MSIDPkeyAuthHelper createDeviceAuthResponse:requestUrl
                                                           challengeData:authHeaderParams
+                                                     externalSSOContext:externalSSOContext
                                                                 context:context];
     if (completionHandler)
     {

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebViewPlatformParams.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebViewPlatformParams.h
@@ -23,16 +23,25 @@
 
 
 #import <Foundation/Foundation.h>
+#import "MSIDExternalSSOContext.h"
 
 @interface MSIDWebViewPlatformParams : NSObject
+
+@property (nonatomic, readonly) MSIDExternalSSOContext *externalSSOContext;
 
 #if TARGET_OS_OSX
 
 @property (nonatomic, readonly) NSRect customWindowRect;
+@property (nonatomic, readonly) BOOL customWindowRectIsSet;
 
 -(id)initWithCoustomWindowRect:(NSRect)customWindowRect;
 
+-(instancetype)initWithExternalSSOContext:(MSIDExternalSSOContext *)externalSSOContext
+                         customWindowRect:(NSRect)customWindowRect;
+
 #endif
+
+-(instancetype)initWithExternalSSOContext:(MSIDExternalSSOContext *)externalSSOContext;
 
 @end
 

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebViewPlatformParams.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebViewPlatformParams.m
@@ -1,3 +1,4 @@
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -19,36 +20,7 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
+
 
 #import <Foundation/Foundation.h>
-
-#include <sys/types.h>
-#include <sys/sysctl.h>
-#include <mach/machine.h>
-
-@interface MSIDDeviceId : NSObject
-
-/*! Returns diagnostic trace data to be sent to the Azure Active Directory servers. */
-+ (NSDictionary *)deviceId;
-
-/*! Returns a short device identifier string containing device type and OS version. */
-+ (NSString *)deviceOSId;
-
-/*! Returns a unique device identifier for telemetry purposes. */
-+ (NSString *)deviceTelemetryId;
-
-/*! Returns application name for telemetry purposes. */
-+ (NSString *)applicationName;
-
-/*! Returns application version for telemetry purposes. */
-+ (NSString *)applicationVersion;
-
-/*! Used by Broker SDK */
-+ (void)setIdValue:(NSString*)value
-            forKey:(NSString*)key;
-
-/*! Returns OS version number */
-+ (NSString *)deviceOSVersion;
-
-@end

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebViewPlatformParams.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebViewPlatformParams.m
@@ -24,3 +24,20 @@
 
 
 #import <Foundation/Foundation.h>
+#import "MSIDWebViewPlatformParams.h"
+
+@implementation MSIDWebViewPlatformParams
+
+-(instancetype)initWithExternalSSOContext:(MSIDExternalSSOContext *)externalSSOContext
+{
+    self = [super init];
+    
+    if (self)
+    {
+        _externalSSOContext = externalSSOContext;
+    }
+    
+    return self;
+}
+
+@end

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebViewPlatformParams.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebViewPlatformParams.m
@@ -32,6 +32,35 @@
     if (self)
     {
         _customWindowRect = customWindowRect;
+        _customWindowRectIsSet = YES;
+    }
+    
+    return self;
+}
+
+-(instancetype)initWithExternalSSOContext:(MSIDExternalSSOContext *)externalSSOContext
+{
+    self = [super init];
+    
+    if (self)
+    {
+        _externalSSOContext = externalSSOContext;
+        _customWindowRectIsSet = NO;
+    }
+    
+    return self;
+}
+
+-(instancetype)initWithExternalSSOContext:(MSIDExternalSSOContext *)externalSSOContext
+                         customWindowRect:(NSRect)customWindowRect
+{
+    self = [super init];
+    
+    if (self)
+    {
+        _externalSSOContext = externalSSOContext;
+        _customWindowRect = customWindowRect;
+        _customWindowRectIsSet = YES;
     }
     
     return self;

--- a/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.h
+++ b/IdentityCore/src/workplacejoin/MSIDPkeyAuthHelper.h
@@ -24,10 +24,13 @@
 #import <Foundation/Foundation.h>
 #import "MSIDRegistrationInformation.h"
 
+@class MSIDExternalSSOContext;
+
 @interface MSIDPkeyAuthHelper : NSObject
 
 + (nullable NSString *)createDeviceAuthResponse:(nonnull NSURL *)authorizationServer
                                   challengeData:(nullable NSDictionary *)challengeData
+                             externalSSOContext:(nullable MSIDExternalSSOContext *)externalSSOContext
                                         context:(nullable id<MSIDRequestContext>)context;
 
 @end

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
@@ -27,6 +27,7 @@
 @class MSIDRegistrationInformation;
 @class MSIDWorkplaceJoinChallenge;
 @class MSIDWPJKeyPairWithCert;
+@class MSIDExternalSSOContext;
 
 @interface MSIDWorkPlaceJoinUtil : MSIDWorkPlaceJoinUtilBase
 
@@ -47,5 +48,9 @@
                                                      key:(nullable NSString *)key
                                                  context:(nullable id<MSIDRequestContext>)context
                                                    error:(NSError*__nullable*__nullable)error;
+
++ (nullable MSIDWPJKeyPairWithCert *)wpjKeyPairWithSSOContext:(nonnull MSIDExternalSSOContext *)ssoContext
+                                                     tenantId:(nullable NSString *)tenantId
+                                                      context:(nullable id<MSIDRequestContext>)context;
 
 @end

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -28,10 +28,18 @@
 #import "MSIDError.h"
 #import "MSIDWorkplaceJoinChallenge.h"
 #import "MSIDWorkPlaceJoinUtilBase+Internal.h"
+#import "MSIDExternalSSOContext.h"
 
 static NSString *kWPJPrivateKeyIdentifier = @"com.microsoft.workplacejoin.privatekey\0";
 
 @implementation MSIDWorkPlaceJoinUtil
+
++ (MSIDWPJKeyPairWithCert *)wpjKeyPairWithSSOContext:(MSIDExternalSSOContext *)ssoContext
+                                            tenantId:(NSString *)tenantId
+                                             context:(id<MSIDRequestContext>)context
+{
+    return nil;
+}
 
 + (MSIDWPJKeyPairWithCert *)getWPJKeysWithTenantId:(NSString *)tenantId context:(id<MSIDRequestContext>)context
 {

--- a/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
@@ -54,6 +54,7 @@
             if (!authorityURL)
             {
                 MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to create authority URL with error %@", authorityURLError);
+                return nil;
             }
             else if (![authorityURL.tenant.rawTenant.lowercaseString isEqualToString:tenantId.lowercaseString])
             {

--- a/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
@@ -39,77 +39,31 @@
                                             tenantId:(NSString *)tenantId
                                              context:(id<MSIDRequestContext>)context
 {
-    if (@available(macOS 13.0, *))
+    if (![NSString msidIsStringNilOrBlank:tenantId])
     {
-        if (![NSString msidIsStringNilOrBlank:tenantId])
+        NSURL *tokenEndpointURL = ssoContext.tokenEndpointURL;
+        
+        if (tokenEndpointURL)
         {
-            NSURL *tokenEndpointURL = ssoContext.loginManager.loginConfiguration.tokenEndpointURL;
+            NSError *authorityURLError = nil;
+            MSIDAADAuthority *authorityURL = [[MSIDAADAuthority alloc] initWithURL:tokenEndpointURL
+                                                                         rawTenant:nil
+                                                                           context:context
+                                                                             error:&authorityURLError];
             
-            if (tokenEndpointURL)
+            if (!authorityURL)
             {
-                NSError *authorityURLError = nil;
-                MSIDAADAuthority *authorityURL = [[MSIDAADAuthority alloc] initWithURL:tokenEndpointURL
-                                                                             rawTenant:nil
-                                                                               context:context
-                                                                                 error:&authorityURLError];
-                
-                if (!authorityURL)
-                {
-                    MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to create authority URL with error %@", authorityURLError);
-                }
-                else if (![authorityURL.tenant.rawTenant.lowercaseString isEqualToString:tenantId.lowercaseString])
-                {
-                    MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"Tenant was specified for matching and it mismatches registration tenant, returning early. Specified tenant %@, registration tenant %@", tenantId, authorityURL.tenant.rawTenant);
-                    return nil;
-                }
+                MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to create authority URL with error %@", authorityURLError);
+            }
+            else if (![authorityURL.tenant.rawTenant.lowercaseString isEqualToString:tenantId.lowercaseString])
+            {
+                MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"Tenant was specified for matching and it mismatches registration tenant, returning early. Specified tenant %@, registration tenant %@", tenantId, authorityURL.tenant.rawTenant);
+                return nil;
             }
         }
-        
-        SecIdentityRef identityRef = [ssoContext.loginManager copyIdentityForKeyType:ASAuthorizationProviderExtensionKeyTypeUserDeviceSigning]; // +1
-        
-        if (!identityRef)
-        {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to copy identity for the ASAuthorizationProviderExtensionKeyTypeUserDeviceSigning keytype");
-            return nil;
-        }
-        
-        SecCertificateRef certificateRef = NULL;
-        OSStatus certCopyStatus = SecIdentityCopyCertificate(identityRef, &certificateRef); // +1
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Certificate copy status from identity %d", (int)certCopyStatus);
-        
-        if (!certificateRef)
-        {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to copy certificate from identityref with status %d", (int)certCopyStatus);
-            CFReleaseNull(identityRef);
-            return nil;
-        }
-        
-        SecKeyRef privateKeyRef = NULL;
-        OSStatus keyCopyStatus = SecIdentityCopyPrivateKey(identityRef, &privateKeyRef); // +1
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Key copy status from identity %d", (int)keyCopyStatus);
-        
-        if (!privateKeyRef)
-        {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to copy private key from identityref with status %d", (int)keyCopyStatus);
-            CFReleaseNull(identityRef);
-            CFReleaseNull(certificateRef);
-            return nil;
-        }
-        
-        MSIDWPJKeyPairWithCert *keypair = [[MSIDWPJKeyPairWithCert alloc] initWithPrivateKey:privateKeyRef
-                                                                                 certificate:certificateRef
-                                                                           certificateIssuer:nil];
-        
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Successfully created MSIDWPJKeyPairWithCert from external SSO context for identity %@", identityRef);
-        
-        CFReleaseNull(identityRef);
-        CFReleaseNull(certificateRef);
-        CFReleaseNull(privateKeyRef);
-        return keypair;
-        
     }
     
-    return nil;
+    return [ssoContext wpjKeyPairWithCertWithContext:context];
 }
 
 + (MSIDRegistrationInformation *)getRegistrationInformation:(id<MSIDRequestContext>)context

--- a/IdentityCore/tests/MSIDAADRequestErrorHandlerTests.m
+++ b/IdentityCore/tests/MSIDAADRequestErrorHandlerTests.m
@@ -112,6 +112,7 @@
                               data:nil
                        httpRequest:httpRequest
                 responseSerializer:[MSIDHttpResponseSerializer new]
+                externalSSOContext:nil
                            context:context
                    completionBlock:block];
 
@@ -144,6 +145,7 @@
                               data:nil
                        httpRequest:httpRequest
                 responseSerializer:[MSIDHttpResponseSerializer new]
+                externalSSOContext:nil
                            context:context
                    completionBlock:block];
 
@@ -181,6 +183,7 @@
                               data:data
                        httpRequest:httpRequest
                 responseSerializer:serializer
+                externalSSOContext:nil
                            context:context
                    completionBlock:block];
 
@@ -225,6 +228,7 @@
                               data:data
                        httpRequest:httpRequest
                 responseSerializer:serializer
+                externalSSOContext:nil
                            context:context
                    completionBlock:block];
 
@@ -263,6 +267,7 @@
                               data:nil
                        httpRequest:httpRequest
                 responseSerializer:serializer
+                externalSSOContext:nil
                            context:context
                    completionBlock:block];
 
@@ -296,6 +301,7 @@
                               data:nil
                        httpRequest:httpRequest
                 responseSerializer:serializer
+                externalSSOContext:nil
                            context:context
                    completionBlock:block];
 
@@ -333,6 +339,7 @@
                               data:responseData
                        httpRequest:httpRequest
                 responseSerializer:serializer
+                externalSSOContext:nil
                            context:context
                    completionBlock:block];
 

--- a/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
+++ b/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
@@ -125,6 +125,7 @@
     BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
                                                      context:context
                                                customHeaders:customHeaders
+                                          externalSSOContext:nil
                                            completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
         XCTAssertNotNil(challengeResponse);
         XCTAssertTrue([[[challengeResponse allHTTPHeaderFields] objectForKey:MSID_REFRESH_TOKEN_CREDENTIAL] isEqual:value], @"RefreshToken should be valid");
@@ -146,6 +147,7 @@
     BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
                                                      context:context
                                                customHeaders:nil
+                                          externalSSOContext:nil
                                            completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
         XCTAssertNotNil(challengeResponse);
         XCTAssertNil([[challengeResponse allHTTPHeaderFields] objectForKey:MSID_REFRESH_TOKEN_CREDENTIAL], @"RefreshToken should be nil");
@@ -169,6 +171,7 @@
     BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
                                                      context:context
                                                customHeaders:customHeaders
+                                          externalSSOContext:nil 
                                            completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
         XCTAssertNotNil(challengeResponse);
         XCTAssertNil([[challengeResponse allHTTPHeaderFields] objectForKey:MSID_REFRESH_TOKEN_CREDENTIAL], @"RefreshToken should be nil");

--- a/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
+++ b/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
@@ -113,6 +113,8 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
                                   @"nonce": @"XNme6ZlnnZgIS4bMHPzY4RihkHFqCH6s1hnRgjv8Y0Q",
                                   @"CertAuthorities": @"OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access+%2cDC%3dwindows+%2cDC%3dnet+"};
     
+    s_registrationInformationToReturn = nil;
+    
     MSIDWPJKeyPairWithCertMock *keyPair = [MSIDWPJKeyPairWithCertMock new];
     [keyPair setPrivateKey:[self privateKey]];
     [keyPair setCertIssuer:@"82dbaca4-3e81-46ca-9c73-0950c1eaca97"];
@@ -137,6 +139,8 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
                                   @"CertAuthorities": @"OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access+%2cDC%3dwindows+%2cDC%3dnet+",
                                   @"TenantId": @"contoso.com"
     };
+    
+    s_registrationInformationToReturn = nil;
     
     MSIDWPJKeyPairWithCertMock *keyPair = [MSIDWPJKeyPairWithCertMock new];
     [keyPair setPrivateKey:[self privateKey]];

--- a/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
+++ b/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
@@ -163,6 +163,8 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
                                   @"CertAuthorities": @"OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access+%2cDC%3dwindows+%2cDC%3dnet+",
                                   @"TenantId": @"contoso2.com"
     };
+    
+    s_registrationInformationToReturn = nil;
         
     MSIDWPJKeyPairWithCertMock *keyPair = [MSIDWPJKeyPairWithCertMock new];
     [keyPair setPrivateKey:[self privateKey]];

--- a/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
+++ b/IdentityCore/tests/MSIDPkeyAuthHelperTests.m
@@ -76,7 +76,7 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
     s_registrationInformationToReturn = regInfo;
     __auto_type url = [[NSURL alloc] initWithString:@"https://someurl.com"];
     
-    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData context:nil];
+    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData externalSSOContext:nil context:nil];
     
     __auto_type expectedResponse = @"PKeyAuth AuthToken=\"ewogICJhbGciIDogIlJTMjU2IiwKICAidHlwIiA6ICJKV1QiLAogICJ4NWMiIDogWwogICAgIlptRnJaU0JrWVhSaCIKICBdCn0.ewogICJhdWQiIDogImh0dHBzOlwvXC9zb21ldXJsLmNvbSIsCiAgIm5vbmNlIiA6ICJYTm1lNlpsbm5aZ0lTNGJNSFB6WTRSaWhrSEZxQ0g2czFoblJnanY4WTBRIiwKICAiaWF0IiA6ICI1Igp9.NI9E37170Ykse1oRZlBqkzCn-VLbde3HGi6MdQOFlnkIopSDlzeh00Fc2-YAVcKMPbmmbHZRpOppoZGTFItRSzOyiDQkpVaC_l89w1ip2OdarOffdc2SmGmFL80RqlsnWEvz7h1tC-Ziq5A1va58alL2hrPwdZe8fTGzQmo87MUz_gLwdf8GHbGqVqgE_csavbFrPo1iHu6qZiIcI8CBYzRpXOZsILDlvjBjtuxQ1cJDSBkmTg1TUemU8yrbxoB4wcTxvgmDbe8QCCCJwyxbo4Ww8leQd0D3cCrhRHihs6bHjI2y9z00vOj-4Qj0JC20hGUW9EdZFuB8vmvwsyT34g\", Context=\"some context\", Version=\"1.0\"";
     
@@ -96,7 +96,7 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
     s_registrationInformationToReturn = regInfo;
     __auto_type url = [[NSURL alloc] initWithString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice"];
     
-    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData context:nil];
+    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData externalSSOContext:nil context:nil];
     
     __auto_type expectedResponse = @"PKeyAuth AuthToken=\"ewogICJhbGciIDogIlJTMjU2IiwKICAidHlwIiA6ICJKV1QiLAogICJ4NWMiIDogWwogICAgIlptRnJaU0JrWVhSaCIKICBdCn0.ewogICJhdWQiIDogImh0dHBzOlwvXC9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tXC9jb21tb25cL29hdXRoMlwvdjIuMFwvdG9rZW4iLAogICJub25jZSIgOiAiWE5tZTZabG5uWmdJUzRiTUhQelk0Umloa0hGcUNINnMxaG5SZ2p2OFkwUSIsCiAgImlhdCIgOiAiNSIKfQ.HMgqNP2ZkDFZC7u_jo4Vlc6lMozr1x05rCTyMaJwvCIQx6vO9bPjhJ2f-fXrd_W9syrAa4TNRQZELfQPm-3dCVzHBpRJzDrH-Z3S3zYE4egWBq59BwNsrSbtgevlyeusd6h9z-WLDOVMZN1n79v4K6sSux0WEwaxGPjU0haTIBZmqaT0NEsLADDdeAMJCLN9Exd4VFi4GeZ9jsTw3_bzHS_2I8lyj5r8lr4yHUpPdxw0rFvOacJepbPqd_vW7jKl2tSZRVDw9iWRA9CxWWgVp3eZrPUesx7oLnkAnp7mIfKuhI4bL3yxAkg1ouErYqlIhJUgK7jR1OPZOKhBXSV98Q\", Context=\"some context\", Version=\"1.0\"";
     
@@ -116,7 +116,7 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
     s_registrationInformationToReturn = regInfo;
     __auto_type url = [[NSURL alloc] initWithString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice"];
     
-    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData context:nil];
+    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData externalSSOContext:nil context:nil];
     
     __auto_type expectedResponse = @"PKeyAuth AuthToken=\"ewogICJhbGciIDogIlJTMjU2IiwKICAidHlwIiA6ICJKV1QiLAogICJ4NWMiIDogWwogICAgIlptRnJaU0JrWVhSaCIKICBdCn0.ewogICJhdWQiIDogImh0dHBzOlwvXC9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tXC9jb21tb25cL29hdXRoMlwvdjIuMFwvdG9rZW4iLAogICJub25jZSIgOiAiWE5tZTZabG5uWmdJUzRiTUhQelk0Umloa0hGcUNINnMxaG5SZ2p2OFkwUSIsCiAgImlhdCIgOiAiNSIKfQ.HMgqNP2ZkDFZC7u_jo4Vlc6lMozr1x05rCTyMaJwvCIQx6vO9bPjhJ2f-fXrd_W9syrAa4TNRQZELfQPm-3dCVzHBpRJzDrH-Z3S3zYE4egWBq59BwNsrSbtgevlyeusd6h9z-WLDOVMZN1n79v4K6sSux0WEwaxGPjU0haTIBZmqaT0NEsLADDdeAMJCLN9Exd4VFi4GeZ9jsTw3_bzHS_2I8lyj5r8lr4yHUpPdxw0rFvOacJepbPqd_vW7jKl2tSZRVDw9iWRA9CxWWgVp3eZrPUesx7oLnkAnp7mIfKuhI4bL3yxAkg1ouErYqlIhJUgK7jR1OPZOKhBXSV98Q\", Context=\"some context\", Version=\"1.0\"";
     
@@ -132,7 +132,7 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
                                   @"CertAuthorities": @"OU=82dbaca4-3e81-46ca-9c73-0950c1eaca97,CN=MS-Organization-Access,DC=windows,DC=net"};
     __auto_type url = [[NSURL alloc] initWithString:@"https://someurl.com"];
     
-    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData context:nil];
+    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData externalSSOContext:nil context:nil];
     
     __auto_type expectedResponse = @"PKeyAuth  Context=\"some context\", Version=\"1.0\"";
     
@@ -152,7 +152,7 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
     s_registrationInformationToReturn = regInfo;
     __auto_type url = [[NSURL alloc] initWithString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice"];
     
-    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData context:nil];
+    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData externalSSOContext:nil context:nil];
     
     __auto_type expectedResponse = @"PKeyAuth  Context=\"some context\", Version=\"1.0\"";
     
@@ -173,7 +173,7 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
     __auto_type url = [[NSURL alloc] initWithString:@"https://some.host.com/adfs/ls/someqp=qp"];
     MSIDLastRequestTelemetry *telemetryObject = [MSIDLastRequestTelemetry sharedInstance];
     
-    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData context:nil];
+    __auto_type response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData externalSSOContext:nil context:nil];
         
     __auto_type expectedResponse = @"PKeyAuth AuthToken=\"ewogICJhbGciIDogIlJTMjU2IiwKICAidHlwIiA6ICJKV1QiLAogICJ4NWMiIDogWwogICAgIlptRnJaU0JrWVhSaCIKICBdCn0.ewogICJhdWQiIDogImh0dHBzOlwvXC9zb21lLmhvc3QuY29tXC9hZGZzXC9sc1wvc29tZXFwPXFwIiwKICAibm9uY2UiIDogIlhObWU2WmxublpnSVM0Yk1IUHpZNFJpaGtIRnFDSDZzMWhuUmdqdjhZMFEiLAogICJpYXQiIDogIjUiCn0.rtB6Pk7Q-y7Hs2l1-74ho3qZTtj1XFzTh6R9aleY-a3IAL81V7Hklq-JIgt8Q8VwLTMtbOQ--J2U4MxKAy8YMLx7Oq4whnLmryqnE2czBG-aAppj4_cqgaw4XJTrFFMMtxZ2_8TVCg5FdyS78r14DMuB9kISkbaic4D0IEucNuPvI4e23-QWj4oygsC5qhDlfvO_xVYf73cXUnINIS_hMFShYljsH_R40HBZtmQGTA4i0wZlvYbOv3j3j-VutNB4v7W2dXVPPVsgbYvN0umNxU_Dcftg1IYtfAVWkemf4UK9Bd_wbP-wufS6iCwwkK9i8-1wvJjEY-7fkxrNpzyr4Q\", Context=\"some context\", Version=\"1.0\"";
     
@@ -187,7 +187,7 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
     // Do not save telemetry for pkeyAuth requests to non-adfs requests
     [telemetryObject updateWithApiId:4 errorString:nil context:nil];
     url = [[NSURL alloc] initWithString:@"https://some.host.com/DeviceAuth?someqp=qp"];
-    response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData context:nil];
+    response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData externalSSOContext:nil context:nil];
     serverTelemetry = [telemetryObject telemetryString];
     XCTAssertFalse([serverTelemetry containsString:@"ADFS_PKEYAUTH_CHLG"]);
     
@@ -196,7 +196,7 @@ static MSIDRegistrationInformation *s_registrationInformationToReturn;
     url = [[NSURL alloc] initWithString:@"https://some.host.com/adfs/ls/someqp=qp"];
     regInfo = nil;
     s_registrationInformationToReturn = regInfo;
-    response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData context:nil];
+    response = [MSIDPkeyAuthHelper createDeviceAuthResponse:url challengeData:challengeData externalSSOContext:nil context:nil];
     serverTelemetry = [telemetryObject telemetryString];
     XCTAssertNotEqualObjects(expectedResponse, response);
     XCTAssertFalse([serverTelemetry containsString:@"ADFS_PKEYAUTH_CHLG"]);

--- a/IdentityCore/tests/integration/MSIDHttpRequestIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDHttpRequestIntegrationTests.m
@@ -62,6 +62,7 @@
 @property (nonatomic) id<MSIDRequestContext> passedContext;
 @property (nonatomic, copy) MSIDHttpRequestDidCompleteBlock passedBlock;
 @property (nonatomic) id<MSIDResponseSerialization> responseSerializer;
+@property (nonatomic) MSIDExternalSSOContext *passedSSOContext;
 
 @end
 
@@ -72,6 +73,7 @@
                data:(NSData *)data
         httpRequest:(id<MSIDHttpRequestProtocol>)httpRequest
  responseSerializer:(id<MSIDResponseSerialization>)responseSerializer
+ externalSSOContext:(MSIDExternalSSOContext *)ssoContext
             context:(id<MSIDRequestContext>)context
     completionBlock:(MSIDHttpRequestDidCompleteBlock)completionBlock
 {
@@ -83,6 +85,7 @@
     self.passedBlock = completionBlock;
     self.responseSerializer = responseSerializer;
     self.handleErrorInvokedCounts++;
+    self.passedSSOContext = ssoContext;
 }
 
 @end

--- a/IdentityCore/tests/mocks/MSIDExternalSSOContextMock.h
+++ b/IdentityCore/tests/mocks/MSIDExternalSSOContextMock.h
@@ -1,3 +1,4 @@
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -19,35 +20,26 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-#import <Foundation/Foundation.h>
-#import "MSIDBaseBrokerOperationRequest.h"
-#import "MSIDBrowserRequestValidating.h"
+
+#import "MSIDExternalSSOContext.h"
+#import "MSIDWPJKeyPairWithCert.h"
+
+@interface MSIDWPJKeyPairWithCertMock : MSIDWPJKeyPairWithCert
+
+- (void)setPrivateKey:(nullable SecKeyRef)privateKey;
+- (void)setCertIssuer:(nullable NSString *)issuer;
+
+@end
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class MSIDAADAuthority;
-@class MSIDExternalSSOContext;
+@interface MSIDExternalSSOContextMock : MSIDExternalSSOContext
 
-@interface MSIDBrokerOperationBrowserTokenRequest : MSIDBaseBrokerOperationRequest
-
-@property (nonatomic, readonly) NSURL *requestURL;
-@property (nonatomic, readonly) NSString *bundleIdentifier;
-@property (nonatomic, readonly) MSIDAADAuthority *authority;
-@property (nonatomic, readonly) NSDictionary *headers;
-@property (nonatomic, readonly) NSData *httpBody;
-@property (nonatomic, readonly) BOOL useSSOCookieFallback;
-@property (nonatomic, readonly) MSIDExternalSSOContext *ssoContext;
-
-- (instancetype)initWithRequest:(NSURL *)requestURL
-                        headers:(NSDictionary *)headers
-                           body:(nullable NSData *)httpBody
-               bundleIdentifier:(NSString *)bundleIdentifier
-               requestValidator:(id<MSIDBrowserRequestValidating>)requestValidator
-           useSSOCookieFallback:(BOOL)useSSOCookieFallback
-                     ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
-                          error:(NSError **)error;
+@property (nonatomic) MSIDWPJKeyPairWithCert *mockedKeyPair;
+@property (nonatomic) NSUInteger wpjCertWithContextCalledCount;
+@property (nonatomic, nullable) NSURL *mockedTokenEndpointURL;
 
 @end
 

--- a/IdentityCore/tests/mocks/MSIDExternalSSOContextMock.m
+++ b/IdentityCore/tests/mocks/MSIDExternalSSOContextMock.m
@@ -23,22 +23,34 @@
 // THE SOFTWARE.  
 
 
-#import <Foundation/Foundation.h>
-#import <AuthenticationServices/AuthenticationServices.h>
+#import "MSIDExternalSSOContextMock.h"
 
-@class MSIDWPJKeyPairWithCert;
+@implementation MSIDWPJKeyPairWithCertMock
 
-NS_ASSUME_NONNULL_BEGIN
+- (void)setPrivateKey:(SecKeyRef)privateKey
+{
+    self->_privateKeyRef = privateKey;
+    self->_certificateRef = (SecCertificateRef)@"";
+}
 
-@interface MSIDExternalSSOContext : NSObject
-
-#if TARGET_OS_OSX
-@property (nonatomic, nullable, strong) ASAuthorizationProviderExtensionLoginManager *loginManager API_AVAILABLE(macos(13.0));
-#endif
-
-- (nullable MSIDWPJKeyPairWithCert *)wpjKeyPairWithCertWithContext:(nullable id<MSIDRequestContext>)context;
-- (nullable NSURL *)tokenEndpointURL;
+- (void)setCertIssuer:(NSString *)issuer
+{
+    self->_certificateIssuer = issuer;
+}
 
 @end
 
-NS_ASSUME_NONNULL_END
+@implementation MSIDExternalSSOContextMock
+
+- (MSIDWPJKeyPairWithCert *)wpjKeyPairWithCertWithContext:(id<MSIDRequestContext>)context
+{
+    self.wpjCertWithContextCalledCount++;
+    return self.mockedKeyPair;
+}
+
+- (nullable NSURL *)tokenEndpointURL
+{
+    return self.mockedTokenEndpointURL;
+}
+
+@end


### PR DESCRIPTION
## Proposed changes

Support external SSO extension context in PkeyAuth calls. This is needed if device keys are supplied externally by the SSO extension.
There're a lot of changes here, but majority of them are simply passing the ssoContext between all layers. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

