### PR TITLE
Add support when bundleId is nil, will use processId/infoIdentifier as suffix instead of null for non-sharable item in login keychain on Mac

### DIFF
--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -346,7 +346,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 
     if (!defaultKeychainGroup)
     {
-        defaultKeychainGroup = [[NSBundle mainBundle] bundleIdentifier];
+        defaultKeychainGroup = [[MSIDKeychainUtil sharedInstance] applicationBundleIdentifier];
     }
 
     s_defaultKeychainGroup = [defaultKeychainGroup copy];
@@ -430,7 +430,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
         
         if (!keychainGroup)
         {
-            keychainGroup = [[NSBundle mainBundle] bundleIdentifier];
+            keychainGroup = [[MSIDKeychainUtil sharedInstance] applicationBundleIdentifier];
         }
 
         MSIDKeychainUtil *keychainUtil = [MSIDLoginKeychainUtil sharedInstance];
@@ -465,7 +465,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
             return nil;
         }
         
-        self.appIdentifier = [NSString stringWithFormat:@"%@;%d", NSBundle.mainBundle.bundleIdentifier,
+        self.appIdentifier = [NSString stringWithFormat:@"%@;%d", [[MSIDKeychainUtil sharedInstance] applicationBundleIdentifier],
                               NSProcessInfo.processInfo.processIdentifier];
 
         self.defaultCacheQuery = @{
@@ -924,7 +924,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     else
     {
         // Non-Shareable item attributes: <keychainGroup>-<app_bundle_id>
-        [attributes setObject:[NSString stringWithFormat:@"%@-%@", self.keychainGroup, [[NSBundle mainBundle] bundleIdentifier]] forKey:(id)kSecAttrAccount];
+        [attributes setObject:[NSString stringWithFormat:@"%@-%@", self.keychainGroup, [[MSIDKeychainUtil sharedInstance] applicationBundleIdentifier]] forKey:(id)kSecAttrAccount];
         [attributes setObject:self.accessControlForNonSharedItems forKey:(id)kSecAttrAccess];
     }
     

--- a/IdentityCore/src/util/MSIDKeychainUtil.h
+++ b/IdentityCore/src/util/MSIDKeychainUtil.h
@@ -28,6 +28,7 @@
 @interface MSIDKeychainUtil : NSObject
 
 @property (readonly, nullable) NSString *teamId;
+@property (readonly, nullable) NSString *applicationBundleIdentifier;
 
 + (nonnull MSIDKeychainUtil *)sharedInstance;
 

--- a/IdentityCore/src/util/mac/MSIDKeychainUtil+MacInternal.h
+++ b/IdentityCore/src/util/mac/MSIDKeychainUtil+MacInternal.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MSIDKeychainUtil ()
 
 @property (readonly) BOOL isAppEntitled;
+@property (atomic, readwrite, nullable) NSString *applicationBundleIdentifier;
 
 - (nullable NSString *)teamIdFromSigningInformation:(NSDictionary *)signingInformation;
 - (nullable NSString *)appIdPrefixFromSigningInformation:(NSDictionary *)signingInformation;


### PR DESCRIPTION

There should be no impact on existing native application can provide bundleId with Mac login keychain

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

