### PR TITLE
Changes to handle PSSO migration from non shared to shared

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -470,6 +470,9 @@
 		23FB5C452255A11D002BF1EB /* MSIDClaimsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C24225517AA002BF1EB /* MSIDClaimsRequest.m */; };
 		23FB5C462255A135002BF1EB /* MSIDIndividualClaimRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C29225517AA002BF1EB /* MSIDIndividualClaimRequest.m */; };
 		23FB5C472255A13A002BF1EB /* MSIDIndividualClaimRequestAdditionalInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C27225517AA002BF1EB /* MSIDIndividualClaimRequestAdditionalInfo.m */; };
+		4E0BF8BF2AEB56C20076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E0BF8BE2AEB56B20076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.h */; };
+		4E0BF8C12AEB57450076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E0BF8C02AEB57450076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.m */; };
+		4E0BF8C42AEB58AE0076D740 /* MSIDExternalSSOContextTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E0BF8C22AEB58910076D740 /* MSIDExternalSSOContextTest.m */; };
 		580E25402719FD10003D1795 /* MSIDPrtHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 580E253E2719FD10003D1795 /* MSIDPrtHeader.h */; };
 		580E25412719FD10003D1795 /* MSIDPrtHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 580E253F2719FD10003D1795 /* MSIDPrtHeader.m */; };
 		580E25422719FD10003D1795 /* MSIDPrtHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 580E253F2719FD10003D1795 /* MSIDPrtHeader.m */; };
@@ -2253,6 +2256,9 @@
 		23FB5C2E22551866002BF1EB /* MSIDClaimsRequest+ClientCapabilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDClaimsRequest+ClientCapabilities.m"; sourceTree = "<group>"; };
 		23FB5C32225585E6002BF1EB /* MSIDClaimsRequestMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDClaimsRequestMock.h; sourceTree = "<group>"; };
 		23FB5C33225585E6002BF1EB /* MSIDClaimsRequestMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDClaimsRequestMock.m; sourceTree = "<group>"; };
+		4E0BF8BE2AEB56B20076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDASAuthorizationProviderExtensionLoginManagerMock.h; sourceTree = "<group>"; };
+		4E0BF8C02AEB57450076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDASAuthorizationProviderExtensionLoginManagerMock.m; sourceTree = "<group>"; };
+		4E0BF8C22AEB58910076D740 /* MSIDExternalSSOContextTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDExternalSSOContextTest.m; sourceTree = "<group>"; };
 		51E364572863C0F300A97F82 /* MSIDTelemetryConditionalCompile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryConditionalCompile.h; sourceTree = "<group>"; };
 		580E253E2719FD10003D1795 /* MSIDPrtHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDPrtHeader.h; sourceTree = "<group>"; };
 		580E253F2719FD10003D1795 /* MSIDPrtHeader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDPrtHeader.m; sourceTree = "<group>"; };
@@ -3535,6 +3541,8 @@
 				B41163B829BAC9BF00E64619 /* MSIDWKNavigationActionMock.m */,
 				B208854729ADB86100A50B88 /* MSIDExternalSSOContextMock.h */,
 				B208854829ADB86100A50B88 /* MSIDExternalSSOContextMock.m */,
+				4E0BF8BE2AEB56B20076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.h */,
+				4E0BF8C02AEB57450076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.m */,
 			);
 			path = mocks;
 			sourceTree = "<group>";
@@ -5317,6 +5325,7 @@
 				A08D09DB24A85A1C00C9193D /* MSIDRefreshTokenGrantRequestTest.m */,
 				A08D09E824A85A1E00C9193D /* MSIDSilentTokenRequestTest.m */,
 				A08D09E224A85A1D00C9193D /* MSIDTokenRequestTest.m */,
+				4E0BF8C22AEB58910076D740 /* MSIDExternalSSOContextTest.m */,
 				B2C758FE207EE58200C1FE74 /* automation */,
 				231CE9BD1FE8710A00E95D3E /* integration */,
 				B86FA7C52383748000E5195A /* mac */,
@@ -5884,6 +5893,7 @@
 				2338ECCE208A675D00809B9E /* MSIDAADRequestErrorHandler.h in Headers */,
 				B26A0B8C2071B763006BD95A /* MSIDAADV1Oauth2Factory.h in Headers */,
 				B2C708B4219A620E00D917B8 /* MSIDBrokerCryptoProvider.h in Headers */,
+				4E0BF8BF2AEB56C20076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.h in Headers */,
 				B2CDB5791FE33A46003A4B5C /* MSIDAccount.h in Headers */,
 				B2AF1D40218BD10A0080C1A0 /* MSIDRequestParameters.h in Headers */,
 				B2C7089721991D0000D917B8 /* MSIDAADV2BrokerResponse.h in Headers */,
@@ -7020,6 +7030,7 @@
 				B286B98B2389DC2F007833AD /* MSIDBrokerOperationResponse.m in Sources */,
 				238E19C52086FC38004DF483 /* MSIDHttpResponseSerializer.m in Sources */,
 				B208854B29ADB86200A50B88 /* MSIDExternalSSOContextMock.m in Sources */,
+				4E0BF8C12AEB57450076D740 /* MSIDASAuthorizationProviderExtensionLoginManagerMock.m in Sources */,
 				B286B96423861852007833AD /* MSIDSignoutWebRequestConfiguration.m in Sources */,
 				B25D495F21B3649500502BE5 /* MSIDPromptType.m in Sources */,
 				B28BDA86217E9676003E5670 /* MSIDB2CIdTokenClaims.m in Sources */,
@@ -7156,6 +7167,7 @@
 				234858DF20490EF8004FBC3C /* MSIDDefaultTokenCacheIntegrationTests.m in Sources */,
 				232C658D2138BED1002A41FE /* MSIDAADAuthorityMetadataResponseSerializerTests.m in Sources */,
 				58EB18392729BB8B00F4DD73 /* MSIDSSOExtensionGetSsoCookiesRequestTests.m in Sources */,
+				4E0BF8C42AEB58AE0076D740 /* MSIDExternalSSOContextTest.m in Sources */,
 				968871E320ACBA28009D6FC3 /* MSIDWebOAuth2ResponseTests.m in Sources */,
 				B25D496521B4BE2A00502BE5 /* MSIDRequestParametersTests.m in Sources */,
 				586CD77F293FD77200550710 /* MSIDRequestControllerFactoryTests.m in Sources */,

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
@@ -137,6 +137,8 @@
 {
     SecIdentityRef deviceIdentityRef = nil;
     
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+    
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
     if (@available(macOS 14.0, *))
     {
@@ -156,6 +158,7 @@
     }
 #else
     deviceIdentityRef =  [self.loginManager copyIdentityForKeyType:ASAuthorizationProviderExtensionKeyTypeUserDeviceSigning];
+#endif
 #endif
     
     return deviceIdentityRef;

--- a/IdentityCore/tests/MSIDExternalSSOContextTest.m
+++ b/IdentityCore/tests/MSIDExternalSSOContextTest.m
@@ -1,0 +1,123 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <XCTest/XCTest.h>
+#import "MSIDTestSwizzle.h"
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+#import "MSIDASAuthorizationProviderExtensionLoginManagerMock.h"
+#import "MSIDExternalSSOContext.h"
+
+@interface MSIDExternalSSOContextTest : XCTestCase
+
+@end
+
+@interface MSIDExternalSSOContext()
+
+- (SecIdentityRef)getPlatformSSOIdentity API_AVAILABLE(macos(13.0));
+- (BOOL)isMigrationFlagSetInLoginManager;
+
+@end
+
+@implementation MSIDExternalSSOContextTest
+
+- (void)testMSIDExternalSSOContext_testGetPlatformSSOIdentity_WhenMigration_ShouldReturnIdentityForUserSigningKey_macOS14
+{
+    if (@available(macOS 13.0, *))
+    {
+        MSIDASAuthorizationProviderExtensionLoginManagerMock *loginManagerMock = [MSIDASAuthorizationProviderExtensionLoginManagerMock alloc];
+        loginManagerMock.copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount = 0;
+        
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+        if (@available(macOS 14.0, *))
+        {
+            
+            [MSIDTestSwizzle instanceMethod:@selector(isMigrationFlagSetInLoginManager)
+                                   class:[MSIDExternalSSOContext class] block:(id)^(void)
+             {
+                return YES;
+            }];
+        }
+#endif
+        MSIDExternalSSOContext *ssoContext = [MSIDExternalSSOContext new];
+        [ssoContext setValue:loginManagerMock forKey:@"loginManager"];
+        [ssoContext getPlatformSSOIdentity];
+        
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+        if (@available(macOS 14.0, *))
+        {
+            XCTAssertEqual(loginManagerMock.copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount,1);
+        }
+        else
+        {
+            XCTAssertEqual(loginManagerMock.copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount,1);
+        }
+#else
+        XCTAssertEqual(loginManagerMock.copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount,1);
+#endif
+    }
+}
+
+
+- (void)MSIDExternalSSOContext_testGetPlatformSSOIdentity_WhenNotMigration_ShouldReturnIdentityForCurrentSigningKey_macOS14
+{
+    if (@available(macOS 13.0, *))
+    {
+        MSIDASAuthorizationProviderExtensionLoginManagerMock *loginManagerMock = [MSIDASAuthorizationProviderExtensionLoginManagerMock alloc];
+        loginManagerMock.copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount = 0;
+        loginManagerMock.copyIdentityForKeyTypeCurrentDeviceSigningKeyInvokedCount = 0;
+        
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+        if (@available(macOS 14.0, *))
+        {
+            
+            [MSIDTestSwizzle instanceMethod:@selector(isMigrationFlagSetInLoginManager)
+                                   class:[MSIDExternalSSOContext class] block:(id)^(void)
+             {
+                return NO;
+            }];
+        }
+#endif
+        MSIDExternalSSOContext *ssoContext = [MSIDExternalSSOContext new];
+        [ssoContext setValue:loginManagerMock forKey:@"loginManager"];
+        [ssoContext getPlatformSSOIdentity];
+        
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+        if (@available(macOS 14.0, *))
+        {
+            XCTAssertEqual(loginManagerMock.copyIdentityForKeyTypeCurrentDeviceSigningKeyInvokedCount,1);
+        }
+        else
+        {
+            XCTAssertEqual(loginManagerMock.copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount,1);
+        }
+#else
+        XCTAssertEqual(loginManagerMock.copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount,1);
+#endif
+    }
+}
+
+@end
+
+#endif

--- a/IdentityCore/tests/MSIDExternalSSOContextTest.m
+++ b/IdentityCore/tests/MSIDExternalSSOContextTest.m
@@ -35,7 +35,7 @@
 
 @interface MSIDExternalSSOContext()
 
-- (SecIdentityRef)getPlatformSSOIdentity API_AVAILABLE(macos(13.0));
+- (void)getPlatformSSOIdentity:(SecIdentityRef _Nullable *_Nullable)identityRef API_AVAILABLE(macos(13.0));
 - (BOOL)isMigrationFlagSetInLoginManager;
 
 @end
@@ -62,7 +62,8 @@
 #endif
         MSIDExternalSSOContext *ssoContext = [MSIDExternalSSOContext new];
         [ssoContext setValue:loginManagerMock forKey:@"loginManager"];
-        [ssoContext getPlatformSSOIdentity];
+        SecIdentityRef identityRef = nil;
+        [ssoContext getPlatformSSOIdentity:&identityRef];
         
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
         if (@available(macOS 14.0, *))

--- a/IdentityCore/tests/mocks/MSIDASAuthorizationProviderExtensionLoginManagerMock.h
+++ b/IdentityCore/tests/mocks/MSIDASAuthorizationProviderExtensionLoginManagerMock.h
@@ -1,0 +1,46 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <Foundation/Foundation.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+
+@class ASAuthorizationProviderExtensionLoginManager;
+@class ASAuthorizationProviderExtensionLoginConfiguration;
+
+API_AVAILABLE(macos(13.0))
+@interface MSIDASAuthorizationProviderExtensionLoginManagerMock : ASAuthorizationProviderExtensionLoginManager
+
+@property (nonatomic) NSInteger copyIdentityForKeyTypeInvokedCount;
+@property (nonatomic,nullable) SecIdentityRef identityRef;
+@property (nonatomic) NSInteger copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount;
+@property (nonatomic) NSInteger copyIdentityForKeyTypeCurrentDeviceSigningKeyInvokedCount;
+
+- (nullable SecIdentityRef)copyIdentityForKeyType:(ASAuthorizationProviderExtensionKeyType)keyType NS_SWIFT_NAME(identity(for:)) CF_RETURNS_RETAINED;
+
+@end
+
+#endif

--- a/IdentityCore/tests/mocks/MSIDASAuthorizationProviderExtensionLoginManagerMock.m
+++ b/IdentityCore/tests/mocks/MSIDASAuthorizationProviderExtensionLoginManagerMock.m
@@ -1,0 +1,64 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+
+#import "MSIDASAuthorizationProviderExtensionLoginManagerMock.h"
+
+
+@interface MSIDASAuthorizationProviderExtensionLoginManagerMock()
+
+@end
+
+API_AVAILABLE(macos(13.0))
+
+@implementation MSIDASAuthorizationProviderExtensionLoginManagerMock
+
+- (nullable SecIdentityRef)copyIdentityForKeyType:(ASAuthorizationProviderExtensionKeyType)keyType
+{
+    self.copyIdentityForKeyTypeInvokedCount++;
+    
+    if (keyType == ASAuthorizationProviderExtensionKeyTypeUserDeviceSigning)
+    {
+        self.copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount++;
+    }
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+    if (@available(macOS 14.0, *))
+    {
+        if (keyType == ASAuthorizationProviderExtensionKeyTypeCurrentDeviceSigning)
+        {
+            self.copyIdentityForKeyTypeCurrentDeviceSigningKeyInvokedCount++;
+        }
+    }
+#endif
+    
+    return self.identityRef;
+}
+
+@end
+
+#endif

--- a/IdentityCore/tests/mocks/MSIDASAuthorizationProviderExtensionLoginManagerMock.m
+++ b/IdentityCore/tests/mocks/MSIDASAuthorizationProviderExtensionLoginManagerMock.m
@@ -46,7 +46,7 @@ API_AVAILABLE(macos(13.0))
     {
         self.copyIdentityForKeyTypeUserDeviceSigningKeyInvokedCount++;
     }
-#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
     if (@available(macOS 14.0, *))
     {
         if (keyType == ASAuthorizationProviderExtensionKeyTypeCurrentDeviceSigning)


### PR DESCRIPTION
## Proposed changes

Changes for PSSO migration scenario from non shared device to shared device mode. We will need to use UserKeys to get the old registration keys and artifacts and use currentKeys for registration on macOS14

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

