### PR TITLE
Ignore broker cache

### DIFF
--- a/IdentityCore/src/MSIDBrokerConstants.h
+++ b/IdentityCore/src/MSIDBrokerConstants.h
@@ -100,3 +100,5 @@ extern NSString * _Nonnull const MSID_EXP_RETRY_ON_NETWORK;
 extern NSString * _Nonnull const MSID_EXP_ENABLE_CONNECTION_CLOSE;
 extern NSString * _Nonnull const MSID_HTTP_CONNECTION;
 extern NSString * _Nonnull const MSID_HTTP_CONNECTION_VALUE;
+extern NSString * _Nonnull const MSID_FORCE_REFRESH_KEY;
+

--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -94,6 +94,8 @@ NSString *const MSID_PLATFORM_SSO_STATUS_KEY = @"platform_sso_status";
 NSString *const JIT_TROUBLESHOOTING_HOST = @"jit_troubleshooting";
 NSString *const MSID_IS_CALLER_MANAGED_KEY = @"isCallerAppManaged";
 NSString *const MSID_BROKER_SDM_WPJ_ATTEMPTED = @"sdm_reg_attempted";
+NSString *const MSID_FORCE_REFRESH_KEY = @"force_refresh";
+
 // Experiments
 NSString *const MSID_EXP_RETRY_ON_NETWORK = @"exp_retry_on_network";
 NSString *const MSID_EXP_ENABLE_CONNECTION_CLOSE = @"exp_enable_connection_close";

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.h
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.h
@@ -46,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *accountHomeTenantId;
 @property (nonatomic, nullable) NSString *clientSku;
 @property (nonatomic) BOOL skipValidateResultAccount;
+@property (nonatomic) BOOL forceRefresh;
 
 + (BOOL)fillRequest:(MSIDBrokerOperationTokenRequest *)request
      withParameters:(MSIDRequestParameters *)parameters

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
@@ -63,7 +63,7 @@ clientBrokerKeyCapabilityNotSupported:parameters.clientBrokerKeyCapabilityNotSup
     request.nonce = parameters.nonce;
     request.clientSku = parameters.clientSku;
     request.skipValidateResultAccount = parameters.skipValidateResultAccount;
-        
+    request.forceRefresh = parameters.forceRefresh;
     return YES;
 }
 
@@ -146,7 +146,7 @@ clientBrokerKeyCapabilityNotSupported:parameters.clientBrokerKeyCapabilityNotSup
     json[MSID_BROKER_ACCOUNT_HOME_TENANT_ID] = self.accountHomeTenantId;
     json[MSID_CLIENT_SKU_KEY] = self.clientSku;
     json[MSID_SKIP_VALIDATE_RESULT_ACCOUNT_KEY] = [@(self.skipValidateResultAccount) stringValue];
-    
+    json[MSID_FORCE_REFRESH_KEY] = [@(self.forceRefresh) stringValue];
     return json;
 }
 

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
@@ -115,6 +115,7 @@ clientBrokerKeyCapabilityNotSupported:parameters.clientBrokerKeyCapabilityNotSup
 
         _clientSku = [json msidStringObjectForKey:MSID_CLIENT_SKU_KEY];
         _skipValidateResultAccount = [json msidBoolObjectForKey:MSID_SKIP_VALIDATE_RESULT_ACCOUNT_KEY];
+        _forceRefresh = [json msidBoolObjectForKey:MSID_FORCE_REFRESH_KEY];
     }
     
     return self;

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -56,6 +56,8 @@
 @property (nonatomic) NSString *nonce;
 @property (nonatomic) NSString *clientSku;
 @property (nonatomic) BOOL skipValidateResultAccount;
+@property (nonatomic) BOOL forceRefresh;
+
 // Additional body parameters that will be appended to all token requests
 @property (nonatomic) NSDictionary *extraTokenRequestParameters;
 // Additional URL query parameters that will be added to both token and authorize requests

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.h
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.h
@@ -45,6 +45,7 @@
 @property (nonatomic, readonly, nonnull) MSIDTokenResponseValidator *tokenResponseValidator;
 @property (nonatomic, nullable) MSIDThrottlingService *throttlingService;
 @property (nonatomic) BOOL skipLocalRt;
+@property (nonatomic) BOOL forceRefresh;
 
 #if TARGET_OS_OSX && !EXCLUDE_FROM_MSALCPP
 @property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -56,7 +56,6 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
 @interface MSIDSilentTokenRequest()
 
 @property (nonatomic) MSIDRequestParameters *requestParameters;
-@property (nonatomic) BOOL forceRefresh;
 @property (nonatomic) MSIDOauth2Factory *oauthFactory;
 @property (nonatomic) MSIDTokenResponseValidator *tokenResponseValidator;
 @property (nonatomic) MSIDAccessToken *extendedLifetimeAccessToken;

--- a/IdentityCore/tests/MSIDBrokerOperationInteractiveTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationInteractiveTokenRequestTests.m
@@ -95,7 +95,7 @@
 
     NSDictionary *json = [request jsonDictionary];
     
-    XCTAssertEqual(24, json.allKeys.count);
+    XCTAssertEqual(25, json.allKeys.count);
     XCTAssertEqualObjects(json[@"authority"], @"https://login.microsoftonline.com/common");
     XCTAssertEqualObjects(json[@"broker_key"], @"broker_key_value");
     XCTAssertEqualObjects(json[@"claims"], @"{\"id_token\":{\"nickname\":null}}");
@@ -120,6 +120,7 @@
     XCTAssertEqualObjects(json[@"username"], @"user@contoso.com");
     XCTAssertEqualObjects(json[@"client_sku"], @"MSAL.iOS");
     XCTAssertEqualObjects(json[@"skip_validate_result_account"], @"0");
+    XCTAssertEqualObjects(json[@"force_refresh"], @"0");
 }
 
 - (void)testJsonDictionary_whenRequiredPropertiesSet_shouldReturnJson
@@ -140,7 +141,7 @@
     
     NSDictionary *json = [request jsonDictionary];
     
-    XCTAssertEqual(11, json.allKeys.count);
+    XCTAssertEqual(12, json.allKeys.count);
     XCTAssertEqualObjects(json[@"authority"], @"https://login.microsoftonline.com/common");
     XCTAssertEqualObjects(json[@"broker_key"], @"broker_key_value");
     XCTAssertEqualObjects(json[@"client_id"], @"client id");
@@ -149,6 +150,8 @@
     XCTAssertEqualObjects(json[@"provider_type"], @"provider_aad_v1");
     XCTAssertEqualObjects(json[@"client_sku"], @"MSAL.iOS");
     XCTAssertEqualObjects(json[@"skip_validate_result_account"], @"0");
+    XCTAssertEqualObjects(json[@"force_refresh"], @"0");
+
 }
 
 - (void)testJsonDictionary_whenBothAccountId_andTenantHintSet_shouldReturnJsonWithBoth
@@ -172,7 +175,7 @@
     
     NSDictionary *json = [request jsonDictionary];
     
-    XCTAssertEqual(14, json.allKeys.count);
+    XCTAssertEqual(15, json.allKeys.count);
     XCTAssertEqualObjects(json[@"authority"], @"https://login.microsoftonline.com/common");
     XCTAssertEqualObjects(json[@"broker_key"], @"broker_key_value");
     XCTAssertEqualObjects(json[@"client_id"], @"client id");
@@ -184,6 +187,7 @@
     XCTAssertEqualObjects(json[@"account_home_tenant_id"], @"aad.tid.hint");
     XCTAssertEqualObjects(json[@"client_sku"], @"MSAL.iOS");
     XCTAssertEqualObjects(json[@"skip_validate_result_account"], @"0");
+    XCTAssertEqualObjects(json[@"force_refresh"], @"0");
 }
 
 - (void)testInitWithJSONDictionary_whenAllProperties_shouldInitRequest

--- a/IdentityCore/tests/MSIDBrokerOperationSilentTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationSilentTokenRequestTests.m
@@ -141,10 +141,11 @@
                                                                         homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
     request.clientSku = @"MSAL.iOS";
     request.skipValidateResultAccount = YES;
-
+    request.forceRefresh = YES;
+    
     NSDictionary *json = [request jsonDictionary];
     
-    XCTAssertEqual(22, json.allKeys.count);
+    XCTAssertEqual(23, json.allKeys.count);
     XCTAssertEqualObjects(json[@"authority"], @"https://login.microsoftonline.com/common");
     XCTAssertEqualObjects(json[@"broker_key"], @"broker_key_value");
     XCTAssertEqualObjects(json[@"claims"], @"{\"id_token\":{\"nickname\":null}}");
@@ -167,6 +168,8 @@
     XCTAssertEqualObjects(json[@"username"], @"user@contoso.com");
     XCTAssertEqualObjects(json[@"client_sku"], @"MSAL.iOS");
     XCTAssertEqualObjects(json[@"skip_validate_result_account"], @"1");
+    XCTAssertEqualObjects(json[@"force_refresh"], @"1");
+
 }
 
 - (void)testJsonDictionary_whenRequiredPropertiesSet_shouldReturnJson
@@ -188,7 +191,7 @@
     
     NSDictionary *json = [request jsonDictionary];
     
-    XCTAssertEqual(12, json.allKeys.count);
+    XCTAssertEqual(13, json.allKeys.count);
     XCTAssertEqualObjects(json[@"authority"], @"https://login.microsoftonline.com/common");
     XCTAssertEqualObjects(json[@"broker_key"], @"broker_key_value");
     XCTAssertEqualObjects(json[@"client_id"], @"client id");
@@ -201,6 +204,7 @@
     XCTAssertEqualObjects(json[@"username"], @"user@contoso.com");
     XCTAssertEqualObjects(json[@"client_sku"], @"MSAL.iOS");
     XCTAssertEqualObjects(json[@"skip_validate_result_account"], @"0");
+    XCTAssertEqualObjects(json[@"force_refresh"], @"0");
 }
 
 - (void)testInitWithJSONDictionary_whenRequiredPropertiesWithHomeAccountId_shouldInitRequest

--- a/IdentityCore/tests/MSIDBrokerOperationTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationTokenRequestTests.m
@@ -111,11 +111,12 @@
     request.nonce = @"e98aba90-bc47-4ff9-8809-b6e1c7e7cd47";
     request.clientSku = @"MSAL.iOS";
     request.skipValidateResultAccount = YES;
+    request.forceRefresh = YES;
     
     NSDictionary *json = [request jsonDictionary];
     
     XCTAssertNotNil(json);
-    XCTAssertEqual(10, json.allKeys.count);
+    XCTAssertEqual(11, json.allKeys.count);
     XCTAssertEqualObjects(json[@"authority"], @"https://login.microsoftonline.com/common");
     XCTAssertEqualObjects(json[@"broker_key"], @"broker_key_value");
     XCTAssertEqualObjects(json[@"client_id"], @"client id");
@@ -127,6 +128,7 @@
     XCTAssertEqualObjects(json[@"nonce"], @"e98aba90-bc47-4ff9-8809-b6e1c7e7cd47");
     XCTAssertEqualObjects(json[@"client_sku"], @"MSAL.iOS");
     XCTAssertEqualObjects(json[@"skip_validate_result_account"], @"1");
+    XCTAssertEqualObjects(json[@"force_refresh"], @"1");
 }
 
 - (void)testInitWithJSONDictionary_whenNoProviderType_shouldReturnError
@@ -204,6 +206,7 @@
         @"authority": @"https://login.microsoftonline.com/common",
         @"redirect_uri": @"redirect uri",
         @"client_id": @"client id",
+        @"force_refresh": @"1"
     };
     
     NSError *error;

--- a/IdentityCore/tests/MSIDThrottlingServiceIntegrationTests.m
+++ b/IdentityCore/tests/MSIDThrottlingServiceIntegrationTests.m
@@ -1465,7 +1465,7 @@
       [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
       //Let's verify that request has been throttled and saved in the cache
-      NSString *expectedThumbprintKey = @"10982619437156935480";
+      NSString *expectedThumbprintKey = @"1028438298371162812";
       NSError *subError = nil;
       MSIDThrottlingCacheRecord *record = [[MSIDLRUCache sharedInstance] objectForKey:expectedThumbprintKey error:&subError];
       XCTAssertNotNil(record);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+TBD
+* Ignore local cache in broker request
+
 Version 1.7.33
 * Implement support for Custom URL Domains (CUD) for CIAM authorities (#1347)
 * Support for QR+PIN (#1317)


### PR DESCRIPTION
## Proposed changes

For silent request, allowing if client passing forceRefresh=Yes in the param will ask broker ignore token cache and using PRT to get new token
## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

