### PR TITLE
Added ccs request id flag in token response to be consumed by OneAuth

### DIFF
--- a/IdentityCore/src/MSIDOAuth2Constants.h
+++ b/IdentityCore/src/MSIDOAuth2Constants.h
@@ -163,3 +163,6 @@ extern NSString *const MSID_PREFERRED_USERNAME_MISSING;
 
 extern NSString *const MSIDServerErrorClientMismatch;
 extern NSString *const MSIDServerErrorBadToken;
+
+extern NSString *const MSID_CCS_REQUEST_ID_KEY;
+extern NSString *const MSID_CCS_REQUEST_ID_RESPONSE;

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -163,3 +163,7 @@ NSString *const MSID_PREFERRED_USERNAME_MISSING          = @"Missing from the to
 
 NSString *const MSIDServerErrorClientMismatch            = @"client_mismatch";
 NSString *const MSIDServerErrorBadToken                  = @"bad_token";
+
+NSString *const MSID_CCS_REQUEST_ID_KEY                  = @"x-ms-ccs-requestid";
+NSString *const MSID_CCS_REQUEST_ID_RESPONSE             = @"ccs-requestid";
+

--- a/IdentityCore/src/network/response_serializer/preprocessor/MSIDAADJsonResponsePreprocessor.m
+++ b/IdentityCore/src/network/response_serializer/preprocessor/MSIDAADJsonResponsePreprocessor.m
@@ -55,6 +55,8 @@
     
     jsonObject[MSID_OAUTH2_CORRELATION_ID_RESPONSE] = httpResponse.allHeaderFields[MSID_OAUTH2_CORRELATION_ID_REQUEST_VALUE];
     
+    jsonObject[MSID_CCS_REQUEST_ID_RESPONSE] = httpResponse.allHeaderFields[MSID_CCS_REQUEST_ID_KEY];
+    
     NSString *clientTelemetry = httpResponse.allHeaderFields[MSID_OAUTH2_CLIENT_TELEMETRY];
     if (![NSString msidIsStringNilOrBlank:clientTelemetry])
     {

--- a/IdentityCore/src/oauth2/MSIDTokenResponse.h
+++ b/IdentityCore/src/oauth2/MSIDTokenResponse.h
@@ -80,6 +80,9 @@
 
 @property (nonatomic, class, readonly) MSIDProviderType providerType;
 
+// CCS Request ID if the request is served by CCS
+@property (nonatomic, nullable) NSString *ccsRequestId;
+
 - (nullable instancetype)initWithJSONDictionary:(nonnull NSDictionary *)json
                                    refreshToken:(nullable MSIDBaseToken<MSIDRefreshableToken> *)token
                                           error:(NSError * _Nullable __autoreleasing *_Nullable)error;

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.h
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.h
@@ -45,5 +45,5 @@
 // Derived properties
 @property (nonatomic, readonly, nullable) NSDate *extendedExpiresOnDate;
 @property (nonatomic, readonly, nullable) NSDate *refreshOnDate;
-
+@property (nonatomic, nullable) NSString *ccsRequestId;
 @end

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.h
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.h
@@ -45,5 +45,4 @@
 // Derived properties
 @property (nonatomic, readonly, nullable) NSDate *extendedExpiresOnDate;
 @property (nonatomic, readonly, nullable) NSDate *refreshOnDate;
-@property (nonatomic, nullable) NSString *ccsRequestId;
 @end

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
@@ -94,7 +94,7 @@
         _extendedExpiresOn = [json msidIntegerObjectForKey:@"ext_expires_on"];
         _refreshIn = [json msidIntegerObjectForKey:MSID_OAUTH2_REFRESH_IN];
         _refreshOn = [json msidIntegerObjectForKey:MSID_OAUTH2_REFRESH_ON];
-        _ccsRequestId = [json msidStringObjectForKey:MSID_CCS_REQUEST_ID_RESPONSE];
+        self.ccsRequestId = [json msidStringObjectForKey:MSID_CCS_REQUEST_ID_RESPONSE];
     }
     
     return self;

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
@@ -47,7 +47,8 @@
                              MSID_OAUTH2_REFRESH_ON,
                              @"url",
                              @"ext_expires_on",
-                             MSID_OAUTH2_SUB_ERROR];
+                             MSID_OAUTH2_SUB_ERROR,
+                             MSID_CCS_REQUEST_ID_RESPONSE];
     
     NSDictionary *additionalInfo = [additionalServerInfo msidDictionaryByRemovingFields:knownFields];
     
@@ -93,6 +94,7 @@
         _extendedExpiresOn = [json msidIntegerObjectForKey:@"ext_expires_on"];
         _refreshIn = [json msidIntegerObjectForKey:MSID_OAUTH2_REFRESH_IN];
         _refreshOn = [json msidIntegerObjectForKey:MSID_OAUTH2_REFRESH_ON];
+        _ccsRequestId = [json msidStringObjectForKey:MSID_CCS_REQUEST_ID_RESPONSE];
     }
     
     return self;
@@ -109,6 +111,7 @@
     json[MSID_OAUTH2_SUB_ERROR] = self.suberror;
     json[@"adi"] = self.additionalUserId;
     json[MSID_OAUTH2_CLIENT_INFO] = self.clientInfo.rawClientInfo;
+    json[MSID_CCS_REQUEST_ID_RESPONSE] = self.ccsRequestId;
     if (!self.error)
     {
         json[MSID_OAUTH2_EXT_EXPIRES_IN] = [@(self.extendedExpiresIn) stringValue];


### PR DESCRIPTION
## Proposed changes

Added ccs request id flag in token response to be consumed by OneAuth.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

