### PR TITLE
CommonCore change to support ssh-cert flow for runtime

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -517,6 +517,9 @@
 		58543C8B24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h in Headers */ = {isa = PBXBuildFile; fileRef = 58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */; };
 		586CD77E293FD77100550710 /* MSIDRequestControllerFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 586CD77B293FD76100550710 /* MSIDRequestControllerFactoryTests.m */; };
 		586CD77F293FD77200550710 /* MSIDRequestControllerFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 586CD77B293FD76100550710 /* MSIDRequestControllerFactoryTests.m */; };
+		5887EBF12BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.h in Headers */ = {isa = PBXBuildFile; fileRef = 5887EBEF2BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.h */; };
+		5887EBF22BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m in Sources */ = {isa = PBXBuildFile; fileRef = 5887EBF02BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m */; };
+		5887EBF32BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m in Sources */ = {isa = PBXBuildFile; fileRef = 5887EBF02BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m */; };
 		589842472525447B0075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898422025253FE00075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m */; };
 		58984254252544850075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898422025253FE00075DFED /* MSIDAccountMetadataCacheMockRemoveAccountMetadataForHomeAccountIdParams.m */; };
 		5898426D2525448A0075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898421025253F050075DFED /* MSIDAccountMetadataCacheMockUpdatePrincipalAccountIdParams.m */; };
@@ -2344,6 +2347,8 @@
 		585337DF272775110080935B /* MSIDSSOExtensionGetDataBaseRequest+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDSSOExtensionGetDataBaseRequest+Internal.h"; sourceTree = "<group>"; };
 		58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDMacKeychainTokenCache+Test.h"; sourceTree = "<group>"; };
 		586CD77B293FD76100550710 /* MSIDRequestControllerFactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDRequestControllerFactoryTests.m; sourceTree = "<group>"; };
+		5887EBEF2BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAuthenticationSchemeSshCert.h; sourceTree = "<group>"; };
+		5887EBF02BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAuthenticationSchemeSshCert.m; sourceTree = "<group>"; };
 		589841EF25253DF30075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h; sourceTree = "<group>"; };
 		589841F025253DF30075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountMetadataCacheMockUpdateAuthorityParameters.m; sourceTree = "<group>"; };
 		589841FF25253E9F0075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountMetadataCacheMockGetAuthorityParameters.h; sourceTree = "<group>"; };
@@ -3425,6 +3430,8 @@
 				1E36589A247EF3260044A072 /* MSIDAuthenticationSchemePop.m */,
 				1E5319A624A425B7007BCF30 /* MSIDAuthenticationScheme.h */,
 				1E5319A724A425B7007BCF30 /* MSIDAuthenticationScheme.m */,
+				5887EBEF2BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.h */,
+				5887EBF02BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m */,
 			);
 			path = auth_scheme;
 			sourceTree = "<group>";
@@ -5912,6 +5919,7 @@
 				B20657C81FC926AE00412B7D /* MSIDTelemetryHttpEvent.h in Headers */,
 				23B39A7E20990E5E000AA905 /* MSIDAuthorityResolving.h in Headers */,
 				58E2A1FC24E497400027A28A /* MSIDWebResponseOperationConstants.h in Headers */,
+				5887EBF12BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.h in Headers */,
 				B2AF1D2E218BCEDE0080C1A0 /* MSIDInteractiveTokenRequest.h in Headers */,
 				1E707FE22407337300716148 /* MSIDBrokerOperationResponse.h in Headers */,
 				B251CC48204105A7005E0179 /* MSIDBaseToken.h in Headers */,
@@ -6932,6 +6940,7 @@
 				2352AF342AA7C7B700FA2253 /* MSIDBrowserNativeMessageGetTokenResponse.m in Sources */,
 				589BDB292718F18800BF3799 /* MSIDCredentialHeader.m in Sources */,
 				B25A356F1FC4D70300C7FD43 /* MSIDLogger.m in Sources */,
+				5887EBF32BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m in Sources */,
 				B2C7088F2198E48E00D917B8 /* NSData+AES.m in Sources */,
 				96F21B3320A65896002B87C3 /* MSIDWebviewAuthorization.m in Sources */,
 				B27893832470CFE700627C28 /* MSIDAssymetricKeyGeneratorFactory.m in Sources */,
@@ -7820,6 +7829,7 @@
 				B239564927A8DF6B00684CA5 /* MSIDWPJKeyPairWithCert.m in Sources */,
 				58BC23BD271F6B9D008A77BE /* MSIDSSOExtensionGetDataBaseRequest.m in Sources */,
 				2371A6192A4BAB43008A71F3 /* MSIDBrowserNativeMessageGetCookiesResponse.m in Sources */,
+				5887EBF22BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m in Sources */,
 				B297E1DD20A0F5D600F370EC /* MSIDDefaultCredentialCacheQuery.m in Sources */,
 				60A504702374917B00648AC5 /* MSIDBrokerOperationGetAccountsResponse.m in Sources */,
 				1E37AAD4252196CC00EBED3B /* NSData+JWT.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -517,6 +517,8 @@
 		58543C8B24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h in Headers */ = {isa = PBXBuildFile; fileRef = 58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */; };
 		586CD77E293FD77100550710 /* MSIDRequestControllerFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 586CD77B293FD76100550710 /* MSIDRequestControllerFactoryTests.m */; };
 		586CD77F293FD77200550710 /* MSIDRequestControllerFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 586CD77B293FD76100550710 /* MSIDRequestControllerFactoryTests.m */; };
+		586DE2A82BC884600082137F /* MSIDAuthenticationSchemeSshCertTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 586DE2A72BC884600082137F /* MSIDAuthenticationSchemeSshCertTest.m */; };
+		586DE2A92BC884600082137F /* MSIDAuthenticationSchemeSshCertTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 586DE2A72BC884600082137F /* MSIDAuthenticationSchemeSshCertTest.m */; };
 		5887EBF12BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.h in Headers */ = {isa = PBXBuildFile; fileRef = 5887EBEF2BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.h */; };
 		5887EBF22BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m in Sources */ = {isa = PBXBuildFile; fileRef = 5887EBF02BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m */; };
 		5887EBF32BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m in Sources */ = {isa = PBXBuildFile; fileRef = 5887EBF02BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m */; };
@@ -2347,6 +2349,7 @@
 		585337DF272775110080935B /* MSIDSSOExtensionGetDataBaseRequest+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDSSOExtensionGetDataBaseRequest+Internal.h"; sourceTree = "<group>"; };
 		58543C8A24930FBC00F7AC14 /* MSIDMacKeychainTokenCache+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDMacKeychainTokenCache+Test.h"; sourceTree = "<group>"; };
 		586CD77B293FD76100550710 /* MSIDRequestControllerFactoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDRequestControllerFactoryTests.m; sourceTree = "<group>"; };
+		586DE2A72BC884600082137F /* MSIDAuthenticationSchemeSshCertTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAuthenticationSchemeSshCertTest.m; sourceTree = "<group>"; };
 		5887EBEF2BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAuthenticationSchemeSshCert.h; sourceTree = "<group>"; };
 		5887EBF02BBF6490005F9634 /* MSIDAuthenticationSchemeSshCert.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAuthenticationSchemeSshCert.m; sourceTree = "<group>"; };
 		589841EF25253DF30075DFED /* MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountMetadataCacheMockUpdateAuthorityParameters.h; sourceTree = "<group>"; };
@@ -5609,6 +5612,7 @@
 				B431B5252AF05B3F0020CD3D /* MSIDBrokerOperationPasskeyCredentialRequestTests.m */,
 				B431B5282AF05C890020CD3D /* MSIDBrokerOperationGetPasskeyAssertionResponseTests.m */,
 				B431B52B2AF19E230020CD3D /* MSIDBrokerOperationGetPasskeyCredentialResponseTests.m */,
+				586DE2A72BC884600082137F /* MSIDAuthenticationSchemeSshCertTest.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -6825,6 +6829,7 @@
 				238A04792088561100989EE0 /* MSIDHttpRequestIntegrationTests.m in Sources */,
 				B41163B929BAC9BF00E64619 /* MSIDWKNavigationActionMock.m in Sources */,
 				96928CEB2220C14600E8EA4E /* MSIDCBAWebAADAuthResponseTests.m in Sources */,
+				586DE2A82BC884600082137F /* MSIDAuthenticationSchemeSshCertTest.m in Sources */,
 				B24130DC247A1C5E002E70C4 /* MSIDPrimaryRefreshTokenTests.m in Sources */,
 				B233F8D5219FA4AD00DC90E3 /* MSIDBrokerTokenRequestTests.m in Sources */,
 				B431B53F2AF1C6BB0020CD3D /* MSIDSSOExtensionPasskeyAssertionRequestMock.m in Sources */,
@@ -7443,6 +7448,7 @@
 				B431B5302AF1BCF10020CD3D /* MSIDSSOExtensionPasskeyAssertionRequestTests.m in Sources */,
 				58E2A1F924E492C30027A28A /* MSIDWebResponseOperationFactoryTests.m in Sources */,
 				B20657D01FC92B8F00412B7D /* MSIDTelemetryUIEventTests.m in Sources */,
+				586DE2A92BC884600082137F /* MSIDAuthenticationSchemeSshCertTest.m in Sources */,
 				B2AE0FDB2427E96800B8FAF1 /* MSIDKeychainUtilTests.m in Sources */,
 				B26A0B972072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m in Sources */,
 				B208854C29ADC0FD00A50B88 /* MSIDPkeyAuthHelperTests.m in Sources */,

--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -83,6 +83,7 @@ typedef NS_ENUM(NSInteger, MSIDAuthScheme)
 {
     MSIDAuthSchemeBearer,
     MSIDAuthSchemePop,
+    MSIDAuthSchemeSshCert,
 };
 
 typedef NS_ENUM(NSInteger, MSIDHeaderType)

--- a/IdentityCore/src/MSIDOAuth2Constants.h
+++ b/IdentityCore/src/MSIDOAuth2Constants.h
@@ -30,6 +30,7 @@ extern NSString *const MSID_OAUTH2_AUTHORIZATION_URI;
 extern NSString *const MSID_OAUTH2_AUTHORITY;
 extern NSString *const MSID_OAUTH2_BEARER;
 extern NSString *const MSID_OAUTH2_POP;
+extern NSString *const MSID_OAUTH2_SSH_CERT;
 extern NSString *const MSID_OAUTH2_CLIENT_ID;
 extern NSString *const MSID_OAUTH2_CLAIMS;
 extern NSString *const MSID_OAUTH2_CODE;

--- a/IdentityCore/src/MSIDOAuth2Constants.h
+++ b/IdentityCore/src/MSIDOAuth2Constants.h
@@ -68,6 +68,7 @@ extern NSString *const MSID_OAUTH2_PROMPT_NONE;
 extern NSString *const MSID_OAUTH2_SIGNOUT_REDIRECT_URI;
 extern NSString *const MSID_OAUTH2_REQUEST_CONFIRMATION;
 extern NSString *const MSID_OAUTH2_REQUEST_ENDPOINT;
+extern NSString *const MSID_OAUTH2_SSH_CERT_KEY_ID;
 
 extern NSString *const MSID_OAUTH2_EXPIRES_ON;
 extern NSString *const MSID_OAUTH2_EXT_EXPIRES_IN;

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -32,6 +32,7 @@ NSString *const MSID_OAUTH2_AUTHORIZATION_CODE = @"authorization_code";
 NSString *const MSID_OAUTH2_AUTHORIZATION_URI  = @"authorization_uri";
 NSString *const MSID_OAUTH2_BEARER             = @"Bearer";
 NSString *const MSID_OAUTH2_POP                = @"Pop";
+NSString *const MSID_OAUTH2_SSH_CERT           = @"ssh-cert";
 NSString *const MSID_OAUTH2_CLIENT_ID          = @"client_id";
 NSString *const MSID_OAUTH2_CLAIMS             = @"claims";
 NSString *const MSID_OAUTH2_CODE               = @"code";

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -68,6 +68,7 @@ NSString *const MSID_OAUTH2_PROMPT_NONE         = @"none";
 NSString *const MSID_OAUTH2_SIGNOUT_REDIRECT_URI    = @"post_logout_redirect_uri";
 NSString *const MSID_OAUTH2_REQUEST_CONFIRMATION = @"req_cnf";
 NSString *const MSID_OAUTH2_REQUEST_ENDPOINT = @"endpointUrl";
+NSString *const MSID_OAUTH2_SSH_CERT_KEY_ID = @"key_id";
 
 NSString *const MSID_OAUTH2_EXPIRES_ON          = @"expires_on";
 NSString *const MSID_OAUTH2_REFRESH_IN          = @"refresh_in";

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.h
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.h
@@ -1,3 +1,4 @@
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -19,34 +20,15 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-#import "MSIDAuthScheme.h"
 
-NSString * MSIDAuthSchemeParamFromType(MSIDAuthScheme type)
-{
-    switch (type) {
-        case MSIDAuthSchemePop:
-            return @"Pop";
-        case MSIDAuthSchemeBearer:
-            return @"Bearer";
-        case MSIDAuthSchemeSshCert:
-            return @"SshCert";
-        default:
-            return @"Bearer";
-    }
-}
+#import "MSIDAuthenticationScheme.h"
 
-MSIDAuthScheme MSIDAuthSchemeTypeFromString(NSString *authSchemeString)
-{
-    if ([authSchemeString isEqualToString:@"Pop"])
-    {
-        return MSIDAuthSchemePop;
-    }
-    else if ([authSchemeString isEqualToString:@"Bearer"])
-    {
-        return MSIDAuthSchemeBearer;
-    }
+NS_ASSUME_NONNULL_BEGIN
 
-    return MSIDAuthSchemeBearer;
-}
+@interface MSIDAuthenticationSchemeSshCert : MSIDAuthenticationScheme
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
@@ -26,6 +26,7 @@
 #import "MSIDAuthenticationSchemeSshCert.h"
 #import "MSIDJsonSerializableFactory.h"
 #import "MSIDAuthScheme.h"
+#import "MSIDAccessTokenWithAuthScheme.h"
 
 @interface MSIDAuthenticationSchemeSshCert()
 
@@ -149,6 +150,19 @@
     json[MSID_OAUTH2_SSH_CERT_KEY_ID] = self.key_id;
     
     return json;
+}
+
+- (MSIDCredentialType)credentialType
+{
+    return MSIDAccessTokenWithAuthSchemeType;
+}
+
+- (MSIDAccessToken *)accessToken
+{
+    MSIDAccessTokenWithAuthScheme *accessToken = [MSIDAccessTokenWithAuthScheme new];
+    accessToken.tokenType = self.tokenType;
+    accessToken.kid = self.key_id;
+    return accessToken;
 }
 
 - (id)copyWithZone:(NSZone *)zone

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
@@ -1,3 +1,4 @@
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -19,34 +20,33 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
+
+#import "MSIDAuthenticationSchemeSshCert.h"
+#import "MSIDJsonSerializableFactory.h"
 #import "MSIDAuthScheme.h"
 
-NSString * MSIDAuthSchemeParamFromType(MSIDAuthScheme type)
+@implementation MSIDAuthenticationSchemeSshCert
+
++ (void)load
 {
-    switch (type) {
-        case MSIDAuthSchemePop:
-            return @"Pop";
-        case MSIDAuthSchemeBearer:
-            return @"Bearer";
-        case MSIDAuthSchemeSshCert:
-            return @"SshCert";
-        default:
-            return @"Bearer";
-    }
+    [MSIDJsonSerializableFactory registerClass:self forClassType:MSIDAuthSchemeParamFromType(MSIDAuthSchemeSshCert)];
 }
 
-MSIDAuthScheme MSIDAuthSchemeTypeFromString(NSString *authSchemeString)
+- (MSIDCredentialType)credentialType
 {
-    if ([authSchemeString isEqualToString:@"Pop"])
-    {
-        return MSIDAuthSchemePop;
-    }
-    else if ([authSchemeString isEqualToString:@"Bearer"])
-    {
-        return MSIDAuthSchemeBearer;
-    }
-
-    return MSIDAuthSchemeBearer;
+    return MSIDCredentialTypeOther;
 }
+
+- (NSString *)tokenType
+{
+    return MSIDAuthSchemeParamFromType(self.authScheme);
+}
+
+- (MSIDAuthScheme)authSchemeFromParameters:(__unused NSDictionary *)schemeParameters
+{
+    return MSIDAuthSchemeSshCert;
+}
+
+@end

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
@@ -105,7 +105,7 @@
         return nil;
     }
     
-    NSString *keyId = json[@"keyId"];
+    NSString *keyId = json[@"key_id"];
     if ([NSString msidIsStringNilOrBlank:authScheme])
     {
         NSString *message = [NSString stringWithFormat:@"Failed to init %@ from json: key_id is nil", self.class];
@@ -113,7 +113,7 @@
         return nil;
     }
     
-    [schemeParameters setObject:keyId forKey:@"keyId"];
+    [schemeParameters setObject:keyId forKey:@"key_id"];
     [schemeParameters setObject:requestConf forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
     [schemeParameters setObject:authScheme forKey:MSID_OAUTH2_TOKEN_TYPE];
     
@@ -148,6 +148,14 @@
     json[@"key_id"] = self.keyId;
     
     return json;
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MSIDAuthenticationSchemeSshCert *authScheme = [super copyWithZone:zone];
+    authScheme->_keyId = [_keyId copyWithZone:zone];
+    authScheme->_req_cnf = [_req_cnf copyWithZone:zone];
+    return authScheme;
 }
 
 @end

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
@@ -60,10 +60,10 @@
             return nil;
         }
         
-        _keyId = [_schemeParameters msidObjectForKey:@"key_id" ofClass:[NSString class]];
+        _keyId = [_schemeParameters msidObjectForKey:MSID_OAUTH2_SSH_CERT_KEY_ID ofClass:[NSString class]];
         if ([NSString msidIsStringNilOrBlank:_keyId])
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to read _keyId from scheme parameters.");
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to read key_id from scheme parameters.");
             return nil;
         }
     }
@@ -105,7 +105,7 @@
         return nil;
     }
     
-    NSString *keyId = json[@"key_id"];
+    NSString *keyId = json[MSID_OAUTH2_SSH_CERT_KEY_ID];
     if ([NSString msidIsStringNilOrBlank:authScheme])
     {
         NSString *message = [NSString stringWithFormat:@"Failed to init %@ from json: key_id is nil", self.class];
@@ -113,7 +113,7 @@
         return nil;
     }
     
-    [schemeParameters setObject:keyId forKey:@"key_id"];
+    [schemeParameters setObject:keyId forKey:MSID_OAUTH2_SSH_CERT_KEY_ID];
     [schemeParameters setObject:requestConf forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
     [schemeParameters setObject:authScheme forKey:MSID_OAUTH2_TOKEN_TYPE];
     
@@ -141,11 +141,11 @@
     
     if ([NSString msidIsStringNilOrBlank:self.keyId])
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create json for %@: req_cnf is nil.", self.class);
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create json for %@: key_id is nil.", self.class);
         return nil;
     }
     
-    json[@"key_id"] = self.keyId;
+    json[MSID_OAUTH2_SSH_CERT_KEY_ID] = self.keyId;
     
     return json;
 }

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
@@ -29,7 +29,7 @@
 
 @interface MSIDAuthenticationSchemeSshCert()
 
-@property (nonatomic) NSString *keyId;
+@property (nonatomic) NSString *key_id;
 @property (nonatomic) NSString *req_cnf;
 
 @end
@@ -60,8 +60,8 @@
             return nil;
         }
         
-        _keyId = [_schemeParameters msidObjectForKey:MSID_OAUTH2_SSH_CERT_KEY_ID ofClass:[NSString class]];
-        if ([NSString msidIsStringNilOrBlank:_keyId])
+        _key_id = [_schemeParameters msidObjectForKey:MSID_OAUTH2_SSH_CERT_KEY_ID ofClass:[NSString class]];
+        if ([NSString msidIsStringNilOrBlank:_key_id])
         {
             MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to read key_id from scheme parameters.");
             return nil;
@@ -71,19 +71,20 @@
     return self;
 }
 
-- (MSIDCredentialType)credentialType
-{
-    return MSIDCredentialTypeOther;
-}
-
 - (NSString *)tokenType
 {
     return MSIDAuthSchemeParamFromType(self.authScheme);
 }
 
-- (MSIDAuthScheme)authSchemeFromParameters:(__unused NSDictionary *)schemeParameters
+- (MSIDAuthScheme)authSchemeFromParameters:(NSDictionary *)schemeParameters
 {
-    return MSIDAuthSchemeSshCert;
+    NSString *scheme = [schemeParameters msidObjectForKey:MSID_OAUTH2_TOKEN_TYPE ofClass:[NSString class]];
+    if (!scheme)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to read auth_scheme from scheme parameters.");
+    }
+    
+    return MSIDAuthSchemeTypeFromString(scheme);
 }
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
@@ -106,7 +107,7 @@
     }
     
     NSString *keyId = json[MSID_OAUTH2_SSH_CERT_KEY_ID];
-    if ([NSString msidIsStringNilOrBlank:authScheme])
+    if ([NSString msidIsStringNilOrBlank:keyId])
     {
         NSString *message = [NSString stringWithFormat:@"Failed to init %@ from json: key_id is nil", self.class];
         if (error) *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, message, nil, nil, nil, nil, nil, YES);
@@ -139,13 +140,13 @@
     
     json[MSID_OAUTH2_REQUEST_CONFIRMATION] = self.req_cnf;
     
-    if ([NSString msidIsStringNilOrBlank:self.keyId])
+    if ([NSString msidIsStringNilOrBlank:self.key_id])
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create json for %@: key_id is nil.", self.class);
         return nil;
     }
     
-    json[MSID_OAUTH2_SSH_CERT_KEY_ID] = self.keyId;
+    json[MSID_OAUTH2_SSH_CERT_KEY_ID] = self.key_id;
     
     return json;
 }
@@ -153,7 +154,7 @@
 - (id)copyWithZone:(NSZone *)zone
 {
     MSIDAuthenticationSchemeSshCert *authScheme = [super copyWithZone:zone];
-    authScheme->_keyId = [_keyId copyWithZone:zone];
+    authScheme->_key_id = [_key_id copyWithZone:zone];
     authScheme->_req_cnf = [_req_cnf copyWithZone:zone];
     return authScheme;
 }

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -47,6 +47,7 @@
 #import "MSIDLastRequestTelemetry.h"
 #import "MSIDCurrentRequestTelemetry.h"
 #import "MSIDAADTokenRequestServerTelemetry.h"
+#import "MSIDAuthenticationScheme.h"
 
 @implementation MSIDAADV2Oauth2Factory
 
@@ -148,6 +149,11 @@
     if (![NSString msidIsStringNilOrBlank:configuration.nestedAuthBrokerClientId])
     {
         accessToken.redirectUri = configuration.redirectUri;
+    }
+    
+    if ([MSID_OAUTH2_SSH_CERT isEqualToString:configuration.authScheme.tokenType])
+    {
+        accessToken.tokenType = configuration.authScheme.tokenType;
     }
 
     return YES;

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -151,9 +151,10 @@
         accessToken.redirectUri = configuration.redirectUri;
     }
     
+    // Map token_type as "ssh-cert" flow for Azure CLI
     if ([MSID_OAUTH2_SSH_CERT isEqualToString:configuration.authScheme.tokenType])
     {
-        accessToken.tokenType = configuration.authScheme.tokenType;
+        accessToken.tokenType = MSID_OAUTH2_SSH_CERT;
     }
 
     return YES;

--- a/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
@@ -152,6 +152,7 @@
     NSDictionary *schemeParameters = self.requestParameters.authScheme.schemeParameters;
     NSString *tokenType = schemeParameters[MSID_OAUTH2_TOKEN_TYPE];
     NSString *requestConf = schemeParameters[MSID_OAUTH2_REQUEST_CONFIRMATION];
+    NSString *keyId = schemeParameters[MSID_OAUTH2_SSH_CERT_KEY_ID];
     
     NSMutableDictionary *queryDictionary = [NSMutableDictionary new];
     [queryDictionary msidSetNonEmptyString:self.requestParameters.authority.url.absoluteString forKey:@"authority"];
@@ -172,6 +173,7 @@
     [queryDictionary msidSetNonEmptyString:self.brokerApplicationToken forKey:@"application_token"];
     [queryDictionary msidSetNonEmptyString:tokenType forKey:MSID_OAUTH2_TOKEN_TYPE];
     [queryDictionary msidSetNonEmptyString:requestConf forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
+    [queryDictionary msidSetNonEmptyString:keyId forKey:MSID_OAUTH2_SSH_CERT_KEY_ID];
     
     if ([self.sdkBrokerCapabilities count])
     {
@@ -206,8 +208,10 @@
     NSDictionary *schemeParameters = self.requestParameters.authScheme.schemeParameters;
     NSString *tokenType = schemeParameters[MSID_OAUTH2_TOKEN_TYPE];
     NSString *requestConf = schemeParameters[MSID_OAUTH2_REQUEST_CONFIRMATION];
+    NSString *keyId = schemeParameters[MSID_OAUTH2_SSH_CERT_KEY_ID];
     [resumeDictionary msidSetNonEmptyString:tokenType forKey:MSID_OAUTH2_TOKEN_TYPE];
     [resumeDictionary msidSetNonEmptyString:requestConf forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
+    [resumeDictionary msidSetNonEmptyString:keyId forKey:MSID_OAUTH2_SSH_CERT_KEY_ID];
     
     if ([self.requestParameters isNestedAuthProtocol])
     {

--- a/IdentityCore/src/util/MSIDAuthScheme.m
+++ b/IdentityCore/src/util/MSIDAuthScheme.m
@@ -31,7 +31,7 @@ NSString * MSIDAuthSchemeParamFromType(MSIDAuthScheme type)
         case MSIDAuthSchemeBearer:
             return @"Bearer";
         case MSIDAuthSchemeSshCert:
-            return @"SshCert";
+            return @"ssh-cert";
         default:
             return @"Bearer";
     }
@@ -46,6 +46,10 @@ MSIDAuthScheme MSIDAuthSchemeTypeFromString(NSString *authSchemeString)
     else if ([authSchemeString isEqualToString:@"Bearer"])
     {
         return MSIDAuthSchemeBearer;
+    }
+    else if ([authSchemeString isEqualToString:@"ssh-cert"])
+    {
+        return MSIDAuthSchemeSshCert;
     }
 
     return MSIDAuthSchemeBearer;

--- a/IdentityCore/tests/MSIDAuthenticationSchemeSshCertTest.m
+++ b/IdentityCore/tests/MSIDAuthenticationSchemeSshCertTest.m
@@ -131,7 +131,7 @@
     XCTAssertNotNil([scheme valueForKey:MSID_OAUTH2_SSH_CERT_KEY_ID]);
     XCTAssertNotNil([scheme valueForKey:MSID_OAUTH2_REQUEST_CONFIRMATION]);
     XCTAssertEqual(scheme.authScheme, MSIDAuthSchemeSshCert);
-    XCTAssertEqual(scheme.credentialType, MSIDAccessTokenType);
+    XCTAssertEqual(scheme.credentialType, MSIDAccessTokenWithAuthSchemeType);
     XCTAssertEqual(scheme.tokenType, MSID_OAUTH2_SSH_CERT);
 }
 

--- a/IdentityCore/tests/MSIDAuthenticationSchemeSshCertTest.m
+++ b/IdentityCore/tests/MSIDAuthenticationSchemeSshCertTest.m
@@ -1,0 +1,138 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <XCTest/XCTest.h>
+#import "MSIDAuthenticationSchemeSshCert.h"
+
+@interface MSIDAuthenticationSchemeSshCertTest : XCTestCase
+
+@end
+
+@implementation MSIDAuthenticationSchemeSshCertTest
+
+- (void)test_InitWithCorrectParams_shouldReturnCompleteScheme
+{
+    MSIDAuthenticationSchemeSshCert *scheme = [[MSIDAuthenticationSchemeSshCert alloc] initWithSchemeParameters:[self prepareSshCertSchemeParameter]];
+    [self test_assertDefaultAttributesInScheme:scheme];
+}
+
+- (void)test_InitWithInCorrectTokenType_shouldReturnNil
+{
+    MSIDAuthenticationSchemeSshCert *scheme = [[MSIDAuthenticationSchemeSshCert alloc] initWithSchemeParameters:[self prepareSshCertSchemeParameter_incorrectTokenType]];
+    XCTAssertNil(scheme);
+}
+
+
+- (void)test_InitWithMissingTokenType_shouldReturnNil
+{
+    NSDictionary *json = [self prepareSshCertSchemeParameter_missingTokenType];
+    NSError *error = nil;
+    MSIDAuthenticationSchemeSshCert *scheme = [[MSIDAuthenticationSchemeSshCert alloc] initWithJSONDictionary:json error:&error];
+    XCTAssertNil(scheme);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
+}
+
+- (void)test_InitWithMissingReqConf_shouldReturnNil
+{
+    MSIDAuthenticationSchemeSshCert *scheme = [[MSIDAuthenticationSchemeSshCert alloc] initWithSchemeParameters:[self prepareSshCertSchemeParameter_missingRequestConf]];
+    XCTAssertNil(scheme);
+}
+
+- (void)test_InitWithMissingKeyId_shouldReturnNil
+{
+    NSDictionary *json = [self prepareSshCertSchemeParameter_missingKeyId];
+    NSError *error = nil;
+    MSIDAuthenticationSchemeSshCert *scheme = [[MSIDAuthenticationSchemeSshCert alloc] initWithJSONDictionary:json error:&error];
+    XCTAssertNil(scheme);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
+}
+
+- (NSDictionary *)prepareSshCertSchemeParameter
+{
+    NSMutableDictionary *params = [NSMutableDictionary new];
+    [params setObject:@"ssh-cert" forKey:MSID_OAUTH2_TOKEN_TYPE];
+    [params setObject:@"key_id_value" forKey:MSID_OAUTH2_SSH_CERT_KEY_ID];
+    NSString *modulus = @"2tNr73xwcj6lH7bqRZrFzgSLj7OeLfbn8";
+    NSString *exponent = @"AQAB";
+    [params setObject:[NSString stringWithFormat:@"{\"kty\":\"RSA\", \"n\":\" + %@ + \", \"e\":\" + %@ + \"}", modulus, exponent] forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
+    return params;
+}
+
+- (NSDictionary *)prepareSshCertSchemeParameter_incorrectTokenType
+{
+    NSMutableDictionary *params = [NSMutableDictionary new];
+    [params setObject:@"ssh_cert" forKey:MSID_OAUTH2_TOKEN_TYPE];
+    [params setObject:@"key_id_value" forKey:MSID_OAUTH2_SSH_CERT_KEY_ID];
+    NSString *modulus = @"2tNr73xwcj6lH7bqRZrFzgSLj7OeLfbn8";
+    NSString *exponent = @"AQAB";
+    [params setObject:[NSString stringWithFormat:@"{\"kty\":\"RSA\", \"n\":\" + %@ + \", \"e\":\" + %@ + \"}", modulus, exponent] forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
+    return params;
+}
+
+- (NSDictionary *)prepareSshCertSchemeParameter_missingRequestConf
+{
+    NSMutableDictionary *params = [NSMutableDictionary new];
+    [params setObject:@"ssh-cert" forKey:MSID_OAUTH2_TOKEN_TYPE];
+    [params setObject:@"key_id_value" forKey:MSID_OAUTH2_SSH_CERT_KEY_ID];
+    NSString *modulus = @"2tNr73xwcj6lH7bqRZrFzgSLj7OeLfbn8";
+    NSString *exponent = @"AQAB";
+    [params setObject:[NSString stringWithFormat:@"{\"kty\":\"RSA\", \"n\":\" + %@ + \", \"e\":\" + %@ + \"}", modulus, exponent] forKey:@"req_cnf_1"];
+    return params;
+}
+
+- (NSDictionary *)prepareSshCertSchemeParameter_missingTokenType
+{
+    NSMutableDictionary *params = [NSMutableDictionary new];
+    [params setObject:@"ssh-cert" forKey:@"token_type1"];
+    [params setObject:@"key_id_value" forKey:MSID_OAUTH2_SSH_CERT_KEY_ID];
+    NSString *modulus = @"2tNr73xwcj6lH7bqRZrFzgSLj7OeLfbn8";
+    NSString *exponent = @"AQAB";
+    [params setObject:[NSString stringWithFormat:@"{\"kty\":\"RSA\", \"n\":\" + %@ + \", \"e\":\" + %@ + \"}", modulus, exponent] forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
+    return params;
+}
+
+- (NSDictionary *)prepareSshCertSchemeParameter_missingKeyId
+{
+    NSMutableDictionary *params = [NSMutableDictionary new];
+    [params setObject:@"ssh-cert" forKey:@"token_type"];
+    [params setObject:@"key_id_value" forKey:@"key_id_1"];
+    NSString *modulus = @"2tNr73xwcj6lH7bqRZrFzgSLj7OeLfbn8";
+    NSString *exponent = @"AQAB";
+    [params setObject:[NSString stringWithFormat:@"{\"kty\":\"RSA\", \"n\":\" + %@ + \", \"e\":\" + %@ + \"}", modulus, exponent] forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
+    return params;
+}
+
+- (void)test_assertDefaultAttributesInScheme:(MSIDAuthenticationSchemeSshCert *)scheme
+{
+    XCTAssertNotNil([scheme valueForKey:MSID_OAUTH2_SSH_CERT_KEY_ID]);
+    XCTAssertNotNil([scheme valueForKey:MSID_OAUTH2_REQUEST_CONFIRMATION]);
+    XCTAssertEqual(scheme.authScheme, MSIDAuthSchemeSshCert);
+    XCTAssertEqual(scheme.credentialType, MSIDAccessTokenType);
+    XCTAssertEqual(scheme.tokenType, MSID_OAUTH2_SSH_CERT);
+}
+
+@end

--- a/IdentityCore/tests/MSIDInteractiveTokenRequestParametersTests.m
+++ b/IdentityCore/tests/MSIDInteractiveTokenRequestParametersTests.m
@@ -29,6 +29,7 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDTestIdentifiers.h"
 #import "MSIDConfiguration.h"
+#import "MSIDAuthenticationSchemeSshCert.h"
 
 @interface MSIDInteractiveTokenRequestParametersTests : XCTestCase
 
@@ -44,6 +45,11 @@
 - (void)testInitWithAllSupportedParameters_shouldInitialize_returnNilError_Bearerflow
 {
     [self testInitWithAllSupportedParameters_shouldInitialize_returnNilError:[MSIDAuthenticationScheme new]];
+}
+
+- (void)testInitWithAllSupportedParameters_shouldInitialize_returnNilError_SshCertflow
+{
+    [self testInitWithAllSupportedParameters_shouldInitialize_returnNilError:[MSIDAuthenticationSchemeSshCert new]];
 }
 
 - (void)testInitWithAllSupportedParameters_shouldInitialize_returnNilError:(MSIDAuthenticationScheme *)authScheme

--- a/IdentityCore/tests/MSIDRequestParametersTests.m
+++ b/IdentityCore/tests/MSIDRequestParametersTests.m
@@ -28,6 +28,7 @@
 #import "NSString+MSIDTestUtil.h"
 #import "MSIDAuthenticationScheme.h"
 #import "MSIDAuthenticationSchemePop.h"
+#import "MSIDAuthenticationSchemeSshCert.h"
 #import "MSIDAccountIdentifier.h"
 
 @interface MSIDRequestParametersTests : XCTestCase
@@ -41,6 +42,7 @@
 {
     [self testInitParameters_withValidParameters_shouldInitReturnNonNil_withAuthScheme:[MSIDAuthenticationScheme new]];
     [self testInitParameters_withValidParameters_shouldInitReturnNonNil_withAuthScheme:[MSIDAuthenticationSchemePop new]];
+    [self testInitParameters_withValidParameters_shouldInitReturnNonNil_withAuthScheme:[MSIDAuthenticationSchemeSshCert new]];
 }
 
 - (void)testInitParameters_withValidParameters_shouldInitReturnNonNil_withAuthScheme:(MSIDAuthenticationScheme *)authScheme
@@ -80,7 +82,7 @@
 {
     [self testInitParameters_withIntersectingOIDCScopes_shouldFailAndReturnNil_withAuthScheme:[MSIDAuthenticationScheme new]];
     [self testInitParameters_withIntersectingOIDCScopes_shouldFailAndReturnNil_withAuthScheme:[MSIDAuthenticationSchemePop new]];
-
+    [self testInitParameters_withIntersectingOIDCScopes_shouldFailAndReturnNil_withAuthScheme:[MSIDAuthenticationSchemeSshCert new]];
 }
 
 - (void)testInitParameters_withIntersectingOIDCScopes_shouldFailAndReturnNil_withAuthScheme:(MSIDAuthenticationScheme *)authScheme

--- a/IdentityCore/tests/integration/MSIDCacheSchemaValidationTests.m
+++ b/IdentityCore/tests/integration/MSIDCacheSchemaValidationTests.m
@@ -38,6 +38,8 @@
 #import "MSIDJsonSerializer.h"
 #import "MSIDAuthenticationSchemePop.h"
 #import "MSIDAccessTokenWithAuthScheme.h"
+#import "MSIDAuthenticationSchemeSshCert.h"
+
 /*
  Those tests validate full schema compliance to test cases defined in the schema spec
  */
@@ -84,6 +86,23 @@
     return response;
 }
 
+- (MSIDTokenResponse *)aadTestTokenResponseATSshCert
+{
+    NSString *jsonResponse = @"{\"token_type\": \"ssh-cert\",\"scope\": \"https://pas.windows.net/CheckMyAccess/Linux/user_impersonation https://pas.windows.net/CheckMyAccess/Linux/.default\",\"expires_in\": 3600,\"ext_expires_in\": 262800,\"access_token\": \"<removed_at>\",\"refresh_token\": \"<removed_rt\",\"id_token\": \"eyJ0eXAiOiJKV1QiLCJyaCI6IjAuQW84RGtxMUY5bzNqR2syMUVOR3dtblNveXBWM3NBVGJqUnBHdS00Qy1lR19lMFljQURvLiIsImFsZyI6IlJTMjU2Iiwia2lkIjoicS0yM2ZhbGV2WmhoRDNobTlDUWJrUDVNUXlVIn0.eyJhdWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhL3YyLjAiLCJpYXQiOjE3MTI4ODk3NTUsIm5iZiI6MTcxMjg4OTc1NSwiZXhwIjoxNzEyODkzNjU1LCJhaW8iOiJBVFFBeS84V0FBQUFmbnBPQXBXTnJJT05RZXQySDRHc3R4RE4xN3N6NERUalRIRlllYzEvUXNuN3NpczlLZFJNN3JwZGxTNDI3WWNNIiwibmFtZSI6IkJBU0lDIElETEFCUyBDbG91ZCBVc2VyIiwib2lkIjoiOWY0ODgwZDgtODBiYS00YzQwLTk3YmMtZjdhMjNjNzAzMDg0IiwicHJlZmVycmVkX3VzZXJuYW1lIjoiaWRsYWJAbXNpZGxhYjQub25taWNyb3NvZnQuY29tIiwicHVpZCI6IjEwMDM3RkZFQTdFQ0ZBMjIiLCJyaCI6IkkiLCJzdWIiOiI1Z3I3c3lMYm0yb21zWmlzUWVuTTVhQ18xTkhlZWtKN2JaeEhDeHhhVVJVIiwidGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIiwidXRpIjoiYVo1aEFoc1JtMHVUa25PaHlIOEhBQSIsInZlciI6IjIuMCJ9.-xDMINJOW7qvf_911OZ-rKobJusbs9eMU8jU1TJsFr2LVnEckttRDa_ja5cR_4Ynghg-AtzgLcpHvB5gmbjvYs8YuhfZC7rwrfanLLjwAtT4bZCAXfzK-8IzgPU7PWYL5PA-paCq_zlVSjy_6gxVG7YCLTHuI5C0bd02eXmldACRO7Y_doAy41PLettl1EUp8d7_fAM2Iex6Qi-t4tdK4KzXgMNvADPd-i0oyflRBLaRMfGDHn1Qm3Aav8wwMHi6o51rjg4WvmBXCQGtnObg-noVAcsgBGRKiwEiRHDW9umD6Gstq1f6EgKsfg2WABnH5kXRjw_rVxbIlEcy3NtPrg\",\"client_info\": \"eyJ1aWQiOiI5ZjQ4ODBkOC04MGJhLTRjNDAtOTdiYy1mN2EyM2M3MDMwODQiLCJ1dGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIn0\"}";
+    
+    NSError *responseError = nil;
+    MSIDJsonSerializer *serializer = [MSIDJsonSerializer new];
+    MSIDAADV2TokenResponse *response = [serializer fromJsonData:[jsonResponse dataUsingEncoding:NSUTF8StringEncoding]
+                                                         ofType:MSIDAADV2TokenResponse.class
+                                                        context:nil
+                                                          error:&responseError];
+    
+    XCTAssertNotNil(response);
+    XCTAssertNil(responseError);
+    
+    return response;
+}
+
 - (MSIDConfiguration *)aadTestConfiguration
 {
     MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
@@ -108,6 +127,25 @@
         @"req_cnf":@"eyJraWQiOiJlQWkyNE9leml1czc5VlRadDhsZlhldFJTejdsR2thSmloWEJFWkIwMnV3In0"
     };
     configuration.authScheme = [[MSIDAuthenticationSchemePop alloc] initWithSchemeParameters:schemeParams];
+    return configuration;
+}
+
+- (MSIDConfiguration *)aadTestConfigurationATSshCert
+{
+    MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
+    
+    MSIDConfiguration *configuration = [[MSIDConfiguration alloc] initWithAuthority:authority
+                                                                        redirectUri:@"msalb6c69a37-df96-4db0-9088-2ab96e1d8215://auth"
+                                                                           clientId:@"b6c69a37-df96-4db0-9088-2ab96e1d8215"
+                                                                             target:@"https://pas.windows.net/CheckMyAccess/Linux/.default"];
+    NSString *modulus = @"2tNr73xwcj6lH7bqRZrFzgSLj7OeLfbn8";
+    NSString *exponent = @"AQAB";
+    NSDictionary *schemeParams = @{
+        @"key_id":@"key1",
+        @"token_type":@"ssh-cert",
+        @"req_cnf":[NSString stringWithFormat:@"{\"kty\":\"RSA\",\"n\":\"%@\",\"e\":\"%@\"}", modulus, exponent]
+    };
+    configuration.authScheme = [[MSIDAuthenticationSchemeSshCert alloc] initWithSchemeParameters:schemeParams];
     return configuration;
 }
 
@@ -209,6 +247,62 @@
     key.target = credential.target;
     
     NSString *expectedServiceKey = @"accesstoken_with_authscheme-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-calendars.read openid profile tasks.read user.read email";
+    XCTAssertEqualObjects(key.service, expectedServiceKey);
+    
+    NSString *expectedAccountKey = @"9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca-login.microsoftonline.com";
+    XCTAssertEqualObjects(key.account, expectedAccountKey);
+    
+    NSString *expectedGenericKey = @"accesstoken_with_authscheme-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+    XCTAssertEqualObjects(key.generic, [expectedGenericKey dataUsingEncoding:NSUTF8StringEncoding]);
+    
+    XCTAssertEqualObjects(key.type, @2007);
+}
+
+- (void)testSchemaComplianceForAccessToken_whenMSSTSResponse_withAADAccount_ATSshCert
+{
+    MSIDAADV2Oauth2Factory *factory = [MSIDAADV2Oauth2Factory new];
+    
+    MSIDAccessToken *accessToken = [factory accessTokenFromResponse:[self aadTestTokenResponseATSshCert]
+                                                      configuration:[self aadTestConfigurationATSshCert]];
+    accessToken.tokenType = @"ssh-cert";
+    
+    MSIDCredentialCacheItem *credential = accessToken.tokenCacheItem;
+    NSDictionary *accessTokenJSON = credential.jsonDictionary;
+    
+    NSDate *currentDate = [NSDate new];
+    NSString *expiresOn = [NSString stringWithFormat:@"%ld", (long)([currentDate timeIntervalSince1970] + 3600)];
+    NSString *extExpiresOn = [NSString stringWithFormat:@"%ld", (long)([currentDate timeIntervalSince1970] + 262800)];
+    NSString *cachedAt = [NSString stringWithFormat:@"%ld", (long)[currentDate timeIntervalSince1970]];
+    
+    // 1. Verify payload
+    NSDictionary *expectedJSON = @{
+        @"token_type": @"ssh-cert",
+        @"secret": @"<removed_at>",
+        @"target": @"https://pas.windows.net/CheckMyAccess/Linux/user_impersonation https://pas.windows.net/CheckMyAccess/Linux/.default",
+        @"extended_expires_on": extExpiresOn,
+        @"credential_type": @"AccessToken_With_AuthScheme",
+        @"environment": @"login.microsoftonline.com",
+        @"realm": @"f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
+        @"expires_on": expiresOn,
+        @"cached_at": cachedAt,
+        @"client_id": @"b6c69a37-df96-4db0-9088-2ab96e1d8215",
+        @"home_account_id": @"9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
+        @"kid" : @"key1"
+    };
+    
+    XCTAssertEqualObjects(accessTokenJSON, expectedJSON);
+    
+    // 2. Verify cache key
+    MSIDDefaultCredentialCacheKey *key = [[MSIDDefaultCredentialCacheKey alloc] initWithHomeAccountId:credential.homeAccountId
+                                                                                          environment:credential.environment
+                                                                                             clientId:credential.clientId
+                                                                                       credentialType:credential.credentialType];
+    
+    key.familyId = credential.familyId;
+    key.realm = credential.realm;
+    key.target = credential.target;
+    
+    NSString *expectedServiceKey = @"accesstoken_with_authscheme-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-https://pas.windows.net/checkmyaccess/linux/user_impersonation https://pas.windows.net/checkmyaccess/linux/.default";
     XCTAssertEqualObjects(key.service, expectedServiceKey);
     
     NSString *expectedAccountKey = @"9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca-login.microsoftonline.com";


### PR DESCRIPTION
## Proposed changes

Add new auth scheme for ssh-cert

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

Broker change: https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/1580