### PR TITLE
Veena/psso use current keys

### DIFF
--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.m
@@ -41,7 +41,8 @@
             return nil;
         }
         
-        SecIdentityRef identityRef = [self.loginManager copyIdentityForKeyType:ASAuthorizationProviderExtensionKeyTypeUserDeviceSigning]; // +1
+        SecIdentityRef identityRef = nil;
+        [self getPlatformSSOIdentity:&identityRef]; // +1
         
         if (!identityRef)
         {
@@ -106,6 +107,27 @@
 #endif
     
     return nil;
+}
+
+- (void)getPlatformSSOIdentity:(SecIdentityRef _Nullable *_Nullable)identityRef API_AVAILABLE(macos(13.0))
+{
+    
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+    if (!identityRef)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"identityRef passed is nil, cannot set identity from LoginManager");
+        return;
+    }
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+    if (@available(macOS 14.0, *))
+    {
+        *identityRef =  [self.loginManager copyIdentityForKeyType:ASAuthorizationProviderExtensionKeyTypeCurrentDeviceSigning];
+        return;
+    }
+#endif
+    *identityRef =  [self.loginManager copyIdentityForKeyType:ASAuthorizationProviderExtensionKeyTypeUserDeviceSigning];
+#endif
+
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

Update code to use Current keys on macOS14. This change was added as part of the migration PR , but now since that is blocked due to Apple's bug , created a new PR to get this change in.

## Type of change

- [ x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

