### PR TITLE
Added code that removes expired AT for apple storage.

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
@@ -113,6 +113,13 @@
                             error:(NSError * _Nullable * _Nullable)error;
 
 /*
+ Removes credentials matching parameters specified in the query
+ */
+- (BOOL)removeExpiredAccessTokensCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
+                          context:(nullable id<MSIDRequestContext>)context
+                            error:(NSError * _Nullable * _Nullable)error;
+
+/*
  Removes a credential
 */
 - (BOOL)removeCredential:(nonnull MSIDCredentialCacheItem *)credential

--- a/IdentityCore/src/cache/key/MSIDDefaultCredentialCacheQuery.h
+++ b/IdentityCore/src/cache/key/MSIDDefaultCredentialCacheQuery.h
@@ -29,7 +29,8 @@ typedef NS_ENUM(NSUInteger, MSIDComparisonOptions) {
     MSIDExactStringMatch,
     MSIDSubSet,
     MSIDIntersect,
-    MSIDSuperSet
+    MSIDSuperSet,
+    MSIDAny
 };
 
 @interface MSIDDefaultCredentialCacheQuery : MSIDDefaultCredentialCacheKey

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -272,6 +272,8 @@
             return [inputSet isSubsetOfOrderedSet:tokenSet];
         case MSIDIntersect:
             return [inputSet intersectsOrderedSet:tokenSet];
+        case MSIDAny:
+            return YES;
         case MSIDExactStringMatch:
         default:
             return NO;
@@ -340,6 +342,14 @@
         return YES;
     }
     
+    if (matchingOptions == MSIDAny)
+    {
+        if ((clientId && [self.clientId.msidNormalizedString isEqualToString:clientId.msidNormalizedString]))
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item any match; actual client ID: %@, expected client ID: %@, actual family ID: %@, expected family ID: %@", NSStringFromClass(self.class), self.clientId, clientId, self.familyId, familyId);
+            return YES;
+        }
+    }
     if (!([NSString msidIsStringNilOrBlank:self.requestedClaims] && [NSString msidIsStringNilOrBlank:requestedClaims]) && !([self.requestedClaims isEqualToString:requestedClaims]))
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"(%@) cached item did not have valid requestedClaims.", NSStringFromClass(self.class));

--- a/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
+++ b/IdentityCore/tests/MSIDAccountCredentialsCacheTests.m
@@ -2782,10 +2782,10 @@
     XCTAssertTrue(result);
     XCTAssertNil(error);
 
-    NSArray *remainignItems = [self.cache getAllItemsWithContext:nil error:&error];
+    NSArray *remainingItems = [self.cache getAllItemsWithContext:nil error:&error];
     XCTAssertNil(error);
-    XCTAssertNotNil(remainignItems);
-    XCTAssertTrue([remainignItems count] == 2);
+    XCTAssertNotNil(remainingItems);
+    XCTAssertTrue([remainingItems count] == 2);
 }
 
 - (void)testRemoveCredentialsWithQuery_whenQueryIsNotExactMatch_andATPopAccessTokensQuery_shouldRemoveAllItems

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.7.23
+* Added code that removes expired AT for Apple storage.
+
 Version 1.7.22
 * Remove references to deprecated api. (#1252)
 


### PR DESCRIPTION
## Proposed changes

@dorinung:

AB#2613823

Added code that removes expired AT for apple storage.
(removeExpiredCredentialsWithQuerys). This method is called from deleteAccessTokens which in turn is called from writeCredentials. Note that is only called from MSAIStorageManagerImpl.m so it will not be part of any other IdentityCore code paths. It relies on the addition getCredentialsWithQuery and matchesWithRealm relying on new value MSIDAny in MSAIMSIDComparisonOptions to return all entries for homeAccountId, environment, realm and clientId in cache query. The returned entries are then tested for expiration. Expired tokens are deleted using removeAllCredentials call.

Here is an MSAL draft PR that shows end to end changes with both XPLAT and apple storage changes.

https://github.com/AzureAD/microsoft-authentication-library-for-cpp/pull/3612

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

