### PR TITLE
Added property to allow developers to set a nil redirect URI in a request.

### DIFF
--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -57,7 +57,7 @@
 @property (nonatomic) NSString *clientSku;
 @property (nonatomic) BOOL skipValidateResultAccount;
 @property (nonatomic) BOOL forceRefresh;
-@property (nonatomic) BOOL skipSendRedirectUri;
+@property (nonatomic) BOOL bypassRedirectURIValidation;
 
 // Additional body parameters that will be appended to all token requests
 @property (nonatomic) NSDictionary *extraTokenRequestParameters;

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -57,6 +57,7 @@
 @property (nonatomic) NSString *clientSku;
 @property (nonatomic) BOOL skipValidateResultAccount;
 @property (nonatomic) BOOL forceRefresh;
+@property (nonatomic) BOOL skipSendRedirectUri;
 
 // Additional body parameters that will be appended to all token requests
 @property (nonatomic) NSDictionary *extraTokenRequestParameters;

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -349,6 +349,11 @@
         MSIDFillAndLogError(error, MSIDErrorInvalidDeveloperParameter, @"Missing target parameter", self.correlationId);
         return NO;
     }
+    
+    if (self.skipSendRedirectUri)
+    {
+        self.redirectUri = nil;
+    }
 
     return YES;
 }

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -332,7 +332,7 @@
         return NO;
     }
 
-    if (!self.redirectUri)
+    if (!self.redirectUri && !self.bypassRedirectURIValidation)
     {
         MSIDFillAndLogError(error, MSIDErrorInvalidDeveloperParameter, @"Missing redirectUri parameter", self.correlationId);
         return NO;
@@ -348,11 +348,6 @@
     {
         MSIDFillAndLogError(error, MSIDErrorInvalidDeveloperParameter, @"Missing target parameter", self.correlationId);
         return NO;
-    }
-    
-    if (self.skipSendRedirectUri)
-    {
-        self.redirectUri = nil;
     }
 
     return YES;

--- a/IdentityCore/tests/MSIDRequestParametersTests.m
+++ b/IdentityCore/tests/MSIDRequestParametersTests.m
@@ -165,6 +165,63 @@
     XCTAssertNotNil(parameters.appRequestMetadata);
 }
 
+- (void)testParameterValidation_withNoBypassRedirectUriValidation_andNilRedirectUri_shouldFail
+{
+    MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
+    NSOrderedSet *scopes = [NSOrderedSet orderedSetWithObjects:@"myscope1", @"myscope2", nil];
+    NSOrderedSet *oidcScopes = [NSOrderedSet orderedSetWithObjects:@"openid", @"offline_access", @"profile", nil];
+
+    NSError *error = nil;
+    MSIDRequestParameters *parameters = [[MSIDRequestParameters alloc] initWithAuthority:authority
+                                                                              authScheme:[MSIDAuthenticationScheme new]
+                                                                             redirectUri:nil
+                                                                                clientId:@"myclient_id"
+                                                                                  scopes:scopes
+                                                                              oidcScopes:oidcScopes
+                                                                           correlationId:nil
+                                                                          telemetryApiId:nil
+                                                                     intuneAppIdentifier:@"com.microsoft.mytest"
+                                                                             requestType:MSIDRequestLocalType
+                                                                                   error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(parameters);
+    
+    parameters.bypassRedirectURIValidation = false;
+    BOOL result = [parameters validateParametersWithError:&error];
+    
+    XCTAssertNotNil(error);
+    XCTAssertEqual(result, false);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+}
+
+- (void)testParameterValidation_withBypassRedirectUriValidation_andNilRedirectUri_shouldNotFail
+{
+    MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
+    NSOrderedSet *scopes = [NSOrderedSet orderedSetWithObjects:@"myscope1", @"myscope2", nil];
+    NSOrderedSet *oidcScopes = [NSOrderedSet orderedSetWithObjects:@"openid", @"offline_access", @"profile", nil];
+
+    NSError *error = nil;
+    MSIDRequestParameters *parameters = [[MSIDRequestParameters alloc] initWithAuthority:authority
+                                                                              authScheme:[MSIDAuthenticationScheme new]
+                                                                             redirectUri:nil
+                                                                                clientId:@"myclient_id"
+                                                                                  scopes:scopes
+                                                                              oidcScopes:oidcScopes
+                                                                           correlationId:nil
+                                                                          telemetryApiId:nil
+                                                                     intuneAppIdentifier:@"com.microsoft.mytest"
+                                                                             requestType:MSIDRequestLocalType
+                                                                                   error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(parameters);
+    
+    parameters.bypassRedirectURIValidation = true;
+    BOOL result = [parameters validateParametersWithError:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertEqual(result, true);
+}
+
 - (void)testUpdateAppRequestMetadata_whenAccountIdIsNil_shouldNotChangeMetadata
 {
     MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];


### PR DESCRIPTION
## Proposed changes

Added property to allow developers to set a nil redirect URI in a request. Needed for Native Auth refresh token call.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

