### PR TITLE
Exclude telemetry logic from commoncore when building against MSAL cpp

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -87,10 +87,9 @@
 #endif
     BOOL v2GroupEntitled = [MSIDWorkPlaceJoinUtil v2AccessGroupAllowedWithContext:context];
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"v2 WPJ group is allowed %d", v2GroupEntitled);
-    
+#if !EXCLUDE_FROM_MSALCPP
     NSMutableArray *platformFields = [NSMutableArray new];
     [platformFields addObject:v2GroupEntitled ? MSID_WPJ_V2_TELEMETRY_KEY : MSID_WPJ_V1_TELEMETRY_KEY];
-#if !EXCLUDE_FROM_MSALCPP
     telemetry.platformFields = platformFields;
     NSString *currentRequestTelemetryString = [telemetry telemetryString];
     [responseReq setValue:currentRequestTelemetryString forHTTPHeaderField:MSID_CURRENT_TELEMETRY_HEADER_NAME];

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -84,10 +84,8 @@
 #if !EXCLUDE_FROM_MSALCPP
     MSIDCurrentRequestTelemetry *telemetry = [MSIDCurrentRequestTelemetry new];
     telemetry.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
-#endif
     BOOL v2GroupEntitled = [MSIDWorkPlaceJoinUtil v2AccessGroupAllowedWithContext:context];
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"v2 WPJ group is allowed %d", v2GroupEntitled);
-#if !EXCLUDE_FROM_MSALCPP
     NSMutableArray *platformFields = [NSMutableArray new];
     [platformFields addObject:v2GroupEntitled ? MSID_WPJ_V2_TELEMETRY_KEY : MSID_WPJ_V1_TELEMETRY_KEY];
     telemetry.platformFields = platformFields;

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -30,8 +30,10 @@
 #import "MSIDDeviceId.h"
 #import "MSIDConstants.h"
 #import "NSDictionary+MSIDExtensions.h"
+#if !EXCLUDE_FROM_MSALCPP
 #import "MSIDCurrentRequestTelemetry.h"
 #import "MSIDRequestTelemetryConstants.h"
+#endif
 #import "MSIDWorkPlaceJoinUtil.h"
 
 @implementation MSIDPKeyAuthHandler
@@ -79,19 +81,21 @@
     [responseReq setValue:kMSIDPKeyAuthHeaderVersion forHTTPHeaderField:kMSIDPKeyAuthHeader];
     [responseReq setValue:authHeader forHTTPHeaderField:MSID_OAUTH2_AUTHORIZATION];
     
+#if !EXCLUDE_FROM_MSALCPP
     MSIDCurrentRequestTelemetry *telemetry = [MSIDCurrentRequestTelemetry new];
     telemetry.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
-    
+#endif
     BOOL v2GroupEntitled = [MSIDWorkPlaceJoinUtil v2AccessGroupAllowedWithContext:context];
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"v2 WPJ group is allowed %d", v2GroupEntitled);
     
     NSMutableArray *platformFields = [NSMutableArray new];
     [platformFields addObject:v2GroupEntitled ? MSID_WPJ_V2_TELEMETRY_KEY : MSID_WPJ_V1_TELEMETRY_KEY];
+#if !EXCLUDE_FROM_MSALCPP
     telemetry.platformFields = platformFields;
-    
     NSString *currentRequestTelemetryString = [telemetry telemetryString];
     [responseReq setValue:currentRequestTelemetryString forHTTPHeaderField:MSID_CURRENT_TELEMETRY_HEADER_NAME];
-
+#endif
+    
     // Adding refreshTokenCredential (PRT) header to the challenge response. Header is available in customheaders dictionary
     NSString *credentialHeader = [customHeaders objectForKey:MSID_REFRESH_TOKEN_CREDENTIAL];
     if (credentialHeader)


### PR DESCRIPTION
## Proposed changes

In order to decrease the size of OneAuth, CommonCore telemetry is excluded, so does the pKeyAuth handler class.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

