### PR TITLE
Make JSON serializer method public

### DIFF
--- a/IdentityCore/src/MSIDJsonSerializer.h
+++ b/IdentityCore/src/MSIDJsonSerializer.h
@@ -28,4 +28,6 @@
 
 @property (nonatomic) BOOL normalizeJSON;
 
+- (NSDictionary *)deserializeJSON:(NSData *)data error:(NSError *__autoreleasing *)error;
+
 @end

--- a/IdentityCore/src/MSIDJsonSerializer.m
+++ b/IdentityCore/src/MSIDJsonSerializer.m
@@ -121,8 +121,6 @@
     return [self fromJsonData:jsonData ofType:klass context:context error:error];
 }
 
-#pragma mark - Private
-
 - (NSDictionary *)deserializeJSON:(NSData *)data error:(NSError *__autoreleasing *)error
 {
     if (!data)


### PR DESCRIPTION
## Proposed changes

MSIDJsonSerializer API has a great internal method to deserialize JSON.
This is needed in broker. Making it public to avoid duplicating code there. 

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

