### PR TITLE
Fix for nullability annotation for `MSIDBaseWebRequestConfiguration soContext` property.

### DIFF
--- a/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.h
+++ b/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 @property (nonatomic, readonly) NSString *state;
-@property (nonatomic, readonly) MSIDExternalSSOContext *ssoContext;
+@property (nullable, nonatomic, readonly) MSIDExternalSSOContext *ssoContext;
 
 // State verification
 // Set this to YES to have the request continue even at state verification failure.


### PR DESCRIPTION
Property can be initialized as nil via nullable param.

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

