### PR TITLE
Adding missing header to MSIDKeyOperationUtil to fix CPP build

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.7.20
+* Minor fix, added missing header in MSIDKeyOperationUtil.h to fix CPP build
+
 Version 1.7.19
 * Updated extraDeviceInfo to include platform sso status on macOS
 * Add support PKeyAuthPlus and ECC based JWT signature generation. (#1044)


### PR DESCRIPTION
## Proposed changes

CPP build complained about missing header in MSIDKeyOperationUtil.h, adding fix to resolve their build.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

