### PR TITLE
Add API copyAndReplaceObjectForKey in MSIDCache

### DIFF
--- a/IdentityCore/src/MSIDCache.h
+++ b/IdentityCore/src/MSIDCache.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable ObjectType)objectForKey:(KeyType)key;
 - (nullable ObjectType)copyAndRemoveObjectForKey:(KeyType)key;
+- (nullable ObjectType)copyAndReplaceObjectForKey:(id)key withObject:(id)obj;
 
 - (void)setObject:(nullable ObjectType)obj forKey:(KeyType)key;
 

--- a/IdentityCore/src/MSIDCache.m
+++ b/IdentityCore/src/MSIDCache.m
@@ -77,6 +77,22 @@
     return object;
 }
 
+- (id)copyAndReplaceObjectForKey:(id)key
+                      withObject:(id)obj
+{
+    if (!key)
+    {
+        return nil;
+    }
+    
+    __block id objectFound;
+    dispatch_barrier_sync(self.synchronizationQueue, ^{
+        objectFound = self.container[key];
+        self.container[key] = obj;
+    });
+    return objectFound;
+}
+
 - (void)setObject:(id)obj forKey:(id)key
 {
     dispatch_barrier_sync(self.synchronizationQueue, ^{

--- a/IdentityCore/tests/MSIDCacheTests.m
+++ b/IdentityCore/tests/MSIDCacheTests.m
@@ -97,6 +97,83 @@
     XCTAssertEqualObjects(remainingObject, @"v1");
 }
 
+- (void)testCopyAndReplaceObject_whenKeyIsNil_shouldReturnNil
+{
+    MSIDCache *cache = [MSIDCache new];
+    id key = nil;
+    
+    id result = [cache copyAndReplaceObjectForKey:key withObject:@"o1"];
+    
+    XCTAssertNil(result);
+}
+
+- (void)testCopyAndReplaceObject_whenObjectDoesNotExist_shouldSetNewObject
+{
+    MSIDCache *cache = [MSIDCache new];
+    [cache setObject:@"o1" forKey:@"k1"];
+    
+    id key = @"k2";
+    id result = [cache copyAndReplaceObjectForKey:key withObject:@"o2"];
+    
+    XCTAssertNil(result);
+    XCTAssertEqual([cache count], 2);
+    id object1 = [cache objectForKey:@"k1"];
+    XCTAssertEqualObjects(object1, @"o1");
+    id object2 = [cache objectForKey:@"k2"];
+    XCTAssertEqualObjects(object2, @"o2");
+}
+
+- (void)testCopyAndReplaceObject_whenObjectExists_shouldReplaceObject
+{
+    MSIDCache *cache = [MSIDCache new];
+    [cache setObject:@"o1" forKey:@"k1"];
+    [cache setObject:@"o2" forKey:@"k2"];
+    
+    id key = @"k2";
+    id result = [cache copyAndReplaceObjectForKey:key withObject:@"o2_"];
+    
+    XCTAssertEqualObjects(result, @"o2");
+    XCTAssertEqual([cache count], 2);
+    
+    id object1 = [cache objectForKey:@"k1"];
+    XCTAssertEqualObjects(object1, @"o1");
+    id object2 = [cache objectForKey:@"k2"];
+    XCTAssertEqualObjects(object2, @"o2_");
+}
+
+- (void)testCopyAndReplaceObject_whenObjectExists_andNewObjectNil_shouldRemoveObject
+{
+    MSIDCache *cache = [MSIDCache new];
+    [cache setObject:@"o1" forKey:@"k1"];
+    [cache setObject:@"o2" forKey:@"k2"];
+    
+    id key = @"k2";
+    id obj = nil;
+    id result = [cache copyAndReplaceObjectForKey:key withObject:obj];
+    
+    XCTAssertEqualObjects(result, @"o2");
+    XCTAssertEqual([cache count], 1);
+    
+    id object1 = [cache objectForKey:@"k1"];
+    XCTAssertEqualObjects(object1, @"o1");
+}
+
+- (void)testCopyAndReplaceObject_whenObjectNotExist_andNewObjectNil_shouldDoNothing
+{
+    MSIDCache *cache = [MSIDCache new];
+    [cache setObject:@"o1" forKey:@"k1"];
+    
+    id key = @"k2";
+    id obj = nil;
+    id result = [cache copyAndReplaceObjectForKey:key withObject:obj];
+    
+    XCTAssertNil(result);
+    XCTAssertEqual([cache count], 1);
+    
+    id object1 = [cache objectForKey:@"k1"];
+    XCTAssertEqualObjects(object1, @"o1");
+}
+
 - (void)testSetObject_whenSetSuccessfully_shouldReturnSameOnObjectForKey
 {
     __auto_type cache = [MSIDCache new];


### PR DESCRIPTION
## Proposed changes

Add API `MSIDCache:copyAndReplaceObjectForKey:withObject:]` in `MSIDCache`, which is needed for fixing race condition bug in broker repo: https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/1522

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

