### PR TITLE
Add new broker failed to open error

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -320,6 +320,10 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     // Throttling errors
     MSIDErrorThrottleCacheNoRecord = -51900,
     MSIDErrorThrottleCacheInvalidSignature = -51901,
+    
+    // App state while failed to open broker error
+    MSIDErrorBrokerAppIsInactive = -51902,
+    MSIDErrorBrokerAppIsInBackground = -51903,
 
 };
 

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -400,6 +400,10 @@ NSString *MSIDErrorCodeToString(MSIDErrorCode errorCode)
             return @"MSIDErrorThrottleCacheNoRecord";
         case MSIDErrorThrottleCacheInvalidSignature:
             return @"MSIDErrorThrottleCacheInvalidSignature";
+        case MSIDErrorBrokerAppIsInactive:
+            return @"MSIDErrorBrokerAppIsInactive";
+        case MSIDErrorBrokerAppIsInBackground:
+            return @"MSIDErrorBrokerAppIsInBackground";
     }
     return @"Unknown";
 }

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -491,15 +491,18 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
     if (!self.fallbackController || !shouldFallbackToLocalController)
     {
         NSString *applicationState = @"";
+        MSIDErrorCode openBrokerErrorCode = MSIDErrorInternal;
         switch ([MSIDAppExtensionUtil sharedApplication].applicationState)
         {
             case UIApplicationStateActive:
                 applicationState = @"active";
                 break;
             case UIApplicationStateInactive:
+                openBrokerErrorCode = MSIDErrorBrokerAppIsInactive;
                 applicationState = @"inactive";
                 break;
             case UIApplicationStateBackground:
+                openBrokerErrorCode = MSIDErrorBrokerAppIsInBackground;
                 applicationState = @"background";
                 break;
             default:
@@ -507,7 +510,7 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
         }
         
         MSID_LOG_WITH_CTX(MSIDLogLevelWarning, self.requestParameters, @"Failed to open broker URL. Should fallback to local controller %d, Application is %@", (int)shouldFallbackToLocalController, applicationState);
-        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, [NSString stringWithFormat:@"Failed to open broker URL. Application is %@", applicationState], nil, nil, nil, nil, nil, NO);
+        NSError *error = MSIDCreateError(MSIDErrorDomain, openBrokerErrorCode, [NSString stringWithFormat:@"Failed to open broker URL. Application is %@", applicationState], nil, nil, nil, nil, nil, NO);
         if (completionBlock) completionBlock(nil, error);
         return;
     }

--- a/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
@@ -1087,7 +1087,7 @@
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
     [MSIDTestURLSession addResponse:discoveryResponse];
 
-    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable __unused result, NSError * _Nullable acquireTokenError) {
 
         if (acquireTokenError.code == MSIDErrorBrokerAppIsInactive)
         {
@@ -1131,7 +1131,7 @@
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
     [MSIDTestURLSession addResponse:discoveryResponse];
 
-    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable __unused result, NSError * _Nullable acquireTokenError) {
 
         if (acquireTokenError.code == MSIDErrorBrokerAppIsInBackground)
         {

--- a/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
@@ -51,12 +51,26 @@
 #import "MSIDTestBrokerResponseHelper.h"
 #import "NSData+MSIDExtensions.h"
 #import "MSIDTestBrokerKeyProviderHelper.h"
+#import "MSIDTestSwizzle.h"
+#import "MSIDAppExtensionUtil.h"
 
 @interface MSIDBrokerInteractiveControllerIntegrationTests : XCTestCase
 
 @end
 
 @implementation MSIDBrokerInteractiveControllerIntegrationTests
+
+- (NSMutableDictionary<NSString *, NSMutableArray<MSIDTestSwizzle *> *> *)swizzleStacks
+{
+    static dispatch_once_t once;
+    static NSMutableDictionary<NSString *, NSMutableArray<MSIDTestSwizzle *> *> *swizzleStacks = nil;
+    
+    dispatch_once(&once, ^{
+        swizzleStacks = [NSMutableDictionary new];
+    });
+    
+    return swizzleStacks;
+}
 
 - (void)setUp
 {
@@ -68,6 +82,7 @@
 
 - (void)tearDown
 {
+    [MSIDTestSwizzle resetWithSwizzleArray:[self.swizzleStacks objectForKey:self.name]];
     // Clear keychain
     NSDictionary *query = @{(id)kSecClass : (id)kSecClassKey,
                             (id)kSecAttrKeyClass : (id)kSecAttrKeyClassSymmetric};
@@ -1032,6 +1047,96 @@
         XCTAssertEqualObjects(result.accessToken, testResult.accessToken);
 
         [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+#endif
+
+#if !AD_BROKER
+- (void)testAcquireToken_whenFailedToLaunchBrokerWhileAppIsInactive_andNoFallbackController_shouldErrorOutWithCorrectCode
+{
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=mykey1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:nil];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:[self requestParameters]
+                                                                                                                 tokenRequestProvider:provider
+                                                                                                                   fallbackController:nil
+                                                                                                                                error:&error];
+    
+    MSIDTestSwizzle *swizzle = [MSIDTestSwizzle instanceMethod:@selector(applicationState)
+                              class:[UIApplication class]
+                              block:(id)^(void)
+    {
+        return UIApplicationStateInactive;
+    }];
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(NSURL *url, __unused NSDictionary<NSString *,id> *options)
+    {
+
+        XCTAssertEqualObjects(url, brokerRequestURL);
+        return NO;
+    }];
+    
+    [[self.swizzleStacks objectForKey:self.name] addObject:swizzle];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Failed with inactive error code"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+
+        if (acquireTokenError.code == MSIDErrorBrokerAppIsInactive)
+        {
+            [expectation fulfill];
+        }
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenFailedToLaunchBrokerWhileAppIsInBackground_andNoFallbackController_shouldErrorOutWithCorrectCode
+{
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=mykey1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:nil];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:[self requestParameters]
+                                                                                                                 tokenRequestProvider:provider
+                                                                                                                   fallbackController:nil
+                                                                                                                                error:&error];
+    
+    MSIDTestSwizzle *swizzle = [MSIDTestSwizzle instanceMethod:@selector(applicationState)
+                              class:[UIApplication class]
+                              block:(id)^(void)
+    {
+        return UIApplicationStateBackground;
+    }];
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(NSURL *url, __unused NSDictionary<NSString *,id> *options)
+    {
+
+        XCTAssertEqualObjects(url, brokerRequestURL);
+        return NO;
+    }];
+    
+    [[self.swizzleStacks objectForKey:self.name] addObject:swizzle];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Failed with background error code"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+
+        if (acquireTokenError.code == MSIDErrorBrokerAppIsInBackground)
+        {
+            [expectation fulfill];
+        }
     }];
 
     [self waitForExpectationsWithTimeout:1.0 handler:nil];


### PR DESCRIPTION
When legacy cannot be opened when app is in background or inactive, return a separate error code for OneAuth telemetry purpose

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

