### PR TITLE
Kaisong1990/dispatch sso ext response

### DIFF
--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
@@ -92,6 +92,10 @@
             dispatchBlock();
         });
     }
+    else
+    {
+        dispatchBlock();
+    }
 }
 
 @end

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionTokenRequestDelegate.m
@@ -26,6 +26,7 @@
 #import "MSIDSSOExtensionRequestDelegate+Internal.h"
 #import "MSIDBrokerOperationTokenResponse.h"
 #import "MSIDJsonSerializableFactory.h"
+#import "MSIDBrokerConstants.h"
 
 @implementation MSIDSSOExtensionTokenRequestDelegate
 
@@ -67,16 +68,30 @@
         return;
     }
     
-    __auto_type operationResponse = (MSIDBrokerOperationTokenResponse *)[MSIDJsonSerializableFactory createFromJSONDictionary:json classTypeJSONKey:MSID_BROKER_OPERATION_RESPONSE_TYPE_JSON_KEY assertKindOfClass:MSIDBrokerOperationTokenResponse.class error:&error];
+    BOOL forceRunOnBackgroundQueue = [[json objectForKey:MSID_BROKER_OPERATION_KEY] isEqualToString:@"refresh"];
+    [self forceRunOnBackgroundQueue:forceRunOnBackgroundQueue dispatchBlock:^{
+        NSError *innerError;
+        __auto_type operationResponse = (MSIDBrokerOperationTokenResponse *)[MSIDJsonSerializableFactory createFromJSONDictionary:json classTypeJSONKey:MSID_BROKER_OPERATION_RESPONSE_TYPE_JSON_KEY assertKindOfClass:MSIDBrokerOperationTokenResponse.class error:&innerError];
 
-    if (!operationResponse)
+        if (!operationResponse)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"operationResponse is nill, error %@", innerError);
+            completionBlockWrapper(nil, innerError);
+            return;
+        }
+        
+        completionBlockWrapper(operationResponse, nil);
+    }];
+}
+
+- (void)forceRunOnBackgroundQueue:(BOOL)forceOnBackgroundQueue dispatchBlock:(void (^)(void))dispatchBlock {
+    if (forceOnBackgroundQueue && [NSThread isMainThread])
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"operationResponse is nill, error %@", error);
-        completionBlockWrapper(nil, error);
-        return;
+        MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, self.context, @"Refresh returns on mainthread, dispatching to global queue");
+        dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+            dispatchBlock();
+        });
     }
-    
-    completionBlockWrapper(operationResponse, nil);
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

MacOS 13.3 and iOS 16.4, Apple has a regression that Sso Extension response will dispatch to main thread even if the original request started from background thread. Adding a workaround to dispatch silent response to global queue if it is on main to offload heavy caching work 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

