### PR TITLE
Filter expired certs in the certificate picker

### DIFF
--- a/IdentityCore/src/util/NSDate+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSDate+MSIDExtensions.h
@@ -28,6 +28,7 @@
 - (NSString *)msidToString;
 - (NSString *)msidDateToTimestamp;
 - (NSString *)msidDateToFractionalTimestamp:(int)precision;
+- (BOOL)msidIsDateBetween:(NSDate *)dateBefore dateAfter:(NSDate *)dateAfter;
 + (NSDate *)msidDateFromTimeStamp:(NSString *)timeStamp;
 + (NSDate *)msidDateFromRetryHeader:(NSString *)retryHeaderString;
 @end

--- a/IdentityCore/src/util/NSDate+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSDate+MSIDExtensions.m
@@ -49,6 +49,20 @@
     return [NSString stringWithFormat:@"%0.*f", precision, [self timeIntervalSince1970]];
 }
 
+- (BOOL)msidIsDateBetween:(NSDate *)dateBefore dateAfter:(NSDate *)dateAfter
+{
+    if (!dateBefore || !dateAfter) return NO;
+    
+    if (([self compare:dateBefore] == NSOrderedDescending) &&
+        ([self compare:dateAfter] == NSOrderedAscending))
+    {
+        return  YES;
+    }
+    
+    return NO;
+    
+}
+
 + (NSDate *)msidDateFromTimeStamp:(NSString *)timeStamp
 {
     if (!timeStamp)

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
@@ -23,6 +23,8 @@
 
 #import "MSIDCertAuthHandler.h"
 #import "MSIDCertificateChooser.h"
+#import "NSDate+MSIDExtensions.h"
+#import "MSIDKeychainUtil.h"
 
 @implementation MSIDCertAuthHandler
 
@@ -50,9 +52,12 @@
         identity = SecIdentityCopyPreferred((CFStringRef)webview.URL.absoluteString, NULL, (CFArrayRef)distinguishedNames);
     }
     
-    if (identity != NULL)
+    BOOL isIdentityValid = [self isIdentityValid:identity context:context];
+    
+    if (isIdentityValid)
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Using preferred identity");
+        
         [self respondCertAuthChallengeWithIdentity:identity context:context completionHandler:completionHandler];
     }
     else
@@ -120,6 +125,7 @@
        (id)kSecClass : (id)kSecClassIdentity,
        (id)kSecReturnRef: @YES,
        (id)kSecMatchLimit : (id)kSecMatchLimitAll,
+       (id)kSecMatchValidOnDate: (id)kCFNull // Pass a value of kCFNull to indicate the current date.
        } mutableCopy];
     
     if (issuers.count > 0)
@@ -127,24 +133,105 @@
         [query setObject:issuers forKey:(id)kSecMatchIssuers];
     }
     
-    CFTypeRef result = NULL;
-    
-    OSStatus status = SecItemCopyMatching((CFDictionaryRef)query, &result);
-    if (status == errSecItemNotFound)
-    {
-        MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"No certificate found matching challenge");
-        completionHandler(nil);
-        return;
-    }
-    else if (status != errSecSuccess)
-    {
-        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"Failed to find identity matching issuers with %d error.", status);
-        completionHandler(nil);
-        return;
-    }
-    
-    [MSIDCertificateChooserHelper showCertSelectionSheet:(__bridge NSArray *)result host:host webview:webview correlationId:correlationId completionHandler:completionHandler];
+    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+        CFTypeRef result = NULL;
+        // This is heavy operation, call it on the bg thread so we don't block UI.
+        OSStatus status = SecItemCopyMatching((CFDictionaryRef)query, &result);
+        
+        // Proceed on the main queue: either show the cert picker or return immediately in case of error.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (status == errSecItemNotFound)
+            {
+                MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"No certificate found matching challenge");
+                completionHandler(nil);
+                return;
+            }
+            else if (status != errSecSuccess)
+            {
+                MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"Failed to find identity matching issuers with %d error.", status);
+                completionHandler(nil);
+                return;
+            }
+            
+            [MSIDCertificateChooserHelper showCertSelectionSheet:(__bridge NSArray *)result host:host webview:webview correlationId:correlationId completionHandler:completionHandler];
+        });
+    });
 }
 
+#pragma mark - Private
+
++ (BOOL)isIdentityValid:(SecIdentityRef)identity context:(id<MSIDRequestContext>)context
+{
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Validating identity...");
+    if (identity == NULL)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Identity validation finished: identity is NULL.");
+        return NO;
+    }
+    
+    BOOL result = NO;
+    
+    SecCertificateRef certificateRef = NULL;
+    OSStatus status = SecIdentityCopyCertificate(identity, &certificateRef); // +1
+    
+    if (certificateRef)
+    {
+        result = [self isCertificatedValid:certificateRef context:context];
+        
+        CFReleaseNull(certificateRef);
+    }
+    else
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to copy certificate from identityref with status %d", (int)status);
+    }
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Identity validation finished, result: %d", result);
+    
+    return result;
+}
+
++ (BOOL)isCertificatedValid:(SecCertificateRef)certificate context:(id<MSIDRequestContext>)context
+{
+    NSDate *notBeforeDate = [self dateFromCertificate:certificate key:kSecOIDX509V1ValidityNotBefore context:context];
+    NSDate *notAfterDate = [self dateFromCertificate:certificate key:kSecOIDX509V1ValidityNotAfter context:context];
+    
+    NSDate *nowDate = [NSDate new];
+    return [nowDate msidIsDateBetween:notBeforeDate dateAfter:notAfterDate];
+}
+
++ (NSDate *)dateFromCertificate:(SecCertificateRef)certificate key:(CFTypeRef)dateKey context:(id<MSIDRequestContext>)context
+{
+    const void *keys[] = {dateKey};
+    
+    CFErrorRef cfError;
+    CFArrayRef keySelection = CFArrayCreate(NULL, keys, sizeof(keys)/sizeof(keys[0]), &kCFTypeArrayCallBacks);
+    CFDictionaryRef dict = SecCertificateCopyValues(certificate, keySelection, &cfError);
+    CFRelease(keySelection);
+    
+    if (dict == NULL)
+    {
+        NSError *error = (__bridge NSError *)cfError;
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to read date form cert with error %@", error);
+
+        return NULL;
+    }
+    
+    CFDictionaryRef metadata = CFDictionaryGetValue(dict, dateKey);
+    CFNumberRef value = metadata ? CFDictionaryGetValue(metadata, kSecPropertyKeyValue) : NULL;
+    
+    NSDate *date;
+    if (value != NULL)
+    {
+        CFAbsoluteTime at;
+        if (CFNumberGetValue(value, kCFNumberDoubleType, &at))
+        {
+            date = [NSDate dateWithTimeIntervalSinceReferenceDate:(NSTimeInterval)at];
+        }
+    }
+    
+    CFRelease(dict);
+    
+    return date;
+}
 
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 TBD
-* Add native message sso ext request. #1253
+* Add native message sso ext request. (#1253)
 * Added code that removes expired AT for Apple storage.
+* Filter expired certs in the certificate picker (#1278)
 
 Version 1.7.22
 * Remove references to deprecated api. (#1252)


### PR DESCRIPTION
## Proposed changes

Steps to test:

**Picker test.**
1. Make sure you have expired and valid certificates in the keychain
2. Open MSAL Mac Test App.
3. Pick: "Passed In" webview.
4. Click "acquire token"
5. Enter upn that supports CBA.
6. Pick "Sign in using x.509 certificate"
7. Make sure only unexpired certificates are shown.

**Preferred expired certificate test.**

1. Comment/remove kSecMatchValidOnDate from the query.
2. Make sure you have expired and valid certificates in the keychain.
3. Build and open MSAL Mac Test App.
4. Pick: "Passed In" webview.
5. Click "acquire token"
6. Enter upn that supports CBA.
7. Pick "Sign in using x.509 certificate"
8. Pick expired certificate
9. Uncomment/put back kSecMatchValidOnDate in the query.
10. Build MSAL Mac Test App again
11. Make sure certificate picker is shown on clicking "Sign in using x.509 certificate" (so preferred cert is ignored since it is expired)

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

