### PR TITLE
Kaisong1990/2435627 relaxing broker_key validation

### DIFF
--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.h
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.h
@@ -36,12 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *clientAppVersion;
 @property (nonatomic, nullable) NSString *clientAppName;
 @property (nonatomic) MSIDClientSDKType clientSDK;
-@property (nonatomic) BOOL isRunTime;
+@property (nonatomic) BOOL clientBrokerKeyCapabilityNotSupported;
 
 + (BOOL)fillRequest:(MSIDBrokerOperationRequest *)request
 keychainAccessGroup:(nullable NSString *)keychainAccessGroup
      clientMetadata:(nullable NSDictionary *)clientMetadata
-          isRunTime:(BOOL)isRunTime
+clientBrokerKeyCapabilityNotSupported:(BOOL)clientBrokerKeyCapabilityNotSupported
             context:(nullable id<MSIDRequestContext>)context;
 
 @end

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.h
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.h
@@ -36,10 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *clientAppVersion;
 @property (nonatomic, nullable) NSString *clientAppName;
 @property (nonatomic) MSIDClientSDKType clientSDK;
+@property (nonatomic) BOOL isRunTime;
 
 + (BOOL)fillRequest:(MSIDBrokerOperationRequest *)request
 keychainAccessGroup:(nullable NSString *)keychainAccessGroup
      clientMetadata:(nullable NSDictionary *)clientMetadata
+          isRunTime:(BOOL)isRunTime
             context:(nullable id<MSIDRequestContext>)context;
 
 @end

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
@@ -28,9 +28,7 @@
 #import "MSIDBrokerKeyProvider.h"
 #import "MSIDVersion.h"
 #import "NSDictionary+MSIDLogging.h"
-#if !TARGET_OS_OSX
-#import "MSIDKeychainUtil.h"
-#else
+#if TARGET_OS_OSX
 #import "MSIDKeychainUtil+MacInternal.h"
 #endif
 

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
@@ -28,6 +28,11 @@
 #import "MSIDBrokerKeyProvider.h"
 #import "MSIDVersion.h"
 #import "NSDictionary+MSIDLogging.h"
+#if !TARGET_OS_OSX
+#import "MSIDKeychainUtil.h"
+#else
+#import "MSIDKeychainUtil+MacInternal.h"
+#endif
 
 @implementation MSIDBrokerOperationRequest
 
@@ -36,11 +41,16 @@ keychainAccessGroup:(NSString *)keychainAccessGroup
      clientMetadata:(NSDictionary *)clientMetadata
             context:(id<MSIDRequestContext>)context
 {
-    NSString *accessGroup = keychainAccessGroup ?: MSIDKeychainTokenCache.defaultKeychainGroup;
-    __auto_type brokerKeyProvider = [[MSIDBrokerKeyProvider alloc] initWithGroup:accessGroup];
-    NSString *base64UrlKey = [brokerKeyProvider base64BrokerKeyWithContext:context
-                                                                     error:nil];
-    request.brokerKey = base64UrlKey;
+    NSString *base64UrlKey = nil;
+    if (![self shouldIgnoreBrokerKey])
+    {
+        NSString *accessGroup = keychainAccessGroup ?: MSIDKeychainTokenCache.defaultKeychainGroup;
+        __auto_type brokerKeyProvider = [[MSIDBrokerKeyProvider alloc] initWithGroup:accessGroup];
+        base64UrlKey = [brokerKeyProvider base64BrokerKeyWithContext:context
+                                                               error:nil];
+        request.brokerKey = base64UrlKey;
+    }
+    
     request.clientVersion = [MSIDVersion sdkVersion];
     request.protocolVersion = MSID_BROKER_PROTOCOL_VERSION_4;
     request.clientAppVersion = clientMetadata[MSID_APP_VER_KEY];
@@ -86,15 +96,28 @@ keychainAccessGroup:(NSString *)keychainAccessGroup
     NSMutableDictionary *json = [NSMutableDictionary new];
     if (!self.brokerKey)
     {
-        MSID_LOG_WITH_CORR(MSIDLogLevelError, self.correlationId, @"Failed to create json for %@ class, brokerKey is nil.", self.class);
-        return nil;
+        
+        if (![MSIDBrokerOperationRequest shouldIgnoreBrokerKey])
+        {
+            MSID_LOG_WITH_CORR(MSIDLogLevelError, self.correlationId, @"Failed to create json for %@ class, brokerKey is nil.", self.class);
+            return nil;
+        }
+        else
+        {
+            MSID_LOG_WITH_CORR(MSIDLogLevelInfo, self.correlationId, @"Broker key is invalid, continue generating broker request for %@ class", self.class);
+        }
     }
-    json[MSID_BROKER_KEY] = self.brokerKey;
+    else
+    {
+        json[MSID_BROKER_KEY] = self.brokerKey;
+    }
+    
     if (self.protocolVersion < 1)
     {
         MSID_LOG_WITH_CORR(MSIDLogLevelError, self.correlationId, @"Failed to create json for %@ class, protocolVersion is invalid.", self.class);
         return nil;
     }
+    
     json[MSID_BROKER_PROTOCOL_VERSION_KEY] = [@(self.protocolVersion) stringValue];
     json[MSID_BROKER_CLIENT_VERSION_KEY] = self.clientVersion;
     json[MSID_BROKER_CLIENT_APP_VERSION_KEY] = self.clientAppVersion;
@@ -106,9 +129,23 @@ keychainAccessGroup:(NSString *)keychainAccessGroup
     return json;
 }
 
--(NSString *)logInfo
+- (NSString *)logInfo
 {
     return [NSString stringWithFormat:@"%@",[self.jsonDictionary msidMaskedRequestDictionary]];
+}
+
++ (BOOL)shouldIgnoreBrokerKey
+{
+#if !TARGET_OS_OSX
+    return NO;
+#else
+        if([MSIDKeychainUtil sharedInstance].isAppEntitled)
+        {
+            return NO;
+        }
+    
+    return YES;
+#endif
 }
 
 @end

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
@@ -39,14 +39,12 @@ keychainAccessGroup:(NSString *)keychainAccessGroup
      clientMetadata:(NSDictionary *)clientMetadata
             context:(id<MSIDRequestContext>)context
 {
-    NSString *base64UrlKey = nil;
     if (![self shouldIgnoreBrokerKey])
     {
         NSString *accessGroup = keychainAccessGroup ?: MSIDKeychainTokenCache.defaultKeychainGroup;
         __auto_type brokerKeyProvider = [[MSIDBrokerKeyProvider alloc] initWithGroup:accessGroup];
-        base64UrlKey = [brokerKeyProvider base64BrokerKeyWithContext:context
+        request.brokerKey = [brokerKeyProvider base64BrokerKeyWithContext:context
                                                                error:nil];
-        request.brokerKey = base64UrlKey;
     }
     
     request.clientVersion = [MSIDVersion sdkVersion];

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
@@ -132,14 +132,14 @@ clientBrokerKeyCapabilityNotSupported:(BOOL)clientBrokerKeyCapabilityNotSupporte
 {
 #if !TARGET_OS_OSX
     return NO;
-#endif
-    
+#else
     if(!self.clientBrokerKeyCapabilityNotSupported || (self.clientBrokerKeyCapabilityNotSupported && [MSIDKeychainUtil sharedInstance].isAppEntitled))
     {
         return NO;
     }
 
     return YES;
+#endif
 }
 
 @end

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
@@ -37,7 +37,7 @@
 + (BOOL)fillRequest:(MSIDBrokerOperationRequest *)request
 keychainAccessGroup:(NSString *)keychainAccessGroup
      clientMetadata:(NSDictionary *)clientMetadata
-          isRunTime:(BOOL)isRunTime
+clientBrokerKeyCapabilityNotSupported:(BOOL)clientBrokerKeyCapabilityNotSupported
             context:(id<MSIDRequestContext>)context
 {
     NSString *accessGroup = keychainAccessGroup ?: MSIDKeychainTokenCache.defaultKeychainGroup;
@@ -49,7 +49,7 @@ keychainAccessGroup:(NSString *)keychainAccessGroup
     request.clientAppVersion = clientMetadata[MSID_APP_VER_KEY];
     request.clientAppName = clientMetadata[MSID_APP_NAME_KEY];
     request.correlationId = context.correlationId;
-    request.isRunTime = isRunTime;
+    request.clientBrokerKeyCapabilityNotSupported = clientBrokerKeyCapabilityNotSupported;
     
     return YES;
 }
@@ -132,14 +132,14 @@ keychainAccessGroup:(NSString *)keychainAccessGroup
 {
 #if !TARGET_OS_OSX
     return NO;
-#else
-        if(!self.isRunTime || (self.isRunTime && [MSIDKeychainUtil sharedInstance].isAppEntitled))
-        {
-            return NO;
-        }
-    
-    return YES;
 #endif
+    
+    if(!self.clientBrokerKeyCapabilityNotSupported || (self.clientBrokerKeyCapabilityNotSupported && [MSIDKeychainUtil sharedInstance].isAppEntitled))
+    {
+        return NO;
+    }
+
+    return YES;
 }
 
 @end

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
@@ -45,6 +45,7 @@
     [self fillRequest:request
   keychainAccessGroup:parameters.keychainAccessGroup
        clientMetadata:parameters.appRequestMetadata
+            isRunTime:parameters.isRunTime
               context:parameters];
     
     request.configuration = parameters.msidConfiguration;

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
@@ -45,7 +45,7 @@
     [self fillRequest:request
   keychainAccessGroup:parameters.keychainAccessGroup
        clientMetadata:parameters.appRequestMetadata
-            isRunTime:parameters.isRunTime
+clientBrokerKeyCapabilityNotSupported:parameters.clientBrokerKeyCapabilityNotSupported
               context:parameters];
     
     request.configuration = parameters.msidConfiguration;

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -60,6 +60,7 @@
 @property (nonatomic) BOOL extendedLifetimeEnabled;
 @property (nonatomic) BOOL instanceAware;
 @property (nonatomic) BOOL allowUsingLocalCachedRtWhenSsoExtFailed;
+@property (nonatomic) BOOL isRunTime;
 @property (nonatomic) NSString *intuneApplicationIdentifier;
 @property (nonatomic) MSIDRequestType requestType;
 #if !EXCLUDE_FROM_MSALCPP

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -60,7 +60,7 @@
 @property (nonatomic) BOOL extendedLifetimeEnabled;
 @property (nonatomic) BOOL instanceAware;
 @property (nonatomic) BOOL allowUsingLocalCachedRtWhenSsoExtFailed;
-@property (nonatomic) BOOL isRunTime;
+@property (nonatomic) BOOL clientBrokerKeyCapabilityNotSupported;
 @property (nonatomic) NSString *intuneApplicationIdentifier;
 @property (nonatomic) MSIDRequestType requestType;
 #if !EXCLUDE_FROM_MSALCPP

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
@@ -147,6 +147,7 @@
     [MSIDBrokerOperationRequest fillRequest:signoutRequest
                         keychainAccessGroup:self.requestParameters.keychainAccessGroup
                              clientMetadata:self.requestParameters.appRequestMetadata
+                                  isRunTime:signoutRequest.isRunTime
                                     context:self.requestParameters];
     
     ASAuthorizationSingleSignOnRequest *ssoRequest = [self.ssoProvider createRequest];

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionSignoutRequest.m
@@ -147,7 +147,7 @@
     [MSIDBrokerOperationRequest fillRequest:signoutRequest
                         keychainAccessGroup:self.requestParameters.keychainAccessGroup
                              clientMetadata:self.requestParameters.appRequestMetadata
-                                  isRunTime:signoutRequest.isRunTime
+         clientBrokerKeyCapabilityNotSupported:signoutRequest.clientBrokerKeyCapabilityNotSupported
                                     context:self.requestParameters];
     
     ASAuthorizationSingleSignOnRequest *ssoRequest = [self.ssoProvider createRequest];

--- a/IdentityCore/src/util/ASAuthorizationSingleSignOnProvider+MSIDExtensions.m
+++ b/IdentityCore/src/util/ASAuthorizationSingleSignOnProvider+MSIDExtensions.m
@@ -45,6 +45,7 @@
     [MSIDBrokerOperationRequest fillRequest:operationRequest
                         keychainAccessGroup:requestParameters.keychainAccessGroup
                              clientMetadata:requestParameters.appRequestMetadata
+                                  isRunTime: requestParameters.isRunTime
                                     context:requestParameters];
     
     ASAuthorizationSingleSignOnRequest *ssoRequest = [self createRequest];

--- a/IdentityCore/src/util/ASAuthorizationSingleSignOnProvider+MSIDExtensions.m
+++ b/IdentityCore/src/util/ASAuthorizationSingleSignOnProvider+MSIDExtensions.m
@@ -45,7 +45,7 @@
     [MSIDBrokerOperationRequest fillRequest:operationRequest
                         keychainAccessGroup:requestParameters.keychainAccessGroup
                              clientMetadata:requestParameters.appRequestMetadata
-                                  isRunTime: requestParameters.isRunTime
+         clientBrokerKeyCapabilityNotSupported: requestParameters.clientBrokerKeyCapabilityNotSupported
                                     context:requestParameters];
     
     ASAuthorizationSingleSignOnRequest *ssoRequest = [self createRequest];

--- a/IdentityCore/src/util/mac/MSIDKeychainUtil+MacInternal.h
+++ b/IdentityCore/src/util/mac/MSIDKeychainUtil+MacInternal.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDKeychainUtil ()
 
+@property (readonly) BOOL isAppEntitled;
+
 - (nullable NSString *)teamIdFromSigningInformation:(NSDictionary *)signingInformation;
 - (nullable NSString *)appIdPrefixFromSigningInformation:(NSDictionary *)signingInformation;
 

--- a/IdentityCore/tests/MSIDBrokerOperationRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationRequestTests.m
@@ -47,7 +47,7 @@
 {
     __auto_type request = [MSIDBrokerOperationRequest new];
     request.protocolVersion = 99;
-    request.isRunTime = YES;
+    request.clientBrokerKeyCapabilityNotSupported = YES;
     
     NSDictionary *json = [request jsonDictionary];
     

--- a/IdentityCore/tests/MSIDBrokerOperationRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationRequestTests.m
@@ -43,14 +43,25 @@
 
 #else
 
-- (void)testJsonDictionary_whenNoBrokerKey_shouldReturnValidJson
+- (void)testJsonDictionary_whenNoBrokerKey_andRunTime_shouldReturnValidJson
+{
+    __auto_type request = [MSIDBrokerOperationRequest new];
+    request.protocolVersion = 99;
+    request.isRunTime = YES;
+    
+    NSDictionary *json = [request jsonDictionary];
+    
+    XCTAssertNotNil(json);
+}
+
+- (void)testJsonDictionary_whenNoBrokerKey_andNotRunTime_shouldReturnInvalidJson
 {
     __auto_type request = [MSIDBrokerOperationRequest new];
     request.protocolVersion = 99;
     
     NSDictionary *json = [request jsonDictionary];
     
-    XCTAssertNotNil(json);
+    XCTAssertNil(json);
 }
 
 #endif

--- a/IdentityCore/tests/MSIDBrokerOperationRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationRequestTests.m
@@ -30,6 +30,7 @@
 
 @implementation MSIDBrokerOperationRequestTests
 
+#if !TARGET_OS_OSX
 - (void)testJsonDictionary_whenNoBrokerKey_shouldReturnNilJson
 {
     __auto_type request = [MSIDBrokerOperationRequest new];
@@ -39,6 +40,20 @@
     
     XCTAssertNil(json);
 }
+
+#else
+
+- (void)testJsonDictionary_whenNoBrokerKey_shouldReturnValidJson
+{
+    __auto_type request = [MSIDBrokerOperationRequest new];
+    request.protocolVersion = 99;
+    
+    NSDictionary *json = [request jsonDictionary];
+    
+    XCTAssertNotNil(json);
+}
+
+#endif
 
 - (void)testInitWithJSONDictionary_whenNoBrokerKey_shouldReturnError
 {


### PR DESCRIPTION
## Proposed changes

Skip broker_key nil check when preparing broker request. The change:
1. Does not impact any current iOS flow
2. Does not impact Mac apps if they are correctly signed with app entitlements
3. Will change for apps without correct app entitlements, and allow using empty broker_key (Broker will use the caller_bundle_identifier as broker_key instead)  
4. This should also help with browser_core work if it cannot add entitlements @antrix1989 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

