### PR TITLE
Fix CIAM Authority Tests

### DIFF
--- a/IdentityCore/src/validation/MSIDCIAMAuthority.m
+++ b/IdentityCore/src/validation/MSIDCIAMAuthority.m
@@ -162,37 +162,18 @@
 }
 
 #pragma mark - Private
-+ (MSIDAADTenant *)tenantFromAuthorityUrl:(NSURL *)url
-                                  context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
-{
-    NSArray *paths = url.pathComponents;
-    
-    if ([paths count] < 2)
-    {
-        if (error)
-        {
-            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"authority must have AAD tenant.", nil, nil, nil, context.correlationId, nil, YES);
-        }
-        
-        return nil;
-    }
-    
-    NSString *rawTenant = [paths[1] lowercaseString];
-    return [[MSIDAADTenant alloc] initWithRawTenant:rawTenant context:context error:error];
-}
-
 + (NSString *)realmFromURL:(NSURL *)url
                    context:(id<MSIDRequestContext>)context
                      error:(NSError **)error
 {
-    if ([self isAuthorityFormatValid:url context:context error:error])
+    //If there is a path component, return it, else return just URL
+    if ([self isAuthorityFormatValid:url context:context error:error] && url.pathComponents.count > 1)
     {
-        return [self tenantFromAuthorityUrl:url context:context error:error].rawTenant;
+        return url.pathComponents[1];
     }
     
-    // We don't support non standard AAD authority formats
-    return nil;
+    // We do support non standard CIAM authority formats
+    return url.path;
 }
 
 @end

--- a/IdentityCore/src/validation/MSIDCIAMAuthority.m
+++ b/IdentityCore/src/validation/MSIDCIAMAuthority.m
@@ -81,6 +81,14 @@
         url = [NSURL URLWithString:[url.absoluteString stringByAppendingString:@".onmicrosoft.com"]];
     }
     
+    if ([_realm length] > 0)
+    {
+        if ([[_realm substringToIndex:1] isEqualToString:@"/"])
+        {
+            _realm = [_realm substringFromIndex:1];
+        }
+    }
+    
     if (self)
     {
         _url = [MSIDAADAuthority normalizedAuthorityUrl:url context:context error:error];

--- a/IdentityCore/src/validation/MSIDCIAMAuthority.m
+++ b/IdentityCore/src/validation/MSIDCIAMAuthority.m
@@ -57,7 +57,6 @@
             if ([self.class isAuthorityFormatValid:url context:context error:nil])
             {
                 _url = [NSURL URLWithString:[NSString stringWithFormat:@"https://%@/%@", [url msidHostWithPortIfNecessary], rawTenant]];
-                url = _url;
                 _realm = rawTenant;
             }
         }
@@ -160,6 +159,21 @@
 #else // MSAL CPP
     return @"";
 #endif
+}
+
+#pragma mark - Private
++ (NSString *)realmFromURL:(NSURL *)url
+                   context:(id<MSIDRequestContext>)context
+                     error:(NSError **)error
+{
+    //If there is a path component, return it, else return just URL
+    if ([self isAuthorityFormatValid:url context:context error:error] && url.pathComponents.count > 1)
+    {
+        return url.pathComponents[1];
+    }
+
+    // We do support non standard CIAM authority formats
+    return url.path;
 }
 
 @end

--- a/IdentityCore/src/validation/MSIDCIAMAuthority.m
+++ b/IdentityCore/src/validation/MSIDCIAMAuthority.m
@@ -80,15 +80,7 @@
         url = [url URLByAppendingPathComponent:hostComponents[0]];
         url = [NSURL URLWithString:[url.absoluteString stringByAppendingString:@".onmicrosoft.com"]];
     }
-    
-    if ([_realm length] > 0)
-    {
-        if ([[_realm substringToIndex:1] isEqualToString:@"/"])
-        {
-            _realm = [_realm substringFromIndex:1];
-        }
-    }
-    
+   
     if (self)
     {
         _url = [MSIDAADAuthority normalizedAuthorityUrl:url context:context error:error];
@@ -189,5 +181,19 @@
     NSString *rawTenant = [paths[1] lowercaseString];
     return [[MSIDAADTenant alloc] initWithRawTenant:rawTenant context:context error:error];
 }
+
++ (NSString *)realmFromURL:(NSURL *)url
+                   context:(id<MSIDRequestContext>)context
+                     error:(NSError **)error
+{
+    if ([self isAuthorityFormatValid:url context:context error:error])
+    {
+        return [self tenantFromAuthorityUrl:url context:context error:error].rawTenant;
+    }
+    
+    // We don't support non standard AAD authority formats
+    return nil;
+}
+
 @end
 #endif

--- a/IdentityCore/src/validation/MSIDCIAMAuthority.m
+++ b/IdentityCore/src/validation/MSIDCIAMAuthority.m
@@ -57,6 +57,7 @@
             if ([self.class isAuthorityFormatValid:url context:context error:nil])
             {
                 _url = [NSURL URLWithString:[NSString stringWithFormat:@"https://%@/%@", [url msidHostWithPortIfNecessary], rawTenant]];
+                url = _url;
                 _realm = rawTenant;
             }
         }

--- a/IdentityCore/src/validation/MSIDCIAMAuthority.m
+++ b/IdentityCore/src/validation/MSIDCIAMAuthority.m
@@ -162,20 +162,5 @@
 #endif
 }
 
-#pragma mark - Private
-+ (NSString *)realmFromURL:(NSURL *)url
-                   context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
-{
-    //If there is a path component, return it, else return just URL
-    if ([self isAuthorityFormatValid:url context:context error:error] && url.pathComponents.count > 1)
-    {
-        return url.pathComponents[1];
-    }
-    
-    // We do support non standard CIAM authority formats
-    return url.path;
-}
-
 @end
 #endif

--- a/IdentityCore/tests/MSIDCIAMAuthorityTests.m
+++ b/IdentityCore/tests/MSIDCIAMAuthorityTests.m
@@ -96,18 +96,6 @@
     XCTAssertNil(error);
 }
 
-- (void)testInitCIAMAuthority_withValidTenant_shouldReturnNilError
-{
-    
-    NSURL *authorityUrl = [[NSURL alloc] initWithString:@"https://example.ciamlogin.com"];
-    NSError *error;
-    
-    __auto_type authority = [[MSIDCIAMAuthority alloc] initWithURL:authorityUrl context:nil error:&error];
-    
-    XCTAssertNotNil(authority);
-    XCTAssertNil(error);
-}
-
 - (void)testInitCIAMAuthority_whenCIAMAuthorityInvalid_shouldReturnError
 {
     NSURL *authorityUrl = [[NSURL alloc] initWithString:@"https://ciamlogin.com/"];


### PR DESCRIPTION
## Proposed changes

This PR is to fix a realm issue in the CIAM authority (makes sure the realm is correctly extracted from the URL and remove any unnecessary characters).

Related PRs:
[MSAL CIAM Changes](https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/1682) 
[Identity Core CIAM Changes](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1227) 

[Related work item](https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Apple/Backlog%20items)

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

