### PR TITLE
Update unit tests after changes on NSURL URLWithString on iOS 17

### DIFF
--- a/IdentityCore/tests/MSIDURLExtensionsTests.m
+++ b/IdentityCore/tests/MSIDURLExtensionsTests.m
@@ -45,16 +45,27 @@
 //which should have been handled by the NSURL class
 - (void)testFragmentParameters
 {
+    NSDictionary* empty = [NSDictionary new];
+    
     //Missing or invalid fragment:
     XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com"]).msidFragmentParameters);
     XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar"]).msidFragmentParameters);
-    XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com#bar=foo#"]).msidFragmentParameters);
-    XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#bar=foo#foo=bar"]).msidFragmentParameters);
-    XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#bar=foo#foo=bar#"]).msidFragmentParameters);
-    XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#        "]).msidFragmentParameters);
+    if (@available(iOS 17.0, *))
+    {
+        XCTAssertEqualObjects(@{@"bar":@"foo#"}, ((NSURL*)[NSURL URLWithString:@"https://stuff.com#bar=foo#"]).msidFragmentParameters);
+        XCTAssertEqualObjects(empty, ((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#bar=foo#foo=bar"]).msidFragmentParameters);
+        XCTAssertEqualObjects(empty, ((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#bar=foo#foo=bar#"]).msidFragmentParameters);
+        XCTAssertEqualObjects(empty, ((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#        "]).msidFragmentParameters);
+    }
+    else
+    {
+        XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com#bar=foo#"]).msidFragmentParameters);
+        XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#bar=foo#foo=bar"]).msidFragmentParameters);
+        XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#bar=foo#foo=bar#"]).msidFragmentParameters);
+        XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#        "]).msidFragmentParameters);
+    }
     
     //Valid fragment, but missing/invalid configuration:
-    NSDictionary* empty = [NSDictionary new];
     XCTAssertEqualObjects(@{@"bar":@""}, ((NSURL*)[NSURL URLWithString:@"https://stuff.com#bar"]).msidFragmentParameters);
     XCTAssertEqualObjects(@{@"bar":@""}, ((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#bar"]).msidFragmentParameters);
     XCTAssertEqualObjects(empty, ((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#bar=foo=bar"]).msidFragmentParameters);

--- a/IdentityCore/tests/MSIDURLExtensionsTests.m
+++ b/IdentityCore/tests/MSIDURLExtensionsTests.m
@@ -50,7 +50,7 @@
     //Missing or invalid fragment:
     XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com"]).msidFragmentParameters);
     XCTAssertNil(((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar"]).msidFragmentParameters);
-    if (@available(iOS 17.0, *))
+    if (@available(iOS 17.0, macOS 14.0, *))
     {
         XCTAssertEqualObjects(@{@"bar":@"foo#"}, ((NSURL*)[NSURL URLWithString:@"https://stuff.com#bar=foo#"]).msidFragmentParameters);
         XCTAssertEqualObjects(empty, ((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#bar=foo#foo=bar"]).msidFragmentParameters);

--- a/IdentityCore/tests/util/MSIDTestIdentifiers.h
+++ b/IdentityCore/tests/util/MSIDTestIdentifiers.h
@@ -40,6 +40,6 @@
 #define DEFAULT_TEST_ID_TOKEN @"id_token"
 #define DEFAULT_TEST_FAMILY_ID @"family"
 #define DEFAULT_TEST_ID_TOKEN_SUBJECT @"sub"
-#define DEFAULT_TEST_REDIRECT_SCHEME   @"msid"DEFAULT_TEST_CLIENT_ID
+#define DEFAULT_TEST_REDIRECT_SCHEME   @"msidtest-client-id"
 #define DEFAULT_TEST_REDIRECT_URI      DEFAULT_TEST_REDIRECT_SCHEME"://auth"
 #define DEFAULT_TEST_SLICE_PARAMS_DICT  @{ @"slice" : @"myslice" }


### PR DESCRIPTION
## Proposed changes

From Apple documentation: https://developer.apple.com/documentation/foundation/nsurl/1572047-urlwithstring:

> For apps linked on or after iOS 17 and aligned OS versions, [NSURL](https://developer.apple.com/documentation/foundation/nsurl) parsing has updated from the obsolete RFC 1738/1808 parsing to the same [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) parsing as [NSURLComponents](https://developer.apple.com/documentation/foundation/nsurlcomponents). This unifies the parsing behaviors of the NSURL and NSURLComponents APIs. Now, NSURL automatically percent- and IDNA-encodes invalid characters to help create a valid URL.

This change will make strings like `https://stuff.com#bar=foo#` be parsed as `https://stuff.com#bar=foo%23` where in the previous version it would return `nil`. Something to keep in mind is that this method will still validate urls and return `nil` when they are incorrect.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

