### PR TITLE
Added null check for additional json info in DeviceInfo

### DIFF
--- a/IdentityCore/src/broker_operation/response/MSIDDeviceInfo.m
+++ b/IdentityCore/src/broker_operation/response/MSIDDeviceInfo.m
@@ -63,8 +63,12 @@ static NSArray *deviceModeEnumString;
         _wpjStatus = [self wpjStatusEnumFromString:[json msidStringObjectForKey:MSID_BROKER_WPJ_STATUS_KEY]];
         _brokerVersion = [json msidStringObjectForKey:MSID_BROKER_BROKER_VERSION_KEY];
         
-        NSData *jsonData = [json[MSID_ADDITIONAL_EXTENSION_DATA_KEY] dataUsingEncoding:NSUTF8StringEncoding];
-        _additionalExtensionData = [NSJSONSerialization msidNormalizedDictionaryFromJsonData:jsonData error:nil];
+        NSString *jsonDataString = [json msidStringObjectForKey:MSID_ADDITIONAL_EXTENSION_DATA_KEY];
+        if (jsonDataString)
+        {
+            _additionalExtensionData = [NSJSONSerialization msidNormalizedDictionaryFromJsonData:[jsonDataString dataUsingEncoding:NSUTF8StringEncoding]
+                                                                                           error:nil];
+        }
         
         NSString *extraDeviceInfoStr = [json msidStringObjectForKey:MSID_EXTRA_DEVICE_INFO_KEY];
         if (extraDeviceInfoStr)

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version 1.7.16
 * Return enrollmentId only if homeAccountId and legacyId are both empty (#1191)
 * Prevent crash when missing completionBlock on local interactive aquireToken (#1193)
 * Add support for memorizing certificate preference for CBA on MacOS (#1194)
+* Fix a crash when additional info is not present in the device info json. (#1203)
 
 Version 1.7.15
 * Fix a crash when no identiy found during getting device registration information on iOS.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,12 @@
+## TBD
+* Fix a crash when no additional info found in the device info json. (#1203)
+
 Version 1.7.16
 * Add more detailed error codes for JIT (#1187)
 * Add support for nested auth protocol (#1175)
 * Return enrollmentId only if homeAccountId and legacyId are both empty (#1191)
 * Prevent crash when missing completionBlock on local interactive aquireToken (#1193)
 * Add support for memorizing certificate preference for CBA on MacOS (#1194)
-* Fix a crash when additional info is not present in the device info json. (#1203)
 
 Version 1.7.15
 * Fix a crash when no identiy found during getting device registration information on iOS.


### PR DESCRIPTION
## Proposed changes

Added null check for additional json info in DeviceInfo to fix the crash given here: https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1659
## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

