### PR TITLE
Teams having compiling issue due to no renaming on those macros, addi…

### DIFF
--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrokerOperationBrowserNativeMessageRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrokerOperationBrowserNativeMessageRequest.m
@@ -28,8 +28,8 @@
 #import "MSIDJsonSerializableFactory.h"
 #import "NSDictionary+MSIDExtensions.h"
 
-NSString *const BROWSER_NATIVE_MESSAGE_REQUEST_PAYLOAD_KEY = @"payload";
-NSString *const BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY = @"method";
+NSString *const MSID_BROWSER_NATIVE_MESSAGE_REQUEST_PAYLOAD_KEY = @"payload";
+NSString *const MSID_BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY = @"method";
 
 @implementation MSIDBrokerOperationBrowserNativeMessageRequest
 
@@ -40,7 +40,7 @@ NSString *const BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY = @"method";
 
 - (NSString *)method
 {
-    return self.payloadJson[BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY];
+    return self.payloadJson[MSID_BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY];
 }
 
 #pragma mark - MSIDBrokerOperationRequest
@@ -58,8 +58,8 @@ NSString *const BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY = @"method";
     
     if (self)
     {
-        if (![json msidAssertType:NSString.class ofKey:BROWSER_NATIVE_MESSAGE_REQUEST_PAYLOAD_KEY required:YES error:error]) return nil;
-        NSString *payload = json[BROWSER_NATIVE_MESSAGE_REQUEST_PAYLOAD_KEY];
+        if (![json msidAssertType:NSString.class ofKey:MSID_BROWSER_NATIVE_MESSAGE_REQUEST_PAYLOAD_KEY required:YES error:error]) return nil;
+        NSString *payload = json[MSID_BROWSER_NATIVE_MESSAGE_REQUEST_PAYLOAD_KEY];
         
         _payloadJson = [NSDictionary msidDictionaryFromJSONString:payload];
         if (!_payloadJson)
@@ -72,7 +72,7 @@ NSString *const BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY = @"method";
             return nil;
         }
         
-        if (!_payloadJson[BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY])
+        if (!_payloadJson[MSID_BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY])
         {
             if (error)
             {
@@ -92,7 +92,7 @@ NSString *const BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY = @"method";
     if (!json) return nil;
     if (!self.payloadJson) return nil;
     
-    json[BROWSER_NATIVE_MESSAGE_REQUEST_PAYLOAD_KEY] = [self.payloadJson msidJSONSerializeWithContext:nil];
+    json[MSID_BROWSER_NATIVE_MESSAGE_REQUEST_PAYLOAD_KEY] = [self.payloadJson msidJSONSerializeWithContext:nil];
     
     return json;
 }

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetCookiesRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetCookiesRequest.m
@@ -26,8 +26,8 @@
 #import "MSIDBrowserNativeMessageGetCookiesRequest.h"
 #import "MSIDJsonSerializableFactory.h"
 
-NSString *const BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_URI_KEY = @"uri";
-NSString *const BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY = @"sender";
+NSString *const MSID_BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_URI_KEY = @"uri";
+NSString *const MSID_BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY = @"sender";
 
 @implementation MSIDBrowserNativeMessageGetCookiesRequest
 
@@ -49,11 +49,11 @@ NSString *const BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY = @"sender
     
     if (self)
     {
-        if (![json msidAssertType:NSString.class ofKey:BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_URI_KEY required:YES error:error]) return nil;
-        _uri = json[BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_URI_KEY];
+        if (![json msidAssertType:NSString.class ofKey:MSID_BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_URI_KEY required:YES error:error]) return nil;
+        _uri = json[MSID_BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_URI_KEY];
         
-        if (![json msidAssertType:NSString.class ofKey:BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY required:YES error:error]) return nil;
-        _sender = json[BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY];
+        if (![json msidAssertType:NSString.class ofKey:MSID_BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY required:YES error:error]) return nil;
+        _sender = json[MSID_BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY];
     }
     
     return self;
@@ -64,10 +64,10 @@ NSString *const BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY = @"sender
     NSMutableDictionary *json = [NSMutableDictionary new];
     
     if ([NSString msidIsStringNilOrBlank:self.uri]) return nil;
-    json[BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_URI_KEY] = self.uri;
+    json[MSID_BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_URI_KEY] = self.uri;
     
     if ([NSString msidIsStringNilOrBlank:self.sender]) return nil;
-    json[BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY] = self.sender;
+    json[MSID_BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_SENDER_KEY] = self.sender;
     
     return json;
 }

--- a/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrokerOperationBrowserNativeMessageResponse.m
+++ b/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrokerOperationBrowserNativeMessageResponse.m
@@ -27,7 +27,7 @@
 #import "MSIDJsonSerializableFactory.h"
 #import "MSIDJsonSerializableTypes.h"
 
-NSString *const BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY = @"payload";
+NSString *const MSID_BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY = @"payload";
 
 @implementation MSIDBrokerOperationBrowserNativeMessageResponse
 
@@ -49,8 +49,8 @@ NSString *const BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY = @"payload";
     
     if (self)
     {
-        if (![json msidAssertType:NSString.class ofKey:BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY required:YES error:error]) return nil;
-        NSString *payload = json[BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY];
+        if (![json msidAssertType:NSString.class ofKey:MSID_BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY required:YES error:error]) return nil;
+        NSString *payload = json[MSID_BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY];
         if ([NSString msidIsStringNilOrBlank:payload])
         {
             if (error)
@@ -74,7 +74,7 @@ NSString *const BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY = @"payload";
     if (!json) return nil;
     if ([NSString msidIsStringNilOrBlank:self.payload]) return nil;
     
-    json[BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY] = self.payload;
+    json[MSID_BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY] = self.payload;
     
     return json;
 }


### PR DESCRIPTION
…ng MSID prefix

## Proposed changes

Teams are having compiling issues due to duplicate symbol after picking up 1.7.26 release. Adding MSID prefix so that OneAuth scripts can do the proper renaming 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

