### PR TITLE
Fix throttling bug

### DIFF
--- a/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
@@ -302,14 +302,14 @@
     __block int count = 0;
     [MSIDTestSwizzle classMethod:@selector(updateLastRefreshTimeDatasource:context:error:)
                            class:[MSIDThrottlingService class]
-                           block:(id)^(id obj)
+                           block:(id)^(__unused id obj)
      {
         count++;
         return YES;
     }];
     XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
 
-    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+    [brokerController acquireToken:^(__unused MSIDTokenResult * _Nullable result, __unused NSError * _Nullable acquireTokenError) {
         
         XCTAssertEqual(count, 1);
         [expectation fulfill];

--- a/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
@@ -288,7 +288,7 @@
     
     MSIDTokenResult *testResult = [self resultWithParameters:parameters];
     
-    [MSIDApplicationTestUtil onOpenURL:^BOOL(NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
         MSIDTestBrokerResponseHandler *brokerResponseHandler = [[MSIDTestBrokerResponseHandler alloc] initWithTestResponse:testResult testError:nil];
         [MSIDBrokerInteractiveController completeAcquireToken:[NSURL URLWithString:@"https://contoso.com"]
                                             sourceApplication:@"com.microsoft.azureauthenticator"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version TBD
 * Include email as scope returned if it was requested and server did not include it. (#1364)
+* Fix throttling bug in fallback legacy broker interactive controller. (#1371)
 
 Version 1.7.34
 * Ignore local cache in broker request


### PR DESCRIPTION
## Proposed changes

Fix bug when fallback to legacy broker interactive controller successfully, it should update last refresh time stamp of throttling cache

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

