### PR TITLE
Veena/device hardware type

### DIFF
--- a/IdentityCore/src/MSIDDeviceId.h
+++ b/IdentityCore/src/MSIDDeviceId.h
@@ -52,6 +52,6 @@
 + (NSString *)deviceOSVersion;
 
 /*! Returns device hardware type */
-+ (NSString *)deviceHardwareType
++ (NSString *)deviceHardwareType;
 
 @end

--- a/IdentityCore/src/MSIDDeviceId.h
+++ b/IdentityCore/src/MSIDDeviceId.h
@@ -51,4 +51,7 @@
 /*! Returns OS version number */
 + (NSString *)deviceOSVersion;
 
+/*! Returns device hardware type */
++ (NSString *)deviceHardwareType
+
 @end

--- a/IdentityCore/src/MSIDDeviceId.m
+++ b/IdentityCore/src/MSIDDeviceId.m
@@ -25,6 +25,7 @@
 #import "MSIDVersion.h"
 #import "MSIDConstants.h"
 #import "MSIDOAuth2Constants.h"
+#import "sys/utsname.h"
 
 #if !TARGET_OS_IPHONE
 #include <CoreFoundation/CoreFoundation.h>
@@ -196,6 +197,15 @@ void MSIDDeviceCopySerialNumber(CFStringRef *serialNumber)
             forKey:(NSString *)key
 {
     [(NSMutableDictionary *)[self deviceId] setObject:value forKey:key];
+}
+
++ (NSString *)deviceHardwareType
+{
+    struct utsname sysinfo;
+    int retVal = uname(&sysinfo);
+    if (EXIT_SUCCESS != retVal) return nil;
+    
+    return [NSString stringWithUTF8String:sysinfo.machine];
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

Added API to read device hardware type . This will give x86_64 on Intel mac and arm64 on M1 mac

## Type of change

- [ x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

