### PR TITLE
Feature/ciam

### DIFF
--- a/IdentityCore/src/logger/MSIDLogger+Internal.h
+++ b/IdentityCore/src/logger/MSIDLogger+Internal.h
@@ -77,6 +77,18 @@
             function:(NSString *)function
               format:(NSString *)format, ... NS_FORMAT_FUNCTION(8, 9);
 
+// Same functionality as above, used for Swift to Objective-C interoperability
+// as Swift cannot call variadic functions
+- (void)logWithLevel:(MSIDLogLevel)level
+             context:(id<MSIDRequestContext>)context
+       correlationId:(NSUUID *)correlationId
+         containsPII:(BOOL)containsPII
+            filename:(NSString *)filename
+          lineNumber:(NSUInteger)lineNumber
+            function:(NSString *)function
+              format:(NSString *)format
+          formatArgs:(va_list)args;
+
 - (void)logToken:(NSString *)token
        tokenType:(NSString *)tokenType
    expiresOnDate:(NSDate *)expiresOn

--- a/IdentityCore/src/network/request_server_telemetry/MSIDAADTokenRequestServerTelemetry.m
+++ b/IdentityCore/src/network/request_server_telemetry/MSIDAADTokenRequestServerTelemetry.m
@@ -47,9 +47,14 @@
     return self;
 }
 
-- (void)handleError:(NSError *)error
+- (void)handleError:(nullable NSError *)error
             context:(id<MSIDRequestContext>)context
 {
+    if (error == nil) {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to handle telemetry. Error is nil");
+        return;
+    }
+
     NSString *errorString = [error msidServerTelemetryErrorString];
     
     [self handleError:error
@@ -57,10 +62,15 @@
               context:context];
 }
 
-- (void)handleError:(NSError *)error
+- (void)handleError:(nullable NSError *)error
         errorString:(NSString *)errorString
             context:(id<MSIDRequestContext>)context
 {
+    if (error == nil) {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to handle telemetry. Error is nil");
+        return;
+    }
+
     [self.lastRequestTelemetry updateWithApiId:self.currentRequestTelemetry.apiId
                                    errorString:errorString
                                        context:context];

--- a/IdentityCore/src/network/request_server_telemetry/MSIDHttpRequestServerTelemetryHandling.h
+++ b/IdentityCore/src/network/request_server_telemetry/MSIDHttpRequestServerTelemetryHandling.h
@@ -29,10 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol MSIDHttpRequestServerTelemetryHandling <NSObject>
 
-- (void)handleError:(NSError *)error
+- (void)handleError:(nullable NSError *)error
             context:(id<MSIDRequestContext>)context;
 
-- (void)handleError:(NSError *)error
+- (void)handleError:(nullable NSError *)error
         errorString:(NSString *)errorString
             context:(id<MSIDRequestContext>)context;
 

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
@@ -58,12 +58,12 @@
                                       configuration:(nonnull MSIDConfiguration *)configuration
                                      requestAccount:(nullable MSIDAccountIdentifier *)accountIdentifier
                                       correlationID:(nonnull NSUUID *)correlationID
-                                              error:(NSError * _Nullable * _Nullable)error;
+                                              error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
 
 - (BOOL)validateAccount:(nonnull MSIDAccountIdentifier *)accountIdentifier
             tokenResult:(nonnull MSIDTokenResult *)tokenResult
           correlationID:(nonnull NSUUID *)correlationID
-                  error:(NSError * _Nullable * _Nullable)error;
+                  error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
 
 - (BOOL)validateTokenResult:(nonnull MSIDTokenResult *)tokenResult
               configuration:(nonnull MSIDConfiguration *)configuration

--- a/IdentityCore/src/telemetry/MSIDTelemetryAPIEvent.h
+++ b/IdentityCore/src/telemetry/MSIDTelemetryAPIEvent.h
@@ -44,6 +44,7 @@
 
 - (void)setLoginHint:(NSString *)loginHint;
 - (void)setErrorCode:(NSUInteger)errorCode;
+- (void)setErrorCodeString:(NSString *)errorCode;
 - (void)setPromptType:(MSIDPromptType)promptType;
 
 - (void)setIsSuccessfulStatus:(NSString *)successStatus;

--- a/IdentityCore/src/telemetry/MSIDTelemetryAPIEvent.m
+++ b/IdentityCore/src/telemetry/MSIDTelemetryAPIEvent.m
@@ -85,6 +85,12 @@
     [self setProperty:MSID_TELEMETRY_KEY_API_ERROR_CODE value:[NSString stringWithFormat:@"%ld", (long)errorCode]];
 }
 
+- (void)setErrorCodeString:(NSString *)errorCode
+{
+    self.errorInEvent = YES;
+    [self setProperty:MSID_TELEMETRY_KEY_API_ERROR_CODE value:errorCode];
+}
+
 - (void)setPromptType:(MSIDPromptType)promptType
 {
     NSString *promptParam = MSIDPromptParamFromType(promptType);

--- a/IdentityCore/tests/MSIDLoggerTests.m
+++ b/IdentityCore/tests/MSIDLoggerTests.m
@@ -97,6 +97,11 @@
     [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
 }
 
+- (void) tearDown
+{
+    [MSIDTestLogger sharedLogger].expectation = [self expectationWithDescription:@""];
+}
+
 #pragma mark - Basic logging
 
 - (void)testLog_whenLogLevelNothingMessageValid_shouldNotThrow
@@ -108,9 +113,23 @@
     XCTAssertNotNil([MSIDTestLogger sharedLogger].lastMessage);
 }
 
+- (void)testLogArgs_whenLogLevelNothingMessageValid_shouldNotThrow
+{
+    [self keyValueObservingExpectationForObject:[MSIDTestLogger sharedLogger] keyPath:@"callbackInvoked" expectedValue:@1];
+    XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelNothing context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Message" formatArgs:nil]);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil([MSIDTestLogger sharedLogger].lastMessage);
+}
+
 - (void)testLog_whenLogLevelErrorMessageNil_shouldNotThrow
 {
     XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:nil]);
+}
+
+- (void)testLogArgs_whenLogLevelErrorMessageNil_shouldNotThrow
+{
+    XCTAssertNoThrow([[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:nil formatArgs:nil]);
 }
 
 #pragma mark - PII flag
@@ -129,6 +148,20 @@
     XCTAssertTrue(testLogger.containsPII);
 }
 
+- (void)testLogArgs_whenPiiEnabled_maskEUIINo_PiiMessage_shouldReturnMessageInCallback
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
+    MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
+    testLogger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"pii-message"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(testLogger.lastMessage);
+    XCTAssertEqual(testLogger.lastLevel, MSIDLogLevelError);
+    XCTAssertTrue(testLogger.containsPII);
+}
+
 - (void)testLog_whenPiiEnabled_maskEUIIYes_PiiMessage_shouldReturnedMaskedMessageInCallback
 {
     [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
@@ -136,6 +169,21 @@
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
     [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"%@", MSID_PII_LOG_EMAIL(@"upn@test.com")];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(testLogger.lastMessage);
+    XCTAssertTrue([testLogger.lastMessage containsString:@" auth.placeholder-8c09101e__test.com"]);
+    XCTAssertEqual(testLogger.lastLevel, MSIDLogLevelError);
+    XCTAssertTrue(testLogger.containsPII);
+}
+
+- (void)testLogArgs_whenPiiEnabled_maskEUIIYes_PiiMessage_shouldReturnedMaskedMessageInCallback
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
+    MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
+    testLogger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"%@", MSID_PII_LOG_EMAIL(@"upn@test.com")];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
@@ -159,6 +207,21 @@
     XCTAssertFalse(testLogger.containsPII);
 }
 
+- (void)testLogArgs_whenPiiEnabled_maskEUIINo_NonPiiMessage_shouldReturnSameMessageInCallback
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
+    MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
+    testLogger.expectation = [self expectationWithDescription:@"Callback Invoked 1"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"non-pii-message"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(testLogger.lastMessage);
+    XCTAssertTrue([testLogger.lastMessage containsString:@" non-pii-message"]);
+    XCTAssertEqual(testLogger.lastLevel, MSIDLogLevelError);
+    XCTAssertFalse(testLogger.containsPII);
+}
+
 - (void)testLog_whenPiiEnabled_maskEUIIYes_NonPiiMessage_shouldReturnSameMessageInCallback
 {
     [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
@@ -166,6 +229,21 @@
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
     [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"non-pii-message"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(testLogger.lastMessage);
+    XCTAssertTrue([testLogger.lastMessage containsString:@" non-pii-message"]);
+    XCTAssertEqual(testLogger.lastLevel, MSIDLogLevelError);
+    XCTAssertFalse(testLogger.containsPII);
+}
+
+- (void)testLogArgs_whenPiiEnabled_maskEUIIYes_NonPiiMessage_shouldReturnSameMessageInCallback
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
+    MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
+    testLogger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"non-pii-message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
@@ -189,6 +267,21 @@
     XCTAssertFalse(testLogger.containsPII);
 }
 
+- (void)testLogArgs_whenPiiNotEnabled_maskEUIINo_NonPiiMessage_shouldReturnSameMessageInCallback
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
+    MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
+    testLogger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"non-pii-message"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(testLogger.lastMessage);
+    XCTAssertTrue([testLogger.lastMessage containsString:@" non-pii-message"]);
+    XCTAssertEqual(testLogger.lastLevel, MSIDLogLevelError);
+    XCTAssertFalse(testLogger.containsPII);
+}
+
 - (void)testLog_whenPiiNotEnabled_maskEUIIYes_NonPiiMessage_shouldReturnSameMessageInCallback
 {
     [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
@@ -196,6 +289,21 @@
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
     [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"non-pii-message"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(testLogger.lastMessage);
+    XCTAssertTrue([testLogger.lastMessage containsString:@" non-pii-message"]);
+    XCTAssertEqual(testLogger.lastLevel, MSIDLogLevelError);
+    XCTAssertFalse(testLogger.containsPII);
+}
+
+- (void)testLogArgs_whenPiiNotEnabled_maskEUIIYes_NonPiiMessage_shouldReturnSameMessageInCallback
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
+    MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
+    testLogger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"non-pii-message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
@@ -217,6 +325,19 @@
     XCTAssertTrue([testLogger.lastMessage containsString:@"pii-message Masked(not-null)"]);
 }
 
+- (void)testLogArgs_whenPiiNotEnabled_maskEUIINo_PiiMessage_shouldInvokeCallbackWithMaskedMessage
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
+    MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
+    testLogger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"pii-message %@", MSID_PII_LOG_MASKABLE(@"test")];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(testLogger.lastMessage);
+    XCTAssertTrue([testLogger.lastMessage containsString:@"pii-message Masked(not-null)"]);
+}
+
 - (void)testLog_whenPiiNotEnabled_maskEUIIYes_PiiMessage_shouldInvokeCallbackWithMaskedMessage
 {
     [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
@@ -224,6 +345,19 @@
     
     [self keyValueObservingExpectationForObject:testLogger keyPath:@"callbackInvoked" expectedValue:@1];
     [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"pii-message %@", MSID_PII_LOG_EMAIL(@"upn@test.com")];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(testLogger.lastMessage);
+    XCTAssertTrue([testLogger.lastMessage containsString:@"pii-message auth.placeholder-8c09101e__test.com"]);
+}
+
+- (void)testLogArgs_whenPiiNotEnabled_maskEUIIYes_PiiMessage_shouldInvokeCallbackWithMaskedMessage
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
+    MSIDTestLogger *testLogger = [MSIDTestLogger sharedLogger];
+    testLogger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"pii-message %@", MSID_PII_LOG_EMAIL(@"upn@test.com")];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(testLogger.lastMessage);
@@ -246,12 +380,40 @@
     XCTAssertEqual(logger.lastLevel, MSIDLogLevelError);
 }
 
+- (void)testLogArgsErrorMacro_shouldReturnMessageNoPIIErrorLevel
+{
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Error message! %d", 0];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertFalse(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"Error message! 0"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelError);
+}
+
 - (void)testLogWarningMacro_shouldReturnMessageNoPIIWarningLevel
 {
     MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
     MSID_LOG_WITH_CTX(MSIDLogLevelWarning,nil, @"Oh no, a %@ thing happened!", @"bad");
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertFalse(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"Oh no, a bad thing happened!"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelWarning);
+}
+
+- (void)testLogArgsWarningMacro_shouldReturnMessageNoPIIWarningLevel
+{
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+
+    [self callLogArgsWithLevel:MSIDLogLevelWarning context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Oh no, a %@ thing happened!", @"bad"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(logger.lastMessage);
@@ -274,12 +436,40 @@
     XCTAssertEqual(logger.lastLevel, MSIDLogLevelInfo);
 }
 
+- (void)testLogArgsInfoMacro_shouldReturnMessageNoPIIInfoLevel
+{
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelInfo context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"This informative message has been seen %d times", 20];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertFalse(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"This informative message has been seen 20 times"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelInfo);
+}
+
 - (void)testLogVerboseMacro_shouldReturnMessageNoPIIVerboseLevel
 {
     MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
     MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,nil, @"So much noise, this message is %@ useful", @"barely");
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertFalse(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"So much noise, this message is barely useful"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelVerbose);
+}
+
+- (void)testLogArgsVerboseMacro_shouldReturnMessageNoPIIVerboseLevel
+{
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelVerbose context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"So much noise, this message is %@ useful", @"barely"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(logger.lastMessage);
@@ -303,6 +493,21 @@
     XCTAssertEqual(logger.lastLevel, MSIDLogLevelError);
 }
 
+- (void)testLogArgsErrorPiiMacro_shouldReturnMessagePIITrueErrorLevel
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"userId: %@ failed to sign in", @"user@contoso.com"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertTrue(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"userId: user@contoso.com failed to sign in"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelError);
+}
+
 - (void)testLogWarningPiiMacro_shouldReturnMessagePIITrueWarningLevel
 {
     [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
@@ -310,6 +515,21 @@
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, nil, @"%@ pressed the cancel button", @"user@contoso.com");
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertTrue(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"user@contoso.com pressed the cancel button"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelWarning);
+}
+
+- (void)testLogArgsWarningPiiMacro_shouldReturnMessagePIITrueWarningLevel
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+
+    [self callLogArgsWithLevel:MSIDLogLevelWarning context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"%@ pressed the cancel button", @"user@contoso.com"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(logger.lastMessage);
@@ -333,6 +553,21 @@
     XCTAssertEqual(logger.lastLevel, MSIDLogLevelInfo);
 }
 
+- (void)testLogArgsInfoPiiMacro_shouldReturnMessagePIITrueInfoLevel
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelInfo context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"%@ is trying to log in", @"user@contoso.com"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertTrue(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"user@contoso.com is trying to log in"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelInfo);
+}
+
 - (void)testLogVerbosePiiMacro_shouldReturnMessagePIITrueVerboseLevel
 {
     [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
@@ -340,6 +575,21 @@
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, nil, @"waiting on response from %@", @"contoso.com");
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertTrue(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"waiting on response from contoso.com"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelVerbose);
+}
+
+- (void)testLogArgsVerbosePiiMacro_shouldReturnMessagePIITrueVerboseLevel
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelVerbose context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"waiting on response from %@", @"contoso.com"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(logger.lastMessage);
@@ -363,6 +613,21 @@
     XCTAssertEqual(logger.lastLevel, MSIDLogLevelVerbose);
 }
 
+- (void)testLogArgsWithContextMacro_whenContainsPii_andPiiDisabled_shouldLogMessageWithMaskedPii
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelVerbose context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"My pii message %@, pii param %@", @"arg1", MSID_PII_LOG_MASKABLE(@"very sensitive data")];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertFalse(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"My pii message arg1, pii param Masked(not-null)"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelVerbose);
+}
+
 - (void)testLogWithContextMacro_whenContainsPii_andPiiEnabled_shouldLogMessageWithRawPii
 {
     [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
@@ -370,6 +635,21 @@
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, nil, @"My pii message %@, pii param %@", @"arg1", MSID_PII_LOG_MASKABLE(@"very sensitive data"));
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertTrue(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"My pii message arg1, pii param very sensitive data"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelVerbose);
+}
+
+- (void)testLogArgsWithContextMacro_whenContainsPii_andPiiEnabled_shouldLogMessageWithRawPii
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelVerbose context:nil correlationId:nil containsPII:YES filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"My pii message %@, pii param %@", @"arg1", MSID_PII_LOG_MASKABLE(@"very sensitive data")];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(logger.lastMessage);
@@ -393,6 +673,19 @@
     XCTAssertNil(logger.lastMessage);
 }
 
+- (void)testSetLogLevel_withLogLevelNothing_shouldNotInvokeCallback_usingArgs
+{
+    [MSIDLogger sharedLogger].level = MSIDLogLevelNothing;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    [logger.expectation setInverted:YES];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"test error message"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNil(logger.lastMessage);
+}
+
 - (void)testSetLogLevel_withLogErrorLoggingError_shouldInvokeCallback
 {
     [MSIDLogger sharedLogger].level = MSIDLogLevelError;
@@ -400,6 +693,21 @@
     
     [self keyValueObservingExpectationForObject:logger keyPath:@"callbackInvoked" expectedValue:@1];
     MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"test error message");
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertFalse(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"test error message"]);
+    XCTAssertEqual(logger.lastLevel, MSIDLogLevelError);
+}
+
+- (void)testSetLogLevel_withLogErrorLoggingError_shouldInvokeCallback_usingArgs
+{
+    [MSIDLogger sharedLogger].level = MSIDLogLevelError;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"test error message"];
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(logger.lastMessage);
@@ -420,6 +728,20 @@
     
     XCTAssertNil(logger.lastMessage);
 }
+
+- (void)testSetLogLevel_withLogErrorLoggingVerbose_shouldNotInvokeCallback_usingArgs
+{
+    [MSIDLogger sharedLogger].level = MSIDLogLevelError;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked"];
+    [logger.expectation setInverted:YES];
+    
+    [self callLogArgsWithLevel:MSIDLogLevelVerbose context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"test error message"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNil(logger.lastMessage);
+}
+
 
 #pragma mark - Logger Connector
 
@@ -470,11 +792,27 @@
     [MSIDLogger sharedLogger].level = MSIDLogLevelNothing;
     [MSIDLogger sharedLogger].loggerConnector = connectorMock;
     [self keyValueObservingExpectationForObject:connectorMock keyPath:@"logMessageValue" handler:^BOOL(id observedObject, __unused NSDictionary *change)
-    {
+     {
         return [((MSIDLoggerConnectorMock *)observedObject).logMessageValue containsString:@"some message"];
     }];
     
     [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:nil lineNumber:1 function:nil format:@"some message"];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testLogArgsWithLevel_whenConnectorIsSetAndLogQueueEnabled_shouldReturnValueFromConnector
+{
+    MSIDLoggerConnectorMock *connectorMock = [MSIDLoggerConnectorMock new];
+    connectorMock.shouldLogValue = YES;
+    connectorMock.loggingQueueEnabledValue = YES;
+    [MSIDLogger sharedLogger].level = MSIDLogLevelNothing;
+    [MSIDLogger sharedLogger].loggerConnector = connectorMock;
+    [self keyValueObservingExpectationForObject:connectorMock keyPath:@"logMessageValue" handler:^BOOL(id observedObject, __unused NSDictionary *change)
+     {
+        return [((MSIDLoggerConnectorMock *)observedObject).logMessageValue containsString:@"some message"];
+    }];
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:nil lineNumber:1 function:nil format:@"some message"];
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
@@ -487,7 +825,7 @@
     [MSIDLogger sharedLogger].level = MSIDLogLevelNothing;
     [MSIDLogger sharedLogger].loggerConnector = connectorMock;
     [self keyValueObservingExpectationForObject:connectorMock keyPath:@"logMessageValue" handler:^BOOL(id observedObject, __unused NSDictionary *change)
-    {
+     {
         return [((MSIDLoggerConnectorMock *)observedObject).logMessageValue containsString:@"some message"];
     }];
     
@@ -495,4 +833,120 @@
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
+
+- (void)testLogArgsWithLevel_whenConnectorIsSetAndLogQueueDisabled_shouldReturnValueFromConnector
+{
+    MSIDLoggerConnectorMock *connectorMock = [MSIDLoggerConnectorMock new];
+    connectorMock.shouldLogValue = YES;
+    connectorMock.loggingQueueEnabledValue = NO;
+    [MSIDLogger sharedLogger].level = MSIDLogLevelNothing;
+    [MSIDLogger sharedLogger].loggerConnector = connectorMock;
+    [self keyValueObservingExpectationForObject:connectorMock keyPath:@"logMessageValue" handler:^BOOL(id observedObject, __unused NSDictionary *change)
+     {
+        return [((MSIDLoggerConnectorMock *)observedObject).logMessageValue containsString:@"some message"];
+    }];
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:nil lineNumber:1 function:nil format:@"some message"];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+#pragma mark - Variadric and VA_List comparison tests
+
+- (void)testLogAndLogArgs_messageSameNoArguments
+{
+    [MSIDLogger sharedLogger].level = MSIDLogLevelError;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked Twice"];
+    logger.expectation.expectedFulfillmentCount = 2;
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Message"];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Message" formatArgs:nil];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    XCTAssertNotNil([logger.messages objectAtIndex:0]);
+    XCTAssertNotNil([logger.messages objectAtIndex:1]);
+    XCTAssertTrue([[logger.messages objectAtIndex:0] isEqualToString:[logger.messages objectAtIndex:1]]);
+}
+
+- (void)testLogAndLogArgs_messageSameIntArguments
+{
+    [MSIDLogger sharedLogger].level = MSIDLogLevelError;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked Twice"];
+    logger.expectation.expectedFulfillmentCount = 2;
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Count %d", 5];
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Count %d", 5];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    XCTAssertNotNil([logger.messages objectAtIndex:0]);
+    XCTAssertNotNil([logger.messages objectAtIndex:1]);
+    XCTAssertTrue([[logger.messages objectAtIndex:0] isEqualToString:[logger.messages objectAtIndex:1]]);
+}
+
+- (void)testLogAndLogArgs_messageSameStringArguments
+{
+    [MSIDLogger sharedLogger].level = MSIDLogLevelError;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked Twice"];
+    logger.expectation.expectedFulfillmentCount = 2;
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Longer message with %@ inside", @"string"];
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Longer message with %@ inside", @"string"];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    XCTAssertNotNil([logger.messages objectAtIndex:0]);
+    XCTAssertNotNil([logger.messages objectAtIndex:1]);
+    XCTAssertTrue([[logger.messages objectAtIndex:0] isEqualToString:[logger.messages objectAtIndex:1]]);
+}
+
+- (void)testLogAndLogArgs_messageSameArguments
+{
+    [MSIDLogger sharedLogger].level = MSIDLogLevelError;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked Twice"];
+    logger.expectation.expectedFulfillmentCount = 2;
+    NSDate *currentDate = [NSDate date];
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Request failed with URL: %@, parameters count %d, date: %@, request return time: %f", @"http://www.contoso.com", 20, currentDate, 0.15f];
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Request failed with URL: %@, parameters count %d, date: %@, request return time: %f", @"http://www.contoso.com", 20, currentDate, 0.15f];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    XCTAssertNotNil([logger.messages objectAtIndex:0]);
+    XCTAssertNotNil([logger.messages objectAtIndex:1]);
+    XCTAssertTrue([[logger.messages objectAtIndex:0] isEqualToString:[logger.messages objectAtIndex:1]]);
+}
+
+- (void)testLogAndLogArgs_messageSameArguments_usingMasks
+{
+    [MSIDLogger sharedLogger].level = MSIDLogLevelError;
+    MSIDTestLogger *logger = [MSIDTestLogger sharedLogger];
+    logger.expectation = [self expectationWithDescription:@"Callback Invoked Twice"];
+    logger.expectation.expectedFulfillmentCount = 2;
+    [[MSIDLogger sharedLogger] logWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Request failed with URL: %@, for user %@, for home account id %@ for email %@", MSID_PII_LOG_MASKABLE(@"http://www.contoso.com"), MSID_EUII_ONLY_LOG_MASKABLE(@"UserAccountDummy"), MSID_PII_LOG_TRACKABLE(@"HiddenHomeAccountId"), MSID_PII_LOG_EMAIL(@"user@contoso.com")];
+    [self callLogArgsWithLevel:MSIDLogLevelError context:nil correlationId:nil containsPII:NO filename:@__FILE__ lineNumber:__LINE__ function:@(__func__) format:@"Request failed with URL: %@, for user %@, for home account id %@ for email %@", MSID_PII_LOG_MASKABLE(@"http://www.contoso.com"), MSID_PII_LOG_MASKABLE(@"UserAccountDummy"), MSID_PII_LOG_TRACKABLE(@"HiddenHomeAccountId"), MSID_PII_LOG_EMAIL(@"user@contoso.com")];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    XCTAssertNotNil([logger.messages objectAtIndex:0]);
+    XCTAssertNotNil([logger.messages objectAtIndex:1]);
+    XCTAssertTrue([[logger.messages objectAtIndex:0] isEqualToString:[logger.messages objectAtIndex:1]]);
+}
+
+#pragma mark - Helper Caller
+
+- (void)callLogArgsWithLevel:(MSIDLogLevel)level
+                     context:(id<MSIDRequestContext> _Nullable)context
+               correlationId:(NSUUID * _Nullable)correlationId
+                 containsPII:(BOOL)containsPII
+                    filename:(NSString *)filename
+                  lineNumber:(NSUInteger)lineNumber
+                    function:(NSString *)function
+                      format:(NSString *)format, ... NS_FORMAT_FUNCTION(8, 9)
+{
+    va_list args;
+    va_start(args, format);
+    [[MSIDLogger sharedLogger] logWithLevel:level
+                                    context:context
+                              correlationId:correlationId
+                                containsPII:containsPII
+                                   filename:filename
+                                 lineNumber:lineNumber
+                                   function:function
+                                     format:format
+                                 formatArgs:args];
+    
+    va_end(args);
+}
+
 @end

--- a/IdentityCore/tests/util/MSIDTestLogger.h
+++ b/IdentityCore/tests/util/MSIDTestLogger.h
@@ -27,6 +27,7 @@
 
 
 #import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
 #import "MSIDLogger.h"
 
 /*!
@@ -38,7 +39,9 @@
 @property (atomic, readwrite) BOOL callbackInvoked;
 @property (atomic, readwrite) BOOL containsPII;
 @property (atomic, readwrite, retain) NSString *lastMessage;
+@property (atomic, readwrite, retain) NSMutableArray *messages;
 @property (atomic, readwrite) MSIDLogLevel lastLevel;
+@property (atomic, readwrite) XCTestExpectation *expectation;
 
 + (MSIDTestLogger *)sharedLogger;
 

--- a/IdentityCore/tests/util/MSIDTestLogger.m
+++ b/IdentityCore/tests/util/MSIDTestLogger.m
@@ -46,6 +46,9 @@
         [[MSIDLogger sharedLogger] setCallback:^(MSIDLogLevel level, NSString *message, BOOL containsPII) {
             [logger logLevel:level isPii:containsPII message:message];
             logger.callbackInvoked = YES;
+            if (![logger.expectation.description isEqualToString:@""]) {
+                [logger.expectation fulfill];
+            }
         }];
     });
     
@@ -57,6 +60,7 @@
     _lastLevel = level;
     _containsPII = isPii;
     _lastMessage = message;
+    [_messages addObject: message];
 }
 
 - (void)reset
@@ -67,6 +71,7 @@
 - (void)reset:(MSIDLogLevel)level
 {
     _lastMessage = nil;
+    _messages = [[NSMutableArray alloc] init];
     _lastLevel = -1;
     _containsPII = NO;
     [[MSIDLogger sharedLogger] setLevel:level];

--- a/IdentityCore/tests/util/network/MSIDTestURLResponse.h
+++ b/IdentityCore/tests/util/network/MSIDTestURLResponse.h
@@ -97,5 +97,6 @@
 - (BOOL)matchesURL:(NSURL *)url;
 - (BOOL)matchesBody:(NSData *)body;
 - (BOOL)matchesHeaders:(NSDictionary *)headers;
+- (void)setError:(NSError *)error;
 
 @end

--- a/IdentityCore/tests/util/network/MSIDTestURLResponse.m
+++ b/IdentityCore/tests/util/network/MSIDTestURLResponse.m
@@ -327,4 +327,9 @@
     return [NSString stringWithFormat:@"<%@: %@>", NSStringFromClass(self.class), _requestURL];
 }
 
+- (void)setError:(NSError *)error
+{
+    _error = error;
+}
+
 @end


### PR DESCRIPTION
## Proposed changes
- This PR includes the changes made in IdentityCore in order to help create the features in [PR 8551: MSAL Objective-C: Native authentication sign-up v2](https://identitydivision.visualstudio.com/Engineering/_git/devexdub-microsoft-authentication-library-for-objc/pullrequest/8551) for the Native Authentication
- Makes error passed in MSIDHttpRequestTelemetryHandling nullable.


## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [X] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

