### PR TITLE
Add expired AT removal code on the MSAL WriteCredential call.

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
@@ -113,6 +113,13 @@
                             error:(NSError * _Nullable * _Nullable)error;
 
 /*
+ Removes credentials matching parameters specified in the query
+ */
+- (BOOL)removeExpiredAccessTokensCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
+                          context:(nullable id<MSIDRequestContext>)context
+                            error:(NSError * _Nullable * _Nullable)error;
+
+/*
  Removes a credential
 */
 - (BOOL)removeCredential:(nonnull MSIDCredentialCacheItem *)credential

--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
@@ -339,7 +339,7 @@
 
     NSArray<MSIDCredentialCacheItem *> *matchedCredentials = [self getCredentialsWithQuery:cacheQuery context:context error:error];
     
-    if (!matchedCredentials) return NO;
+    if (!matchedCredentials.count) return NO;
     
     // Check for expiry here to leave only expired ones in matchedCredentials
     for (MSIDCredentialCacheItem *cacheItem in matchedCredentials)

--- a/IdentityCore/src/cache/key/MSIDDefaultCredentialCacheQuery.h
+++ b/IdentityCore/src/cache/key/MSIDDefaultCredentialCacheQuery.h
@@ -29,7 +29,8 @@ typedef NS_ENUM(NSUInteger, MSIDComparisonOptions) {
     MSIDExactStringMatch,
     MSIDSubSet,
     MSIDIntersect,
-    MSIDSuperSet
+    MSIDSuperSet,
+    MSIDAny
 };
 
 @interface MSIDDefaultCredentialCacheQuery : MSIDDefaultCredentialCacheKey

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -272,6 +272,8 @@
             return [inputSet isSubsetOfOrderedSet:tokenSet];
         case MSIDIntersect:
             return [inputSet intersectsOrderedSet:tokenSet];
+        case MSIDAny:
+            return YES;
         case MSIDExactStringMatch:
         default:
             return NO;
@@ -340,6 +342,14 @@
         return YES;
     }
     
+    if (matchingOptions == MSIDAny)
+    {
+        if ((clientId && [self.clientId.msidNormalizedString isEqualToString:clientId.msidNormalizedString]))
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item any match; actual client ID: %@, expected client ID: %@, actual family ID: %@, expected family ID: %@", NSStringFromClass(self.class), self.clientId, clientId, self.familyId, familyId);
+            return YES;
+        }
+    }
     if (!([NSString msidIsStringNilOrBlank:self.requestedClaims] && [NSString msidIsStringNilOrBlank:requestedClaims]) && !([self.requestedClaims isEqualToString:requestedClaims]))
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item did not have valid requestedClaims.", NSStringFromClass(self.class));


### PR DESCRIPTION
## Proposed changes
AB#2613823

Added code that removes expired AT for apple storage. 
(removeExpiredCredentialsWithQuerys). This method is called from deleteAccessTokens which in turn is called from writeCredentials. Note that  is only called from MSAIStorageManagerImpl.m so it will not be part of any other IdentityCore code paths. It relies on the addition getCredentialsWithQuery and matchesWithRealm relying on new value MSIDAny in MSAIMSIDComparisonOptions to return all entries for homeAccountId, environment, realm and clientId in cache query. The returned entries are then tested for expiration. Expired tokens are deleted using removeAllCredentials call.

Here is an MSAL draft PR that shows end to end changes with both XPLAT and apple storage changes.

https://github.com/AzureAD/microsoft-authentication-library-for-cpp/pull/3612


## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

