### PR TITLE
Adding property to use most secure storage for WPJ in broker automation request

### DIFF
--- a/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.h
+++ b/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.h
@@ -84,6 +84,7 @@ typedef NS_ENUM(NSUInteger, MSIDAutomationWPJRegistrationAPIMode)
 @property (nonatomic) NSString *wpjRegistrationTenantId;
 @property (nonatomic) NSString *wpjRegistrationUpn;
 @property (nonatomic) BOOL operateOnPrimaryWPJ;
+@property (nonatomic) BOOL useMostSecureStorageForWpj;
 
 - (BOOL)usesEmbeddedWebView;
 

--- a/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.m
+++ b/IdentityCore/tests/automation/shared/MSIDAutomationTestRequest.m
@@ -101,6 +101,7 @@
         _wpjRegistrationTenantId = json[@"wpj_registration_tid"];
         _wpjRegistrationUpn = json[@"wpj_registration_upn"];
         _operateOnPrimaryWPJ = [json[@"wpj_operate_on_primary_reg"] boolValue];
+        _useMostSecureStorageForWpj = [json[@"use_most_secure_storage"] boolValue];
     }
 
     return self;
@@ -177,6 +178,7 @@
     json[@"wpj_registration_tid"] = _wpjRegistrationTenantId;
     json[@"wpj_registration_upn"] = _wpjRegistrationUpn;
     json[@"wpj_operate_on_primary_reg"] = @(_operateOnPrimaryWPJ);
+    json[@"use_most_secure_storage"] = @(_useMostSecureStorageForWpj);
     
     return json;
 }


### PR DESCRIPTION
## Proposed changes

Adding property in automation WPJ request to propagate useMostSecureStorage in WorkplaceJoin

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

