### PR TITLE
Introduce a way to inject external WKWebviewConfiguration for MSIDWebviewUIController (needed for MSAL C++) 

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -50,6 +50,7 @@ NSWindowController
 #endif
 
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration;
++ (void)setSharedWKWebviewConfiguration:(WKWebViewConfiguration *)configuration;
 
 - (id)initWithContext:(id<MSIDRequestContext>)context;
 

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -46,6 +46,8 @@ static WKWebViewConfiguration *s_webConfig;
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+        // initialize method can never be called simultaneously with any other MSAIMSIDWebviewUIController method
+        // hence there is no need to synchronize access to s_webConfig here
         s_webConfig = [MSIDWebviewUIController defaultWKWebviewConfiguration];
     });
 }
@@ -57,6 +59,13 @@ static WKWebViewConfiguration *s_webConfig;
     webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
 
     return webConfig;
+}
+
++ (void)setSharedWKWebviewConfiguration:(WKWebViewConfiguration *)configuration
+{
+    @synchronized(self) {
+        s_webConfig = configuration;
+    }
 }
 
 - (id)initWithContext:(id<MSIDRequestContext>)context

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -43,6 +43,8 @@ static WKWebViewConfiguration *s_webConfig;
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+        // initialize method can never be called simultaneously with any other MSAIMSIDWebviewUIController method
+        // hence there is no need to synchronize access to s_webConfig here
         s_webConfig = [MSIDWebviewUIController defaultWKWebviewConfiguration];
     });
 }
@@ -57,6 +59,13 @@ static WKWebViewConfiguration *s_webConfig;
         webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
     }
     return webConfig;
+}
+
++ (void)setSharedWKWebviewConfiguration:(WKWebViewConfiguration *)configuration
+{
+    @synchronized(self) {
+        s_webConfig = configuration;
+    }
 }
 
 - (id)initWithContext:(id<MSIDRequestContext>)context

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+TBD
+* Introduce a way to inject external WKWebviewConfiguration for MSIDWebviewUIController - needed for MSAL C++ (#1308)
+
 Version 1.7.28
 * Report WPJ v2 telemetry capability. (#1297)
 * Add separate error code for OneAuth telemetry purpose (#1292)


### PR DESCRIPTION
## Proposed changes

MSAL C++ needs to isolate the local web browsing state from that of the app. We need to use non-persistent website data store, and they need to clear cookies because MSAL has "retry" UX flows that can be triggered from error page. However, it is only possible to truly "go back in time" if the cookies are cleared.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

