### PR TITLE
Add isCallerAppManaged to extraDeviceInfoDict

### DIFF
--- a/IdentityCore/src/MSIDBrokerConstants.h
+++ b/IdentityCore/src/MSIDBrokerConstants.h
@@ -90,3 +90,4 @@ extern NSString * _Nonnull const MSID_PRIMARY_REGISTRATION_CERTIFICATE_THUMBPRIN
 extern NSString * _Nonnull const MSID_PLATFORM_SSO_STATUS_KEY;
 extern NSString * _Nonnull const MSID_BROKER_REQUEST_SENT_TIMESTAMP;
 extern NSString * _Nonnull const JIT_TROUBLESHOOTING_HOST;
+extern NSString * _Nonnull const MSID_IS_CALLER_MANAGED_KEY;

--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -86,3 +86,4 @@ NSString *const MSID_PRIMARY_REGISTRATION_CLOUD = @"primary_registration_metadat
 NSString *const MSID_PRIMARY_REGISTRATION_CERTIFICATE_THUMBPRINT = @"primary_registration_metadata_certificate_thumbprint";
 NSString *const MSID_PLATFORM_SSO_STATUS_KEY = @"platform_sso_status";
 NSString *const JIT_TROUBLESHOOTING_HOST = @"jit_troubleshooting";
+NSString *const MSID_IS_CALLER_MANAGED_KEY = @"isCallerAppManaged";

--- a/IdentityCore/tests/MSIDDeviceInfoTests.m
+++ b/IdentityCore/tests/MSIDDeviceInfoTests.m
@@ -253,6 +253,39 @@
     XCTAssertEqualObjects(expectedJson, [deviceInfo jsonDictionary]);
 }
 
+- (void)testJsonDictionaryFromOldSDK_whenDeserialize_shouldGenerateCorrectJson {
+    MSIDDeviceInfo *deviceInfo = [MSIDDeviceInfo new];
+    deviceInfo.deviceMode = MSIDDeviceModeShared;
+    deviceInfo.wpjStatus = MSIDWorkPlaceJoinStatusJoined;
+    deviceInfo.brokerVersion = @"1.2.3";
+    
+    NSDictionary *additionalData = @{@"feature_flag1":@1,@"token":@"",@"dict":@{@"key":@"value"}};
+    deviceInfo.additionalExtensionData = additionalData;
+#if TARGET_OS_IPHONE
+    deviceInfo.extraDeviceInfo = @{MSID_BROKER_MDM_ID_KEY:@"mdmId",MSID_ENROLLED_USER_OBJECT_ID_KEY:@"objectId"};
+#endif
+#if TARGET_OS_OSX
+    NSDictionary *expectedJson = @{
+        MSID_BROKER_DEVICE_MODE_KEY : @"shared",
+        MSID_BROKER_SSO_EXTENSION_MODE_KEY : @"full",
+        MSID_BROKER_WPJ_STATUS_KEY : @"joined",
+        MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
+        MSID_PLATFORM_SSO_STATUS_KEY : @"platformSSONotEnabled",
+        MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"dict\":{\"key\":\"value\"},\"feature_flag1\":1,\"token\":\"\"}"
+    };
+#else
+    NSDictionary *expectedJson = @{
+        MSID_BROKER_DEVICE_MODE_KEY : @"shared",
+        MSID_BROKER_SSO_EXTENSION_MODE_KEY : @"full",
+        MSID_BROKER_WPJ_STATUS_KEY : @"joined",
+        MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
+        MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"dict\":{\"key\":\"value\"},\"feature_flag1\":1,\"token\":\"\"}",
+        MSID_EXTRA_DEVICE_INFO_KEY:@"{\"mdm_id\":\"mdmId\",\"object_id\":\"objectId\"}"
+    };
+#endif
+    XCTAssertEqualObjects(expectedJson, [deviceInfo jsonDictionary]);
+}
+
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
 - (void)testInitWithJSONDictionary_whenJsonValid_PlatformSSOEnabled_shouldInitWithJsonWithPlatformSSOStatus {
     NSDictionary *json = @{

--- a/IdentityCore/tests/MSIDDeviceInfoTests.m
+++ b/IdentityCore/tests/MSIDDeviceInfoTests.m
@@ -44,7 +44,7 @@
         MSID_BROKER_WPJ_STATUS_KEY : @"joined",
         MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
         MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"token\":\"\",\"dict\":{\"key\":\"value\"},\"feature_flag1\":1}",
-        MSID_EXTRA_DEVICE_INFO_KEY:@"{\"mdm_id\":\"mdmId\",\"object_id\":\"objectId\"}"
+        MSID_EXTRA_DEVICE_INFO_KEY:@"{\"mdm_id\":\"mdmId\",\"object_id\":\"objectId\",\"isCallerAppManaged\":\"1\"}"
     };
     
     NSError *error;
@@ -59,7 +59,7 @@
     
     NSDictionary *expectedAdditionalData = @{@"feature_flag1":@1,@"token":@"",@"dict":@{@"key":@"value"}};
     XCTAssertEqualObjects(deviceInfo.additionalExtensionData, expectedAdditionalData);
-    NSDictionary *expectedExtraDeviceInfo = @{@"mdm_id":@"mdmId",@"object_id":@"objectId"};
+    NSDictionary *expectedExtraDeviceInfo = @{@"mdm_id":@"mdmId",@"object_id":@"objectId", @"isCallerAppManaged":@"1"};
     XCTAssertEqualObjects(deviceInfo.extraDeviceInfo, expectedExtraDeviceInfo);
 }
 
@@ -228,7 +228,9 @@
     
     NSDictionary *additionalData = @{@"feature_flag1":@1,@"token":@"",@"dict":@{@"key":@"value"}};
     deviceInfo.additionalExtensionData = additionalData;
-    deviceInfo.extraDeviceInfo = @{MSID_BROKER_MDM_ID_KEY:@"mdmId",MSID_ENROLLED_USER_OBJECT_ID_KEY:@"objectId"};
+#if TARGET_OS_IPHONE
+    deviceInfo.extraDeviceInfo = @{MSID_BROKER_MDM_ID_KEY:@"mdmId",MSID_ENROLLED_USER_OBJECT_ID_KEY:@"objectId", MSID_IS_CALLER_MANAGED_KEY:@"1"};
+#endif
 #if TARGET_OS_OSX
     NSDictionary *expectedJson = @{
         MSID_BROKER_DEVICE_MODE_KEY : @"shared",
@@ -236,8 +238,7 @@
         MSID_BROKER_WPJ_STATUS_KEY : @"joined",
         MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
         MSID_PLATFORM_SSO_STATUS_KEY : @"platformSSONotEnabled",
-        MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"dict\":{\"key\":\"value\"},\"feature_flag1\":1,\"token\":\"\"}",
-        MSID_EXTRA_DEVICE_INFO_KEY:@"{\"mdm_id\":\"mdmId\",\"object_id\":\"objectId\"}"
+        MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"dict\":{\"key\":\"value\"},\"feature_flag1\":1,\"token\":\"\"}"
     };
 #else
     NSDictionary *expectedJson = @{
@@ -246,7 +247,7 @@
         MSID_BROKER_WPJ_STATUS_KEY : @"joined",
         MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
         MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"dict\":{\"key\":\"value\"},\"feature_flag1\":1,\"token\":\"\"}",
-        MSID_EXTRA_DEVICE_INFO_KEY:@"{\"mdm_id\":\"mdmId\",\"object_id\":\"objectId\"}"
+        MSID_EXTRA_DEVICE_INFO_KEY:@"{\"isCallerAppManaged\":\"1\",\"mdm_id\":\"mdmId\",\"object_id\":\"objectId\"}"
     };
 #endif
     XCTAssertEqualObjects(expectedJson, [deviceInfo jsonDictionary]);
@@ -261,7 +262,6 @@
         MSID_BROKER_BROKER_VERSION_KEY : @"1.2.3",
         MSID_PLATFORM_SSO_STATUS_KEY : @"platformSSOEnabledNotRegistered",
         MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"token\":\"\",\"dict\":{\"key\":\"value\"},\"feature_flag1\":1}",
-        MSID_EXTRA_DEVICE_INFO_KEY:@"{\"mdm_id\":\"mdmId\",\"object_id\":\"objectId\"}"
     };
     
     NSError *error;
@@ -276,8 +276,6 @@
     XCTAssertEqual(deviceInfo.platformSSOStatus, MSIDPlatformSSOEnabledNotRegistered);
     NSDictionary *expectedAdditionalData = @{@"feature_flag1":@1,@"token":@"",@"dict":@{@"key":@"value"}};
     XCTAssertEqualObjects(deviceInfo.additionalExtensionData, expectedAdditionalData);
-    NSDictionary *expectedExtraDeviceInfo = @{@"mdm_id":@"mdmId",@"object_id":@"objectId"};
-    XCTAssertEqualObjects(deviceInfo.extraDeviceInfo, expectedExtraDeviceInfo);
 }
 
 - (void)testJsonDictionaryWithPlatformSSOStatus_whenDeserialize_shouldGenerateCorrectJson
@@ -290,7 +288,6 @@
     
     NSDictionary *additionalData = @{@"feature_flag1":@1,@"token":@"",@"dict":@{@"key":@"value"}};
     deviceInfo.additionalExtensionData = additionalData;
-    deviceInfo.extraDeviceInfo = @{MSID_BROKER_MDM_ID_KEY:@"mdmId",MSID_ENROLLED_USER_OBJECT_ID_KEY:@"objectId"};
     
     NSDictionary *expectedJson = @{
         MSID_BROKER_DEVICE_MODE_KEY : @"personal",
@@ -300,7 +297,6 @@
         MSID_PLATFORM_SSO_STATUS_KEY :
             @"platformSSOEnabledAndRegistered",
         MSID_ADDITIONAL_EXTENSION_DATA_KEY: @"{\"dict\":{\"key\":\"value\"},\"feature_flag1\":1,\"token\":\"\"}",
-        MSID_EXTRA_DEVICE_INFO_KEY:@"{\"mdm_id\":\"mdmId\",\"object_id\":\"objectId\"}"
     };
     
     XCTAssertEqualObjects(expectedJson, [deviceInfo jsonDictionary]);


### PR DESCRIPTION
## Proposed changes

Expose is CallerApp managed in extraDeviceInfo dict for MAM sdk

## Type of change

- [x ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

