### PR TITLE
update deprecated symbol kIOMasterPortDefault

### DIFF
--- a/IdentityCore/src/MSIDDeviceId.m
+++ b/IdentityCore/src/MSIDDeviceId.m
@@ -42,8 +42,18 @@ void MSIDDeviceCopySerialNumber(CFStringRef *serialNumber)
     {
         *serialNumber = NULL;
         
-        io_service_t    platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault,
-                                                                     IOServiceMatching("IOPlatformExpertDevice"));
+        io_service_t    platformExpert;
+        if (@available(macOS 12.0, iOS 15.0, *))
+        {
+            platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+        }
+        else
+        {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+#pragma clang diagnostic pop
+        }
         
         if (platformExpert)
         {


### PR DESCRIPTION
## Proposed changes

[kIOMasterPortDefault](https://developer.apple.com/documentation/iokit/kiomasterportdefault?language=objc) was deprecated and renamed to [kIOMainPortDefault](https://developer.apple.com/documentation/iokit/kiomainportdefault?language=objc).

IDO: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2673884?src=WorkItemMention&src-action=artifact_link

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

