### PR TITLE
Cherry picking changes for release 1.7.18

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
 ## TBD
 * Fix function declaration without prototype on Xcode 14.3 (#1200)
 * Fix a crash when no additional info found in the device info json (#1203)
-* Add support PKeyAuthPlus and ECC based JWT signature generation. (#1044)
 
 Version 1.7.16
 * Add more detailed error codes for JIT (#1187)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
-## TBD
+Version 1.7.18
+* Add support PKeyAuthPlus and ECC based JWT signature generation. (#1213)
+
+## 1.7.17
 * Fix function declaration without prototype on Xcode 14.3 (#1200)
 * Fix a crash when no additional info found in the device info json (#1203)
 


### PR DESCRIPTION
## Proposed changes

Cherry picking changes for PkeyAuth+ changes for release/1.7.18. These changes also include some external key prt changes but it is fine as to include it as they are broker changes and will be taken up by broker later

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

