### PR TITLE
Replace deprecated NSProgressIndicatorSpinningStyle with NSProgressIndicatorStyleSpinning

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -220,7 +220,7 @@ static WKWebViewConfiguration *s_webConfig;
     }
 
     NSProgressIndicator *loadingIndicator = [[NSProgressIndicator alloc] initWithFrame:NSMakeRect(windowWidth / 2 - 16, windowHeight / 2 - 16, 32, 32)];
-    [loadingIndicator setStyle:NSProgressIndicatorSpinningStyle];
+    [loadingIndicator setStyle:NSProgressIndicatorStyleSpinning];
     // Keep the item centered in the window even if it's resized.
     [loadingIndicator setAutoresizingMask:NSViewMinXMargin | NSViewMaxXMargin | NSViewMinYMargin | NSViewMaxYMargin];
     


### PR DESCRIPTION
## Proposed changes

Replace deprecated NSProgressIndicatorSpinningStyle based on: remyjette
https://developer.apple.com/documentation/appkit/nsprogressindicatorspinningstyle

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
This PR is same a this fork PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1258
