### PR TITLE
Account validation when user deleted & recreated

### DIFF
--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
@@ -91,6 +91,15 @@
     {
         MSID_LOG_WITH_CORR_PII(MSIDLogLevelError, correlationID, @"Different account was returned from the server. Original account %@, returned account %@", MSID_PII_LOG_TRACKABLE(accountIdentifier.uid), MSID_PII_LOG_TRACKABLE(tokenResult.account.accountIdentifier.uid));
         
+        // Probably the account was deleted and re-created with the same upn and request contained old cached user's object id
+        if (tokenResult.account.accountIdentifier.utid != nil &&
+            [tokenResult.account.accountIdentifier.utid isEqualToString:accountIdentifier.utid] &&
+            [tokenResult.account.accountIdentifier.displayableId isEqualToString:accountIdentifier.displayableId])
+        {
+            MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationID, @"For the same tenant, different account uids were returned from server but have the same UPN. Probably the account was deleted and recreated with same UPN");
+            return YES;
+        }
+        
         if (error)
         {
             NSDictionary *userInfo = @{MSIDInvalidTokenResultKey : tokenResult};


### PR DESCRIPTION
## Proposed changes

When an admin deletes and recreates a user with the same UPN, the new user is created with a new uid. If out local cache has the account with old account id, there is a mismatch between request and response uid.

In this case, we should compare UPNs for the same tenantId and return YES for validateAccount

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

