### PR TITLE
Do not log error when checking if key supports a signing alg

### DIFF
--- a/IdentityCore/src/util/MSIDKeyOperationUtil.m
+++ b/IdentityCore/src/util/MSIDKeyOperationUtil.m
@@ -139,7 +139,7 @@
 {
     if (error)
     {
-        *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, errorMessage, nil, nil, underlyingError, context.correlationId, nil, YES);
+        *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, errorMessage, nil, nil, underlyingError, context.correlationId, nil, NO);
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Do not log error if key doesn't support signing alg : Bug fix for https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2609499

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

