### PR TITLE
Enable warning -Wexplicit-ownership-type

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -8887,6 +8887,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4E931FC3626A00CD70C5 /* identitycore__debug.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = YES;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -8903,6 +8904,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4E9C1FC3626B00CD70C5 /* identitycore__release.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = YES;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(MSID_SYSTEMWV)",

--- a/IdentityCore/src/MSIDJsonSerializableFactory.h
+++ b/IdentityCore/src/MSIDJsonSerializableFactory.h
@@ -65,7 +65,7 @@ This method is tread safe.
 + (nullable id<MSIDJsonSerializable>)createFromJSONDictionary:(NSDictionary *)json
                                              classTypeJSONKey:(NSString *)classTypeJSONKey
                                             assertKindOfClass:(Class)aClass
-                                                        error:(NSError **)error;
+                                                        error:(NSError *__autoreleasing*)error;
 
 /*!
  Create instance of class from the provided json payload.
@@ -77,7 +77,7 @@ This method is tread safe.
 + (nullable id<MSIDJsonSerializable>)createFromJSONDictionary:(NSDictionary *)json
                                                     classType:(NSString *)classType
                                             assertKindOfClass:(Class)aClass
-                                                        error:(NSError **)error;
+                                                        error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/MSIDJsonSerializableFactory.m
+++ b/IdentityCore/src/MSIDJsonSerializableFactory.m
@@ -81,7 +81,7 @@ static NSMutableDictionary<NSString *, NSString *> *s_keysMap = nil;
 + (id<MSIDJsonSerializable>)createFromJSONDictionary:(NSDictionary *)json
                                     classTypeJSONKey:(NSString *)classTypeJSONKey
                                    assertKindOfClass:(Class)aClass
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     if (![json msidAssertType:NSString.class ofKey:classTypeJSONKey required:YES error:error]) return nil;
     NSString *classTypeValue = json[classTypeJSONKey];
@@ -108,7 +108,7 @@ static NSMutableDictionary<NSString *, NSString *> *s_keysMap = nil;
 + (id<MSIDJsonSerializable>)createFromJSONDictionary:(NSDictionary *)json
                                       classType:(NSString *)classTypeValue
                                    assertKindOfClass:(Class)aClass
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     return [self createFromJSONDictionary:json containerKey:classTypeValue assertKindOfClass:aClass error:error];
 }
@@ -129,7 +129,7 @@ static NSMutableDictionary<NSString *, NSString *> *s_keysMap = nil;
 + (id<MSIDJsonSerializable>)createFromJSONDictionary:(NSDictionary *)json
                                         containerKey:(NSString *)containerKey
                                    assertKindOfClass:(Class)aClass
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     Class class = (Class<MSIDJsonSerializable>)s_container[containerKey];
     

--- a/IdentityCore/src/MSIDJsonSerializer.m
+++ b/IdentityCore/src/MSIDJsonSerializer.m
@@ -50,7 +50,7 @@
 
 - (NSData *)toJsonData:(id<MSIDJsonSerializable>)serializable
                context:(id<MSIDRequestContext>)context
-                 error:(NSError **)error
+                 error:(NSError *__autoreleasing*)error
 {
     __auto_type jsonDictionary = [serializable jsonDictionary];
     return [self serializeToJsonData:jsonDictionary error:error];
@@ -59,7 +59,7 @@
 - (id<MSIDJsonSerializable>)fromJsonData:(NSData *)data
                                   ofType:(Class)klass
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     NSParameterAssert([klass conformsToProtocol:@protocol(MSIDJsonSerializable)]);
     if (![klass conformsToProtocol:@protocol(MSIDJsonSerializable)]) return nil;
@@ -85,7 +85,7 @@
 
 - (NSString *)toJsonString:(id<MSIDJsonSerializable>)serializable
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     NSData *jsonData = [self toJsonData:serializable context:context error:error];
     if (!jsonData) return nil;
@@ -96,7 +96,7 @@
 - (id<MSIDJsonSerializable>)fromJsonString:(NSString *)jsonString
                                     ofType:(Class)klass
                                    context:(id<MSIDRequestContext>)context
-                                     error:(NSError **)error
+                                     error:(NSError *__autoreleasing*)error
 {
     NSParameterAssert([klass conformsToProtocol:@protocol(MSIDJsonSerializable)]);
     if (![klass conformsToProtocol:@protocol(MSIDJsonSerializable)]) return nil;

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationScheme.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationScheme.m
@@ -81,7 +81,7 @@
     return YES;
 }
 
-- (instancetype)initWithJSONDictionary:(__unused NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(__unused NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     return [self initWithSchemeParameters:[NSDictionary new]];
 }

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemePop.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemePop.m
@@ -127,7 +127,7 @@
     return accessToken.kid && self.kid && [self.kid isEqualToString:accessToken.kid];
 }
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     NSMutableDictionary *schemeParameters = [NSMutableDictionary new];
     NSString *requestConf = json[MSID_OAUTH2_REQUEST_CONFIRMATION];

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemeSshCert.m
@@ -88,7 +88,7 @@
     return MSIDAuthSchemeTypeFromString(scheme);
 }
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     NSMutableDictionary *schemeParameters = [NSMutableDictionary new];
     NSString *requestConf = json[MSID_OAUTH2_REQUEST_CONFIRMATION];

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationGetDeviceInfoRequest.m
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationGetDeviceInfoRequest.m
@@ -41,7 +41,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     
@@ -56,5 +56,3 @@
 }
 
 @end
-
-

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationPasskeyAssertionRequest.m
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationPasskeyAssertionRequest.m
@@ -50,7 +50,7 @@ NSString *const MSID_PASSKEY_ASSERTION_KEY_ID_KEY = @"keyId";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
 

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationPasskeyCredentialRequest.m
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationPasskeyCredentialRequest.m
@@ -44,7 +44,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
 

--- a/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
+++ b/IdentityCore/src/broker_operation/request/MSIDBrokerOperationRequest.m
@@ -56,7 +56,7 @@ clientBrokerKeyCapabilityNotSupported:(BOOL)clientBrokerKeyCapabilityNotSupporte
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     

--- a/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationGetAccountsRequest.m
+++ b/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationGetAccountsRequest.m
@@ -42,7 +42,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationRemoveAccountRequest.m
+++ b/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationRemoveAccountRequest.m
@@ -48,7 +48,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationSignoutFromDeviceRequest.m
+++ b/IdentityCore/src/broker_operation/request/account_request/MSIDBrokerOperationSignoutFromDeviceRequest.m
@@ -52,7 +52,7 @@ NSString *const MSID_WIPE_CACHE_ALL_ACCOUNTS_KEY = @"wipe_cache_all_accounts";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrokerOperationBrowserNativeMessageRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrokerOperationBrowserNativeMessageRequest.m
@@ -52,7 +52,7 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_REQUEST_METHOD_KEY = @"method";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetCookiesRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetCookiesRequest.m
@@ -42,7 +42,7 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_GET_COOKIES_REQUEST_URI_KEY = @"uri"
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     if (!self) return nil;

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
@@ -58,7 +58,7 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_REQUEST_KEY = @"request";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     if (!self) return nil;

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageRequest.m
@@ -33,7 +33,7 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_METHOD_KEY = @"method";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageSignOutRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageSignOutRequest.m
@@ -42,7 +42,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     if (!self) return nil;

--- a/IdentityCore/src/broker_operation/request/interactive_token_request/MSIDBrokerOperationInteractiveTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/interactive_token_request/MSIDBrokerOperationInteractiveTokenRequest.m
@@ -76,7 +76,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/request/silent_token_request/MSIDBrokerOperationSilentTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/silent_token_request/MSIDBrokerOperationSilentTokenRequest.m
@@ -74,7 +74,7 @@ static NSString *const MSID_ACCOUNT_DISPLAYABLE_ID_JSON_KEY = @"username";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/request/sso_cookies_request/MSIDBrokerOperationGetSsoCookiesRequest.m
+++ b/IdentityCore/src/broker_operation/request/sso_cookies_request/MSIDBrokerOperationGetSsoCookiesRequest.m
@@ -46,7 +46,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.h
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
                requestValidator:(id<MSIDBrowserRequestValidating>)requestValidator
            useSSOCookieFallback:(BOOL)useSSOCookieFallback
                      ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
-                          error:(NSError **)error;
+                          error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.m
@@ -38,7 +38,7 @@
                requestValidator:(id<MSIDBrowserRequestValidating>)requestValidator
            useSSOCookieFallback:(BOOL)useSSOCookieFallback
                      ssoContext:(MSIDExternalSSOContext *)ssoContext
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     if (self)

--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationTokenRequest.m
@@ -69,7 +69,7 @@ clientBrokerKeyCapabilityNotSupported:parameters.clientBrokerKeyCapabilityNotSup
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerNativeAppOperationResponse.m
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerNativeAppOperationResponse.m
@@ -91,7 +91,7 @@ NSString *const MSID_BROKER_REQUEST_RECEIVED_TIMESTAMP = @"request_received_time
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     
@@ -150,4 +150,3 @@ NSString *const MSID_BROKER_REQUEST_RECEIVED_TIMESTAMP = @"request_received_time
 #endif
 
 @end
-

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerOperationGetAccountsResponse.m
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerOperationGetAccountsResponse.m
@@ -42,7 +42,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerOperationGetPasskeyAssertionResponse.m
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerOperationGetPasskeyAssertionResponse.m
@@ -43,7 +43,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
 

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerOperationGetPasskeyCredentialResponse.m
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerOperationGetPasskeyCredentialResponse.m
@@ -43,7 +43,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
 

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerOperationGetSsoCookiesResponse.m
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerOperationGetSsoCookiesResponse.m
@@ -50,7 +50,7 @@ static NSString *const MSID_SSO_COOKIES = @"sso_cookies";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     
@@ -119,7 +119,7 @@ static NSString *const MSID_SSO_COOKIES = @"sso_cookies";
     return headersJson.count > 0 ? headersJson : nil;
 }
 
-- (nullable NSArray<MSIDCredentialHeader*> *)parseCredentialHeaderFrom:(NSDictionary *)json credentialName:(NSString *)name error:(NSError **)error
+- (nullable NSArray<MSIDCredentialHeader*> *)parseCredentialHeaderFrom:(NSDictionary *)json credentialName:(NSString *)name error:(NSError *__autoreleasing*)error
 {
     if(!json || !json[name]) return nil;
 

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerOperationResponse.m
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerOperationResponse.m
@@ -29,7 +29,7 @@ NSString *const MSID_BROKER_OPERATION_JSON_KEY = @"operation";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     

--- a/IdentityCore/src/broker_operation/response/MSIDBrokerOperationTokenResponse.m
+++ b/IdentityCore/src/broker_operation/response/MSIDBrokerOperationTokenResponse.m
@@ -48,7 +48,7 @@ NSString *const MSID_BROKER_ADDITIONAL_TOKEN_RESPONSE_JSON_KEY = @"additional_to
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/response/MSIDDeviceInfo.m
+++ b/IdentityCore/src/broker_operation/response/MSIDDeviceInfo.m
@@ -52,7 +52,7 @@ static NSArray *deviceModeEnumString;
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     self = [super init];
     

--- a/IdentityCore/src/broker_operation/response/MSIDPasskeyAssertion.m
+++ b/IdentityCore/src/broker_operation/response/MSIDPasskeyAssertion.m
@@ -53,7 +53,7 @@ NSString *const MSID_BROKER_PASSKEY_ASSERTION_CREDENTIAL_ID_JSON_KEY = @"credent
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     self = [super init];
 

--- a/IdentityCore/src/broker_operation/response/MSIDPasskeyCredential.m
+++ b/IdentityCore/src/broker_operation/response/MSIDPasskeyCredential.m
@@ -53,7 +53,7 @@ NSString *const MSID_BROKER_PASSKEY_CREDENTIAL_USERNAME_JSON_KEY = @"userName";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     self = [super init];
 

--- a/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrokerOperationBrowserNativeMessageResponse.m
+++ b/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrokerOperationBrowserNativeMessageResponse.m
@@ -43,7 +43,7 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_RESPONSE_PAYLOAD_KEY = @"payload";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageGetCookiesResponse.m
+++ b/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageGetCookiesResponse.m
@@ -57,7 +57,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     @throw MSIDException(MSIDGenericException, @"Not implemented.", nil);
 }

--- a/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageGetTokenResponse.m
+++ b/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageGetTokenResponse.m
@@ -55,7 +55,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     @throw MSIDException(MSIDGenericException, @"Not implemented.", nil);
 }
@@ -86,4 +86,3 @@
 }
 
 @end
-

--- a/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageSignOutResponse.m
+++ b/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageSignOutResponse.m
@@ -29,7 +29,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     @throw MSIDException(MSIDGenericException, @"Not implemented.", nil);
 }

--- a/IdentityCore/src/broker_operation/response/sso_cookies_response/MSIDCredentialHeader.m
+++ b/IdentityCore/src/broker_operation/response/sso_cookies_response/MSIDCredentialHeader.m
@@ -30,7 +30,7 @@ static NSString *const MSID_CREDENTIAL_HEADER_JSON_KEY = @"header";
 
 @implementation MSIDCredentialHeader
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     

--- a/IdentityCore/src/broker_operation/response/sso_cookies_response/MSIDCredentialInfo.m
+++ b/IdentityCore/src/broker_operation/response/sso_cookies_response/MSIDCredentialInfo.m
@@ -30,7 +30,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     

--- a/IdentityCore/src/broker_operation/response/sso_cookies_response/MSIDDeviceHeader.m
+++ b/IdentityCore/src/broker_operation/response/sso_cookies_response/MSIDDeviceHeader.m
@@ -29,7 +29,7 @@ static NSString *const MSID_PRT_HEADER_TENANT_ID = @"tenant_id";
 
 @implementation MSIDDeviceHeader
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/broker_operation/response/sso_cookies_response/MSIDPrtHeader.m
+++ b/IdentityCore/src/broker_operation/response/sso_cookies_response/MSIDPrtHeader.m
@@ -32,7 +32,7 @@ static NSString *const MSID_PRT_HEADER_DISPLAYABLE_ID = @"displayable_id";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/cache/MSIDCacheAccessor.h
+++ b/IdentityCore/src/cache/MSIDCacheAccessor.h
@@ -49,7 +49,7 @@
                            response:(MSIDTokenResponse *)response
                             factory:(MSIDOauth2Factory *)factory
                             context:(id<MSIDRequestContext>)context
-                              error:(NSError **)error;
+                              error:(NSError *__autoreleasing*)error;
 
 /*!
  This method saves only the SSO artifacts to the cache based on the response.
@@ -58,51 +58,51 @@
                              response:(MSIDTokenResponse *)response
                               factory:(MSIDOauth2Factory *)factory
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error;
+                                error:(NSError *__autoreleasing*)error;
 
 /* Read cache */
 - (MSIDRefreshToken *)getRefreshTokenWithAccount:(MSIDAccountIdentifier *)account
                                         familyId:(NSString *)familyId
                                    configuration:(MSIDConfiguration *)configuration
                                          context:(id<MSIDRequestContext>)context
-                                           error:(NSError **)error;
+                                           error:(NSError *__autoreleasing*)error;
 
 - (MSIDPrimaryRefreshToken *)getPrimaryRefreshTokenWithAccount:(MSIDAccountIdentifier *)account
                                                       familyId:(NSString *)familyId
                                                  configuration:(MSIDConfiguration *)configuration
                                                        context:(id<MSIDRequestContext>)context
-                                                         error:(NSError **)error;
+                                                         error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDAccount *> *)accountsWithAuthority:(MSIDAuthority *)authority
                                          clientId:(NSString *)clientId
                                          familyId:(NSString *)familyId
                                 accountIdentifier:(MSIDAccountIdentifier *)accountIdentifier
                                           context:(id<MSIDRequestContext>)context
-                                            error:(NSError **)error;
+                                            error:(NSError *__autoreleasing*)error;
 
 - (BOOL)clearWithContext:(id<MSIDRequestContext>)context
-                   error:(NSError **)error;
+                   error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDBaseToken *> *)allTokensWithContext:(id<MSIDRequestContext>)context
-                                             error:(NSError **)error;
+                                             error:(NSError *__autoreleasing*)error;
 
 - (BOOL)clearCacheForAccount:(MSIDAccountIdentifier *)account
                    authority:(MSIDAuthority *)authority
                     clientId:(NSString *)clientId
                     familyId:(NSString *)familyId
                      context:(id<MSIDRequestContext>)context
-                       error:(NSError **)error;
+                       error:(NSError *__autoreleasing*)error;
 
 - (BOOL)validateAndRemoveRefreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)token
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error;
+                                error:(NSError *__autoreleasing*)error;
 
 - (BOOL)validateAndRemovePrimaryRefreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)token
                                      context:(id<MSIDRequestContext>)context
-                                       error:(NSError **)error;
+                                       error:(NSError *__autoreleasing*)error;
 
 - (BOOL)removeAccessToken:(MSIDAccessToken *)token
                   context:(id<MSIDRequestContext>)context
-                    error:(NSError **)error;
+                    error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/cache/MSIDExtendedTokenCacheDataSource.h
+++ b/IdentityCore/src/cache/MSIDExtendedTokenCacheDataSource.h
@@ -40,32 +40,32 @@
                 key:(MSIDCacheKey *)key
          serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
             context:(id<MSIDRequestContext>)context
-              error:(NSError **)error;
+              error:(NSError *__autoreleasing*)error;
 
 - (MSIDAccountCacheItem *)accountWithKey:(MSIDCacheKey *)key
                               serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error;
+                                   error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDAccountCacheItem *> *)accountsWithKey:(MSIDCacheKey *)key
                                           serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                              context:(id<MSIDRequestContext>)context
-                                               error:(NSError **)error;
+                                               error:(NSError *__autoreleasing*)error;
 
 - (BOOL)removeAccountsWithKey:(MSIDCacheKey *)key
                       context:(id<MSIDRequestContext>)context
-                        error:(NSError **)error;
+                        error:(NSError *__autoreleasing*)error;
 
 // JSON Object
 - (NSArray<MSIDJsonObject *> *)jsonObjectsWithKey:(MSIDCacheKey *)key
                                        serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                           context:(id<MSIDRequestContext>)context
-                                            error:(NSError **)error;
+                                            error:(NSError *__autoreleasing*)error;
 
 - (BOOL)saveJsonObject:(MSIDJsonObject *)jsonObject
             serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                    key:(MSIDCacheKey *)key
                context:(id<MSIDRequestContext>)context
-                 error:(NSError **)error;
+                 error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/cache/MSIDKeychainTokenCache.m
+++ b/IdentityCore/src/cache/MSIDKeychainTokenCache.m
@@ -186,7 +186,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
               key:(MSIDCacheKey *)key
        serializer:(id<MSIDCacheItemSerializing>)serializer
           context:(id<MSIDRequestContext>)context
-            error:(NSError **)error
+            error:(NSError *__autoreleasing*)error
 {
     assert(item);
     assert(serializer);
@@ -226,7 +226,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (MSIDCredentialCacheItem *)tokenWithKey:(MSIDCacheKey *)key
                                serializer:(id<MSIDCacheItemSerializing>)serializer
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,context, @"itemWithKey:serializer:context:error:");
     NSArray<MSIDCredentialCacheItem *> *items = [self tokensWithKey:key serializer:serializer context:context error:error];
@@ -247,7 +247,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (NSArray<MSIDCredentialCacheItem *> *)tokensWithKey:(MSIDCacheKey *)key
                                            serializer:(id<MSIDCacheItemSerializing>)serializer
                                               context:(id<MSIDRequestContext>)context
-                                                error:(NSError **)error
+                                                error:(NSError *__autoreleasing*)error
 {
     MSIDCacheKey *tokenCacheKey = [self overrideTokenKey:key];
     
@@ -273,7 +273,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
                 key:(MSIDCacheKey *)key
          serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
             context:(id<MSIDRequestContext>)context
-              error:(NSError **)error
+              error:(NSError *__autoreleasing*)error
 {
     assert(item);
     assert(serializer);
@@ -301,7 +301,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (MSIDAccountCacheItem *)accountWithKey:(MSIDCacheKey *)key
                               serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     NSArray<MSIDAccountCacheItem *> *items = [self accountsWithKey:key serializer:serializer context:context error:error];
     
@@ -321,7 +321,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (NSArray<MSIDAccountCacheItem *> *)accountsWithKey:(MSIDCacheKey *)key
                                           serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                              context:(id<MSIDRequestContext>)context
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     return [self cacheItemsWithKey:key serializer:serializer cacheItemClass:[MSIDAccountCacheItem class] context:context error:error];
 }
@@ -332,7 +332,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
                     key:(MSIDCacheKey *)key
              serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                 context:(id<MSIDRequestContext>)context
-                  error:(NSError **)error
+                  error:(NSError *__autoreleasing*)error
 {
     if (!item || !serializer)
     {
@@ -368,7 +368,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (NSArray<MSIDAppMetadataCacheItem *> *)appMetadataEntriesWithKey:(MSIDCacheKey *)key
                                                         serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                            context:(id<MSIDRequestContext>)context
-                                                             error:(NSError **)error
+                                                             error:(NSError *__autoreleasing*)error
 {
     return [self cacheItemsWithKey:key serializer:serializer cacheItemClass:[MSIDAppMetadataCacheItem class] context:context error:error];
 }
@@ -378,7 +378,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (NSArray<MSIDJsonObject *> *)jsonObjectsWithKey:(MSIDCacheKey *)key
                                        serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                           context:(id<MSIDRequestContext>)context
-                                            error:(NSError **)error
+                                            error:(NSError *__autoreleasing*)error
 {
     return [self cacheItemsWithKey:key serializer:serializer cacheItemClass:[MSIDJsonObject class] context:context error:error];
 }
@@ -387,7 +387,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
             serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                    key:(MSIDCacheKey *)key
                context:(id<MSIDRequestContext>)context
-                 error:(NSError **)error
+                 error:(NSError *__autoreleasing*)error
 {
     assert(jsonObject);
     assert(serializer);
@@ -416,7 +416,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
                         key:(MSIDCacheKey *)key
                  serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
 
     if (!item)
@@ -441,7 +441,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (MSIDAccountMetadataCacheItem *)accountMetadataWithKey:(MSIDCacheKey *)key
                                               serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                  context:(id<MSIDRequestContext>)context
-                                                   error:(NSError **)error
+                                                   error:(NSError *__autoreleasing*)error
 {
     NSArray *metadataItems = [self accountsMetadataWithKey:key serializer:serializer context:context error:error];
     if (!metadataItems) return nil;
@@ -458,7 +458,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (NSArray<MSIDAccountMetadataCacheItem *> *)accountsMetadataWithKey:(MSIDCacheKey *)key
                                                           serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                              context:(id<MSIDRequestContext>)context
-                                                               error:(NSError **)error
+                                                               error:(NSError *__autoreleasing*)error
 {
     return [self cacheItemsWithKey:key serializer:serializer cacheItemClass:MSIDAccountMetadataCacheItem.class context:context error:error];
 }
@@ -467,7 +467,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 
 - (BOOL)removeTokensWithKey:(MSIDCacheKey *)key
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     MSIDCacheKey *tokenCacheKey = [self overrideTokenKey:key];
     
@@ -476,28 +476,28 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 
 - (BOOL)removeAccountsWithKey:(MSIDCacheKey *)key
                       context:(id<MSIDRequestContext>)context
-                        error:(NSError **)error
+                        error:(NSError *__autoreleasing*)error
 {
     return [self removeItemsWithKey:key context:context error:error];
 }
 
 - (BOOL)removeMetadataItemsWithKey:(MSIDCacheKey *)key
                            context:(id<MSIDRequestContext>)context
-                             error:(NSError **)error
+                             error:(NSError *__autoreleasing*)error
 {
     return [self removeItemsWithKey:key context:context error:error];
 }
 
 - (BOOL)removeAccountMetadataForKey:(MSIDCacheKey *)key
                             context:(id<MSIDRequestContext>)context
-                              error:(NSError **)error
+                              error:(NSError *__autoreleasing*)error
 {
     return [self removeItemsWithKey:key context:context error:error];
 }
 
 - (BOOL)removeItemsWithKey:(MSIDCacheKey *)key
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     NSString *account = key.account;
     NSString *service = key.service;
@@ -562,7 +562,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 #pragma mark - Wipe
 
 - (BOOL)saveWipeInfoWithContext:(id<MSIDRequestContext>)context
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     NSString *appIdentifier = [[NSBundle mainBundle] bundleIdentifier];
     
@@ -610,7 +610,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 }
 
 - (NSDictionary *)wipeInfo:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     NSMutableDictionary *query = [self.defaultWipeQuery mutableCopy];
     [query setObject:@YES forKey:(id)kSecReturnData];
@@ -735,7 +735,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
                     serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                 cacheItemClass:(Class)resultClass
                        context:(id<MSIDRequestContext>)context
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {
     NSArray *items = [self itemsWithKey:key context:context error:error];
     
@@ -769,7 +769,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 
 - (NSArray *)itemsWithKey:(MSIDCacheKey *)key
                   context:(id<MSIDRequestContext>)context
-                    error:(NSError **)error
+                    error:(NSError *__autoreleasing*)error
 {
     NSString *account = key.account;
     NSString *service = key.service;
@@ -832,7 +832,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 - (BOOL)saveData:(NSData *)itemData
              key:(MSIDCacheKey *)key
          context:(id<MSIDRequestContext>)context
-           error:(NSError **)error
+           error:(NSError *__autoreleasing*)error
 {
     assert(key);
     
@@ -919,7 +919,7 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 }
 
 - (BOOL)clearWithContext:(id<MSIDRequestContext>)context
-                   error:(NSError **)error
+                   error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"Clearing the whole context. This should only be executed in tests");
 
@@ -946,4 +946,3 @@ static NSString *s_defaultKeychainGroup = MSIDAdalKeychainGroup;
 
 
 @end
-

--- a/IdentityCore/src/cache/MSIDMacTokenCache.h
+++ b/IdentityCore/src/cache/MSIDMacTokenCache.h
@@ -46,7 +46,7 @@
 
 - (nullable NSData *)serialize;
 - (BOOL)deserialize:(nullable NSData*)data
-              error:(NSError * _Nullable * _Nullable)error;
+              error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (void)clear;
 

--- a/IdentityCore/src/cache/MSIDMacTokenCache.m
+++ b/IdentityCore/src/cache/MSIDMacTokenCache.m
@@ -110,7 +110,7 @@ return NO; \
 }
 
 - (BOOL)deserialize:(nullable NSData*)data
-              error:(NSError **)error
+              error:(NSError *__autoreleasing*)error
 {
     NSDictionary *cache = nil;
     
@@ -233,7 +233,7 @@ return NO; \
 
 - (BOOL)removeTokensWithKey:(MSIDCacheKey *)key
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     return [self removeItemsWithKey:key context:context error:error];
 }
@@ -265,13 +265,13 @@ return NO; \
 #pragma mark - Wipe
 
 - (BOOL)saveWipeInfoWithContext:(__unused id<MSIDRequestContext>)context
-                          error:(__unused NSError **)error
+                          error:(__unused NSError *__autoreleasing*)error
 {
     return NO;
 }
 
 - (NSDictionary *)wipeInfo:(__unused id<MSIDRequestContext>)context
-                     error:(__unused NSError **)error
+                     error:(__unused NSError *__autoreleasing*)error
 {
     return nil;
 }
@@ -323,7 +323,7 @@ return NO; \
 }
 
 - (BOOL)validateCache:(NSDictionary *)dict
-                error:(NSError **)error
+                error:(NSError *__autoreleasing*)error
 {
     RETURN_ERROR_IF_CONDITION_FALSE([dict isKindOfClass:[NSDictionary class]], MSIDErrorCacheBadFormat, @"Root level object of cache is not a NSDictionary.");
     RETURN_ERROR_IF_CONDITION_FALSE(dict[@"version"], MSIDErrorCacheBadFormat, @"Missing version number from cache.");
@@ -360,7 +360,7 @@ return NO; \
 
 - (BOOL)removeItemsWithKeyImpl:(MSIDCacheKey *)key
                        context:(id<MSIDRequestContext>)context
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {
     if (!key)
     {
@@ -410,7 +410,7 @@ return NO; \
                 key:(MSIDCacheKey *)key
          serializer:(__unused id<MSIDCacheItemSerializing>)serializer
             context:(id<MSIDRequestContext>)context
-              error:(NSError **)error
+              error:(NSError *__autoreleasing*)error
 {
     assert(key);
     
@@ -475,7 +475,7 @@ return NO; \
 - (NSArray<MSIDCredentialCacheItem *> *)itemsWithKeyImpl:(MSIDCacheKey *)key
                                          serializer:(__unused id<MSIDCacheItemSerializing>)serializer
                                             context:(id<MSIDRequestContext>)context
-                                              error:(__unused NSError **)error
+                                              error:(__unused NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Get items, key info (account: %@ service: %@)", MSID_PII_LOG_MASKABLE(key.account), key.service);
 
@@ -526,7 +526,7 @@ return NO; \
 }
 
 - (BOOL)clearWithContext:(id<MSIDRequestContext>)context
-                   error:(__unused NSError **)error
+                   error:(__unused NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"Clearing the whole context. This should only be executed in tests");
     [self clear];

--- a/IdentityCore/src/cache/MSIDTokenCacheDataSource.h
+++ b/IdentityCore/src/cache/MSIDTokenCacheDataSource.h
@@ -38,32 +38,32 @@
               key:(MSIDCacheKey *)key
        serializer:(id<MSIDCacheItemSerializing>)serializer
           context:(id<MSIDRequestContext>)context
-            error:(NSError **)error;
+            error:(NSError *__autoreleasing*)error;
 
 - (MSIDCredentialCacheItem *)tokenWithKey:(MSIDCacheKey *)key
                                serializer:(id<MSIDCacheItemSerializing>)serializer
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error;
+                                    error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDCredentialCacheItem *> *)tokensWithKey:(MSIDCacheKey *)key
                                            serializer:(id<MSIDCacheItemSerializing>)serializer
                                               context:(id<MSIDRequestContext>)context
-                                                error:(NSError **)error;
+                                                error:(NSError *__autoreleasing*)error;
 
 // Wipe info
 - (BOOL)saveWipeInfoWithContext:(id<MSIDRequestContext>)context
-                          error:(NSError **)error;
+                          error:(NSError *__autoreleasing*)error;
 
 - (NSDictionary *)wipeInfo:(id<MSIDRequestContext>)context
-                     error:(NSError **)error;
+                     error:(NSError *__autoreleasing*)error;
 
 // Removal
 - (BOOL)removeTokensWithKey:(MSIDCacheKey *)key
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error;
+                      error:(NSError *__autoreleasing*)error;
 
 // Clear all
 - (BOOL)clearWithContext:(id<MSIDRequestContext>)context
-                   error:(NSError **)error;
+                   error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.h
@@ -48,149 +48,149 @@
  */
 - (nullable NSArray<MSIDCredentialCacheItem *> *)getCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
                                                                  context:(nullable id<MSIDRequestContext>)context
-                                                                   error:(NSError * _Nullable * _Nullable)error;
+                                                                   error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Gets a credential for a particular key
 */
 - (nullable MSIDCredentialCacheItem *)getCredential:(nonnull MSIDDefaultCredentialCacheKey *)key
                                             context:(nullable id<MSIDRequestContext>)context
-                                              error:(NSError * _Nullable * _Nullable)error;
+                                              error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Gets all credentials which a matching type
 */
 - (nullable NSArray<MSIDCredentialCacheItem *> *)getAllCredentialsWithType:(MSIDCredentialType)type
                                                                    context:(nullable id<MSIDRequestContext>)context
-                                                                     error:(NSError * _Nullable * _Nullable)error;
+                                                                     error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Gets all accounts matching the parameters specified in the query
  */
 - (nullable NSArray<MSIDAccountCacheItem *> *)getAccountsWithQuery:(nonnull MSIDDefaultAccountCacheQuery *)cacheQuery
                                                            context:(nullable id<MSIDRequestContext>)context
-                                                             error:(NSError * _Nullable * _Nullable)error;
+                                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Gets an account for a particular key
 */
 - (nullable MSIDAccountCacheItem *)getAccount:(nonnull MSIDDefaultAccountCacheKey *)key
                                       context:(nullable id<MSIDRequestContext>)context
-                                        error:(NSError * _Nullable * _Nullable)error;
+                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Gets all accounts which a matching type
  */
 - (nullable NSArray<MSIDAccountCacheItem *> *)getAllAccountsWithType:(MSIDAccountType)type
                                                              context:(nullable id<MSIDRequestContext>)context
-                                                               error:(NSError * _Nullable * _Nullable)error;
+                                                               error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Gets all items
  */
 - (nullable NSArray<MSIDCredentialCacheItem *> *)getAllItemsWithContext:(nullable id<MSIDRequestContext>)context
-                                                                  error:(NSError * _Nullable * _Nullable)error;
+                                                                  error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Saves a credential
 */
 - (BOOL)saveCredential:(nonnull MSIDCredentialCacheItem *)credential
                context:(nullable id<MSIDRequestContext>)context
-                 error:(NSError * _Nullable * _Nullable)error;
+                 error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Saves an account
 */
 - (BOOL)saveAccount:(nonnull MSIDAccountCacheItem *)account
             context:(nullable id<MSIDRequestContext>)context
-              error:(NSError * _Nullable * _Nullable)error;
+              error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Removes credentials matching parameters specified in the query
  */
 - (BOOL)removeCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
                           context:(nullable id<MSIDRequestContext>)context
-                            error:(NSError * _Nullable * _Nullable)error;
+                            error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Removes credentials matching parameters specified in the query
  */
 - (BOOL)removeExpiredAccessTokensCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
                           context:(nullable id<MSIDRequestContext>)context
-                            error:(NSError * _Nullable * _Nullable)error;
+                            error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Removes a credential
 */
 - (BOOL)removeCredential:(nonnull MSIDCredentialCacheItem *)credential
                  context:(nullable id<MSIDRequestContext>)context
-                   error:(NSError * _Nullable * _Nullable)error;
+                   error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Removes multiple accounts matching parameters
 */
 - (BOOL)removeAccountsWithQuery:(nonnull MSIDDefaultAccountCacheQuery *)cacheQuery
                         context:(nullable id<MSIDRequestContext>)context
-                          error:(NSError * _Nullable * _Nullable)error;
+                          error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Removes an account
 */
 - (BOOL)removeAccount:(nonnull MSIDAccountCacheItem *)account
               context:(nullable id<MSIDRequestContext>)context
-                error:(NSError * _Nullable * _Nullable)error;
+                error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Clears the whole cache, should only be used for testing!
  */
 - (BOOL)clearWithContext:(nullable id<MSIDRequestContext>)context
-                   error:(NSError * _Nullable * _Nullable)error;
+                   error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Removes all credentials in the array
  */
 - (BOOL)removeAllCredentials:(nonnull NSArray<MSIDCredentialCacheItem *> *)credentials
                      context:(nullable id<MSIDRequestContext>)context
-                       error:(NSError * _Nullable * _Nullable)error;
+                       error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Removes all accounts in the array
  */
 - (BOOL)removeAllAccounts:(nonnull NSArray<MSIDAccountCacheItem *> *)accounts
                   context:(nullable id<MSIDRequestContext>)context
-                    error:(NSError * _Nullable * _Nullable)error;
+                    error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Returns latest wipe info
  */
 - (nullable NSDictionary *)wipeInfoWithContext:(nullable id<MSIDRequestContext>)context
-                                         error:(NSError * _Nullable * _Nullable)error;
+                                         error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 
 /*
   Saves the latest wipe info
  */
 - (BOOL)saveWipeInfoWithContext:(nullable id<MSIDRequestContext>)context
-                          error:(NSError * _Nullable * _Nullable)error;
+                          error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Saves app metadata
  */
 - (BOOL)saveAppMetadata:(nonnull MSIDAppMetadataCacheItem *)metadata
                 context:(nullable id<MSIDRequestContext>)context
-                  error:(NSError * _Nullable * _Nullable)error;
+                  error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*
  Remove app metadata
  */
 - (BOOL)removeAppMetadata:(nonnull MSIDAppMetadataCacheItem *)appMetadata
                   context:(nullable id<MSIDRequestContext>)context
-                    error:(NSError * _Nullable * _Nullable)error;
+                    error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 
 //Get app metadata entries for a query
 - (nullable NSArray<MSIDAppMetadataCacheItem *> *)getAppMetadataEntriesWithQuery:(nonnull MSIDAppMetadataCacheQuery *)query
                                                                          context:(nullable id<MSIDRequestContext>)context
-                                                                           error:(NSError * _Nullable * _Nullable)error;
+                                                                           error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end

--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
@@ -66,7 +66,7 @@
 // Reading credentials
 - (nullable NSArray<MSIDCredentialCacheItem *> *)getCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
                                                                  context:(nullable id<MSIDRequestContext>)context
-                                                                   error:(NSError * _Nullable * _Nullable)error
+                                                                   error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     NSString *className = NSStringFromClass(self.class);
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(%@) retrieving cached credentials using credential query", className);
@@ -129,7 +129,7 @@
 
 - (nullable MSIDCredentialCacheItem *)getCredential:(nonnull MSIDDefaultCredentialCacheKey *)key
                                        context:(nullable id<MSIDRequestContext>)context
-                                         error:(NSError * _Nullable * _Nullable)error
+                                         error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(key);
 
@@ -140,7 +140,7 @@
 
 - (nullable NSArray<MSIDCredentialCacheItem *> *)getAllCredentialsWithType:(MSIDCredentialType)type
                                                               context:(nullable id<MSIDRequestContext>)context
-                                                                error:(NSError * _Nullable * _Nullable)error
+                                                                error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, context, @"(Default cache) Get all credentials with type %@", [MSIDCredentialTypeHelpers credentialTypeAsString:type]);
 
@@ -153,7 +153,7 @@
 // Reading accounts
 - (nullable NSArray<MSIDAccountCacheItem *> *)getAccountsWithQuery:(nonnull MSIDDefaultAccountCacheQuery *)cacheQuery
                                                            context:(nullable id<MSIDRequestContext>)context
-                                                             error:(NSError * _Nullable * _Nullable)error
+                                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(cacheQuery);
 
@@ -188,7 +188,7 @@
 
 - (nullable MSIDAccountCacheItem *)getAccount:(nonnull MSIDDefaultCredentialCacheKey *)key
                                       context:(nullable id<MSIDRequestContext>)context
-                                        error:(NSError * _Nullable * _Nullable)error
+                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(key);
 
@@ -199,7 +199,7 @@
 
 - (nullable NSArray<MSIDAccountCacheItem *> *)getAllAccountsWithType:(MSIDAccountType)type
                                                              context:(nullable id<MSIDRequestContext>)context
-                                                               error:(NSError * _Nullable * _Nullable)error
+                                                               error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, context, @"(Default cache) Get all accounts with type %@", [MSIDAccountTypeHelpers accountTypeAsString:type]);
 
@@ -210,7 +210,7 @@
 }
 
 - (nullable NSArray<MSIDCredentialCacheItem *> *)getAllItemsWithContext:(nullable id<MSIDRequestContext>)context
-                                                             error:(NSError * _Nullable * _Nullable)error
+                                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, context, @"(Default cache) Get all items from cache");
 
@@ -222,7 +222,7 @@
 // Writing credentials
 - (BOOL)saveCredential:(nonnull MSIDCredentialCacheItem *)credential
                context:(nullable id<MSIDRequestContext>)context
-                 error:(NSError * _Nullable * _Nullable)error
+                 error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(credential);
 
@@ -251,7 +251,7 @@
 // Writing accounts
 - (BOOL)saveAccount:(nonnull MSIDAccountCacheItem *)account
             context:(nullable id<MSIDRequestContext>)context
-              error:(NSError * _Nullable * _Nullable)error
+              error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(account);
 
@@ -293,7 +293,7 @@
 // Remove credentials
 - (BOOL)removeCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
                           context:(nullable id<MSIDRequestContext>)context
-                            error:(NSError * _Nullable * _Nullable)error
+                            error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(cacheQuery);
 
@@ -316,7 +316,7 @@
 // Remove credentials
 - (BOOL)removeExpiredAccessTokensCredentialsWithQuery:(nonnull MSIDDefaultCredentialCacheQuery *)cacheQuery
                           context:(nullable id<MSIDRequestContext>)context
-                            error:(NSError * _Nullable * _Nullable)error
+                            error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(cacheQuery);
     cacheQuery.targetMatchingOptions = MSIDAny;
@@ -360,7 +360,7 @@
 
 - (BOOL)removeCredential:(nonnull MSIDCredentialCacheItem *)credential
                  context:(nullable id<MSIDRequestContext>)context
-                   error:(NSError * _Nullable * _Nullable)error
+                   error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(credential);
 
@@ -393,7 +393,7 @@
 // Remove accounts
 - (BOOL)removeAccountsWithQuery:(nonnull MSIDDefaultAccountCacheQuery *)cacheQuery
                         context:(nullable id<MSIDRequestContext>)context
-                          error:(NSError * _Nullable * _Nullable)error
+                          error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(cacheQuery);
 
@@ -411,7 +411,7 @@
 
 - (BOOL)removeAccount:(nonnull MSIDAccountCacheItem *)account
               context:(nullable id<MSIDRequestContext>)context
-                error:(NSError * _Nullable * _Nullable)error
+                error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(account);
 
@@ -427,7 +427,7 @@
 
 // Clear all
 - (BOOL)clearWithContext:(nullable id<MSIDRequestContext>)context
-                   error:(NSError * _Nullable * _Nullable)error
+                   error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"(Default cache) Clearing the whole cache, this method should only be called in tests");
     return [_dataSource clearWithContext:context error:error];
@@ -435,7 +435,7 @@
 
 - (BOOL)removeAllCredentials:(nonnull NSArray<MSIDCredentialCacheItem *> *)credentials
                      context:(nullable id<MSIDRequestContext>)context
-                       error:(NSError * _Nullable * _Nullable)error
+                       error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(credentials);
 
@@ -453,7 +453,7 @@
 
 - (BOOL)removeAllAccounts:(nonnull NSArray<MSIDAccountCacheItem *> *)accounts
                   context:(nullable id<MSIDRequestContext>)context
-                    error:(NSError * _Nullable * _Nullable)error
+                    error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(accounts);
 
@@ -470,13 +470,13 @@
 }
 
 - (nullable NSDictionary *)wipeInfoWithContext:(nullable id<MSIDRequestContext>)context
-                                         error:(NSError * _Nullable * _Nullable)error
+                                         error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     return [_dataSource wipeInfo:context error:error];
 }
 
 - (BOOL)saveWipeInfoWithContext:(nullable id<MSIDRequestContext>)context
-                          error:(NSError * _Nullable * _Nullable)error
+                          error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     return [_dataSource saveWipeInfoWithContext:context error:error];
 }
@@ -484,7 +484,7 @@
 // Writing metadata
 - (BOOL)saveAppMetadata:(nonnull MSIDAppMetadataCacheItem *)metadata
                 context:(nullable id<MSIDRequestContext>)context
-                  error:(NSError * _Nullable * _Nullable)error
+                  error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(metadata);
     
@@ -504,7 +504,7 @@
 
 - (BOOL)removeAppMetadata:(nonnull MSIDAppMetadataCacheItem *)appMetadata
                   context:(nullable id<MSIDRequestContext>)context
-                    error:(NSError * _Nullable * _Nullable)error
+                    error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(appMetadata);
     
@@ -520,7 +520,7 @@
 
 - (nullable NSArray<MSIDAppMetadataCacheItem *> *)getAppMetadataEntriesWithQuery:(nonnull MSIDAppMetadataCacheQuery *)cacheQuery
                                                                          context:(nullable id<MSIDRequestContext>)context
-                                                                           error:(NSError * _Nullable * _Nullable)error
+                                                                           error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     assert(cacheQuery);
     

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.h
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.h
@@ -47,13 +47,13 @@
 - (MSIDAccessToken *)getAccessTokenForAccount:(MSIDAccountIdentifier *)account
                                 configuration:(MSIDConfiguration *)configuration
                                       context:(id<MSIDRequestContext>)context
-                                        error:(NSError **)error;
+                                        error:(NSError *__autoreleasing*)error;
 
 - (MSIDIdToken *)getIDTokenForAccount:(MSIDAccountIdentifier *)account
                         configuration:(MSIDConfiguration *)configuration
                           idTokenType:(MSIDCredentialType)idTokenType
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error;
+                                error:(NSError *__autoreleasing*)error;
 
 - (MSIDAccount *)getAccountForIdentifier:(MSIDAccountIdentifier *)accountIdentifier
                                authority:(MSIDAuthority *)authority
@@ -61,31 +61,31 @@
                      accountHomeTenantId:(NSString *)accountHomeTenantId
                      accountSelectionLog:(NSString **)accountSelectionLog
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error;
+                                   error:(NSError *__autoreleasing*)error;
 
 - (BOOL)removeToken:(MSIDBaseToken *)token
             context:(id<MSIDRequestContext>)context
-              error:(NSError **)error;
+              error:(NSError *__autoreleasing*)error;
 
 - (BOOL)saveToken:(MSIDBaseToken *)token
           context:(id<MSIDRequestContext>)context
-            error:(NSError **)error;
+            error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDAppMetadataCacheItem *> *)getAppMetadataEntries:(MSIDConfiguration *)configuration
                                                        context:(id<MSIDRequestContext>)context
-                                                         error:(NSError **)error;
+                                                         error:(NSError *__autoreleasing*)error;
 
 - (BOOL)saveAppMetadataWithConfiguration:(MSIDConfiguration *)configuration
                                 response:(MSIDTokenResponse *)response
                                  factory:(MSIDOauth2Factory *)factory
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error;
+                                   error:(NSError *__autoreleasing*)error;
 
 - (BOOL)updateAppMetadataWithFamilyId:(NSString *)familyId
                              clientId:(NSString *)clientId
                             authority:(MSIDAuthority *)authority
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error;
+                                error:(NSError *__autoreleasing*)error;
 
 - (BOOL)clearCacheForAccount:(MSIDAccountIdentifier *)accountIdentifier
                    authority:(MSIDAuthority *)authority
@@ -93,10 +93,10 @@
                     familyId:(NSString *)familyId
                clearAccounts:(BOOL)clearAccounts
                      context:(id<MSIDRequestContext>)context
-                       error:(NSError **)error;
+                       error:(NSError *__autoreleasing*)error;
 
 - (BOOL)clearCacheForAllAccountsWithContext:(id<MSIDRequestContext>)context
-                                      error:(NSError **)error;
+                                      error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDAccount *> *)accountsWithAuthority:(MSIDAuthority *)authority
                                          clientId:(NSString *)clientId
@@ -105,10 +105,10 @@
                              accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
                              signedInAccountsOnly:(BOOL)signedInAccountsOnly
                                           context:(id<MSIDRequestContext>)context
-                                            error:(NSError **)error;
+                                            error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDPrimaryRefreshToken *> *)getPrimaryRefreshTokensForConfiguration:(MSIDConfiguration *)configuration
                                                                         context:(id<MSIDRequestContext>)context
-                                                                          error:(NSError **)error;
+                                                                          error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -192,7 +192,7 @@
 
 - (NSArray<MSIDPrimaryRefreshToken *> *)getPrimaryRefreshTokensForConfiguration:(MSIDConfiguration *)configuration
                                                                         context:(id<MSIDRequestContext>)context
-                                                                          error:(NSError **)error
+                                                                          error:(NSError *__autoreleasing*)error
 {
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
     query.environmentAliases = [configuration.authority defaultCacheEnvironmentAliases];
@@ -262,7 +262,7 @@
 #pragma mark - Clear cache
 
 - (BOOL)clearWithContext:(id<MSIDRequestContext>)context
-                   error:(NSError **)error
+                   error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"(Default accessor) Clearing everything in cache. This method should only be called in tests!");
     return [_accountCredentialCache clearWithContext:context error:error];
@@ -271,7 +271,7 @@
 #pragma mark - Read all tokens
 
 - (NSArray<MSIDBaseToken *> *)allTokensWithContext:(id<MSIDRequestContext>)context
-                                             error:(NSError **)error
+                                             error:(NSError *__autoreleasing*)error
 {
     CONDITIONAL_START_CACHE_EVENT(event, MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP, context);
 
@@ -287,7 +287,7 @@
 - (MSIDAccessToken *)getAccessTokenForAccount:(MSIDAccountIdentifier *)accountIdentifier
                                 configuration:(MSIDConfiguration *)configuration
                                       context:(id<MSIDRequestContext>)context
-                                        error:(NSError **)error
+                                        error:(NSError *__autoreleasing*)error
 {
 
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
@@ -324,7 +324,7 @@
                         configuration:(MSIDConfiguration *)configuration
                           idTokenType:(MSIDCredentialType)idTokenType
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error
+                                error:(NSError *__autoreleasing*)error
 {
     if (idTokenType!=MSIDIDTokenType && idTokenType!=MSIDLegacyIDTokenType)
     {
@@ -365,7 +365,7 @@
                                 accountIdentifier:(MSIDAccountIdentifier *)accountIdentifier
                                          clientId:(NSString *)clientId
                                           context:(id<MSIDRequestContext>)context
-                                            error:(NSError **)error
+                                            error:(NSError *__autoreleasing*)error
 {
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
     query.homeAccountId = accountIdentifier.homeAccountId;
@@ -379,7 +379,7 @@
 
 - (BOOL)removeAccessToken:(MSIDAccessToken *)token
                   context:(id<MSIDRequestContext>)context
-                    error:(NSError **)error
+                    error:(NSError *__autoreleasing*)error
 {
     return [self removeToken:token
                      context:context
@@ -393,7 +393,7 @@
                                          familyId:(NSString *)familyId
                                 accountIdentifier:(MSIDAccountIdentifier *)accountIdentifier
                                           context:(id<MSIDRequestContext>)context
-                                            error:(NSError **)error
+                                            error:(NSError *__autoreleasing*)error
 {
     return [self accountsWithAuthority:authority
                               clientId:clientId
@@ -411,7 +411,7 @@
                              accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
                              signedInAccountsOnly:(BOOL)signedInAccountsOnly
                                           context:(id<MSIDRequestContext>)context
-                                            error:(NSError **)error
+                                            error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(Default accessor) Get accounts.");
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default accessor) Get accounts with environment %@, clientId %@, familyId %@, account %@, username %@", authority.environment, clientId, familyId, accountIdentifier.maskedHomeAccountId, accountIdentifier.maskedDisplayableId);
@@ -527,9 +527,9 @@
                                authority:(MSIDAuthority *)authority
                                realmHint:(NSString *)realmHint
                      accountHomeTenantId:(NSString *)accountHomeTenantId
-                     accountSelectionLog:(NSString **)accountSelectionLog
+                     accountSelectionLog:(NSString *__autoreleasing*)accountSelectionLog
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default accessor) Looking for account with authority %@, legacy user ID %@, home account ID %@", authority.url, accountIdentifier.maskedDisplayableId, accountIdentifier.maskedHomeAccountId);
 
@@ -606,7 +606,7 @@
                     clientId:(NSString *)clientId
                     familyId:(NSString *)familyId
                      context:(id<MSIDRequestContext>)context
-                       error:(NSError **)error
+                       error:(NSError *__autoreleasing*)error
 {
     return [self clearCacheForAccount:accountIdentifier
                             authority:authority
@@ -623,7 +623,7 @@
                     familyId:(NSString *)familyId
                clearAccounts:(BOOL)clearAccounts
                      context:(id<MSIDRequestContext>)context
-                       error:(NSError **)error
+                       error:(NSError *__autoreleasing*)error
 {
     if (!accountIdentifier)
     {
@@ -710,7 +710,7 @@
 }
 
 - (BOOL)clearCacheForAllAccountsWithContext:(id<MSIDRequestContext>)context
-                                      error:(NSError **)error
+                                      error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"(Default accessor) Clearing cache for all accounts");
 
@@ -748,7 +748,7 @@
 
 - (BOOL)validateAndRemoveRefreshToken:(MSIDRefreshToken *)token
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error
+                                error:(NSError *__autoreleasing*)error
 {
     return [self validateAndRemoveRefreshableToken:token
                                     credentialType:MSIDRefreshTokenType
@@ -758,7 +758,7 @@
 
 - (BOOL)validateAndRemovePrimaryRefreshToken:(MSIDRefreshToken *)token
                                      context:(id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     return [self validateAndRemoveRefreshableToken:token
                                     credentialType:MSIDPrimaryRefreshTokenType
@@ -769,7 +769,7 @@
 - (BOOL)validateAndRemoveRefreshableToken:(MSIDRefreshToken *)token
                            credentialType:(MSIDCredentialType)credentialType
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     if (credentialType != MSIDRefreshTokenType && credentialType != MSIDPrimaryRefreshTokenType) return NO;
 
@@ -818,7 +818,7 @@
 
 - (BOOL)checkAccountIdentifier:(NSString *)accountIdentifier
                        context:(id<MSIDRequestContext>)context
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {
     if (!accountIdentifier)
     {
@@ -840,7 +840,7 @@
                                 response:(MSIDTokenResponse *)response
                                  factory:(MSIDOauth2Factory *)factory
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     MSIDAccessToken *accessToken = [factory accessTokenFromResponse:response configuration:configuration];
     if (!accessToken)
@@ -882,7 +882,7 @@
                             response:(MSIDTokenResponse *)response
                              factory:(MSIDOauth2Factory *)factory
                              context:(id<MSIDRequestContext>)context
-                               error:(NSError **)error
+                               error:(NSError *__autoreleasing*)error
 {
     MSIDIdToken *idToken = [factory idTokenFromResponse:response configuration:configuration];
 
@@ -900,7 +900,7 @@
                                  response:(MSIDTokenResponse *)response
                                   factory:(MSIDOauth2Factory *)factory
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     MSIDRefreshToken *refreshToken = [factory refreshTokenFromResponse:response configuration:configuration];
 
@@ -933,7 +933,7 @@
                             response:(MSIDTokenResponse *)response
                              factory:(MSIDOauth2Factory *)factory
                              context:(id<MSIDRequestContext>)context
-                               error:(NSError **)error
+                               error:(NSError *__autoreleasing*)error
 {
     MSIDAccount *account = [factory accountFromResponse:response configuration:configuration];
 
@@ -950,7 +950,7 @@
 
 - (BOOL)removeToken:(MSIDBaseToken *)token
             context:(id<MSIDRequestContext>)context
-              error:(NSError **)error
+              error:(NSError *__autoreleasing*)error
 {
     if (!token)
     {
@@ -975,7 +975,7 @@
 - (NSString *)homeAccountIdForLegacyId:(NSString *)legacyAccountId
                              authority:(MSIDAuthority *)authority
                                context:(id<MSIDRequestContext>)context
-                                 error:(NSError **)error
+                                 error:(NSError *__autoreleasing*)error
 {
     CONDITIONAL_START_CACHE_EVENT(event, MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP, context);
 
@@ -1002,7 +1002,7 @@
 - (MSIDBaseToken *)getTokenWithEnvironment:(NSString *)environment
                                 cacheQuery:(MSIDDefaultCredentialCacheQuery *)cacheQuery
                                    context:(id<MSIDRequestContext>)context
-                                     error:(NSError **)error
+                                     error:(NSError *__autoreleasing*)error
 {
     CONDITIONAL_START_CACHE_EVENT(event, MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP, context);
 
@@ -1042,7 +1042,7 @@
 - (NSArray<MSIDBaseToken *> *)getTokensWithEnvironment:(NSString *)requestedEnvironment
                                             cacheQuery:(MSIDDefaultCredentialCacheQuery *)cacheQuery
                                                context:(id<MSIDRequestContext>)context
-                                                 error:(NSError **)error
+                                                 error:(NSError *__autoreleasing*)error
 {
     CONDITIONAL_START_CACHE_EVENT(event, MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP, context);
 
@@ -1086,7 +1086,7 @@
                                              familyId:(NSString *)familyId
                                        credentialType:(MSIDCredentialType)credentialType
                                               context:(id<MSIDRequestContext>)context
-                                                error:(NSError **)error
+                                                error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Default accessor) Looking for token with authority %@, clientId %@, legacy userId %@", authority, clientId, accountIdentifier.maskedDisplayableId);
 
@@ -1118,7 +1118,7 @@
 
 - (BOOL)saveToken:(MSIDBaseToken *)token
           context:(id<MSIDRequestContext>)context
-            error:(NSError **)error
+            error:(NSError *__autoreleasing*)error
 {
     if (![self checkAccountIdentifier:token.accountIdentifier.homeAccountId context:context error:error])
     {
@@ -1135,7 +1135,7 @@
 
 - (BOOL)saveAccount:(MSIDAccount *)account
             context:(id<MSIDRequestContext>)context
-              error:(NSError **)error
+              error:(NSError *__autoreleasing*)error
 {
     if (![self checkAccountIdentifier:account.accountIdentifier.homeAccountId context:context error:error])
     {
@@ -1172,7 +1172,7 @@
                                                  familyId:(NSString *)familyId
                                    accountCredentialCache:(MSIDAccountCredentialCache *)accountCredentialCache
                                                   context:(id<MSIDRequestContext>)context
-                                                    error:(NSError **)error
+                                                    error:(NSError *__autoreleasing*)error
 {
     // Retrieve refresh tokens in cache, and return account ids for those refresh tokens
     MSIDDefaultCredentialCacheQuery *refreshTokenQuery = [MSIDDefaultCredentialCacheQuery new];
@@ -1200,7 +1200,7 @@
                                                               clientId:(NSString *)clientId
                                                   accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
                                                   signedInAccountsOnly:(BOOL)signedInAccountsOnly
-                                                   noReturnAccountUPNs:(NSMutableSet<NSString *> **)noReturnAccountUPNs
+                                                   noReturnAccountUPNs:(NSMutableSet<NSString *> *__autoreleasing*)noReturnAccountUPNs
 {
     NSMutableSet<MSIDAccount *> *returnAccountsSet = [NSMutableSet new];
     NSMutableSet<NSString *> *noReturnAccountsSet = [NSMutableSet new];
@@ -1313,7 +1313,7 @@
                                 response:(MSIDTokenResponse *)response
                                  factory:(MSIDOauth2Factory *)factory
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     MSIDAppMetadataCacheItem *metadata = [factory appMetadataFromResponse:response configuration:configuration];
     if (!metadata)
@@ -1347,7 +1347,7 @@
                              clientId:(NSString *)clientId
                             authority:(MSIDAuthority *)authority
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error
+                                error:(NSError *__autoreleasing*)error
 {
     MSIDAppMetadataCacheQuery *metadataQuery = [[MSIDAppMetadataCacheQuery alloc] init];
     metadataQuery.clientId = clientId;

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.h
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.h
@@ -41,16 +41,16 @@
 - (MSIDLegacyAccessToken *)getAccessTokenForAccount:(MSIDAccountIdentifier *)account
                                       configuration:(MSIDConfiguration *)configuration
                                             context:(id<MSIDRequestContext>)context
-                                              error:(NSError **)error;
+                                              error:(NSError *__autoreleasing*)error;
 
 - (MSIDLegacySingleResourceToken *)getSingleResourceTokenForAccount:(MSIDAccountIdentifier *)account
                                                       configuration:(MSIDConfiguration *)configuration
                                                             context:(id<MSIDRequestContext>)context
-                                                              error:(NSError **)error;
+                                                              error:(NSError *__autoreleasing*)error;
 
 - (BOOL)saveRefreshToken:(MSIDLegacyRefreshToken *)refreshToken
            configuration:(MSIDConfiguration *)configuration
                  context:(id<MSIDRequestContext>)context
-                   error:(NSError **)error;
+                   error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDLegacyTokenCacheAccessor.m
@@ -78,7 +78,7 @@
                            response:(MSIDTokenResponse *)response
                             factory:(MSIDOauth2Factory *)factory
                             context:(id<MSIDRequestContext>)context
-                              error:(NSError **)error
+                              error:(NSError *__autoreleasing*)error
 {
     if (response.isMultiResource)
     {
@@ -100,7 +100,7 @@
                              response:(MSIDTokenResponse *)response
                               factory:(MSIDOauth2Factory *)factory
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error
+                                error:(NSError *__autoreleasing*)error
 {
     if (!response)
     {
@@ -144,7 +144,7 @@
                                         familyId:(NSString *)familyId
                                    configuration:(MSIDConfiguration *)configuration
                                          context:(id<MSIDRequestContext>)context
-                                           error:(NSError **)error
+                                           error:(NSError *__autoreleasing*)error
 {
     MSIDRefreshToken *refreshToken = [self getRefreshableTokenWithAccount:accountIdentifier
                                                                  familyId:familyId
@@ -177,7 +177,7 @@
                                                       familyId:(NSString *)familyId
                                                  configuration:(MSIDConfiguration *)configuration
                                                        context:(id<MSIDRequestContext>)context
-                                                         error:(NSError **)error
+                                                         error:(NSError *__autoreleasing*)error
 {
     MSIDConfiguration *config = [configuration copy];
     config.clientId = MSID_LEGACY_CACHE_NIL_KEY;
@@ -214,7 +214,7 @@
                                       credentialType:(MSIDCredentialType)credentialType
                                        configuration:(MSIDConfiguration *)configuration
                                              context:(id<MSIDRequestContext>)context
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Legacy accessor) Get token %@ with authority %@, clientId %@, familyID %@, account %@", [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType], configuration.authority, configuration.clientId, familyId, accountIdentifier.maskedHomeAccountId);
     
@@ -233,7 +233,7 @@
 #pragma mark - Clear cache
 
 - (BOOL)clearWithContext:(id<MSIDRequestContext>)context
-                   error:(NSError **)error
+                   error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"(Legacy accessor) Clearing everything in cache. This method should only be called in tests!");
     return [_dataSource clearWithContext:context error:error];
@@ -246,7 +246,7 @@
                                          familyId:(NSString *)familyId
                                 accountIdentifier:(MSIDAccountIdentifier *)accountIdentifier
                                           context:(id<MSIDRequestContext>)context
-                                            error:(NSError **)error
+                                            error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"(Legacy accessor) Get accounts with environment %@, clientId %@, familyId %@, account identifier %@, legacy identifier %@", authority.environment, clientId, familyId, accountIdentifier.maskedHomeAccountId, accountIdentifier.maskedDisplayableId);
     CONDITIONAL_START_CACHE_EVENT(event, MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP, context);
@@ -352,7 +352,7 @@
 - (MSIDLegacyAccessToken *)getAccessTokenForAccount:(MSIDAccountIdentifier *)accountIdentifier
                                       configuration:(MSIDConfiguration *)configuration
                                             context:(id<MSIDRequestContext>)context
-                                              error:(NSError **)error
+                                              error:(NSError *__autoreleasing*)error
 {
     NSArray *aliases = [configuration.authority legacyAccessTokenLookupAuthorities] ?: @[];
 
@@ -370,7 +370,7 @@
 - (MSIDLegacySingleResourceToken *)getSingleResourceTokenForAccount:(MSIDAccountIdentifier *)accountIdentifier
                                                       configuration:(MSIDConfiguration *)configuration
                                                             context:(id<MSIDRequestContext>)context
-                                                              error:(NSError **)error
+                                                              error:(NSError *__autoreleasing*)error
 {
     NSArray *aliases = [configuration.authority legacyAccessTokenLookupAuthorities] ?: @[];
 
@@ -387,21 +387,21 @@
 
 - (BOOL)validateAndRemoveRefreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)token
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error
+                                error:(NSError *__autoreleasing*)error
 {
     return [self validateAndRemoveRefreshableToken:token context:context error:error];
 }
 
 - (BOOL)validateAndRemovePrimaryRefreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)token
                                      context:(id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     return [self validateAndRemoveRefreshableToken:token context:context error:error];
 }
 
 - (BOOL)validateAndRemoveRefreshableToken:(MSIDBaseToken<MSIDRefreshableToken> *)token
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     if (!token || [NSString msidIsStringNilOrBlank:token.refreshToken])
     {
@@ -459,7 +459,7 @@
 
 - (BOOL)removeAccessToken:(MSIDAccessToken *)token
                   context:(id<MSIDRequestContext>)context
-                    error:(NSError **)error
+                    error:(NSError *__autoreleasing*)error
 {
     return [self removeTokenEnvironment:token.environment
                                   realm:token.realm
@@ -478,7 +478,7 @@
                     clientId:(NSString *)clientId
                     familyId:(NSString *)familyId
                      context:(id<MSIDRequestContext>)context
-                       error:(NSError **)error 
+                       error:(NSError *__autoreleasing*)error
 {
     if (!accountIdentifier)
     {
@@ -559,7 +559,7 @@
                                                      credentialType:(MSIDCredentialType)credentialType
                                                       configuration:(MSIDConfiguration *)configuration
                                                             context:(id<MSIDRequestContext>)context
-                                                              error:(NSError **)error
+                                                              error:(NSError *__autoreleasing*)error
 {
     
     
@@ -583,7 +583,7 @@
                                 response:(MSIDTokenResponse *)response
                                  factory:(MSIDOauth2Factory *)factory
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     MSIDLegacyAccessToken *accessToken = [factory legacyAccessTokenFromResponse:response configuration:configuration];
 
@@ -603,7 +603,7 @@
 - (BOOL)saveRefreshToken:(MSIDLegacyRefreshToken *)refreshToken
            configuration:(__unused MSIDConfiguration *)configuration
                  context:(id<MSIDRequestContext>)context
-                   error:(NSError **)error
+                   error:(NSError *__autoreleasing*)error
 {
     if (!refreshToken)
     {
@@ -638,7 +638,7 @@
                                  response:(MSIDTokenResponse *)response
                                   factory:(MSIDOauth2Factory *)factory
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     MSIDLegacyRefreshToken *refreshToken = [factory legacyRefreshTokenFromResponse:response configuration:configuration];
     
@@ -655,7 +655,7 @@
                                               response:(MSIDTokenResponse *)response
                                                factory:(MSIDOauth2Factory *)factory
                                                context:(id<MSIDRequestContext>)context
-                                                 error:(NSError **)error
+                                                 error:(NSError *__autoreleasing*)error
 {
     MSIDLegacySingleResourceToken *legacyToken = [factory legacyTokenFromResponse:response configuration:configuration];
 
@@ -675,7 +675,7 @@
 
 - (BOOL)saveToken:(MSIDBaseToken<MSIDLegacyCredentialCacheCompatible> *)token
           context:(id<MSIDRequestContext>)context
-            error:(NSError **)error
+            error:(NSError *__autoreleasing*)error
 {
     CONDITIONAL_START_CACHE_EVENT(event, MSID_TELEMETRY_EVENT_TOKEN_CACHE_WRITE, context);
     
@@ -709,7 +709,7 @@
 }
 
 - (NSArray<MSIDBaseToken *> *)allTokensWithContext:(id<MSIDRequestContext>)context
-                                             error:(NSError **)error
+                                             error:(NSError *__autoreleasing*)error
 {
     CONDITIONAL_START_CACHE_EVENT(event, MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP, context);
 
@@ -741,7 +741,7 @@
                         appKey:(NSString *)appKey
          applicationIdentifier:(NSString *)applicationIdentifier
                        context:(id<MSIDRequestContext>)context
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {
     if (!environment || !clientId || !userId)
     {
@@ -786,7 +786,7 @@
                                  resource:(NSString *)resource
                             appIdentifier:(NSString *)appIdentifier
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     CONDITIONAL_START_CACHE_EVENT(event, MSID_TELEMETRY_EVENT_TOKEN_CACHE_LOOKUP, context);
 

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGenerating.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGenerating.h
@@ -31,18 +31,18 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MSIDAssymetricKeyGenerating <NSObject>
 
 - (nullable MSIDAssymetricKeyPair *)generateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
-                                                           error:(NSError **)error;
+                                                           error:(NSError *__autoreleasing*)error;
 
 - (MSIDAssymetricKeyPair *)readOrGenerateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
-                                                        error:(NSError **)error;
+                                                        error:(NSError *__autoreleasing*)error;
 
 - (nullable MSIDAssymetricKeyPair *)readKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
-                                              error:(NSError **)error;
+                                              error:(NSError *__autoreleasing*)error;
 
-- (MSIDAssymetricKeyPair *)generateEphemeralKeyPair:(NSError **)error;
+- (MSIDAssymetricKeyPair *)generateEphemeralKeyPair:(NSError *__autoreleasing*)error;
 
 - (BOOL)deleteItemWithAttributes:(NSDictionary *)attributes
-                          error:(NSError **)error;
+                          error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGeneratorFactory.h
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGeneratorFactory.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDAssymetricKeyGeneratorFactory : NSObject
 
-+ (id<MSIDAssymetricKeyGenerating>)defaultKeyGeneratorWithCacheConfig:(MSIDCacheConfig *)cacheConfig error:(NSError **)error;
++ (id<MSIDAssymetricKeyGenerating>)defaultKeyGeneratorWithCacheConfig:(MSIDCacheConfig *)cacheConfig error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGeneratorFactory.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyGeneratorFactory.m
@@ -32,7 +32,7 @@
 
 @implementation MSIDAssymetricKeyGeneratorFactory
 
-+ (id<MSIDAssymetricKeyGenerating>)defaultKeyGeneratorWithCacheConfig:(MSIDCacheConfig *)cacheConfig error:(NSError **)error
++ (id<MSIDAssymetricKeyGenerating>)defaultKeyGeneratorWithCacheConfig:(MSIDCacheConfig *)cacheConfig error:(NSError *__autoreleasing*)error
 {
 #if TARGET_OS_IPHONE
     return [self iOSDefaultKeyGeneratorWithCacheConfig:cacheConfig error:error];
@@ -41,13 +41,13 @@
 #endif
 }
 
-+ (id<MSIDAssymetricKeyGenerating>)iOSDefaultKeyGeneratorWithCacheConfig:(MSIDCacheConfig *)cacheConfig error:(NSError **)error
++ (id<MSIDAssymetricKeyGenerating>)iOSDefaultKeyGeneratorWithCacheConfig:(MSIDCacheConfig *)cacheConfig error:(NSError *__autoreleasing*)error
 {
     return [[MSIDAssymetricKeyKeychainGenerator alloc] initWithGroup:cacheConfig.keychainGroup error:error];
 }
 
 #if !TARGET_OS_IPHONE
-+ (id<MSIDAssymetricKeyGenerating>)macDefaultKeyGeneratorWithCacheConfig:(MSIDCacheConfig *)cacheConfig error:(NSError **)error
++ (id<MSIDAssymetricKeyGenerating>)macDefaultKeyGeneratorWithCacheConfig:(MSIDCacheConfig *)cacheConfig error:(NSError *__autoreleasing*)error
 {
     if (@available(macOS 10.15, *))
     {

--- a/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
+++ b/IdentityCore/src/cache/crypto/MSIDAssymetricKeyKeychainGenerator.m
@@ -92,7 +92,7 @@ static const OSStatus kNoStatus = -1;
 #pragma mark - MSIDAssymetricKeyGenerating
 
 - (MSIDAssymetricKeyPair *)generateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
-                                                  error:(NSError **)error
+                                                  error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:attributes.privateKeyIdentifier])
     {
@@ -117,7 +117,7 @@ static const OSStatus kNoStatus = -1;
 }
 
 - (MSIDAssymetricKeyPair *)readOrGenerateKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
-                                                        error:(NSError **)error
+                                                        error:(NSError *__autoreleasing*)error
 {
     NSError *readError = nil;
     MSIDAssymetricKeyPair *keyPair = [self readKeyPairForAttributes:attributes error:&readError];
@@ -132,7 +132,7 @@ static const OSStatus kNoStatus = -1;
 }
 
 - (MSIDAssymetricKeyPair *)readKeyPairForAttributes:(MSIDAssymetricKeyLookupAttributes *)attributes
-                                             error:(NSError **)error
+                                             error:(NSError *__autoreleasing*)error
 {
     
     if ([NSString msidIsStringNilOrBlank:attributes.privateKeyIdentifier])
@@ -172,7 +172,7 @@ static const OSStatus kNoStatus = -1;
 
 #pragma mark - Cleanup
 
-- (BOOL)deleteItemWithAttributes:(NSDictionary *)attributes error:(NSError **)error
+- (BOOL)deleteItemWithAttributes:(NSDictionary *)attributes error:(NSError *__autoreleasing*)error
 {
     NSDictionary *queryAttributes = [self keychainQueryWithAttributes:attributes];
     OSStatus result = SecItemDelete((CFDictionaryRef)queryAttributes);
@@ -191,7 +191,7 @@ static const OSStatus kNoStatus = -1;
 
 #pragma mark - Private
 
-- (NSDictionary *)keyAttributesWithQueryDictionary:(NSDictionary *)queryDictionary error:(NSError **)error
+- (NSDictionary *)keyAttributesWithQueryDictionary:(NSDictionary *)queryDictionary error:(NSError *__autoreleasing*)error
 {
     NSMutableDictionary *keychainQuery = [[self keychainQueryWithAttributes:queryDictionary] mutableCopy];
     CFDictionaryRef keyCFDict = NULL;
@@ -221,7 +221,7 @@ static const OSStatus kNoStatus = -1;
     return keyPairAttr;
 }
 
-- (MSIDAssymetricKeyPair *)generateEphemeralKeyPair:(NSError **)error
+- (MSIDAssymetricKeyPair *)generateEphemeralKeyPair:(NSError *__autoreleasing*)error
 {
     NSDictionary *attributesDict = @{(__bridge id)kSecAttrKeyType : (__bridge id)kSecAttrKeyTypeRSA,
                                      (__bridge id)kSecAttrKeySizeInBits : @2048};
@@ -229,7 +229,7 @@ static const OSStatus kNoStatus = -1;
 }
 
 - (MSIDAssymetricKeyPair *)generateKeyPairForKeyDict:(NSDictionary *)attributes
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     CFErrorRef keyGenerationError = NULL;
     SecKeyRef privateKeyRef = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &keyGenerationError);
@@ -280,7 +280,7 @@ static const OSStatus kNoStatus = -1;
 
 #pragma mark - Utils
 
-- (BOOL)logAndFillError:(NSString *)errorTitle status:(OSStatus)status error:(NSError **)error
+- (BOOL)logAndFillError:(NSString *)errorTitle status:(OSStatus)status error:(NSError *__autoreleasing*)error
 {
     NSString *description = [NSString stringWithFormat:@"Operation failed with title \"%@\", status %ld", errorTitle, (long)status];
     MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"%@", description);

--- a/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.h
+++ b/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDAssymetricKeyLoginKeychainGenerator : MSIDAssymetricKeyKeychainGenerator
 
-- (instancetype)initWithKeychainGroup:(nullable NSString *)keychainGroup accessRef:(nullable SecAccessRef)accessRef error:(NSError * _Nullable * _Nullable)error;
+- (instancetype)initWithKeychainGroup:(nullable NSString *)keychainGroup accessRef:(nullable SecAccessRef)accessRef error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end
 

--- a/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.m
+++ b/IdentityCore/src/cache/crypto/mac/MSIDAssymetricKeyLoginKeychainGenerator.m
@@ -31,7 +31,7 @@
 
 @implementation MSIDAssymetricKeyLoginKeychainGenerator
 
-- (instancetype)initWithKeychainGroup:(nullable NSString *)keychainGroup accessRef:(nullable SecAccessRef)accessRef error:(NSError * _Nullable * _Nullable)error
+- (instancetype)initWithKeychainGroup:(nullable NSString *)keychainGroup accessRef:(nullable SecAccessRef)accessRef error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     _accessRef = accessRef;
     self = [super initWithGroup:keychainGroup error:error];

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.h
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.h
@@ -43,21 +43,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)saveData:(nonnull NSData *)data
       attributes:(nonnull NSDictionary *)attributes
          context:(nullable id<MSIDRequestContext>)context
-           error:(NSError * _Nullable * _Nullable)error;
+           error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 
 - (BOOL)removeItemWithAttributes:(nonnull NSDictionary *)attributes
                          context:(nullable id<MSIDRequestContext>)context
-                           error:(NSError * _Nullable * _Nullable)error;
+                           error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 
 - (nullable NSData *)getDataWithAttributes:(nonnull NSDictionary *)attributes
                                    context:(nullable id<MSIDRequestContext>)context
-                                     error:(NSError * _Nullable * _Nullable)error;
+                                     error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (BOOL)clearWithAttributes:(nonnull NSDictionary *)attributes
                     context:(nullable id<MSIDRequestContext>)context
-                      error:(NSError * _Nullable * _Nullable)error;
+                      error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 #pragma mark - Util
 

--- a/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
+++ b/IdentityCore/src/cache/mac/MSIDMacACLKeychainAccessor.m
@@ -122,7 +122,7 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
 
 #pragma mark - Access Control Lists
 
-- (NSArray *)trustedAppListWithCurrentApp:(NSError **)error
+- (NSArray *)trustedAppListWithCurrentApp:(NSError *__autoreleasing*)error
 {
     static dispatch_once_t s_onceCreateTrustedAppListWithCurrentApp;
     static NSArray *trustedAppListWithCurrentApp;
@@ -157,7 +157,7 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
 
 - (id)accessCreateWithChangeACL:(NSArray<id> *)trustedApplications
                     accessLabel:(NSString *)accessLabel
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     SecAccessRef access;
 #pragma clang diagnostic push
@@ -190,7 +190,7 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
                      aclAuthorizationTag:(CFStringRef)aclAuthorizationTag
                      trustedApplications:(NSArray<id> *)trustedApplications
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -239,7 +239,7 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
 - (BOOL)createError:(NSString*)message
              domain:(NSErrorDomain)domain
           errorCode:(NSInteger)code
-              error:(NSError *_Nullable *_Nullable)error
+              error:(NSError *_Nullable __autoreleasing *_Nullable)error
             context:(id<MSIDRequestContext>)context
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"%@", message);
@@ -256,7 +256,7 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
 - (BOOL)saveData:(NSData *)data
       attributes:(NSDictionary *)attributes
          context:(id<MSIDRequestContext>)context
-           error:(NSError **)error
+           error:(NSError *__autoreleasing*)error
 {
     if (!data)
     {
@@ -298,7 +298,7 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
 
 - (BOOL)removeItemWithAttributes:(NSDictionary *)attributes
                          context:(id<MSIDRequestContext>)context
-                           error:(NSError **)error
+                           error:(NSError *__autoreleasing*)error
 {
     NSMutableDictionary *query = [NSMutableDictionary new];
     query[(id)kSecClass] = (id)kSecClassGenericPassword;
@@ -325,7 +325,7 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
 
 - (NSData *)getDataWithAttributes:(NSDictionary *)attributes
                           context:(id<MSIDRequestContext>)context
-                            error:(NSError **)error
+                            error:(NSError *__autoreleasing*)error
 {
     NSMutableDictionary *query = [NSMutableDictionary new];
     query[(id)kSecClass] = (id)kSecClassGenericPassword;
@@ -368,7 +368,7 @@ static dispatch_queue_t s_defaultSynchronizationQueue;
 // A test-only method that deletes all items from the cache for the given context.
 - (BOOL)clearWithAttributes:(NSDictionary *)attributes
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelWarning,context, @"Clearing the whole context. This should only be executed in tests.");

--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -500,7 +500,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
                 key:(MSIDCacheKey *)key
          serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
             context:(id<MSIDRequestContext>)context
-              error:(NSError **)error
+              error:(NSError *__autoreleasing*)error
 {
     assert(account);
     assert(serializer);
@@ -520,7 +520,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (MSIDAccountCacheItem *)accountWithKey:(MSIDCacheKey *)key
                               serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     MSID_TRACE;
     NSArray<MSIDAccountCacheItem *> *items = [self accountsWithKey:key
@@ -547,7 +547,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (NSArray<MSIDAccountCacheItem *> *)accountsWithKey:(MSIDCacheKey *)key
                                           serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                              context:(id<MSIDRequestContext>)context
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     MSIDMacCredentialStorageItem *storageItem = [self syncStorageItem:key.isShared serializer:serializer context:context error:error];
     NSArray *itemList = [storageItem storedItemsForKey:key];
@@ -561,7 +561,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 //
 - (BOOL)removeAccountsWithKey:(MSIDCacheKey *)key
                       context:(id<MSIDRequestContext>)context
-                        error:(NSError **)error
+                        error:(NSError *__autoreleasing*)error
 {
     return [self removeItemsWithKey:key context:context inBucket:MSID_ACCOUNT_CACHE_TYPE error:error];
 }
@@ -587,7 +587,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
               key:(MSIDCacheKey *)key
        serializer:(id<MSIDCacheItemSerializing>)serializer
           context:(id<MSIDRequestContext>)context
-            error:(NSError **)error
+            error:(NSError *__autoreleasing*)error
 {
     assert(credential);
     assert(serializer);
@@ -603,7 +603,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (MSIDCredentialCacheItem *)tokenWithKey:(MSIDCacheKey *)key
                                serializer:(id<MSIDCacheItemSerializing>)serializer
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     MSID_TRACE;
     NSArray<MSIDCredentialCacheItem *> *items = [self tokensWithKey:key
@@ -627,7 +627,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (NSArray<MSIDCredentialCacheItem *> *)tokensWithKey:(MSIDCacheKey *)key
                                            serializer:(id<MSIDCacheItemSerializing>)serializer
                                               context:(id<MSIDRequestContext>)context
-                                                error:(NSError **)error
+                                                error:(NSError *__autoreleasing*)error
 {
     NSArray *itemList;
     
@@ -691,7 +691,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (nullable NSArray<MSIDCredentialCacheItem *> *)getAllItemsWithKey:(MSIDCacheKey *)key
                                                             context:(nullable id<MSIDRequestContext>)context
                                                          serializer:(id<MSIDCacheItemSerializing>)serializer
-                                                              error:(NSError * _Nullable * _Nullable)error
+                                                              error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     NSMutableArray *allTokens = [NSMutableArray new];
     
@@ -711,7 +711,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
                         context:(id<MSIDRequestContext>)context
                      serializer:(__unused id<MSIDCacheItemSerializing>)serializer
                        isShared:(BOOL)isShared
-                          error:(NSError * _Nullable * _Nullable)error
+                          error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     BOOL result = YES;
     MSIDMacCredentialStorageItem *storageItem = [self syncStorageItem:isShared serializer:self.serializer context:context error:error];
@@ -760,7 +760,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (MSIDMacCredentialStorageItem *)syncStorageItem:(BOOL)isShared
                                        serializer:(id<MSIDCacheItemSerializing>)serializer
                                           context:(id<MSIDRequestContext>)context
-                                            error:(NSError **)error
+                                            error:(NSError *__autoreleasing*)error
 {
     /*
      Sync in memory cache with persistent cache at the time of look up.
@@ -780,7 +780,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
                isShared:(BOOL)isShared
              serializer:(id<MSIDCacheItemSerializing>)serializer
                 context:(id<MSIDRequestContext>)context
-                  error:(NSError **)error
+                  error:(NSError *__autoreleasing*)error
 {
     assert(storageItem);
     NSData *itemData = [serializer serializeCredentialStorageItem:storageItem];
@@ -810,7 +810,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 
 - (BOOL)removeStorageItem:(BOOL)isShared
                   context:(id<MSIDRequestContext>)context
-                    error:(NSError **)error
+                    error:(NSError *__autoreleasing*)error
 {
     NSMutableDictionary *query = [self.defaultCacheQuery mutableCopy];
     [query addEntriesFromDictionary:[self primaryAttributesForItem:isShared context:context error:error]];
@@ -822,7 +822,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (MSIDMacCredentialStorageItem *)queryStorageItem:(BOOL)isShared
                                         serializer:(id<MSIDCacheItemSerializing>)serializer
                                            context:(id<MSIDRequestContext>)context
-                                             error:(NSError **)error
+                                             error:(NSError *__autoreleasing*)error
 {
     MSID_TRACE;
     
@@ -888,7 +888,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (BOOL)removeItemsWithKey:(MSIDCacheKey *)key
                    context:(id<MSIDRequestContext>)context
                   inBucket:(__unused NSString *)bucket
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     MSID_TRACE;
     
@@ -911,7 +911,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
     return [self removeStorageItem:key.isShared context:context error:error];
 }
 
-- (NSDictionary *)primaryAttributesForItem:(BOOL)isShared context:(__unused id<MSIDRequestContext>)context error:(__unused NSError **)error
+- (NSDictionary *)primaryAttributesForItem:(BOOL)isShared context:(__unused id<MSIDRequestContext>)context error:(__unused NSError *__autoreleasing*)error
 {
     NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
     
@@ -938,7 +938,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
                     key:(__unused MSIDCacheKey *)key
              serializer:(__unused id<MSIDExtendedCacheItemSerializing>)serializer
                 context:(__unused id<MSIDRequestContext>)context
-                  error:(__unused NSError **)error
+                  error:(__unused NSError *__autoreleasing*)error
 {
     assert(metadata);
     assert(serializer);
@@ -952,7 +952,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (NSArray<MSIDAppMetadataCacheItem *> *)appMetadataEntriesWithKey:(MSIDCacheKey *)key
                                                         serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                            context:(id<MSIDRequestContext>)context
-                                                             error:(NSError **)error
+                                                             error:(NSError *__autoreleasing*)error
 {
     MSIDMacCredentialStorageItem *storageItem = key.isShared ? self.sharedStorageItem : self.appStorageItem;
     NSArray *itemList = [storageItem storedItemsForKey:key];
@@ -972,7 +972,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 // Remove items with the given Metadata key from the macOS keychain cache.
 - (BOOL)removeMetadataItemsWithKey:(__unused MSIDCacheKey *)key
                            context:(__unused id<MSIDRequestContext>)context
-                             error:(NSError **)error
+                             error:(NSError *__autoreleasing*)error
 {
     return [self removeItemsWithKey:key context:context inBucket:MSID_APPLICATION_METADATA_CACHE_TYPE error:error];
 }
@@ -1019,7 +1019,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 - (NSArray<MSIDAccountMetadataCacheItem *> *)accountsMetadataWithKey:(MSIDCacheKey *)key
                                                           serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                              context:(id<MSIDRequestContext>)context
-                                                               error:(NSError **)error
+                                                               error:(NSError *__autoreleasing*)error
 {
     MSIDMacCredentialStorageItem *storageItem = key.isShared ? self.sharedStorageItem : self.appStorageItem;
     NSArray *itemList = [storageItem storedItemsForKey:key];
@@ -1045,7 +1045,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 
 // Saves information about the app which most-recently removed a token.
 - (BOOL)saveWipeInfoWithContext:(id<MSIDRequestContext>)context
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     [self createUnimplementedError:error context:context];
     return NO;
@@ -1053,7 +1053,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 
 // Read information about the app which most-recently removed a token.
 - (NSDictionary *)wipeInfo:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     [self createUnimplementedError:error context:context];
     return nil;
@@ -1063,7 +1063,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 
 // A test-only method that deletes all items from the cache for the given context.
 - (BOOL)clearWithContext:(id<MSIDRequestContext>)context
-                   error:(NSError **)error
+                   error:(NSError *__autoreleasing*)error
 
 {
     // Clear in-memory cache
@@ -1077,7 +1077,7 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 #pragma mark - Utilities
 
 // Allocate a "Not Implemented" NSError object.
-- (BOOL)createUnimplementedError:(NSError *_Nullable *_Nullable)error
+- (BOOL)createUnimplementedError:(NSError *_Nullable __autoreleasing *_Nullable)error
                          context:(id<MSIDRequestContext>)context
 {
     return [self createError:@"Not Implemented."

--- a/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.h
+++ b/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.h
@@ -43,7 +43,7 @@
                   clientId:(NSString *)clientId
              instanceAware:(BOOL)instanceAware
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error;
+                     error:(NSError *__autoreleasing*)error;
 
 - (BOOL)updateAuthorityURL:(NSURL *)cacheAuthorityURL
              forRequestURL:(NSURL *)requestAuthorityURL
@@ -51,30 +51,30 @@
                   clientId:(NSString *)clientId
              instanceAware:(BOOL)instanceAware
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error;
+                     error:(NSError *__autoreleasing*)error;
 
 - (MSIDAccountMetadataState)signInStateForHomeAccountId:(NSString *)homeAccountId
                                                clientId:(NSString *)clientId
                                                 context:(id<MSIDRequestContext>)context
-                                                  error:(NSError **)error;
+                                                  error:(NSError *__autoreleasing*)error;
 
 - (BOOL)updateSignInStateForHomeAccountId:(NSString *)homeAccountId
                                  clientId:(NSString *)clientId
                                     state:(MSIDAccountMetadataState)state
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error;
+                                    error:(NSError *__autoreleasing*)error;
 
 - (MSIDAccountIdentifier *)principalAccountIdForClientId:(NSString *)clientId
                                                  context:(id<MSIDRequestContext>)context
-                                                   error:(NSError **)error;
+                                                   error:(NSError *__autoreleasing*)error;
 
 - (BOOL)updatePrincipalAccountIdForClientId:(NSString *)clientId
                          principalAccountId:(MSIDAccountIdentifier *)principalAccountId
                 principalAccountEnvironment:(NSString *)principalAccountEnvironment
                                     context:(id<MSIDRequestContext>)context
-                                      error:(NSError **)error;
+                                      error:(NSError *__autoreleasing*)error;
 
 - (MSIDAccountMetadataCacheItem *)retrieveAccountMetadataCacheItemForClientId:(NSString *)clientId
                                                                       context:(id<MSIDRequestContext>)context
-                                                                        error:(NSError **)error;
+                                                                        error:(NSError *__autoreleasing*)error;
 @end

--- a/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
+++ b/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.m
@@ -53,7 +53,7 @@
                   clientId:(NSString *)clientId
              instanceAware:(BOOL)instanceAware
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if (!requestAuthorityURL
         || [NSString msidIsStringNilOrBlank:homeAccountId]
@@ -78,7 +78,7 @@
                   clientId:(NSString *)clientId
              instanceAware:(BOOL)instanceAware
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if (!cacheAuthorityURL || !requestAuthorityURL || !homeAccountId || !clientId)
     {
@@ -137,7 +137,7 @@
 - (MSIDAccountMetadataState)signInStateForHomeAccountId:(NSString *)homeAccountId
                                                clientId:(NSString *)clientId
                                                 context:(id<MSIDRequestContext>)context
-                                                  error:(NSError **)error
+                                                  error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:homeAccountId]
         || [NSString msidIsStringNilOrBlank:clientId])
@@ -164,7 +164,7 @@
                                  clientId:(NSString *)clientId
                                     state:(MSIDAccountMetadataState)state
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:homeAccountId])
     {
@@ -213,7 +213,7 @@
 
 - (MSIDAccountIdentifier *)principalAccountIdForClientId:(NSString *)clientId
                                                  context:(id<MSIDRequestContext>)context
-                                                   error:(NSError **)error
+                                                   error:(NSError *__autoreleasing*)error
 {
     MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipMemoryCacheForAccountMetadata context:context error:error];
     
@@ -229,7 +229,7 @@
                          principalAccountId:(MSIDAccountIdentifier *)principalAccountId
                 principalAccountEnvironment:(NSString *)principalAccountEnvironment
                                     context:(id<MSIDRequestContext>)context
-                                      error:(NSError **)error
+                                      error:(NSError *__autoreleasing*)error
 {
     NSError *accountMetadataError;
     MSIDAccountMetadataCacheItem *cacheItem = [self retrieveAccountMetadataCacheItemForClientId:clientId skipCache:self.skipMemoryCacheForAccountMetadata context:context error:&accountMetadataError];
@@ -257,7 +257,7 @@
 
 - (MSIDAccountMetadataCacheItem *)retrieveAccountMetadataCacheItemForClientId:(NSString *)clientId
                                                                       context:(id<MSIDRequestContext>)context
-                                                                        error:(NSError **)error
+                                                                        error:(NSError *__autoreleasing*)error
 {
     return [self retrieveAccountMetadataCacheItemForClientId:clientId
                                                    skipCache:NO
@@ -270,7 +270,7 @@
 - (MSIDAccountMetadataCacheItem *)retrieveAccountMetadataCacheItemForClientId:(NSString *)clientId
                                                                     skipCache:(BOOL)skipCache
                                                                       context:(id<MSIDRequestContext>)context
-                                                                        error:(NSError **)error
+                                                                        error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:clientId])
     {
@@ -291,7 +291,7 @@
 // Remove account metadata for all clients based on home account id
 - (BOOL)removeAccountMetadataForHomeAccountId:(NSString *)homeAccountId
                                       context:(id<MSIDRequestContext>)context
-                                        error:(NSError **)error
+                                        error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:homeAccountId])
     {
@@ -344,7 +344,7 @@
 }
 
 - (NSArray<MSIDAccountMetadataCacheItem *> *)allAccountMetadataCacheItemsWithContext:(id<MSIDRequestContext>)context
-                                                                               error:(NSError **)error
+                                                                               error:(NSError *__autoreleasing*)error
 {
     return [_metadataCache allAccountMetadataCacheItemsWithContext:context error:error];
 }

--- a/IdentityCore/src/cache/metadata/MSIDMetadataCache.h
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCache.h
@@ -37,22 +37,22 @@
 - (BOOL)saveAccountMetadataCacheItem:(MSIDAccountMetadataCacheItem *)item
                                  key:(MSIDCacheKey *)key
                              context:(id<MSIDRequestContext>)context
-                               error:(NSError **)error;
+                               error:(NSError *__autoreleasing*)error;
 
 - (BOOL)removeAccountMetadataCacheItemForKey:(MSIDCacheKey *)key
                                      context:(id<MSIDRequestContext>)context
-                                       error:(NSError **)error;
+                                       error:(NSError *__autoreleasing*)error;
 
 - (MSIDAccountMetadataCacheItem *)accountMetadataCacheItemWithKey:(MSIDCacheKey *)key
                                                           context:(id<MSIDRequestContext>)context
-                                                            error:(NSError **)error;
+                                                            error:(NSError *__autoreleasing*)error;
 
 - (MSIDAccountMetadataCacheItem *)accountMetadataCacheItemWithKey:(MSIDCacheKey *)key
                                                         skipCache:(BOOL)skipCache
                                                           context:(id<MSIDRequestContext>)context
-                                                            error:(NSError **)error;
+                                                            error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDAccountMetadataCacheItem *> *)allAccountMetadataCacheItemsWithContext:(id<MSIDRequestContext>)context
-                                                                               error:(NSError **)error;
+                                                                               error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCache.m
@@ -60,7 +60,7 @@
 - (BOOL)saveAccountMetadataCacheItem:(MSIDAccountMetadataCacheItem *)item
                                  key:(MSIDCacheKey *)key
                              context:(id<MSIDRequestContext>)context
-                               error:(NSError **)error
+                               error:(NSError *__autoreleasing*)error
 {
     if (!item || !key)
     {
@@ -101,7 +101,7 @@
 
 - (MSIDAccountMetadataCacheItem *)accountMetadataCacheItemWithKey:(MSIDCacheKey *)key
                                                           context:(id<MSIDRequestContext>)context
-                                                            error:(NSError **)error
+                                                            error:(NSError *__autoreleasing*)error
 {
     return [self accountMetadataCacheItemWithKey:key skipCache:NO context:context error:error];
 }
@@ -109,7 +109,7 @@
 - (MSIDAccountMetadataCacheItem *)accountMetadataCacheItemWithKey:(MSIDCacheKey *)key
                                                         skipCache:(BOOL)skipCache
                                                           context:(id<MSIDRequestContext>)context
-                                                            error:(NSError **)error
+                                                            error:(NSError *__autoreleasing*)error
 {
     if (!key)
     {
@@ -156,7 +156,7 @@
 }
 
 - (NSArray<MSIDAccountMetadataCacheItem *> *)allAccountMetadataCacheItemsWithContext:(id<MSIDRequestContext>)context
-                                                                               error:(NSError **)error
+                                                                               error:(NSError *__autoreleasing*)error
 {
     MSIDAccountMetadataCacheKey *key = [[MSIDAccountMetadataCacheKey alloc] initWithClientId:nil];
 
@@ -190,7 +190,7 @@
 
 - (BOOL)removeAccountMetadataCacheItemForKey:(MSIDCacheKey *)key
                                      context:(id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     if (!key)
     {

--- a/IdentityCore/src/cache/metadata/MSIDMetadataCacheDataSource.h
+++ b/IdentityCore/src/cache/metadata/MSIDMetadataCacheDataSource.h
@@ -32,36 +32,36 @@
                         key:(MSIDCacheKey *)key
                  serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error;
+                      error:(NSError *__autoreleasing*)error;
 
 - (MSIDAccountMetadataCacheItem *)accountMetadataWithKey:(MSIDCacheKey *)key
                                               serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                  context:(id<MSIDRequestContext>)context
-                                                   error:(NSError **)error;
+                                                   error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDAccountMetadataCacheItem *> *)accountsMetadataWithKey:(MSIDCacheKey *)key
                                                           serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                              context:(id<MSIDRequestContext>)context
-                                                               error:(NSError **)error;
+                                                               error:(NSError *__autoreleasing*)error;
 
 - (BOOL)removeAccountMetadataForKey:(MSIDCacheKey *)key
                             context:(id<MSIDRequestContext>)context
-                              error:(NSError **)error;
+                              error:(NSError *__autoreleasing*)error;
 
 // App metadata
 - (BOOL)saveAppMetadata:(MSIDAppMetadataCacheItem *)item
                     key:(MSIDCacheKey *)key
              serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                 context:(id<MSIDRequestContext>)context
-                  error:(NSError **)error;
+                  error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDAppMetadataCacheItem *> *)appMetadataEntriesWithKey:(MSIDCacheKey *)key
                                                         serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                            context:(id<MSIDRequestContext>)context
-                                                             error:(NSError **)error;
+                                                             error:(NSError *__autoreleasing*)error;
 
 - (BOOL)removeMetadataItemsWithKey:(MSIDCacheKey *)key
                            context:(id<MSIDRequestContext>)context
-                             error:(NSError **)error;
+                             error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadata.h
+++ b/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadata.h
@@ -49,7 +49,7 @@ typedef NS_ENUM(NSInteger, MSIDAccountMetadataState)
 - (BOOL)setCachedURL:(NSURL *)cachedURL
        forRequestURL:(NSURL *)requestURL
        instanceAware:(BOOL)instanceAware
-               error:(NSError **)error;
+               error:(NSError *__autoreleasing*)error;
 - (NSURL *)cachedURL:(NSURL *)requestURL instanceAware:(BOOL)instanceAware;
 
 // Update sign in state

--- a/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadata.m
+++ b/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadata.m
@@ -60,7 +60,7 @@ static const NSString *AccountMetadataURLMapKey = @"URLMap";
 - (BOOL)setCachedURL:(NSURL *)cachedURL
        forRequestURL:(NSURL *)requestURL
        instanceAware:(BOOL)instanceAware
-               error:(NSError **)error
+               error:(NSError *__autoreleasing*)error
 {
     _signInState = MSIDAccountMetadataStateSignedIn;
     

--- a/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadataCacheItem.h
+++ b/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadataCacheItem.h
@@ -42,10 +42,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)addAccountMetadata:(MSIDAccountMetadata *)accountMetadata
           forHomeAccountId:(NSString *)homeAccountId
-                     error:(NSError **)error;
+                     error:(NSError *__autoreleasing*)error;
 
 - (BOOL)removeAccountMetadataForHomeAccountId:(NSString *)homeAccountId
-                                        error:(NSError **)error;
+                                        error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadataCacheItem.m
+++ b/IdentityCore/src/cache/metadata/accountMetadata/MSIDAccountMetadataCacheItem.m
@@ -61,7 +61,7 @@
     return _accountMetadataMap[homeAccountId];
 }
 
-- (BOOL)addAccountMetadata:(MSIDAccountMetadata *)accountMetadata forHomeAccountId:(NSString *)homeAccountId error:(NSError **)error
+- (BOOL)addAccountMetadata:(MSIDAccountMetadata *)accountMetadata forHomeAccountId:(NSString *)homeAccountId error:(NSError *__autoreleasing*)error
 {
     if (!homeAccountId || !accountMetadata)
     {
@@ -76,7 +76,7 @@
 }
 
 - (BOOL)removeAccountMetadataForHomeAccountId:(NSString *)homeAccountId
-                                        error:(NSError **)error
+                                        error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:homeAccountId])
     {

--- a/IdentityCore/src/cache/token/MSIDAccountCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDAccountCacheItem.m
@@ -121,7 +121,7 @@
 
 #pragma mark - JSON
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     MSID_TRACE;
     if (!(self = [super init]))

--- a/IdentityCore/src/cache/token/MSIDAppMetadataCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDAppMetadataCacheItem.m
@@ -83,7 +83,7 @@
 
 #pragma mark - JSON
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     if (!(self = [super init]))
     {

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -159,7 +159,7 @@
 
 #pragma mark - JSON
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     MSID_TRACE;
     if (!(self = [super init]))

--- a/IdentityCore/src/cache/token/MSIDPRTCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDPRTCacheItem.m
@@ -63,7 +63,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     if (!(self = [super initWithJSONDictionary:json error:error]))
     {

--- a/IdentityCore/src/claims/MSIDClaimsRequest.h
+++ b/IdentityCore/src/claims/MSIDClaimsRequest.h
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)requestClaim:(MSIDIndividualClaimRequest *)request
            forTarget:(MSIDClaimsRequestTarget)target
-               error:(NSError * _Nullable * _Nullable)error;
+               error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*!
  Return the array of requested claims for the target.
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)removeClaimRequestWithName:(NSString *)name
                             target:(MSIDClaimsRequestTarget)target
-                             error:(NSError * _Nullable * _Nullable)error;
+                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end
 

--- a/IdentityCore/src/claims/MSIDClaimsRequest.m
+++ b/IdentityCore/src/claims/MSIDClaimsRequest.m
@@ -58,7 +58,7 @@
 
 - (BOOL)requestClaim:(MSIDIndividualClaimRequest *)request
            forTarget:(MSIDClaimsRequestTarget)target
-               error:(NSError **)error
+               error:(NSError *__autoreleasing*)error
 {
     if (!request)
     {
@@ -105,7 +105,7 @@
 
 - (BOOL)removeClaimRequestWithName:(NSString *)name
                             target:(MSIDClaimsRequestTarget)target
-                             error:(NSError **)error
+                             error:(NSError *__autoreleasing*)error
 {
     if (!name)
     {
@@ -148,7 +148,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     if (self)
@@ -213,7 +213,7 @@
 
 #pragma mark - Private
 
-- (MSIDClaimsRequestTarget)targetFromString:(NSString *)string error:(NSError **)error
+- (MSIDClaimsRequestTarget)targetFromString:(NSString *)string error:(NSError *__autoreleasing*)error
 {
     if ([string isEqualToString:MSID_OAUTH2_ID_TOKEN]) return MSIDClaimsRequestTargetIdToken;
     if ([string isEqualToString:MSID_OAUTH2_ACCESS_TOKEN]) return MSIDClaimsRequestTargetAccessToken;

--- a/IdentityCore/src/claims/MSIDIndividualClaimRequest.m
+++ b/IdentityCore/src/claims/MSIDIndividualClaimRequest.m
@@ -44,7 +44,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     if (self)

--- a/IdentityCore/src/claims/MSIDIndividualClaimRequestAdditionalInfo.m
+++ b/IdentityCore/src/claims/MSIDIndividualClaimRequestAdditionalInfo.m
@@ -38,7 +38,7 @@ static NSString *const kValuesJsonParam = @"values";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     if (self)

--- a/IdentityCore/src/configuration/MSIDConfiguration.m
+++ b/IdentityCore/src/configuration/MSIDConfiguration.m
@@ -153,7 +153,7 @@ NSString *const MSID_NESTED_AUTH_BROKER_REDIRECT_URI_JSON_KEY = @"brk_redirect_u
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     MSIDAuthority *authority = (MSIDAuthority *)[MSIDJsonSerializableFactory createFromJSONDictionary:json classTypeJSONKey:MSID_PROVIDER_TYPE_JSON_KEY assertKindOfClass:MSIDAuthority.class error:error];
     if (!authority) return nil;

--- a/IdentityCore/src/configuration/webview/MSIDAuthorizeWebRequestConfiguration.m
+++ b/IdentityCore/src/configuration/webview/MSIDAuthorizeWebRequestConfiguration.m
@@ -55,7 +55,7 @@
 - (MSIDWebviewResponse *)responseWithResultURL:(NSURL *)url
                                        factory:(MSIDWebviewFactory *)factory
                                        context:(id<MSIDRequestContext>)context
-                                         error:(NSError **)error
+                                         error:(NSError *__autoreleasing*)error
 {
     return [factory oAuthResponseWithURL:url
                        requestState:self.state

--- a/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.h
+++ b/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.h
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable MSIDWebviewResponse *)responseWithResultURL:(NSURL *)url
                                                 factory:(MSIDWebviewFactory *)factory
                                                 context:(nullable id<MSIDRequestContext>)context
-                                                  error:(NSError * _Nullable * _Nullable)error;
+                                                  error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end
 

--- a/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.m
+++ b/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.m
@@ -64,7 +64,7 @@
 - (MSIDWebviewResponse *)responseWithResultURL:(__unused NSURL *)url
                                        factory:(__unused MSIDWebviewFactory *)factory
                                        context:(__unused id<MSIDRequestContext>)context
-                                         error:(__unused NSError **)error
+                                         error:(__unused NSError *__autoreleasing*)error
 {
     return nil;
 }

--- a/IdentityCore/src/configuration/webview/MSIDSignoutWebRequestConfiguration.m
+++ b/IdentityCore/src/configuration/webview/MSIDSignoutWebRequestConfiguration.m
@@ -33,7 +33,7 @@
 - (MSIDWebviewResponse *)responseWithResultURL:(NSURL *)url
                                        factory:(__unused MSIDWebviewFactory *)factory
                                        context:(id<MSIDRequestContext>)context
-                                         error:(NSError **)error
+                                         error:(NSError *__autoreleasing*)error
 {
     return [[MSIDWebOAuth2Response alloc] initWithURL:url
                                          requestState:self.state

--- a/IdentityCore/src/controllers/MSIDBaseRequestController.h
+++ b/IdentityCore/src/controllers/MSIDBaseRequestController.h
@@ -45,7 +45,7 @@ typedef void(^MSIDAuthorityCompletion)(BOOL resolved, NSError * _Nullable error)
 - (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
                               tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                 fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
-                                             error:(NSError * _Nullable * _Nullable)error;
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 #if !EXCLUDE_FROM_MSALCPP
 - (nullable MSIDTelemetryAPIEvent *)telemetryAPIEvent;

--- a/IdentityCore/src/controllers/MSIDBaseRequestController.m
+++ b/IdentityCore/src/controllers/MSIDBaseRequestController.m
@@ -41,7 +41,7 @@
 - (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
                               tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                 fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
-                                             error:(NSError * _Nullable * _Nullable)error
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self = [super init];
 

--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.h
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.h
@@ -35,6 +35,6 @@
 
 - (nullable instancetype)initWithInteractiveRequestParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                          tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                                        error:(NSError * _Nullable * _Nullable)error;
+                                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end

--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
@@ -50,7 +50,7 @@
 
 - (nullable instancetype)initWithInteractiveRequestParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                          tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                                        error:(NSError * _Nullable * _Nullable)error
+                                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self = [super initWithRequestParameters:parameters
                        tokenRequestProvider:tokenRequestProvider

--- a/IdentityCore/src/controllers/MSIDRequestControllerFactory.h
+++ b/IdentityCore/src/controllers/MSIDRequestControllerFactory.h
@@ -44,17 +44,17 @@ typedef NS_ENUM(NSInteger, MSIDSilentControllerLocalRtUsageType)
                                                         forceRefresh:(BOOL)forceRefresh
                                                          skipLocalRt:(MSIDSilentControllerLocalRtUsageType)skipLocalRt
                                                 tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                                               error:(NSError * _Nullable * _Nullable)error;
+                                                               error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 + (nullable id<MSIDRequestControlling>)interactiveControllerForParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                                      tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                                                    error:(NSError * _Nullable * _Nullable)error;
+                                                                    error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 + (nullable MSIDSignoutController *)signoutControllerForParameters:(nonnull MSIDInteractiveRequestParameters *)parameters
                                                       oauthFactory:(nonnull MSIDOauth2Factory *)oauthFactory
                                           shouldSignoutFromBrowser:(BOOL)shouldSignoutFromBrowser
                                                  shouldWipeAccount:(BOOL)shouldWipeAccount
                                      shouldWipeCacheForAllAccounts:(BOOL)shouldWipeCacheForAllAccounts
-                                                             error:(NSError * _Nullable * _Nullable)error;
+                                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end

--- a/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
+++ b/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
@@ -42,7 +42,7 @@
                                                         forceRefresh:(BOOL)forceRefresh
                                                          skipLocalRt:(MSIDSilentControllerLocalRtUsageType)skipLocalRt
                                                 tokenRequestProvider:(id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                                               error:(NSError **)error
+                                                               error:(NSError *__autoreleasing*)error
 {
     // Nested auth protocol - Reverse client id & redirect uri
     if ([parameters isNestedAuthProtocol])
@@ -106,7 +106,7 @@
 
 + (nullable id<MSIDRequestControlling>)interactiveControllerForParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                                      tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                                                    error:(NSError * _Nullable * _Nullable)error
+                                                                    error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     // Nested auth protocol - Reverse client id & redirect uri
     if ([parameters isNestedAuthProtocol])
@@ -132,7 +132,7 @@
 
 + (nullable id<MSIDRequestControlling>)platformInteractiveController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                                 tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                                               error:(NSError * _Nullable * _Nullable)error
+                                                               error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     id<MSIDRequestControlling> localController = [self localInteractiveController:parameters
                                                              tokenRequestProvider:tokenRequestProvider
@@ -163,7 +163,7 @@
 + (nullable id<MSIDRequestControlling>)brokerController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                    tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                      fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
-                                                  error:(NSError * _Nullable * _Nullable)error
+                                                  error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     MSIDBrokerInteractiveController *brokerController = nil;
     
@@ -209,7 +209,7 @@
 + (nullable id<MSIDRequestControlling>)brokerController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                    tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                      fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
-                                                  error:(NSError * _Nullable * _Nullable)error
+                                                  error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     return [self ssoExtensionInteractiveController:parameters
                               tokenRequestProvider:tokenRequestProvider
@@ -221,7 +221,7 @@
 + (nullable id<MSIDRequestControlling>)ssoExtensionInteractiveController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                                     tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                                       fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
-                                                                   error:(NSError * _Nullable * _Nullable)error
+                                                                   error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     if (@available(macOS 10.15, *))
     {
@@ -240,7 +240,7 @@
 
 + (nullable id<MSIDRequestControlling>)localInteractiveController:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                              tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                                            error:(NSError * _Nullable * _Nullable)error
+                                                            error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
 #if TARGET_OS_IPHONE
     if ([MSIDAppExtensionUtil isExecutingInAppExtension]
@@ -272,7 +272,7 @@
                                           shouldSignoutFromBrowser:(BOOL)shouldSignoutFromBrowser
                                                  shouldWipeAccount:(BOOL)shouldWipeAccount
                                      shouldWipeCacheForAllAccounts:(BOOL)shouldWipeCacheForAllAccounts
-                                                             error:(NSError **)error
+                                                             error:(NSError *__autoreleasing*)error
 {
     if ([parameters shouldUseBroker])
     {

--- a/IdentityCore/src/controllers/MSIDSignoutController.h
+++ b/IdentityCore/src/controllers/MSIDSignoutController.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithRequestParameters:(MSIDInteractiveRequestParameters *)parameters
                  shouldSignoutFromBrowser:(BOOL)shouldSignoutFromBrowser
                              oauthFactory:(MSIDOauth2Factory *)oauthFactory
-                                    error:(NSError * _Nullable * _Nullable)error;
+                                    error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (void)executeRequestWithCompletion:(MSIDSignoutRequestCompletionBlock)completionBlock;
 

--- a/IdentityCore/src/controllers/MSIDSignoutController.m
+++ b/IdentityCore/src/controllers/MSIDSignoutController.m
@@ -45,7 +45,7 @@
 - (instancetype)initWithRequestParameters:(MSIDInteractiveRequestParameters *)parameters
                  shouldSignoutFromBrowser:(BOOL)shouldSignoutFromBrowser
                              oauthFactory:(MSIDOauth2Factory *)oauthFactory
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     if (!parameters || !oauthFactory)
     {

--- a/IdentityCore/src/controllers/MSIDSilentController.h
+++ b/IdentityCore/src/controllers/MSIDSilentController.h
@@ -34,12 +34,12 @@
 - (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
                                       forceRefresh:(BOOL)forceRefresh
                               tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                             error:(NSError * _Nullable * _Nullable)error;
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
                                       forceRefresh:(BOOL)forceRefresh
                               tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                      fallbackInteractiveController:(nullable id<MSIDRequestControlling>)fallbackController
-                                             error:(NSError * _Nullable * _Nullable)error;
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end

--- a/IdentityCore/src/controllers/MSIDSilentController.m
+++ b/IdentityCore/src/controllers/MSIDSilentController.m
@@ -47,7 +47,7 @@
 - (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
                                       forceRefresh:(BOOL)forceRefresh
                               tokenRequestProvider:(id<MSIDTokenRequestProviding>)tokenRequestProvider
-                                             error:(NSError * _Nullable * _Nullable)error
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     return [self initWithRequestParameters:parameters
                               forceRefresh:forceRefresh
@@ -60,7 +60,7 @@
                                       forceRefresh:(BOOL)forceRefresh
                               tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                      fallbackInteractiveController:(nullable id<MSIDRequestControlling>)fallbackController
-                                             error:(NSError * _Nullable * _Nullable)error
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self = [super initWithRequestParameters:parameters
                        tokenRequestProvider:tokenRequestProvider

--- a/IdentityCore/src/controllers/broker/MSIDSSOExtensionInteractiveTokenRequestController.h
+++ b/IdentityCore/src/controllers/broker/MSIDSSOExtensionInteractiveTokenRequestController.h
@@ -31,7 +31,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 - (nullable instancetype)initWithInteractiveRequestParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                          tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                            fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
-                                                        error:(NSError * _Nullable * _Nullable)error NS_DESIGNATED_INITIALIZER;
+                                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error NS_DESIGNATED_INITIALIZER;
 
 + (BOOL)canPerformRequest;
 

--- a/IdentityCore/src/controllers/broker/MSIDSSOExtensionInteractiveTokenRequestController.m
+++ b/IdentityCore/src/controllers/broker/MSIDSSOExtensionInteractiveTokenRequestController.m
@@ -35,7 +35,7 @@
 - (instancetype)initWithInteractiveRequestParameters:(MSIDInteractiveTokenRequestParameters *)parameters
                                 tokenRequestProvider:(id<MSIDTokenRequestProviding>)tokenRequestProvider
                                   fallbackController:(id<MSIDRequestControlling>)fallbackController
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     self = [super initWithInteractiveRequestParameters:parameters
                                   tokenRequestProvider:tokenRequestProvider

--- a/IdentityCore/src/controllers/broker/MSIDSSOExtensionSignoutController.m
+++ b/IdentityCore/src/controllers/broker/MSIDSSOExtensionSignoutController.m
@@ -42,7 +42,7 @@
                         shouldWipeAccount:(BOOL)shouldWipeAccount
             shouldWipeCacheForAllAccounts:(BOOL)shouldWipeCacheForAllAccounts
                              oauthFactory:(MSIDOauth2Factory *)oauthFactory
-                                    error:(NSError * _Nullable * _Nullable)error
+                                    error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self = [super initWithRequestParameters:parameters
                    shouldSignoutFromBrowser:shouldSignoutFromBrowser

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.h
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.h
@@ -39,12 +39,12 @@
 - (nullable instancetype)initWithInteractiveRequestParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                          tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                            fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
-                                                        error:(NSError * _Nullable * _Nullable)error;
+                                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (nullable instancetype)initWithInteractiveRequestParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                          tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                             brokerInstallLink:(nonnull NSURL *)brokerInstallLink
-                                                        error:(NSError * _Nullable * _Nullable)error;
+                                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 + (BOOL)completeAcquireToken:(nullable NSURL *)resultURL
            sourceApplication:(nullable NSString *)sourceApplication

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -66,7 +66,7 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
 - (nullable instancetype)initWithInteractiveRequestParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                          tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                            fallbackController:(nullable id<MSIDRequestControlling>)fallbackController
-                                                        error:(NSError * _Nullable * _Nullable)error
+                                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self = [super initWithRequestParameters:parameters
                        tokenRequestProvider:tokenRequestProvider
@@ -86,7 +86,7 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
 - (nullable instancetype)initWithInteractiveRequestParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                          tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                             brokerInstallLink:(nonnull NSURL *)brokerInstallLink
-                                                        error:(NSError * _Nullable * _Nullable)error
+                                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self = [self initWithInteractiveRequestParameters:parameters
                                  tokenRequestProvider:tokenRequestProvider

--- a/IdentityCore/src/intune/MSIDIntuneEnrollmentIdsCache.m
+++ b/IdentityCore/src/intune/MSIDIntuneEnrollmentIdsCache.m
@@ -77,7 +77,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 - (NSString *)enrollmentIdForUserObjectId:(NSString *)userObjectId
                                  tenantId:(NSString *)tenantId
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     if (!userObjectId || !tenantId) return nil;
     
@@ -100,7 +100,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 - (NSString *)enrollmentIdForHomeAccountId:(NSString *)homeAccountId
                               legacyUserId:(NSString *)legacyUserId
                                    context:(id<MSIDRequestContext>)context
-                                     error:(NSError **)error
+                                     error:(NSError *__autoreleasing*)error
 {
     NSString *enrollmentId = nil;
     
@@ -135,7 +135,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 
 - (NSString *)enrollmentIdForHomeAccountId:(NSString *)homeAccountId
                                    context:(id<MSIDRequestContext>)context
-                                     error:(NSError **)error
+                                     error:(NSError *__autoreleasing*)error
 {
     NSString* enrollmentId = [self queryEnrollmentIdWithKey:MSID_INTUNE_HOME_ACCOUNT_ID
                                      validationId:homeAccountId
@@ -146,7 +146,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 
 - (NSString *)enrollmentIdForUserId:(NSString *)userId
                             context:(id<MSIDRequestContext>)context
-                              error:(NSError **)error
+                              error:(NSError *__autoreleasing*)error
 {
     NSString* enrollmentId = [self queryEnrollmentIdWithKey:MSID_INTUNE_USER_ID
                                      validationId:userId
@@ -158,7 +158,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 -(NSString *)queryEnrollmentIdWithKey:(NSString *)key
                          validationId:(NSString *)validationId
                               context:(id<MSIDRequestContext>)context
-                                error:(NSError **)error
+                                error:(NSError *__autoreleasing*)error
 {
     validationId = [validationId msidNormalizedString];
     NSArray *enrollIds = [self fetchAllEnrollmentIdsWithContext:context error:error];
@@ -178,7 +178,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 
 
 - (NSString *)enrollmentIdIfAvailableWithContext:(id<MSIDRequestContext>)context
-                                           error:(NSError **)error
+                                           error:(NSError *__autoreleasing*)error
 {
     NSArray *enrollIds = [self fetchAllEnrollmentIdsWithContext:context error:error];
     if (enrollIds)
@@ -193,7 +193,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 }
 
 - (NSArray *)fetchAllEnrollmentIdsWithContext:(id<MSIDRequestContext>)context
-                                         error:(NSError **)error
+                                         error:(NSError *__autoreleasing*)error
 {
     NSDictionary *jsonDictionary = [self.dataSource jsonDictionaryForKey:MSID_INTUNE_ENROLLMENT_ID_KEY];
     if (![self isValid:jsonDictionary context:context error:error]) return nil;
@@ -205,7 +205,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 
 - (BOOL)setEnrollmentIdsJsonDictionary:(NSDictionary *)jsonDictionary
                                context:(id<MSIDRequestContext>)context
-                                 error:(NSError **)error
+                                 error:(NSError *__autoreleasing*)error
 {
     if (![self isValid:jsonDictionary context:context error:error]) return NO;
     
@@ -214,7 +214,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 }
 
 - (NSDictionary *)enrollmentIdsJsonDictionaryWithContext:(id<MSIDRequestContext>)context
-                                                   error:(NSError **)error
+                                                   error:(NSError *__autoreleasing*)error
 {
     __auto_type jsonDictionary = [self.dataSource jsonDictionaryForKey:MSID_INTUNE_ENROLLMENT_ID_KEY];
     if (![self isValid:jsonDictionary context:context error:error]) return nil;
@@ -231,7 +231,7 @@ static MSIDIntuneEnrollmentIdsCache *s_sharedCache;
 
 - (BOOL)isValid:(NSDictionary *)json
         context:(id<MSIDRequestContext>)context
-          error:(NSError **)error
+          error:(NSError *__autoreleasing*)error
 {
     if (!json) return YES;
     

--- a/IdentityCore/src/intune/MSIDIntuneMAMResourcesCache.m
+++ b/IdentityCore/src/intune/MSIDIntuneMAMResourcesCache.m
@@ -74,7 +74,7 @@ static MSIDIntuneMAMResourcesCache *s_sharedCache;
 
 - (NSString *)resourceForAuthority:(MSIDAuthority *)authority
                            context:(id<MSIDRequestContext>)context
-                             error:(NSError **)error
+                             error:(NSError *__autoreleasing*)error
 {
     NSDictionary *jsonDictionary = [self.dataSource jsonDictionaryForKey:MSID_INTUNE_RESOURCE_ID_KEY];
     if (!jsonDictionary)
@@ -98,7 +98,7 @@ static MSIDIntuneMAMResourcesCache *s_sharedCache;
 
 - (BOOL)setResourcesJsonDictionary:(NSDictionary *)jsonDictionary
                            context:(id<MSIDRequestContext>)context
-                             error:(NSError **)error
+                             error:(NSError *__autoreleasing*)error
 {
     if (![self isValid:jsonDictionary context:context error:error]) return NO;
     
@@ -107,7 +107,7 @@ static MSIDIntuneMAMResourcesCache *s_sharedCache;
 }
 
 - (NSDictionary *)resourcesJsonDictionaryWithContext:(id<MSIDRequestContext>)context
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     __auto_type jsonDictionary = [self.dataSource jsonDictionaryForKey:MSID_INTUNE_RESOURCE_ID_KEY];
     if (![self isValid:jsonDictionary context:context error:error]) return nil;
@@ -124,7 +124,7 @@ static MSIDIntuneMAMResourcesCache *s_sharedCache;
 
 - (BOOL)isValid:(NSDictionary *)json
         context:(id<MSIDRequestContext>)context
-          error:(NSError **)error
+          error:(NSError *__autoreleasing*)error
 {
     NSString *errorDescription = @"Intune Resource JSON structure is incorrect.";
     __auto_type validationError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, errorDescription, nil, nil, nil, context.correlationId, nil, NO);

--- a/IdentityCore/src/network/request/MSIDAADAuthorityMetadataResponseSerializer.m
+++ b/IdentityCore/src/network/request/MSIDAADAuthorityMetadataResponseSerializer.m
@@ -40,7 +40,7 @@
 - (id)responseObjectForResponse:(NSHTTPURLResponse *)httpResponse
                            data:(NSData *)data
                         context:(id <MSIDRequestContext>)context
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     NSError *jsonError;
     NSDictionary *jsonObject = [super responseObjectForResponse:httpResponse data:data context:context error:&jsonError];

--- a/IdentityCore/src/network/request/MSIDAADOpenIdConfigurationInfoResponseSerializer.m
+++ b/IdentityCore/src/network/request/MSIDAADOpenIdConfigurationInfoResponseSerializer.m
@@ -42,7 +42,7 @@ static NSString *s_tenantIdPlaceholder = @"{tenantid}";
 - (id)responseObjectForResponse:(NSHTTPURLResponse *)httpResponse
                            data:(NSData *)data
                         context:(id <MSIDRequestContext>)context
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     NSError *jsonError;
     NSMutableDictionary *jsonObject = [[super responseObjectForResponse:httpResponse data:data context:context error:&jsonError] mutableCopy];

--- a/IdentityCore/src/network/request/MSIDDRSDiscoveryResponseSerializer.m
+++ b/IdentityCore/src/network/request/MSIDDRSDiscoveryResponseSerializer.m
@@ -40,7 +40,7 @@
 - (id)responseObjectForResponse:(NSHTTPURLResponse *)httpResponse
                            data:(NSData *)data
                         context:(id <MSIDRequestContext>)context
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     NSError *jsonError;
     NSDictionary *jsonObject = [[super responseObjectForResponse:httpResponse data:data context:context error:&jsonError] mutableCopy];

--- a/IdentityCore/src/network/request/MSIDUrlResponseSerializer.m
+++ b/IdentityCore/src/network/request/MSIDUrlResponseSerializer.m
@@ -29,7 +29,7 @@
 - (id)responseObjectForResponse:(NSHTTPURLResponse *)httpResponse
                            data:(NSData *)data
                         context:(id <MSIDRequestContext>)context
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     if (!httpResponse)
     {

--- a/IdentityCore/src/network/response_serializer/MSIDHttpResponseSerializer.m
+++ b/IdentityCore/src/network/response_serializer/MSIDHttpResponseSerializer.m
@@ -28,7 +28,7 @@
 - (id)responseObjectForResponse:(NSHTTPURLResponse *)httpResponse
                            data:(NSData *)data
                         context:(id <MSIDRequestContext>)context
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     id result;
     if (self.preprocessor)

--- a/IdentityCore/src/network/response_serializer/MSIDTokenResponseSerializer.m
+++ b/IdentityCore/src/network/response_serializer/MSIDTokenResponseSerializer.m
@@ -32,7 +32,7 @@
 - (id)responseObjectForResponse:(NSHTTPURLResponse *)httpResponse
                            data:(NSData *)data
                         context:(id <MSIDRequestContext>)context
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     NSError *localError;
     NSDictionary *jsonObject = [super responseObjectForResponse:httpResponse

--- a/IdentityCore/src/network/response_serializer/preprocessor/MSIDAADJsonResponsePreprocessor.m
+++ b/IdentityCore/src/network/response_serializer/preprocessor/MSIDAADJsonResponsePreprocessor.m
@@ -30,7 +30,7 @@
 - (id)responseObjectForResponse:(NSHTTPURLResponse *)httpResponse
                            data:(NSData *)data
                         context:(id <MSIDRequestContext>)context
-                          error:(NSError **)error
+                          error:(NSError *__autoreleasing*)error
 {
     NSError *jsonError;
     NSMutableDictionary *jsonObject = [[super responseObjectForResponse:httpResponse data:data context:context error:&jsonError] mutableCopy];

--- a/IdentityCore/src/oauth2/MSIDIdTokenClaims.m
+++ b/IdentityCore/src/oauth2/MSIDIdTokenClaims.m
@@ -49,7 +49,7 @@ MSID_JSON_ACCESSOR(ID_TOKEN_MIDDLE_NAME, middleName)
 MSID_JSON_ACCESSOR(ID_TOKEN_EMAIL, email)
 MSID_JSON_ACCESSOR(ID_TOKEN_ISSUER, issuer)
 
-- (instancetype)initWithRawIdToken:(NSString *)rawIdTokenString error:(NSError **)error
+- (instancetype)initWithRawIdToken:(NSString *)rawIdTokenString error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:rawIdTokenString])
     {

--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.h
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.h
@@ -87,7 +87,7 @@
 
 - (MSIDAuthority *)resultAuthorityWithConfiguration:(MSIDConfiguration *)configuration
                                       tokenResponse:(MSIDTokenResponse *)response
-                                              error:(NSError **)error;
+                                              error:(NSError *__autoreleasing*)error;
 
 // Webview Factory
 @property (readonly) MSIDWebviewFactory *webviewFactory;
@@ -95,4 +95,3 @@
 @property (nonatomic, readonly, class) MSIDProviderType providerType;
 
 @end
-

--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.m
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.m
@@ -59,14 +59,14 @@
 
 - (MSIDTokenResponse *)tokenResponseFromJSON:(NSDictionary *)json
                                      context:(__unused id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     return [[MSIDTokenResponse alloc] initWithJSONDictionary:json error:error];
 }
 
 - (BOOL)verifyResponse:(MSIDTokenResponse *)response
                context:(id<MSIDRequestContext>)context
-                 error:(NSError **)error
+                 error:(NSError *__autoreleasing*)error
 {
     if (!response)
     {
@@ -487,7 +487,7 @@
 
 - (MSIDAuthority *)resultAuthorityWithConfiguration:(MSIDConfiguration *)configuration
                                       tokenResponse:(MSIDTokenResponse *)response
-                                              error:(__unused NSError **)error
+                                              error:(__unused NSError *__autoreleasing*)error
 {
     if (response.idTokenObj.issuerAuthority)
     {

--- a/IdentityCore/src/oauth2/MSIDTokenResponse+Internal.h
+++ b/IdentityCore/src/oauth2/MSIDTokenResponse+Internal.h
@@ -27,6 +27,6 @@
 
 @interface MSIDTokenResponse ()
 
-- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError **)error;
+- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/oauth2/MSIDTokenResponse.m
+++ b/IdentityCore/src/oauth2/MSIDTokenResponse.m
@@ -34,7 +34,7 @@
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json
                           refreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)token
-                                 error:(NSError **)error
+                                 error:(NSError *__autoreleasing*)error
 {
     self = [self initWithJSONDictionary:json error:error];
     if (self)
@@ -133,14 +133,14 @@
 
 #pragma mark - Protected
 
-- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError **)error
+- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError *__autoreleasing*)error
 {
     return [[MSIDIdTokenClaims alloc] initWithRawIdToken:rawIdToken error:error];
 }
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super init];
     if (self)

--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.h
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.h
@@ -75,7 +75,7 @@
                                  requestState:(NSString *)requestState
                            ignoreInvalidState:(BOOL)ignoreInvalidState
                                       context:(id<MSIDRequestContext>)context
-                                        error:(NSError **)error;
+                                        error:(NSError *__autoreleasing*)error;
 
 // Helper for generating state for state verification
 - (NSString *)generateStateValue;

--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.m
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.m
@@ -225,7 +225,7 @@
                             requestState:(NSString *)requestState
                       ignoreInvalidState:(BOOL)ignoreInvalidState
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     //  return base response
     NSError *responseCreationError = nil;

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADIdTokenClaimsFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADIdTokenClaimsFactory.m
@@ -31,7 +31,7 @@
 
 @implementation MSIDAADIdTokenClaimsFactory
 
-+ (MSIDIdTokenClaims *)claimsFromRawIdToken:(NSString *)rawIdTokenString error:(NSError **)error
++ (MSIDIdTokenClaims *)claimsFromRawIdToken:(NSString *)rawIdTokenString error:(NSError *__autoreleasing*)error
 {
     MSIDIdTokenClaims *claims = [[MSIDIdTokenClaims alloc] initWithRawIdToken:rawIdTokenString error:error];
 

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADOauth2Factory.m
@@ -50,7 +50,7 @@
 
 - (BOOL)checkResponseClass:(MSIDTokenResponse *)response
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if (![response isKindOfClass:[MSIDAADTokenResponse class]])
     {
@@ -71,7 +71,7 @@
 
 - (MSIDTokenResponse *)tokenResponseFromJSON:(NSDictionary *)json
                                      context:(__unused id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     return [[MSIDAADTokenResponse alloc] initWithJSONDictionary:json error:error];
 }

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADTokenResponse.m
@@ -81,7 +81,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     if (self)

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
@@ -134,7 +134,7 @@
                                  requestState:(NSString *)requestState
                            ignoreInvalidState:(BOOL)ignoreInvalidState
                                       context:(id<MSIDRequestContext>)context
-                                        error:(NSError **)error
+                                        error:(NSError *__autoreleasing*)error
 {
     // Try to create CBA response
 #if AD_BROKER

--- a/IdentityCore/src/oauth2/aad_v1/MSIDAADV1BrokerResponse.m
+++ b/IdentityCore/src/oauth2/aad_v1/MSIDAADV1BrokerResponse.m
@@ -37,7 +37,7 @@ MSID_FORM_ACCESSOR(MSID_OAUTH2_SUB_ERROR, subError);
 MSID_FORM_ACCESSOR(@"user_id", userId);
 
 - (instancetype)initWithDictionary:(NSDictionary *)form
-                             error:(NSError **)error
+                             error:(NSError *__autoreleasing*)error
 {
     self = [super initWithDictionary:form error:error];
 

--- a/IdentityCore/src/oauth2/aad_v1/MSIDAADV1Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v1/MSIDAADV1Oauth2Factory.m
@@ -54,7 +54,7 @@
 
 - (BOOL)checkResponseClass:(MSIDTokenResponse *)response
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if (![response isKindOfClass:[MSIDAADV1TokenResponse class]])
     {
@@ -75,7 +75,7 @@
 
 - (MSIDTokenResponse *)tokenResponseFromJSON:(NSDictionary *)json
                                      context:(__unused id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     return [[MSIDAADV1TokenResponse alloc] initWithJSONDictionary:json error:error];
 }
@@ -240,7 +240,7 @@
 
 - (MSIDAuthority *)resultAuthorityWithConfiguration:(__unused MSIDConfiguration *)configuration
                                       tokenResponse:(__unused MSIDTokenResponse *)response
-                                              error:(__unused NSError **)error
+                                              error:(__unused NSError *__autoreleasing*)error
 {
     return configuration.authority;
 }

--- a/IdentityCore/src/oauth2/aad_v1/MSIDAADV1TokenResponse.m
+++ b/IdentityCore/src/oauth2/aad_v1/MSIDAADV1TokenResponse.m
@@ -35,7 +35,7 @@
     [MSIDJsonSerializableFactory mapJSONKey:MSID_PROVIDER_TYPE_JSON_KEY keyValue:MSID_JSON_TYPE_PROVIDER_AADV1 kindOfClass:MSIDTokenResponse.class toClassType:MSID_JSON_TYPE_AADV1_TOKEN_RESPONSE];
 }
 
-- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError **)error
+- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError *__autoreleasing*)error
 {
     return [[MSIDAADV1IdTokenClaims alloc] initWithRawIdToken:rawIdToken error:error];
 }
@@ -64,7 +64,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     if (self)

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2BrokerResponse.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2BrokerResponse.m
@@ -33,7 +33,7 @@
 MSID_FORM_ACCESSOR(@"scope", scope);
 
 - (instancetype)initWithDictionary:(NSDictionary *)form
-                             error:(NSError **)error
+                             error:(NSError *__autoreleasing*)error
 {
     self = [super initWithDictionary:form error:error];
 

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2Factory.m
@@ -60,7 +60,7 @@
 
 - (BOOL)checkResponseClass:(MSIDTokenResponse *)response
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if (![response isKindOfClass:[MSIDAADV2TokenResponse class]])
     {
@@ -81,7 +81,7 @@
 
 - (MSIDTokenResponse *)tokenResponseFromJSON:(NSDictionary *)json
                                      context:(__unused id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     return [[MSIDAADV2TokenResponse alloc] initWithJSONDictionary:json error:error];
 }
@@ -295,7 +295,7 @@
 
 - (MSIDAuthority *)resultAuthorityWithConfiguration:(MSIDConfiguration *)configuration
                                       tokenResponse:(MSIDTokenResponse *)response
-                                              error:(NSError **)error
+                                              error:(NSError *__autoreleasing*)error
 {
     if (response.idTokenObj.realm)
     {

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2FactoryForV1Request.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2Oauth2FactoryForV1Request.m
@@ -43,7 +43,7 @@
 
 - (MSIDTokenResponse *)tokenResponseFromJSON:(NSDictionary *)json
                                      context:(__unused id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     return [[MSIDAADV2TokenResponseForV1Request alloc] initWithJSONDictionary:json error:error];
 }

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2TokenResponse.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2TokenResponse.m
@@ -37,7 +37,7 @@
     [MSIDJsonSerializableFactory mapJSONKey:MSID_PROVIDER_TYPE_JSON_KEY keyValue:MSID_JSON_TYPE_PROVIDER_AADV2 kindOfClass:MSIDTokenResponse.class toClassType:MSID_JSON_TYPE_AADV2_TOKEN_RESPONSE];
 }
 
-- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError **)error
+- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError *__autoreleasing*)error
 {
     return [[MSIDAADV2IdTokenClaims alloc] initWithRawIdToken:rawIdToken error:error];
 }

--- a/IdentityCore/src/oauth2/aad_v2/MSIDAADV2TokenResponseForV1Request.m
+++ b/IdentityCore/src/oauth2/aad_v2/MSIDAADV2TokenResponseForV1Request.m
@@ -29,7 +29,7 @@
 
 @implementation MSIDAADV2TokenResponseForV1Request
 
-- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError **)error
+- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError *__autoreleasing*)error
 {
     return [[MSIDAADV1IdTokenClaims alloc] initWithRawIdToken:rawIdToken error:error];
 }

--- a/IdentityCore/src/oauth2/account/MSIDAccount.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccount.m
@@ -178,7 +178,7 @@
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     if (!(self = [super init]))
     {

--- a/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.h
+++ b/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.h
@@ -52,6 +52,6 @@ typedef NS_ENUM(NSInteger, MSIDLegacyAccountIdentifierType)
 + (NSString *)legacyAccountIdentifierTypeAsString:(MSIDLegacyAccountIdentifierType)type;
 + (MSIDLegacyAccountIdentifierType)legacyAccountIdentifierTypeFromString:(NSString *)typeString;
 + (NSString *)homeAccountIdentifierFromUid:(NSString *)uid utid:(NSString *)utid;
-+ (BOOL)isAccountIdValid:(NSString *)accountId error:(NSError **)error;
++ (BOOL)isAccountIdValid:(NSString *)accountId error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccountIdentifier.m
@@ -103,7 +103,7 @@ static NSString *const MSID_ACCOUNT_HOME_ID_JSON_KEY = @"home_account_id";
     else return nil;
 }
 
-+ (BOOL)isAccountIdValid:(NSString *)accountId error:(NSError **)error
++ (BOOL)isAccountIdValid:(NSString *)accountId error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:accountId])
     {
@@ -179,7 +179,7 @@ static NSString *const MSID_ACCOUNT_HOME_ID_JSON_KEY = @"home_account_id";
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     NSString *displayableId = [json msidStringObjectForKey:MSID_ACCOUNT_DISPLAYABLE_ID_JSON_KEY];
     NSString *homeAccountId = [json msidStringObjectForKey:MSID_ACCOUNT_HOME_ID_JSON_KEY];

--- a/IdentityCore/src/oauth2/b2c/MSIDB2COauth2Factory.m
+++ b/IdentityCore/src/oauth2/b2c/MSIDB2COauth2Factory.m
@@ -45,7 +45,7 @@
 
 - (BOOL)checkResponseClass:(MSIDB2CTokenResponse *)response
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if (![response isKindOfClass:[MSIDB2CTokenResponse class]])
     {
@@ -66,7 +66,7 @@
 
 - (MSIDB2CTokenResponse *)tokenResponseFromJSON:(NSDictionary *)json
                                         context:(__unused id<MSIDRequestContext>)context
-                                          error:(NSError **)error
+                                          error:(NSError *__autoreleasing*)error
 {
     return [[MSIDB2CTokenResponse alloc] initWithJSONDictionary:json error:error];
 }
@@ -138,7 +138,7 @@
 
 - (MSIDAuthority *)resultAuthorityWithConfiguration:(MSIDConfiguration *)configuration
                                       tokenResponse:(MSIDB2CTokenResponse *)response
-                                              error:(NSError **)error
+                                              error:(NSError *__autoreleasing*)error
 {
     return [[MSIDB2CAuthority alloc] initWithURL:configuration.authority.url
                                   validateFormat:NO

--- a/IdentityCore/src/oauth2/b2c/MSIDB2CTokenResponse.m
+++ b/IdentityCore/src/oauth2/b2c/MSIDB2CTokenResponse.m
@@ -41,7 +41,7 @@
     [MSIDJsonSerializableFactory mapJSONKey:MSID_PROVIDER_TYPE_JSON_KEY keyValue:MSID_JSON_TYPE_PROVIDER_B2C kindOfClass:MSIDTokenResponse.class toClassType:MSID_JSON_TYPE_B2C_TOKEN_RESPONSE];
 }
 
-- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError **)error
+- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError *__autoreleasing*)error
 {
     return [[MSIDB2CIdTokenClaims alloc] initWithRawIdToken:rawIdToken error:error];
 }

--- a/IdentityCore/src/oauth2/ciam/MSIDCIAMOauth2Factory.m
+++ b/IdentityCore/src/oauth2/ciam/MSIDCIAMOauth2Factory.m
@@ -45,7 +45,7 @@
 
 - (BOOL)checkResponseClass:(MSIDCIAMTokenResponse *)response
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if (![response isKindOfClass:[MSIDCIAMTokenResponse class]])
     {
@@ -66,7 +66,7 @@
 
 - (MSIDCIAMTokenResponse *)tokenResponseFromJSON:(NSDictionary *)json
                                         context:(__unused id<MSIDRequestContext>)context
-                                          error:(NSError **)error
+                                          error:(NSError *__autoreleasing*)error
 {
     return [[MSIDCIAMTokenResponse alloc] initWithJSONDictionary:json error:error];
 }
@@ -132,7 +132,7 @@
 
 - (MSIDAuthority *)resultAuthorityWithConfiguration:(MSIDConfiguration *)configuration
                                       tokenResponse:(MSIDCIAMTokenResponse *)response
-                                              error:(NSError **)error
+                                              error:(NSError *__autoreleasing*)error
 {
     return [[MSIDCIAMAuthority alloc] initWithURL:configuration.authority.url
                                   validateFormat:NO

--- a/IdentityCore/src/oauth2/ciam/MSIDCIAMTokenResponse.m
+++ b/IdentityCore/src/oauth2/ciam/MSIDCIAMTokenResponse.m
@@ -41,7 +41,7 @@
     [MSIDJsonSerializableFactory mapJSONKey:MSID_PROVIDER_TYPE_JSON_KEY keyValue:MSID_JSON_TYPE_PROVIDER_CIAM kindOfClass:MSIDTokenResponse.class toClassType:MSID_JSON_TYPE_CIAM_TOKEN_RESPONSE];
 }
 
-- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError **)error
+- (MSIDIdTokenClaims *)tokenClaimsFromRawIdToken:(NSString *)rawIdToken error:(NSError *__autoreleasing*)error
 {
     return [[MSIDAADV2IdTokenClaims alloc] initWithRawIdToken:rawIdToken error:error];
 }

--- a/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
                     brokerOptions:(nullable MSIDBrokerInvocationOptions *)brokerOptions
                       requestType:(MSIDRequestType)requestType
               intuneAppIdentifier:(nullable NSString *)intuneApplicationIdentifier
-                            error:(NSError * _Nullable * _Nullable)error;
+                            error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end
 

--- a/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.m
@@ -40,7 +40,7 @@
                     brokerOptions:(MSIDBrokerInvocationOptions *)brokerOptions
                       requestType:(MSIDRequestType)requestType
               intuneAppIdentifier:(NSString *)intuneApplicationIdentifier
-                            error:(NSError **)error
+                            error:(NSError *__autoreleasing*)error
 {
     self = [super initWithAuthority:authority
                          authScheme:authScheme
@@ -107,7 +107,7 @@
     return authorizeParams;
 }
 
-- (BOOL)validateParametersWithError:(NSError **)error
+- (BOOL)validateParametersWithError:(NSError *__autoreleasing*)error
 {
     BOOL result = [super validateParametersWithError:error];
 

--- a/IdentityCore/src/parameters/MSIDRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.h
@@ -110,7 +110,7 @@
 - (void)setCloudAuthorityWithCloudHostName:(NSString *)cloudHostName;
 - (NSString *)allTokenRequestScopes;
 
-- (BOOL)validateParametersWithError:(NSError **)error;
+- (BOOL)validateParametersWithError:(NSError *__autoreleasing*)error;
 
 - (void)updateAppRequestMetadata:(NSString *)homeAccountId;
 
@@ -129,6 +129,6 @@
                    telemetryApiId:(NSString *)telemetryApiId
               intuneAppIdentifier:(NSString *)intuneApplicationIdentifier
                       requestType:(MSIDRequestType)requestType
-                            error:(NSError **)error;
+                            error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -61,7 +61,7 @@
                    telemetryApiId:(NSString *)telemetryApiId
               intuneAppIdentifier:(NSString *)intuneApplicationIdentifier
                       requestType:(MSIDRequestType)requestType
-                            error:(NSError **)error
+                            error:(NSError *__autoreleasing*)error
 {
     self = [super init];
 
@@ -324,7 +324,7 @@
 
 #pragma mark - Validate
 
-- (BOOL)validateParametersWithError:(NSError **)error
+- (BOOL)validateParametersWithError:(NSError *__autoreleasing*)error
 {
     if (!self.authority)
     {

--- a/IdentityCore/src/pop_manager/MSIDDevicePopManager.m
+++ b/IdentityCore/src/pop_manager/MSIDDevicePopManager.m
@@ -191,7 +191,7 @@
     return signedJwtHeader;
 }
 
-- (BOOL)logAndFillError:(NSString *)description error:(NSError **)error
+- (BOOL)logAndFillError:(NSString *)description error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"%@", description);
     
@@ -204,4 +204,3 @@
 }
 
 @end
-

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -625,7 +625,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
 
 #pragma mark - Abstract
 
-- (nullable MSIDAccessToken *)accessTokenWithError:(__unused NSError **)error
+- (nullable MSIDAccessToken *)accessTokenWithError:(__unused NSError *__autoreleasing*)error
 {
     NSAssert(NO, @"Abstract method. Should be implemented in a subclass");
     return nil;
@@ -633,26 +633,26 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
 
 - (nullable MSIDTokenResult *)resultWithAccessToken:(__unused MSIDAccessToken *)accessToken
                                        refreshToken:(__unused id<MSIDRefreshableToken>)refreshToken
-                                              error:(__unused NSError * _Nullable * _Nullable)error
+                                              error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error
 {
     NSAssert(NO, @"Abstract method. Should be implemented in a subclass");
     return nil;
 }
 
-- (nullable MSIDRefreshToken *)familyRefreshTokenWithError:(__unused NSError * _Nullable * _Nullable)error
+- (nullable MSIDRefreshToken *)familyRefreshTokenWithError:(__unused NSError * _Nullable __autoreleasing * _Nullable)error
 {
     NSAssert(NO, @"Abstract method. Should be implemented in a subclass");
     return nil;
 }
 
-- (nullable MSIDBaseToken<MSIDRefreshableToken> *)appRefreshTokenWithError:(__unused NSError * _Nullable * _Nullable)error
+- (nullable MSIDBaseToken<MSIDRefreshableToken> *)appRefreshTokenWithError:(__unused NSError * _Nullable __autoreleasing * _Nullable)error
 {
     NSAssert(NO, @"Abstract method. Should be implemented in a subclass");
     return nil;
 }
 
 - (BOOL)updateFamilyIdCacheWithServerError:(__unused NSError *)serverError
-                                cacheError:(__unused NSError **)cacheError
+                                cacheError:(__unused NSError *__autoreleasing*)cacheError
 {
     NSAssert(NO, @"Abstract method. Should be implemented in a subclass");
     return NO;

--- a/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.h
+++ b/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.h
@@ -31,7 +31,7 @@
 
 - (nullable NSDictionary *)decryptBrokerResponse:(nonnull NSDictionary *)response
                                    correlationId:(nullable NSUUID *)correlationId
-                                           error:(NSError * _Nullable * _Nullable)error;
+                                           error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (nullable NSData *)decryptData:(nonnull NSData *)response
                  protocolVersion:(NSUInteger)version;

--- a/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerCryptoProvider.m
@@ -50,7 +50,7 @@
 
 - (NSDictionary *)decryptBrokerResponse:(NSDictionary *)response
                           correlationId:(NSUUID *)correlationId
-                                  error:(NSError **)error
+                                  error:(NSError *__autoreleasing*)error
 {
     NSString *hash = response[@"hash"];
 

--- a/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.h
+++ b/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.h
@@ -46,13 +46,13 @@ enum {
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-- (NSData *)brokerKeyWithError:(NSError **)error;
+- (NSData *)brokerKeyWithError:(NSError *__autoreleasing*)error;
 
 - (NSString *)base64BrokerKeyWithContext:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error;
+                                   error:(NSError *__autoreleasing*)error;
 
-- (BOOL)saveApplicationToken:(NSString *)appToken forClientId:(NSString *)clientId error:(NSError **)error;
+- (BOOL)saveApplicationToken:(NSString *)appToken forClientId:(NSString *)clientId error:(NSError *__autoreleasing*)error;
 
-- (NSString *)getApplicationToken:(NSString *)clientId error:(NSError **)error;
+- (NSString *)getApplicationToken:(NSString *)clientId error:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerKeyProvider.m
@@ -81,7 +81,7 @@
     return self;
 }
 
-- (NSData *)brokerKeyWithError:(NSError **)error
+- (NSData *)brokerKeyWithError:(NSError *__autoreleasing*)error
 {
     OSStatus err = noErr;
 
@@ -144,7 +144,7 @@
 }
 
 - (NSString *)base64BrokerKeyWithContext:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     NSError *localError;
     NSData *brokerKey = [self brokerKeyWithError:&localError];
@@ -173,7 +173,7 @@
     return base64UrlKey;
 }
 
-- (NSData *)createBrokerKeyWithError:(NSError **)error
+- (NSData *)createBrokerKeyWithError:(NSError *__autoreleasing*)error
 {
     uint8_t *symmetricKey = NULL;
     OSStatus err = errSecSuccess;
@@ -240,7 +240,7 @@
     return keyData;
 }
 
-- (BOOL)deleteSymmetricKeyWithError:(NSError **)error
+- (BOOL)deleteSymmetricKeyWithError:(NSError *__autoreleasing*)error
 {
     OSStatus err = noErr;
 
@@ -268,7 +268,7 @@
     return YES;
 }
 
-- (BOOL)saveApplicationToken:(NSString *)appToken forClientId:(NSString *)clientId error:(NSError **)error
+- (BOOL)saveApplicationToken:(NSString *)appToken forClientId:(NSString *)clientId error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Saving broker application token for clientId %@.", clientId);
     NSString *tag = [NSString stringWithFormat:@"%@-%@", MSID_BROKER_APPLICATION_TOKEN_TAG, clientId];
@@ -300,7 +300,7 @@
     return YES;
 }
 
-- (NSString *)getApplicationToken:(NSString *)clientId error:(NSError **)error
+- (NSString *)getApplicationToken:(NSString *)clientId error:(NSError *__autoreleasing*)error
 {
     NSString *tag = [NSString stringWithFormat:@"%@-%@", MSID_BROKER_APPLICATION_TOKEN_TAG, clientId];
     

--- a/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.h
+++ b/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 brokerKey:(NSString *)brokerKey
                    brokerApplicationToken:(NSString *)brokerApplicationToken
                           sdkCapabilities:(nullable NSArray *)sdkCapabilities
-                                    error:(NSError **)error;
+                                    error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
@@ -57,7 +57,7 @@
                                 brokerKey:(NSString *)brokerKey
                    brokerApplicationToken:(NSString *)brokerApplicationToken
                           sdkCapabilities:(NSArray *)sdkCapabilities
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     self = [super init];
 
@@ -80,7 +80,7 @@
     return self;
 }
 
-- (BOOL)initPayloadContentsWithError:(NSError **)error
+- (BOOL)initPayloadContentsWithError:(NSError *__autoreleasing*)error
 {
     NSMutableDictionary *contents = [NSMutableDictionary new];
 
@@ -132,7 +132,7 @@
 
 #pragma mark - Default contents
 
-- (NSDictionary *)defaultPayloadContents:(NSError **)error
+- (NSDictionary *)defaultPayloadContents:(NSError *__autoreleasing*)error
 {
     if (![self checkParameter:self.requestParameters.authority parameterName:@"authority" error:error]) return nil;
     if (![self checkParameter:self.requestParameters.target parameterName:@"target" error:error]) return nil;
@@ -229,7 +229,7 @@
 
 - (BOOL)checkParameter:(id)parameter
          parameterName:(NSString *)parameterName
-                 error:(NSError **)error
+                 error:(NSError *__autoreleasing*)error
 {
     if (!parameter)
     {
@@ -311,7 +311,7 @@
 #pragma mark - Abstract
 
 // Thos parameters will be different depending on the broker protocol version
-- (NSDictionary *)protocolPayloadContentsWithError:(__unused NSError **)error
+- (NSDictionary *)protocolPayloadContentsWithError:(__unused NSError *__autoreleasing*)error
 {
     return @{};
 }

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.h
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.h
@@ -37,7 +37,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 
 - (nullable instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
                         returnOnlySignedInAccounts:(BOOL)returnOnlySignedInAccounts
-                                             error:(NSError * _Nullable * _Nullable)error;
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (void)executeRequestWithCompletion:(nonnull MSIDGetAccountsRequestCompletionBlock)completionBlock;
 

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetAccountsRequest.m
@@ -59,7 +59,7 @@
 
 - (nullable instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
                         returnOnlySignedInAccounts:(BOOL)returnOnlySignedInAccounts
-                                             error:(NSError * _Nullable * _Nullable)error
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self = [super init];
     

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDataBaseRequest.h
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDataBaseRequest.h
@@ -40,7 +40,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 @property (nonatomic, readonly) MSIDRequestParameters *requestParameters;
 
 - (nullable instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
-                                             error:(NSError * _Nullable * _Nullable)error;
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (void)executeBrokerOperationRequest:(MSIDBrokerOperationRequest *)request
                            requiresUI:(BOOL)requiresUI

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDataBaseRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDataBaseRequest.m
@@ -30,7 +30,7 @@
 @implementation MSIDSSOExtensionGetDataBaseRequest
 
 - (instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
-                                             error:(NSError **)error
+                                             error:(NSError *__autoreleasing*)error
 {
     if (!requestParameters)
     {

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.h
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.h
@@ -36,7 +36,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
 @property (nonatomic, readonly) MSIDRequestParameters *requestParameters;
 
 - (nullable instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
-                                             error:(NSError * _Nullable * _Nullable)error;
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (void)executeRequestWithCompletion:(nonnull MSIDGetDeviceInfoRequestCompletionBlock)completionBlock;
 

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetDeviceInfoRequest.m
@@ -54,7 +54,7 @@
 @implementation MSIDSSOExtensionGetDeviceInfoRequest
 
 - (nullable instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
-                                             error:(NSError * _Nullable * _Nullable)error
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self = [super init];
     

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetSsoCookiesRequest.h
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetSsoCookiesRequest.h
@@ -54,7 +54,7 @@ API_AVAILABLE(ios(13.0), macos(10.15))
                                  accountIdentifier:(nullable MSIDAccountIdentifier *)accountIdentifier
                                             ssoUrl:(NSString *)ssoUrl
                                      correlationId:(nullable NSUUID *)correlationId
-                                             error:(NSError * _Nullable * _Nullable)error;
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (void)executeRequestWithCompletion:(nonnull MSIDGetSsoCookiesRequestCompletionBlock)completionBlock;
 

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionGetSsoCookiesRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionGetSsoCookiesRequest.m
@@ -40,7 +40,7 @@
                         accountIdentifier:(MSIDAccountIdentifier *)accountIdentifier
                                    ssoUrl:(NSString *)ssoUrl
                             correlationId:(NSUUID *)correlationId
-                                    error:(NSError **)error{
+                                    error:(NSError *__autoreleasing*)error{
     self = [super initWithRequestParameters:requestParameters error:error];
     if (self)
     {

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionPasskeyAssertionRequest.h
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionPasskeyAssertionRequest.h
@@ -55,7 +55,7 @@ API_AVAILABLE(macos(14.0))
                                     relyingPartyId:(NSString *)relyingPartyId
                                              keyId:(NSData *)keyId
                                      correlationId:(nullable NSUUID *)correlationId
-                                             error:(NSError * _Nullable * _Nullable)error;
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (void)executeRequestWithCompletion:(nonnull MSIDPasskeyAssertionRequestCompletionBlock)completionBlock;
 

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionPasskeyAssertionRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionPasskeyAssertionRequest.m
@@ -43,7 +43,7 @@
                            relyingPartyId:(NSString *)relyingPartyId
                                     keyId:(NSData *)keyId
                             correlationId:(NSUUID *)correlationId
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     self = [super initWithRequestParameters:requestParameters error:error];
     if (self)

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionPasskeyCredentialRequest.h
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionPasskeyCredentialRequest.h
@@ -46,7 +46,7 @@ API_AVAILABLE(macos(14.0))
  */
 - (nullable instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
                                      correlationId:(nullable NSUUID *)correlationId
-                                             error:(NSError * _Nullable * _Nullable)error;
+                                             error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (void)executeRequestWithCompletion:(nonnull MSIDPasskeyCredentialRequestCompletionBlock)completionBlock;
 

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionPasskeyCredentialRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionPasskeyCredentialRequest.m
@@ -40,7 +40,7 @@
 
 - (instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
                             correlationId:(NSUUID *)correlationId
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     self = [super initWithRequestParameters:requestParameters error:error];
     if (self)

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionRequestDelegate+Internal.h
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionRequestDelegate+Internal.h
@@ -33,10 +33,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) MSIDJsonSerializer *jsonSerializer;
 
 - (nullable ASAuthorizationSingleSignOnCredential *)ssoCredentialFromCredential:(id <ASAuthorizationCredential>)credential
-                                                                          error:(NSError **)error;
+                                                                          error:(NSError *__autoreleasing*)error;
 
 - (NSDictionary *)jsonPayloadFromSSOCredential:(ASAuthorizationSingleSignOnCredential *)ssoCredential
-                                         error:(NSError **)error;
+                                         error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionRequestDelegate.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionRequestDelegate.m
@@ -98,7 +98,7 @@
 #pragma mark - Protected
 
 - (ASAuthorizationSingleSignOnCredential *)ssoCredentialFromCredential:(id <ASAuthorizationCredential>)credential
-                                                                 error:(NSError **)error
+                                                                 error:(NSError *__autoreleasing*)error
 {
     if (![credential isKindOfClass:ASAuthorizationSingleSignOnCredential.class])
     {
@@ -115,7 +115,7 @@
 }
 
 - (NSDictionary *)jsonPayloadFromSSOCredential:(ASAuthorizationSingleSignOnCredential *)ssoCredential
-                                         error:(__unused NSError **)error
+                                         error:(__unused NSError *__autoreleasing*)error
 {
     return ssoCredential.authenticatedResponse.allHeaderFields;
 }

--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.h
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithOauthFactory:(MSIDOauth2Factory *)factory
                        tokenResponseValidator:(MSIDTokenResponseValidator *)responseValidator;
 
-- (nullable MSIDTokenResult *)handleBrokerResponseWithURL:(NSURL *)url sourceApplication:(nullable NSString *)sourceApplication error:(NSError * _Nullable * _Nullable)error;
+- (nullable MSIDTokenResult *)handleBrokerResponseWithURL:(NSURL *)url sourceApplication:(nullable NSString *)sourceApplication error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (BOOL)canHandleBrokerResponse:(NSURL *)response
              hasCompletionBlock:(BOOL)hasCompletionBlock;

--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
@@ -76,7 +76,7 @@
 
 #pragma mark - Broker response
 
-- (MSIDTokenResult *)handleBrokerResponseWithURL:(NSURL *)response sourceApplication:(NSString *)sourceApplication error:(NSError **)error
+- (MSIDTokenResult *)handleBrokerResponseWithURL:(NSURL *)response sourceApplication:(NSString *)sourceApplication error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Handling broker response.");
     
@@ -220,7 +220,7 @@
 
 #pragma mark - Helpers
 
-- (NSDictionary *)verifyResumeStateDictionary:(NSURL *)response error:(NSError **)error
+- (NSDictionary *)verifyResumeStateDictionary:(NSURL *)response error:(NSError *__autoreleasing*)error
 {
     if (!response)
     {
@@ -292,21 +292,21 @@
                                                  correlationId:(__unused NSUUID *)correlationID
                                                     authScheme:(__unused MSIDAuthenticationScheme *)authScheme
                                                    redirectUri:(__unused NSString *)redirectUri
-                                                         error:(__unused NSError **)error
+                                                         error:(__unused NSError *__autoreleasing*)error
 {
     NSAssert(NO, @"Abstract method, implemented in subclasses");
     return nil;
 }
 
 - (id<MSIDCacheAccessor>)cacheAccessorWithKeychainGroup:(__unused NSString *)keychainGroup
-                                                  error:(__unused NSError **)error
+                                                  error:(__unused NSError *__autoreleasing*)error
 {
     NSAssert(NO, @"Abstract method, implemented in subclasses");
     return nil;
 }
 
 - (MSIDAccountMetadataCacheAccessor *)accountMetadataCacheWithKeychainGroup:(__unused NSString *)keychainGroup
-                                                                      error:(__unused NSError **)error
+                                                                      error:(__unused NSError *__autoreleasing*)error
 {
     NSAssert(NO, @"Abstract method, implemented in subclasses");
     return nil;

--- a/IdentityCore/src/requests/sdk/MSIDTokenRequestProviding.h
+++ b/IdentityCore/src/requests/sdk/MSIDTokenRequestProviding.h
@@ -41,7 +41,7 @@
                                                             brokerKey:(nonnull NSString *)brokerKey
                                                brokerApplicationToken:(NSString * _Nullable )brokerApplicationToken
                                                       sdkCapabilities:(nullable NSArray *)sdkCapabilities
-                                                                error:(NSError * _Nullable * _Nullable)error;
+                                                                error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (nullable MSIDInteractiveTokenRequest *)interactiveSSOExtensionTokenRequestWithParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters;
 

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.h
@@ -39,7 +39,7 @@
                                       accountMetadataCache:(nullable MSIDAccountMetadataCacheAccessor *)metadataCache
                                          requestParameters:(nonnull MSIDRequestParameters *)parameters
                                           saveSSOStateOnly:(BOOL)saveSSOStateOnly
-                                                     error:(NSError * _Nullable * _Nullable)error;
+                                                     error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (nullable MSIDTokenResult *)validateAndSaveBrokerResponse:(nonnull MSIDBrokerResponse *)brokerResponse
                                                   oidcScope:(nullable NSString *)oidcScope
@@ -51,24 +51,24 @@
                                               correlationID:(nullable NSUUID *)correlationID
                                            saveSSOStateOnly:(BOOL)saveSSOStateOnly
                                                  authScheme:(nonnull MSIDAuthenticationScheme *)authScheme
-                                                      error:(NSError * _Nullable * _Nullable)error;
+                                                      error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 - (nullable MSIDTokenResult *)validateTokenResponse:(nonnull MSIDTokenResponse *)tokenResponse
                                        oauthFactory:(nonnull MSIDOauth2Factory *)factory
                                       configuration:(nonnull MSIDConfiguration *)configuration
                                      requestAccount:(nullable MSIDAccountIdentifier *)accountIdentifier
                                       correlationID:(nonnull NSUUID *)correlationID
-                                              error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
+                                              error:(NSError * _Nullable __autoreleasing * _Nullable)error NS_SWIFT_NOTHROW;
 
 - (BOOL)validateAccount:(nonnull MSIDAccountIdentifier *)accountIdentifier
             tokenResult:(nonnull MSIDTokenResult *)tokenResult
           correlationID:(nonnull NSUUID *)correlationID
-                  error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
+                  error:(NSError * _Nullable __autoreleasing * _Nullable)error NS_SWIFT_NOTHROW;
 
 - (BOOL)validateTokenResult:(nonnull MSIDTokenResult *)tokenResult
               configuration:(nonnull MSIDConfiguration *)configuration
                   oidcScope:(nullable NSString *)oidcScope
               correlationID:(nonnull NSUUID *)correlationID
-                      error:(NSError * _Nullable * _Nullable)error;
+                      error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end

--- a/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/MSIDTokenResponseValidator.m
@@ -43,7 +43,7 @@
                              configuration:(MSIDConfiguration *)configuration
                             requestAccount:(__unused MSIDAccountIdentifier *)accountIdentifier
                              correlationID:(NSUUID *)correlationID
-                                     error:(NSError **)error
+                                     error:(NSError *__autoreleasing*)error
 {
     if (!tokenResponse)
     {
@@ -79,7 +79,7 @@
                                      configuration:(MSIDConfiguration *)configuration
                                     requestAccount:(__unused MSIDAccountIdentifier *)accountIdentifier
                                      correlationID:(NSUUID *)correlationID
-                                             error:(NSError **)error
+                                             error:(NSError *__autoreleasing*)error
 
 {
     MSIDAccessToken *accessToken = [factory accessTokenFromResponse:tokenResponse configuration:configuration];
@@ -125,7 +125,7 @@
               configuration:(__unused MSIDConfiguration *)configuration
                   oidcScope:(__unused NSString *)oidcScope
               correlationID:(__unused NSUUID *)correlationID
-                      error:(__unused NSError **)error
+                      error:(__unused NSError *__autoreleasing*)error
 {
     // Post saving validation
     return YES;
@@ -149,7 +149,7 @@
                                      correlationID:(NSUUID *)correlationID
                                   saveSSOStateOnly:(BOOL)saveSSOStateOnly
                                         authScheme:(MSIDAuthenticationScheme *)authScheme
-                                             error:(NSError **)error
+                                             error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationID, @"Validating broker response.");
     
@@ -245,7 +245,7 @@
                              accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
                                 requestParameters:(MSIDRequestParameters *)parameters
                                  saveSSOStateOnly:(BOOL)saveSSOStateOnly
-                                            error:(NSError **)error
+                                            error:(NSError *__autoreleasing*)error
 {
     MSIDTokenResult *tokenResult = [self validateTokenResponse:tokenResponse
                                                   oauthFactory:factory
@@ -308,7 +308,7 @@
                       tokenCache:(id<MSIDCacheAccessor>)tokenCache
                 saveSSOStateOnly:(BOOL)saveSSOStateOnly
                          context:(id<MSIDRequestContext>)context
-                           error:(NSError **)error
+                           error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Saving token response, only save SSO state %d", saveSSOStateOnly);
     

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyBrokerResponseHandler.m
@@ -45,7 +45,7 @@
 @implementation MSIDLegacyBrokerResponseHandler
 
 - (id<MSIDCacheAccessor>)cacheAccessorWithKeychainGroup:(__unused NSString *)keychainGroup
-                                                  error:(__unused NSError **)error
+                                                  error:(__unused NSError *__autoreleasing*)error
 {
 #if TARGET_OS_IPHONE
     MSIDKeychainTokenCache *dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:keychainGroup error:error];
@@ -78,7 +78,7 @@
                                                  correlationId:(NSUUID *)correlationID
                                                     authScheme:(MSIDAuthenticationScheme *)authScheme
                                                    redirectUri:(__unused NSString *)redirectUri
-                                                         error:(NSError **)error
+                                                         error:(NSError *__autoreleasing*)error
 {
     // Successful case
     if ([NSString msidIsStringNilOrBlank:encryptedParams[@"error_code"]])
@@ -208,7 +208,7 @@
 }
 
 - (MSIDAccountMetadataCacheAccessor *)accountMetadataCacheWithKeychainGroup:(__unused NSString *)keychainGroup
-                                                                      error:(__unused NSError **)error
+                                                                      error:(__unused NSError *__autoreleasing*)error
 {
     return nil;
 }

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyBrokerTokenRequest.m
@@ -35,7 +35,7 @@
 #pragma mark - Abstract impl
 
 // Those parameters will be different depending on the broker protocol version
-- (NSDictionary *)protocolPayloadContentsWithError:(__unused NSError **)error
+- (NSDictionary *)protocolPayloadContentsWithError:(__unused NSError *__autoreleasing*)error
 {
     NSString *skipCacheValue = @"NO";
 

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacySilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacySilentTokenRequest.m
@@ -60,7 +60,7 @@
 
 #pragma mark - Abstract impl
 
-- (nullable MSIDAccessToken *)accessTokenWithError:(__unused NSError **)error
+- (nullable MSIDAccessToken *)accessTokenWithError:(__unused NSError *__autoreleasing*)error
 {
     // TODO: ADAL pieces
     return nil;
@@ -68,26 +68,26 @@
 
 - (nullable MSIDTokenResult *)resultWithAccessToken:(__unused MSIDAccessToken *)accessToken
                                        refreshToken:(__unused id<MSIDRefreshableToken>)refreshToken
-                                              error:(__unused NSError * _Nullable * _Nullable)error
+                                              error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error
 {
     // TODO: ADAL pieces
     return nil;
 }
 
-- (nullable MSIDRefreshToken *)familyRefreshTokenWithError:(__unused NSError * _Nullable * _Nullable)error
+- (nullable MSIDRefreshToken *)familyRefreshTokenWithError:(__unused NSError * _Nullable __autoreleasing * _Nullable)error
 {
     // TODO: ADAL pieces
     return nil;
 }
 
-- (nullable MSIDBaseToken<MSIDRefreshableToken> *)appRefreshTokenWithError:(__unused NSError * _Nullable * _Nullable)error
+- (nullable MSIDBaseToken<MSIDRefreshableToken> *)appRefreshTokenWithError:(__unused NSError * _Nullable __autoreleasing * _Nullable)error
 {
     // TODO: ADAL pieces
     return nil;
 }
 
 - (BOOL)updateFamilyIdCacheWithServerError:(__unused NSError *)serverError
-                                cacheError:(__unused NSError **)cacheError
+                                cacheError:(__unused NSError *__autoreleasing*)cacheError
 {
     // TODO: ADAL pieces
     return NO;

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenRequestProvider.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenRequestProvider.m
@@ -81,7 +81,7 @@
                                                             brokerKey:(nonnull NSString *)brokerKey
                                                brokerApplicationToken:(NSString * _Nullable )brokerApplicationToken
                                                       sdkCapabilities:(NSArray *)sdkCapabilities
-                                                                error:(NSError * _Nullable * _Nullable)error
+                                                                error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     return [[MSIDLegacyBrokerTokenRequest alloc] initWithRequestParameters:parameters
                                                                  brokerKey:brokerKey

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacyTokenResponseValidator.m
@@ -38,7 +38,7 @@
               configuration:(__unused MSIDConfiguration *)configuration
                   oidcScope:(__unused NSString *)oidcScope
               correlationID:(NSUUID *)correlationID
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     if (!tokenResult.account)
     {
@@ -60,7 +60,7 @@
                                      configuration:(MSIDConfiguration *)configuration
                                     requestAccount:(__unused MSIDAccountIdentifier *)accountIdentifier
                                      correlationID:(NSUUID *)correlationID
-                                             error:(__unused NSError **)error
+                                             error:(__unused NSError *__autoreleasing*)error
 
 {
     MSIDLegacyAccessToken *accessToken = [factory legacyAccessTokenFromResponse:tokenResponse configuration:configuration];
@@ -82,7 +82,7 @@
 - (BOOL)validateAccount:(MSIDAccountIdentifier *)accountIdentifier
             tokenResult:(MSIDTokenResult *)tokenResult
           correlationID:(NSUUID *)correlationID
-                  error:(NSError **)error
+                  error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CORR_PII(MSIDLogLevelVerbose, correlationID, @"Checking returned account, Input account id %@, returned account ID %@, local account ID %@", MSID_PII_LOG_MASKABLE(accountIdentifier.maskedDisplayableId), MSID_PII_LOG_MASKABLE(tokenResult.account.accountIdentifier.maskedDisplayableId), MSID_PII_LOG_TRACKABLE(tokenResult.account.localAccountId));
     

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
@@ -72,7 +72,7 @@
                                                  correlationId:(NSUUID *)correlationID
                                                     authScheme:(MSIDAuthenticationScheme *)authScheme
                                                    redirectUri:(NSString *)redirectUri
-                                                         error:(NSError **)error
+                                                         error:(NSError *__autoreleasing*)error
 {
     MSIDTokenResult *tokenResult = nil;
     NSDictionary *decryptedResponse = [self.brokerCryptoProvider decryptBrokerResponse:encryptedParams
@@ -172,7 +172,7 @@
 }
 
 - (id<MSIDCacheAccessor>)cacheAccessorWithKeychainGroup:(__unused NSString *)keychainGroup
-                                                  error:(NSError **)error
+                                                  error:(NSError *__autoreleasing*)error
 {
 #if TARGET_OS_IPHONE
     MSIDKeychainTokenCache *dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:keychainGroup error:error];
@@ -201,7 +201,7 @@
 }
 
 - (MSIDAccountMetadataCacheAccessor *)accountMetadataCacheWithKeychainGroup:(__unused NSString *)keychainGroup
-                                                                      error:(__unused NSError **)error
+                                                                      error:(__unused NSError *__autoreleasing*)error
 {
     MSIDKeychainTokenCache *dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:keychainGroup error:error];
     

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
@@ -31,7 +31,7 @@
 @implementation MSIDDefaultBrokerTokenRequest
 
 // Those parameters will be different depending on the broker protocol version
-- (NSDictionary *)protocolPayloadContentsWithError:(__unused NSError **)error
+- (NSDictionary *)protocolPayloadContentsWithError:(__unused NSError *__autoreleasing*)error
 {
     NSString *homeAccountId = self.requestParameters.accountIdentifier.homeAccountId;
     NSString *username = self.requestParameters.accountIdentifier.displayableId;

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.h
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
                               accountMetadataCache:(nonnull MSIDAccountMetadataCacheAccessor *)accountMetadataCache;
 
 -(MSIDIdToken *)getIDTokenForTokenType:(MSIDCredentialType)idTokenType
-                                 error:(NSError **)error;
+                                 error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
@@ -74,7 +74,7 @@
 
 #pragma mark - Abstract impl
 
-- (nullable MSIDAccessToken *)accessTokenWithError:(NSError **)error
+- (nullable MSIDAccessToken *)accessTokenWithError:(NSError *__autoreleasing*)error
 {
     NSError *cacheError = nil;
     MSIDAccessToken *accessToken = [self.defaultAccessor getAccessTokenForAccount:self.requestParameters.accountIdentifier
@@ -98,7 +98,7 @@
 
 - (nullable MSIDTokenResult *)resultWithAccessToken:(MSIDAccessToken *)accessToken
                                        refreshToken:(id<MSIDRefreshableToken>)refreshToken
-                                              error:(__unused NSError * _Nullable * _Nullable)error
+                                              error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error
 {
     if (!accessToken)
     {
@@ -151,13 +151,13 @@
     return result;
 }
 
--(MSIDIdToken *)getIDToken:(NSError **)error
+-(MSIDIdToken *)getIDToken:(NSError *__autoreleasing*)error
 {
     return [self getIDTokenForTokenType:MSIDIDTokenType error:error];
 }
 
 -(MSIDIdToken *)getIDTokenForTokenType:(MSIDCredentialType)idTokenType
-                                 error:(NSError **)error
+                                 error:(NSError *__autoreleasing*)error
 {
     return [self.defaultAccessor getIDTokenForAccount:self.requestParameters.accountIdentifier
                                         configuration:self.requestParameters.msidConfiguration
@@ -166,7 +166,7 @@
                                                 error:error];
 }
 
-- (nullable MSIDRefreshToken *)familyRefreshTokenWithError:(NSError * _Nullable * _Nullable)error
+- (nullable MSIDRefreshToken *)familyRefreshTokenWithError:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self.appMetadata = [self appMetadataWithError:error];
 
@@ -185,7 +185,7 @@
     return nil;
 }
 
-- (nullable MSIDBaseToken<MSIDRefreshableToken> *)appRefreshTokenWithError:(NSError * _Nullable * _Nullable)error
+- (nullable MSIDBaseToken<MSIDRefreshableToken> *)appRefreshTokenWithError:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     return [self.defaultAccessor getRefreshTokenWithAccount:self.requestParameters.accountIdentifier
                                                    familyId:nil
@@ -195,7 +195,7 @@
 }
 
 - (BOOL)updateFamilyIdCacheWithServerError:(NSError *)serverError
-                                cacheError:(NSError **)cacheError
+                                cacheError:(NSError *__autoreleasing*)cacheError
 {
     //When FRT is used by client which is not part of family, the server returns "client_mismatch" as sub-error
     NSString *subError = serverError.msidSubError;
@@ -238,7 +238,7 @@
 
 #pragma mark - Helpers
 
-- (MSIDAppMetadataCacheItem *)appMetadataWithError:(NSError * _Nullable * _Nullable)error
+- (MSIDAppMetadataCacheItem *)appMetadataWithError:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     NSError *cacheError = nil;
     NSArray<MSIDAppMetadataCacheItem *> *appMetadataEntries = [self.defaultAccessor getAppMetadataEntries:self.requestParameters.msidConfiguration

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenRequestProvider.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenRequestProvider.m
@@ -87,7 +87,7 @@
                                                             brokerKey:(nonnull NSString *)brokerKey
                                                brokerApplicationToken:(NSString * _Nullable )brokerApplicationToken
                                                       sdkCapabilities:(NSArray *)sdkCapabilities
-                                                                error:(NSError * _Nullable * _Nullable)error
+                                                                error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     MSIDDefaultBrokerTokenRequest *request = [[MSIDDefaultBrokerTokenRequest alloc] initWithRequestParameters:parameters
                                                                                                     brokerKey:brokerKey

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.m
@@ -36,7 +36,7 @@
               configuration:(MSIDConfiguration *)configuration
                   oidcScope:(NSString *)oidcScope
               correlationID:(NSUUID *)correlationID
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     /*
      If server returns less scopes than developer requested,
@@ -95,7 +95,7 @@
 - (BOOL)validateAccount:(MSIDAccountIdentifier *)accountIdentifier
             tokenResult:(MSIDTokenResult *)tokenResult
               correlationID:(NSUUID *)correlationID
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     if (accountIdentifier.uid != nil
         && ![accountIdentifier.uid isEqualToString:tokenResult.account.accountIdentifier.uid])

--- a/IdentityCore/src/throttling/MSIDThrottlingService.m
+++ b/IdentityCore/src/throttling/MSIDThrottlingService.m
@@ -110,7 +110,7 @@
  */
 + (BOOL)updateLastRefreshTimeDatasource:(id<MSIDExtendedTokenCacheDataSource>)datasource
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     if(![MSIDThrottlingService isThrottlingEnabled])
     {

--- a/IdentityCore/src/throttling/cache/MSIDLRUCache.h
+++ b/IdentityCore/src/throttling/cache/MSIDLRUCache.h
@@ -54,20 +54,20 @@ if nil object or key is provided, this API will return NO, and an error will be 
  */
 - (BOOL)setObject:(ObjectType)cacheRecord
            forKey:(KeyType)key
-            error:(NSError * _Nullable * _Nullable)error;
+            error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /**
 remove object that corresponds to the given key.
 If nil key is provided, or no object exists that maps to the input key, this API will return NO, and an error will be generated.
  */
 - (BOOL)removeObjectForKey:(KeyType)key
-                     error:(NSError * _Nullable * _Nullable)error;
+                     error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /**
  retrieve object corresponding to the input key, and move the object to the front of LRU cache.
  */
 - (nullable ObjectType)objectForKey:(KeyType)key
-                              error:(NSError * _Nullable * _Nullable)error;
+                              error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /**
  return all cached elements sorted from most recently used (first) to least recently used (last)

--- a/IdentityCore/src/throttling/cache/MSIDLRUCache.m
+++ b/IdentityCore/src/throttling/cache/MSIDLRUCache.m
@@ -160,7 +160,7 @@ static NSString *const TAIL_SIGNATURE = @"TAIL";
 if node already exists, update and move it to the front of LRU cache */
 - (BOOL)setObject:(id)cacheRecord
            forKey:(id)key
-            error:(NSError **)error
+            error:(NSError *__autoreleasing*)error
 {
     __block NSError *subError = nil;
     BOOL result = YES;
@@ -219,7 +219,7 @@ if node already exists, update and move it to the front of LRU cache */
 
 
 - (BOOL)removeObjectForKey:(id)key
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     __block NSError *subError = nil;
     BOOL result = YES;
@@ -257,7 +257,7 @@ if node already exists, update and move it to the front of LRU cache */
 }
 
 - (BOOL)removeObjectForKeyImpl:(NSString *)signature
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {
     if (!signature)
     {
@@ -302,7 +302,7 @@ if node already exists, update and move it to the front of LRU cache */
 
 //retrieve cache record from the corresponding node, and move the node to the front of LRU cache.
 - (id)objectForKey:(id)key
-             error:(NSError **)error
+             error:(NSError *__autoreleasing*)error
 {
     __block id cacheRecord;
     __block NSError *subError = nil;
@@ -334,7 +334,7 @@ if node already exists, update and move it to the front of LRU cache */
 }
 
 - (id)objectForKeyImpl:(NSString *)signature
-                 error:(NSError **)error
+                 error:(NSError *__autoreleasing*)error
 {
     if (!signature)
     {
@@ -463,7 +463,7 @@ if node already exists, update and move it to the front of LRU cache */
     return signature;
 }
 
-- (BOOL)removeAllObjects:(NSError **)error
+- (BOOL)removeAllObjects:(NSError *__autoreleasing*)error
 {
     __block NSError *subError = nil;
     BOOL result = YES;

--- a/IdentityCore/src/throttling/metadata/MSIDThrottlingMetaData.m
+++ b/IdentityCore/src/throttling/metadata/MSIDThrottlingMetaData.m
@@ -29,7 +29,7 @@
 
 @implementation MSIDThrottlingMetaData
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
     

--- a/IdentityCore/src/throttling/metadata/MSIDThrottlingMetaDataCache.m
+++ b/IdentityCore/src/throttling/metadata/MSIDThrottlingMetaDataCache.m
@@ -40,7 +40,7 @@
  */
 + (NSDate *)getLastRefreshTimeWithDatasource:(id<MSIDExtendedTokenCacheDataSource>)datasource
                                      context:(id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     MSIDThrottlingMetaData *metadata = [MSIDThrottlingMetaDataCache getThrottlingMetadataWithDatasource:datasource context:context error:error];
     NSString *stringDate = metadata.lastRefreshTime;
@@ -49,7 +49,7 @@
 
 + (BOOL)updateLastRefreshTimeWithDatasource:(id<MSIDExtendedTokenCacheDataSource>)datasource
                                     context:(id<MSIDRequestContext>)context
-                                      error:(NSError*__nullable*__nullable)error
+                                      error:(NSError*__nullable __autoreleasing*__nullable)error
 {
     MSIDThrottlingMetaData *metadata = [[MSIDThrottlingMetaData alloc] init];
     metadata.lastRefreshTime = [[NSDate new] msidDateToTimestamp];
@@ -66,7 +66,7 @@
 
 + (MSIDThrottlingMetaData *)getThrottlingMetadataWithDatasource:(id<MSIDExtendedTokenCacheDataSource>)datasource
                                                         context:(id<MSIDRequestContext>)context
-                                                          error:(NSError*__nullable*__nullable)error
+                                                          error:(NSError*__nullable __autoreleasing*__nullable)error
 {
     MSIDThrottlingMetaData *result = nil;
     if (!datasource) return nil;

--- a/IdentityCore/src/throttling/model/MSIDThrottlingModelFactory.m
+++ b/IdentityCore/src/throttling/model/MSIDThrottlingModelFactory.m
@@ -131,7 +131,7 @@
 
 + (MSIDThrottlingCacheRecord *)getDBRecordWithStrictThumbprint:(NSString *)strictThumbprint
                                                 fullThumbprint:(NSString *)fullThumbprint
-                                                         error:(NSError **)error
+                                                         error:(NSError *__autoreleasing*)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"Query throttling database with thumbprint strict value: %@, full value: %@", strictThumbprint, fullThumbprint);
     MSIDThrottlingCacheRecord *cacheRecord;

--- a/IdentityCore/src/util/ASAuthorizationSingleSignOnProvider+MSIDExtensions.h
+++ b/IdentityCore/src/util/ASAuthorizationSingleSignOnProvider+MSIDExtensions.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable ASAuthorizationSingleSignOnRequest *)createSSORequestWithOperationRequest:(MSIDBrokerOperationRequest *)operationRequest
                                                                     requestParameters:(MSIDRequestParameters *)requestParameters
                                                                            requiresUI:(BOOL)requiresUI
-                                                                                error:(NSError * _Nullable * _Nullable)error;
+                                                                                error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end
 

--- a/IdentityCore/src/util/ASAuthorizationSingleSignOnProvider+MSIDExtensions.m
+++ b/IdentityCore/src/util/ASAuthorizationSingleSignOnProvider+MSIDExtensions.m
@@ -40,7 +40,7 @@
 - (ASAuthorizationSingleSignOnRequest *)createSSORequestWithOperationRequest:(MSIDBrokerOperationRequest *)operationRequest
                                                            requestParameters:(MSIDRequestParameters *)requestParameters
                                                                   requiresUI:(BOOL)requiresUI
-                                                                       error:(NSError **)error
+                                                                       error:(NSError *__autoreleasing*)error
 {
     [MSIDBrokerOperationRequest fillRequest:operationRequest
                         keychainAccessGroup:requestParameters.keychainAccessGroup

--- a/IdentityCore/src/util/MSIDKeyOperationUtil.h
+++ b/IdentityCore/src/util/MSIDKeyOperationUtil.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
                         algorithm:(_Nonnull SecKeyAlgorithm)algorithm
                               key:(_Nonnull SecKeyRef)key
                           context:(_Nullable id<MSIDRequestContext>)context
-                            error:(NSError * _Nullable * _Nullable)error API_AVAILABLE(macos(10.12), ios(10.0), tvos(10.0), watchos(3.0));
+                            error:(NSError * _Nullable __autoreleasing * _Nullable)error API_AVAILABLE(macos(10.12), ios(10.0), tvos(10.0), watchos(3.0));
 
 /// Get asymmetric verifying algorithm to be put as 'alg' claim in JWT. Depending on the key supplied and algorithms supported returns alg.
 /// @param key key used for signing JWT
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param error error determining alg
 - (_Nullable MSIDJwtAlgorithm)getJwtAlgorithmForKey:(SecKeyRef _Nonnull )key
                                             context:(_Nullable id<MSIDRequestContext>)context
-                                              error:(NSError * _Nullable * _Nullable)error API_AVAILABLE(macos(10.12), ios(10.0), tvos(10.0), watchos(3.0));
+                                              error:(NSError * _Nullable __autoreleasing * _Nullable)error API_AVAILABLE(macos(10.12), ios(10.0), tvos(10.0), watchos(3.0));
 
 /// Returns signature after using supplied key to sign supplied data. Uses SecKeyCreateSignature which signs(SHA256(data))
 /// @param rawData Data to be signed. Method will SHA256 this internally
@@ -67,6 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
                                       privateKey:(_Nonnull SecKeyRef)privateKey
                                 signingAlgorithm:(SecKeyAlgorithm)algorithm
                                          context:(_Nullable id<MSIDRequestContext>)context
-                                           error:(NSError * _Nullable * _Nullable)error API_AVAILABLE(macos(10.12), ios(10.0), tvos(10.0), watchos(3.0));
+                                           error:(NSError * _Nullable __autoreleasing * _Nullable)error API_AVAILABLE(macos(10.12), ios(10.0), tvos(10.0), watchos(3.0));
 @end
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/util/MSIDKeyOperationUtil.m
+++ b/IdentityCore/src/util/MSIDKeyOperationUtil.m
@@ -135,7 +135,7 @@
     return signature;
 }
 
-- (void)generateErrorWithMessage:(NSString *)errorMessage underlyingError:(NSError *)underlyingError context:(id<MSIDRequestContext> _Nullable)context error:(NSError **)error
+- (void)generateErrorWithMessage:(NSString *)errorMessage underlyingError:(NSError *)underlyingError context:(id<MSIDRequestContext> _Nullable)context error:(NSError *__autoreleasing*)error
 {
     if (error)
     {

--- a/IdentityCore/src/util/MSIDRedirectUriVerifier.h
+++ b/IdentityCore/src/util/MSIDRedirectUriVerifier.h
@@ -35,6 +35,6 @@
                          bypassRedirectValidation:(BOOL)bypassRedirectValidation
                                             error:(NSError * __autoreleasing *)error;
 
-+ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(NSError **)error;
++ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(NSError *__autoreleasing*)error;
 
 @end

--- a/IdentityCore/src/util/NSDictionary+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSDictionary+MSIDExtensions.h
@@ -41,14 +41,14 @@
 - (NSInteger)msidIntegerObjectForKey:(NSString *)key;
 - (BOOL)msidBoolObjectForKey:(NSString *)key;
 
-- (BOOL)msidAssertType:(Class)type ofKey:(NSString *)key required:(BOOL)required error:(NSError **)error;
-- (BOOL)msidAssertTypeIsOneOf:(NSArray<Class> *)types ofKey:(NSString *)key required:(BOOL)required error:(NSError **)error;
+- (BOOL)msidAssertType:(Class)type ofKey:(NSString *)key required:(BOOL)required error:(NSError *__autoreleasing*)error;
+- (BOOL)msidAssertTypeIsOneOf:(NSArray<Class> *)types ofKey:(NSString *)key required:(BOOL)required error:(NSError *__autoreleasing*)error;
 - (BOOL)msidAssertTypeIsOneOf:(NSArray<Class> *)types
                         ofKey:(NSString *)key
                      required:(BOOL)required
                       context:(id<MSIDRequestContext>)context
                     errorCode:(NSInteger)errorCode
-                        error:(NSError **)error;
+                        error:(NSError *__autoreleasing*)error;
 
 - (NSDictionary *)msidNormalizedJSONDictionary;
 

--- a/IdentityCore/src/util/NSDictionary+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSDictionary+MSIDExtensions.m
@@ -96,12 +96,12 @@
     return mutableDict;
 }
 
-- (BOOL)msidAssertType:(Class)type ofKey:(NSString *)key required:(BOOL)required error:(NSError **)error
+- (BOOL)msidAssertType:(Class)type ofKey:(NSString *)key required:(BOOL)required error:(NSError *__autoreleasing*)error
 {
     return [self msidAssertTypeIsOneOf:@[type] ofKey:key required:required error:error];
 }
 
-- (BOOL)msidAssertTypeIsOneOf:(NSArray<Class> *)types ofKey:(NSString *)key required:(BOOL)required error:(NSError **)error
+- (BOOL)msidAssertTypeIsOneOf:(NSArray<Class> *)types ofKey:(NSString *)key required:(BOOL)required error:(NSError *__autoreleasing*)error
 {
     return [self msidAssertTypeIsOneOf:types ofKey:key required:required context:nil errorCode:MSIDErrorInvalidInternalParameter error:error];
 }
@@ -111,7 +111,7 @@
                      required:(BOOL)required
                       context:(id<MSIDRequestContext>)context
                     errorCode:(NSInteger)errorCode
-                        error:(NSError **)error
+                        error:(NSError *__autoreleasing*)error
 {
     id obj = self[key];
     if (!obj && !required) return YES;

--- a/IdentityCore/src/util/NSDictionary+MSIDJsonSerializable.m
+++ b/IdentityCore/src/util/NSDictionary+MSIDJsonSerializable.m
@@ -28,7 +28,7 @@
 #pragma mark - MSIDJsonSerializable
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json
-                                 error:(__unused NSError **)error
+                                 error:(__unused NSError *__autoreleasing*)error
 {
     return [self initWithDictionary:json];
 }

--- a/IdentityCore/src/util/NSJSONSerialization+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSJSONSerialization+MSIDExtensions.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSJSONSerialization (MSIDExtensions)
 
-+ (nullable NSDictionary *)msidNormalizedDictionaryFromJsonData:(NSData *)data error:(NSError * _Nullable * _Nullable)error;
++ (nullable NSDictionary *)msidNormalizedDictionaryFromJsonData:(NSData *)data error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end
 

--- a/IdentityCore/src/util/NSJSONSerialization+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSJSONSerialization+MSIDExtensions.m
@@ -26,7 +26,7 @@
 
 @implementation NSJSONSerialization (MSIDExtensions)
 
-+ (NSDictionary *)msidNormalizedDictionaryFromJsonData:(NSData *)data error:(NSError **)error
++ (NSDictionary *)msidNormalizedDictionaryFromJsonData:(NSData *)data error:(NSError *__autoreleasing*)error
 {
     if (!data.length)
     {

--- a/IdentityCore/src/util/NSKeyedArchiver+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSKeyedArchiver+MSIDExtensions.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSData *)msidArchivedDataWithRootObject:(id)object
                               requiringSecureCoding:(BOOL)requiresSecureCoding
-                                              error:(NSError **)error;
+                                              error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/util/NSKeyedArchiver+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSKeyedArchiver+MSIDExtensions.m
@@ -43,7 +43,7 @@
 
 + (NSData *)msidArchivedDataWithRootObject:(id)object
                      requiringSecureCoding:(BOOL)requiresSecureCoding
-                                     error:(NSError **)error
+                                     error:(NSError *__autoreleasing*)error
 {
     NSData *result;
     result = [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:requiresSecureCoding error:error];

--- a/IdentityCore/src/util/NSKeyedUnarchiver+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSKeyedUnarchiver+MSIDExtensions.h
@@ -27,9 +27,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSKeyedUnarchiver (MSIDExtensions)
 
-+ (nullable instancetype)msidCreateForReadingFromData:(NSData *)data error:(NSError **)error;
++ (nullable instancetype)msidCreateForReadingFromData:(NSData *)data error:(NSError *__autoreleasing*)error;
 
-+ (nullable id)msidUnarchivedObjectOfClasses:(NSSet<Class> *)classes fromData:(NSData *)data error:(NSError **)error;
++ (nullable id)msidUnarchivedObjectOfClasses:(NSSet<Class> *)classes fromData:(NSData *)data error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/src/util/NSKeyedUnarchiver+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSKeyedUnarchiver+MSIDExtensions.m
@@ -25,7 +25,7 @@
 
 @implementation NSKeyedUnarchiver (MSIDExtensions)
 
-+ (instancetype)msidCreateForReadingFromData:(NSData *)data error:(NSError **)error
++ (instancetype)msidCreateForReadingFromData:(NSData *)data error:(NSError *__autoreleasing*)error
 {
     NSKeyedUnarchiver *unarchiver;
     unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:error];
@@ -33,7 +33,7 @@
     return unarchiver;
 }
 
-+ (id)msidUnarchivedObjectOfClasses:(NSSet<Class> *)classes fromData:(NSData *)data error:(NSError **)error
++ (id)msidUnarchivedObjectOfClasses:(NSSet<Class> *)classes fromData:(NSData *)data error:(NSError *__autoreleasing*)error
 {
     id result;
     result = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:error];

--- a/IdentityCore/src/util/NSURL+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSURL+MSIDExtensions.m
@@ -107,7 +107,7 @@
     return [NSString stringWithFormat:@"%@:%d", self.host.lowercaseString, port.intValue];
 }
 
-- (NSURL *)msidURLForHost:(NSString *)preferredHost context:(id<MSIDRequestContext>)context error:(NSError **)error
+- (NSURL *)msidURLForHost:(NSString *)preferredHost context:(id<MSIDRequestContext>)context error:(NSError *__autoreleasing*)error
 {
     NSURL *url = [self copy];
     

--- a/IdentityCore/src/util/ios/MSIDRedirectUriVerifier.m
+++ b/IdentityCore/src/util/ios/MSIDRedirectUriVerifier.m
@@ -127,7 +127,7 @@
     return NO;
 }
 
-+ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(__unused NSError **)error
++ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(__unused NSError *__autoreleasing*)error
 {
 #if !AD_BROKER
     

--- a/IdentityCore/src/util/mac/MSIDRedirectUriVerifier.m
+++ b/IdentityCore/src/util/mac/MSIDRedirectUriVerifier.m
@@ -51,7 +51,7 @@
                                           brokerCapable:YES];
 }
 
-+ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(__unused NSError **)error
++ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(__unused NSError *__autoreleasing*)error
 {
     return YES;
 }

--- a/IdentityCore/src/validation/MSIDAADAuthority.m
+++ b/IdentityCore/src/validation/MSIDAADAuthority.m
@@ -53,7 +53,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     self = [super initWithURL:url context:context error:error];
     if (self)
@@ -70,7 +70,7 @@
 - (nullable instancetype)initWithURL:(nonnull NSURL *)url
                            rawTenant:(NSString *)rawTenant
                              context:(nullable id<MSIDRequestContext>)context
-                               error:(NSError **)error
+                               error:(NSError *__autoreleasing*)error
 {
     self = [self initWithURL:url context:context error:error];
     if (self)
@@ -169,7 +169,7 @@
 
 + (BOOL)isAuthorityFormatValid:(NSURL *)url
                        context:(id<MSIDRequestContext>)context
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {
     if (![super isAuthorityFormatValid:url context:context error:error]) return NO;
     
@@ -213,7 +213,7 @@
 + (instancetype)aadAuthorityWithEnvironment:(NSString *)environment
                                    rawTenant:(NSString *)rawTenant
                                      context:(id<MSIDRequestContext>)context
-                                       error:(NSError **)error
+                                       error:(NSError *__autoreleasing*)error
 {
     __auto_type authorityUrl = [NSURL msidAADURLWithEnvironment:environment tenant:rawTenant];
     __auto_type authority = [[MSIDAADAuthority alloc] initWithURL:authorityUrl context:context error:error];
@@ -224,7 +224,7 @@
 - (NSString *)enrollmentIdForHomeAccountId:(NSString *)homeAccountId
                               legacyUserId:(NSString *)legacyUserId
                                    context:(id<MSIDRequestContext>)context
-                                     error:(NSError **)error
+                                     error:(NSError *__autoreleasing*)error
 {
     return [[MSIDIntuneEnrollmentIdsCache sharedCache] enrollmentIdForHomeAccountId:homeAccountId
                                                                        legacyUserId:legacyUserId
@@ -279,7 +279,7 @@
 
 + (NSString *)realmFromURL:(NSURL *)url
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if ([self isAuthorityFormatValid:url context:context error:error])
     {
@@ -299,7 +299,7 @@
 
 + (NSURL *)normalizedAuthorityUrl:(NSURL *)url
                           context:(id<MSIDRequestContext>)context
-                            error:(NSError **)error
+                            error:(NSError *__autoreleasing*)error
 {
     // Normalization requires url to have at least 1 path and a host.
     // Return nil otherwise.
@@ -316,7 +316,7 @@
 
 + (MSIDAADTenant *)tenantFromAuthorityUrl:(NSURL *)url
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     NSArray *paths = url.pathComponents;
     
@@ -336,7 +336,7 @@
 
 #pragma mark - Sovereign
 
-- (MSIDAuthority *)authorityWithUpdatedCloudHostInstanceName:(NSString *)cloudHostInstanceName error:(NSError **)error
+- (MSIDAuthority *)authorityWithUpdatedCloudHostInstanceName:(NSString *)cloudHostInstanceName error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:cloudHostInstanceName]) return nil;
     

--- a/IdentityCore/src/validation/MSIDADFSAuthority.m
+++ b/IdentityCore/src/validation/MSIDADFSAuthority.m
@@ -41,7 +41,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     self = [super initWithURL:url context:context error:error];
     if (self)
@@ -55,7 +55,7 @@
 
 + (BOOL)isAuthorityFormatValid:(NSURL *)url
                        context:(id<MSIDRequestContext>)context
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {
     if (![super isAuthorityFormatValid:url context:context error:error]) return NO;
     
@@ -98,7 +98,7 @@
 
 + (NSURL *)normalizedAuthorityUrl:(NSURL *)url
                           context:(id<MSIDRequestContext>)context
-                            error:(NSError **)error
+                            error:(NSError *__autoreleasing*)error
 {
     // Normalization requires url to have at least 1 path and a host.
     // Return nil otherwise.

--- a/IdentityCore/src/validation/MSIDAuthority+Internal.h
+++ b/IdentityCore/src/validation/MSIDAuthority+Internal.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
                              context:(nullable id<MSIDRequestContext>)context
                                error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
-- (nullable MSIDAuthority *)authorityWithUpdatedCloudHostInstanceName:(NSString *)cloudHostInstanceName error:(NSError * _Nullable * _Nullable)error;
+- (nullable MSIDAuthority *)authorityWithUpdatedCloudHostInstanceName:(NSString *)cloudHostInstanceName error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 NS_ASSUME_NONNULL_END
 @end

--- a/IdentityCore/src/validation/MSIDAuthority.m
+++ b/IdentityCore/src/validation/MSIDAuthority.m
@@ -89,7 +89,7 @@ NSString *const MSID_AUTHORITY_TYPE_JSON_KEY = @"authority_type";
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     return [self initWithURL:url validateFormat:YES context:context error:error];
 }
@@ -166,7 +166,7 @@ NSString *const MSID_AUTHORITY_TYPE_JSON_KEY = @"authority_type";
 - (NSString *)enrollmentIdForHomeAccountId:(__unused NSString *)homeAccountId
                               legacyUserId:(__unused NSString *)legacyUserId
                                    context:(__unused id<MSIDRequestContext>)context
-                                     error:(__unused NSError **)error
+                                     error:(__unused NSError *__autoreleasing*)error
 {
     return nil;
 }
@@ -260,7 +260,7 @@ NSString *const MSID_AUTHORITY_TYPE_JSON_KEY = @"authority_type";
 
 + (BOOL)isAuthorityFormatValid:(NSURL *)url
                        context:(id<MSIDRequestContext>)context
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:url.absoluteString])
     {
@@ -343,7 +343,7 @@ NSString *const MSID_AUTHORITY_TYPE_JSON_KEY = @"authority_type";
 
 + (NSString *)realmFromURL:(NSURL *)url
                    context:(__unused id<MSIDRequestContext>)context
-                     error:(__unused NSError **)error
+                     error:(__unused NSError *__autoreleasing*)error
 {
     return url.path;
 }
@@ -357,14 +357,14 @@ NSString *const MSID_AUTHORITY_TYPE_JSON_KEY = @"authority_type";
 #pragma mark - Sovereign
 
 - (MSIDAuthority *)authorityWithUpdatedCloudHostInstanceName:(__unused NSString *)cloudHostInstanceName
-                                                       error:(__unused NSError **)error
+                                                       error:(__unused NSError *__autoreleasing*)error
 {
     return nil;
 }
 
 #pragma mark - MSIDJsonSerializable
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     NSString *authorityString = json[MSID_AUTHORITY_URL_JSON_KEY];
     NSURL *authorityUrl = authorityString ? [[NSURL alloc] initWithString:authorityString] : nil;

--- a/IdentityCore/src/validation/MSIDAuthorityFactory.m
+++ b/IdentityCore/src/validation/MSIDAuthorityFactory.m
@@ -32,7 +32,7 @@
 
 + (MSIDAuthority *)authorityFromUrl:(NSURL *)url
                                context:(id<MSIDRequestContext>)context
-                                 error:(NSError **)error
+                                 error:(NSError *__autoreleasing*)error
 {
     return [self authorityFromUrl:url rawTenant:nil context:context error:error];
 }
@@ -40,7 +40,7 @@
 + (MSIDAuthority *)authorityFromUrl:(NSURL *)url
                           rawTenant:(NSString *)rawTenant
                             context:(id<MSIDRequestContext>)context
-                              error:(NSError **)error
+                              error:(NSError *__autoreleasing*)error
 {
     NSError *underlyingError;
 #if !EXCLUDE_FROM_MSALCPP

--- a/IdentityCore/src/validation/MSIDB2CAuthority.m
+++ b/IdentityCore/src/validation/MSIDB2CAuthority.m
@@ -42,7 +42,7 @@
 - (nullable instancetype)initWithURL:(NSURL *)url
                       validateFormat:(BOOL)validateFormat
                              context:(id<MSIDRequestContext>)context
-                               error:(NSError **)error
+                               error:(NSError *__autoreleasing*)error
 {
     self = [super initWithURL:url validateFormat:validateFormat context:context error:error];
     if (self)
@@ -56,7 +56,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     return [self initWithURL:url validateFormat:YES context:context error:error];
 }
@@ -65,7 +65,7 @@
                       validateFormat:(BOOL)validateFormat
                            rawTenant:(nullable NSString *)rawTenant
                              context:(nullable id<MSIDRequestContext>)context
-                               error:(NSError **)error
+                               error:(NSError *__autoreleasing*)error
 {
     self = [self initWithURL:url validateFormat:validateFormat context:context error:error];
     if (self)
@@ -85,7 +85,7 @@
 
 + (BOOL)isAuthorityFormatValid:(NSURL *)url
                        context:(id<MSIDRequestContext>)context
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {    
     if (![super isAuthorityFormatValid:url context:context error:error]) return NO;
     
@@ -140,7 +140,7 @@
 
 + (NSString *)realmFromURL:(NSURL *)url
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if ([self isAuthorityFormatValid:url context:context error:error])
     {
@@ -161,7 +161,7 @@
 + (NSURL *)normalizedAuthorityUrl:(NSURL *)url
                   formatValidated:(BOOL)formatValidated
                           context:(id<MSIDRequestContext>)context
-                            error:(NSError **)error
+                            error:(NSError *__autoreleasing*)error
 {
     if (!url)
     {

--- a/IdentityCore/src/validation/MSIDCIAMAuthority.m
+++ b/IdentityCore/src/validation/MSIDCIAMAuthority.m
@@ -47,7 +47,7 @@
                       validateFormat:(BOOL)validateFormat
                            rawTenant:(nullable NSString *)rawTenant
                              context:(nullable id<MSIDRequestContext>)context
-                               error:(NSError **)error
+                               error:(NSError *__autoreleasing*)error
 {
     self = [self initWithURL:url validateFormat:validateFormat context:context error:error];
     if (self)
@@ -68,7 +68,7 @@
 - (nullable instancetype)initWithURL:(NSURL *)url
                       validateFormat:(BOOL)validateFormat
                              context:(id<MSIDRequestContext>)context
-                               error:(NSError **)error
+                               error:(NSError *__autoreleasing*)error
 {
     self = [super initWithURL:url validateFormat:validateFormat context:context error:error];
     
@@ -107,14 +107,14 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     return [self initWithURL:url validateFormat:YES context:context error:error];
 }
 
 + (BOOL)isAuthorityFormatValid:(NSURL *)url
                        context:(id<MSIDRequestContext>)context
-                         error:(NSError **)error
+                         error:(NSError *__autoreleasing*)error
 {
     if (![super isAuthorityFormatValid:url context:context error:error]) return NO;
     
@@ -157,7 +157,7 @@
 + (NSURL *)normalizedAuthorityUrl:(NSURL *)url
                   formatValidated:(BOOL)formatValidated
                           context:(id<MSIDRequestContext>)context
-                            error:(NSError **)error
+                            error:(NSError *__autoreleasing*)error
 {
     
     if (!url)
@@ -210,7 +210,7 @@
 #pragma mark - Private
 + (NSString *)realmFromURL:(NSURL *)url
                    context:(id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     //If there is a path component, return it, else return just URL
     if ([self isAuthorityFormatValid:url context:context error:error] && url.pathComponents.count > 1)

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -169,7 +169,7 @@
     [self endWebAuthWithURL:nil error:error];
 }
 
-- (BOOL)loadView:(NSError **)error
+- (BOOL)loadView:(NSError *__autoreleasing*)error
 {
     // create and load the view if not provided
     BOOL result = [super loadView:error];

--- a/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
+++ b/IdentityCore/src/webview/embeddedWebview/ui/MSIDWebviewUIController.h
@@ -57,7 +57,7 @@ NSWindowController
 - (id)initWithContext:(id<MSIDRequestContext>)context
        platformParams:(MSIDWebViewPlatformParams *)platformParams;
 
-- (BOOL)loadView:(NSError **)error;
+- (BOOL)loadView:(NSError *__autoreleasing*)error;
 - (void)presentView;
 - (void)dismissWebview:(void (^)(void))completion;
 - (void)showLoadingIndicator;

--- a/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/ios/MSIDWebviewUIController.m
@@ -104,7 +104,7 @@ static WKWebViewConfiguration *s_webConfig;
     [[MSIDBackgroundTaskManager sharedInstance] stopOperationWithType:MSIDBackgroundTaskTypeInteractiveRequest];
 }
 
-- (BOOL)loadView:(NSError **)error
+- (BOOL)loadView:(NSError *__autoreleasing*)error
 {
     /* Start background transition tracking,
      so we can start a background task, when app transitions to background */

--- a/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
+++ b/IdentityCore/src/webview/embeddedWebview/ui/mac/MSIDWebviewUIController.m
@@ -92,7 +92,7 @@ static WKWebViewConfiguration *s_webConfig;
     return self;
 }
 
-- (BOOL)loadView:(__unused NSError **)error
+- (BOOL)loadView:(__unused NSError *__autoreleasing*)error
 {
     if (_webView)
     {

--- a/IdentityCore/src/webview/operations/MSIDWebOpenBrowserResponseOperation.m
+++ b/IdentityCore/src/webview/operations/MSIDWebOpenBrowserResponseOperation.m
@@ -40,7 +40,7 @@
 @implementation MSIDWebOpenBrowserResponseOperation
 
 - (nullable instancetype)initWithResponse:(nonnull MSIDWebviewResponse *)response
-                                    error:(NSError * _Nullable *)error
+                                    error:(NSError * _Nullable __autoreleasing *)error
 {
     self = [super initWithResponse:response
                              error:error];

--- a/IdentityCore/src/webview/operations/MSIDWebResponseBaseOperation.h
+++ b/IdentityCore/src/webview/operations/MSIDWebResponseBaseOperation.h
@@ -31,11 +31,11 @@
 @interface MSIDWebResponseBaseOperation : NSObject
 
 - (nullable instancetype)initWithResponse:(nonnull MSIDWebviewResponse *)response
-                                    error:(NSError * _Nullable *_Nullable)error;
+                                    error:(NSError * _Nullable __autoreleasing *_Nullable)error;
 
 - (void)invokeWithInteractiveTokenRequestParameters:(nonnull MSIDInteractiveRequestParameters *)interactiveTokenRequestParameters
                                tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider
                                          completion:(nonnull MSIDRequestCompletionBlock)completion;
 - (BOOL)doActionWithCorrelationId:(nullable NSUUID *)correlationId
-                            error:(NSError * _Nullable *_Nullable)error;
+                            error:(NSError * _Nullable __autoreleasing *_Nullable)error;
 @end

--- a/IdentityCore/src/webview/operations/MSIDWebResponseBaseOperation.m
+++ b/IdentityCore/src/webview/operations/MSIDWebResponseBaseOperation.m
@@ -26,7 +26,7 @@
 @implementation MSIDWebResponseBaseOperation
 
 - (nullable instancetype)initWithResponse:(nonnull __unused MSIDWebviewResponse *)response
-                                    error:(__unused NSError * _Nullable *)error
+                                    error:(__unused NSError * _Nullable __autoreleasing *)error
 {
     self = [super init];
     return self;
@@ -42,7 +42,7 @@
 }
 
 - (BOOL)doActionWithCorrelationId:(__unused NSUUID *)correlationId
-                            error:(NSError * _Nullable *_Nullable)error
+                            error:(NSError * _Nullable __autoreleasing *_Nullable)error
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Cannot find operation for this response type");
     if (error)

--- a/IdentityCore/src/webview/operations/MSIDWebResponseBrokerInstallOperation.m
+++ b/IdentityCore/src/webview/operations/MSIDWebResponseBrokerInstallOperation.m
@@ -46,7 +46,7 @@
 @implementation MSIDWebResponseBrokerInstallOperation
 
 - (nullable instancetype)initWithResponse:(__unused MSIDWebviewResponse *)response
-                                    error:(__unused NSError **)error
+                                    error:(__unused NSError *__autoreleasing*)error
 {
     #if TARGET_OS_IPHONE
         self = [super initWithResponse:response

--- a/IdentityCore/src/webview/operations/MSIDWebResponseOperationFactory.h
+++ b/IdentityCore/src/webview/operations/MSIDWebResponseOperationFactory.h
@@ -36,6 +36,6 @@
 + (void)unRegisterforResponse:(nonnull MSIDWebviewResponse *)response;
 
 + (nullable MSIDWebResponseBaseOperation *)createOperationForResponse:(nonnull MSIDWebviewResponse *)response
-                                                                error:(NSError * _Nullable *_Nullable)error;
+                                                                error:(NSError * _Nullable __autoreleasing *_Nullable)error;
 
 @end

--- a/IdentityCore/src/webview/operations/MSIDWebResponseOperationFactory.m
+++ b/IdentityCore/src/webview/operations/MSIDWebResponseOperationFactory.m
@@ -66,7 +66,7 @@ static NSMutableDictionary *s_container = nil;
 }
 
 + (nullable MSIDWebResponseBaseOperation *)createOperationForResponse:(nonnull MSIDWebviewResponse *)response
-                                                                error:(NSError * _Nullable *)error
+                                                                error:(NSError * _Nullable __autoreleasing *)error
 {
     NSString *operation = [response.class operation];
     Class operationClass = s_container[operation];

--- a/IdentityCore/src/webview/response/MSIDCBAWebAADAuthResponse.m
+++ b/IdentityCore/src/webview/response/MSIDCBAWebAADAuthResponse.m
@@ -38,7 +38,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     // Check for WPJ or broker response
     if (![self.class isCBAWebAADAuthResponse:url])

--- a/IdentityCore/src/webview/response/MSIDJITTroubleshootingResponse.m
+++ b/IdentityCore/src/webview/response/MSIDJITTroubleshootingResponse.m
@@ -34,7 +34,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id <MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     // Check for JIT retry response
     if (![self isJITRetryResponse:url] && ![self isJITTroubleshootingResponse:url])

--- a/IdentityCore/src/webview/response/MSIDWebAADAuthCodeResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebAADAuthCodeResponse.m
@@ -31,7 +31,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     self = [super initWithURL:url context:context error:error];
     if (self)
@@ -46,7 +46,7 @@
                requestState:(NSString *)requestState
          ignoreInvalidState:(BOOL)ignoreInvalidState
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     self = [super initWithURL:url requestState:requestState ignoreInvalidState:ignoreInvalidState context:context error:error];
     if (self)

--- a/IdentityCore/src/webview/response/MSIDWebOAuth2AuthCodeResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebOAuth2AuthCodeResponse.m
@@ -32,7 +32,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     self = [super initWithURL:url context:context error:error];
     
@@ -85,4 +85,3 @@
 }
 
 @end
-

--- a/IdentityCore/src/webview/response/MSIDWebOAuth2Response.h
+++ b/IdentityCore/src/webview/response/MSIDWebOAuth2Response.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
                         requestState:(nullable NSString *)requestState
                   ignoreInvalidState:(BOOL)ignoreInvalidState
                              context:(nullable id<MSIDRequestContext>)context
-                               error:(NSError * _Nullable * _Nullable)error;
+                               error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end
 

--- a/IdentityCore/src/webview/response/MSIDWebOAuth2Response.m
+++ b/IdentityCore/src/webview/response/MSIDWebOAuth2Response.m
@@ -29,7 +29,7 @@
                requestState:(NSString *)requestState
          ignoreInvalidState:(BOOL)ignoreInvalidState
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     // state check
     NSError *stateCheckError = nil;
@@ -49,7 +49,7 @@
 
 + (BOOL)verifyRequestState:(NSString *)requestState
                responseURL:(NSURL *)url
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     // Check for auth response
     // Try both the URL and the fragment parameters:

--- a/IdentityCore/src/webview/response/MSIDWebOpenBrowserResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebOpenBrowserResponse.m
@@ -38,7 +38,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     NSString *scheme = url.scheme;
     

--- a/IdentityCore/src/webview/response/MSIDWebUpgradeRegResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebUpgradeRegResponse.m
@@ -40,7 +40,7 @@ static NSString *const UPGRADE_REG = @"upgradeReg";
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     // Check for upgrade registration
     if (![self isBrokerUpgradeRegResponse:url])

--- a/IdentityCore/src/webview/response/MSIDWebWPJResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebWPJResponse.m
@@ -64,7 +64,7 @@
  **/
 - (instancetype)initResponseWithURL:(NSURL *)url
                             context:(id<MSIDRequestContext>)context
-                              error:(NSError **)error
+                              error:(NSError *__autoreleasing*)error
 {
     self = [super initWithURL:url context:context error:error];
     if (self)

--- a/IdentityCore/src/webview/response/MSIDWebWPJResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebWPJResponse.m
@@ -40,7 +40,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     // Check for WPJ or broker response
     if (![self isBrokerInstallResponse:url])

--- a/IdentityCore/src/webview/response/MSIDWebviewResponse.h
+++ b/IdentityCore/src/webview/response/MSIDWebviewResponse.h
@@ -37,7 +37,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error;
+                      error:(NSError *__autoreleasing*)error;
 
 + (NSDictionary *)msidWebResponseParametersFromURL:(NSURL *)url;
 

--- a/IdentityCore/src/webview/response/MSIDWebviewResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebviewResponse.m
@@ -32,7 +32,7 @@
 
 - (instancetype)initWithURL:(NSURL *)url
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     if (!url)
     {

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtil.h
@@ -37,13 +37,13 @@
 
 + (nullable NSString *)getWPJStringDataForIdentifier:(nonnull NSString *)identifier
                                              context:(nullable id<MSIDRequestContext>)context
-                                               error:(NSError*__nullable*__nullable)error;
+                                               error:(NSError*__nullable __autoreleasing*__nullable)error;
 
 + (nullable NSString *)getWPJStringDataFromV2ForTenantId:(NSString *_Nullable)tenantId
                                               identifier:(nonnull NSString *)identifier
                                                      key:(nullable NSString *)key
                                                  context:(nullable id<MSIDRequestContext>)context
-                                                   error:(NSError*__nullable*__nullable)error;
+                                                   error:(NSError*__nullable __autoreleasing*__nullable)error;
 
 + (nullable MSIDWPJKeyPairWithCert *)wpjKeyPairWithSSOContext:(nonnull MSIDExternalSSOContext *)ssoContext
                                                      tenantId:(nullable NSString *)tenantId

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtilBase+Internal.h
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtilBase+Internal.h
@@ -33,14 +33,14 @@
 + (nullable NSString *)getWPJStringDataForIdentifier:(nonnull NSString *)identifier
                                          accessGroup:(nullable NSString *)accessGroup
                                              context:(nullable id<MSIDRequestContext>)context
-                                               error:(NSError*__nullable*__nullable)error;
+                                               error:(NSError*__nullable __autoreleasing*__nullable)error;
 
 + (NSString *_Nullable)getWPJStringDataFromV2ForTenantId:(NSString *_Nullable)tenantId
                                               identifier:(nonnull NSString *)identifier
                                                      key:(nullable NSString *)key
                                              accessGroup:(nullable NSString *)accessGroup
                                                  context:(id<MSIDRequestContext>_Nullable)context
-                                                   error:(NSError*__nullable*__nullable)error;
+                                                   error:(NSError*__nullable __autoreleasing*__nullable)error;
 
 + (nullable NSString *)getPrimaryEccTenantWithSharedAccessGroup:(NSString *_Nullable)sharedAccessGroup
                                                         context:(id <MSIDRequestContext> _Nullable)context

--- a/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtilBase.m
+++ b/IdentityCore/src/workplacejoin/MSIDWorkPlaceJoinUtilBase.m
@@ -37,7 +37,7 @@ static NSString *kECPrivateKeyTagSuffix = @"-EC";
 + (NSString *_Nullable)getWPJStringDataForIdentifier:(nonnull NSString *)identifier
                                          accessGroup:(nullable NSString *)accessGroup
                                              context:(id<MSIDRequestContext>_Nullable)context
-                                               error:(NSError*__nullable*__nullable)error
+                                               error:(NSError*__nullable __autoreleasing*__nullable)error
 {
     return [self getWPJStringDataFromV2ForTenantId:nil
                                         identifier:identifier
@@ -52,7 +52,7 @@ static NSString *kECPrivateKeyTagSuffix = @"-EC";
                                                      key:(nullable NSString *)key
                                              accessGroup:(nullable NSString *)accessGroup
                                                  context:(id<MSIDRequestContext>_Nullable)context
-                                                   error:(NSError*__nullable*__nullable)error
+                                                   error:(NSError*__nullable __autoreleasing*__nullable)error
 {
     // Building dictionary to retrieve given identifier from the keychain
     NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
@@ -395,7 +395,7 @@ static NSString *kECPrivateKeyTagSuffix = @"-EC";
     return legacyKeys;
 }
 
-+ (NSString *)getPrimaryEccTenantWithSharedAccessGroup:(NSString *)sharedAccessGroup context:(id<MSIDRequestContext>_Nullable)context error:(NSError **)error
++ (NSString *)getPrimaryEccTenantWithSharedAccessGroup:(NSString *)sharedAccessGroup context:(id<MSIDRequestContext>_Nullable)context error:(NSError *__autoreleasing*)error
 {
     NSString *res = nil;
     NSMutableDictionary *query = [NSMutableDictionary new];
@@ -441,7 +441,7 @@ static NSString *kECPrivateKeyTagSuffix = @"-EC";
                                       tenantIdentifier:(NSString *)tenantIdentifier
                                             domainName:(NSString *)domainName
                                                context:(id<MSIDRequestContext>)context
-                                                 error:(NSError **)error
+                                                 error:(NSError *__autoreleasing*)error
 {
     NSMutableDictionary *query = [NSMutableDictionary new];
     query[(id)kSecClass] = (id)kSecClassGenericPassword;

--- a/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/ios/MSIDWorkPlaceJoinUtil.m
@@ -107,8 +107,8 @@
 
 + (SecIdentityRef)copyWPJIdentity:(__unused id<MSIDRequestContext>)context
                 sharedAccessGroup:(NSString *)accessGroup
-                certificateIssuer:(NSString **)issuer
-                   privateKeyDict:(NSDictionary **)keyDict
+                certificateIssuer:(NSString *__autoreleasing*)issuer
+                   privateKeyDict:(NSDictionary *__autoreleasing*)keyDict
 
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, context, @"Attempting to get registration information - %@ shared access Group", accessGroup);
@@ -148,7 +148,7 @@
 
 + (nullable NSString *)getWPJStringDataForIdentifier:(nonnull NSString *)identifier
                                              context:(nullable id<MSIDRequestContext>)context
-                                               error:(NSError*__nullable*__nullable)error
+                                               error:(NSError*__nullable __autoreleasing*__nullable)error
 {
     return [self getWPJStringDataFromV2ForTenantId:nil identifier:identifier key:nil context:context error:error];
 }
@@ -157,7 +157,7 @@
                                               identifier:(nonnull NSString *)identifier
                                                      key:(nullable NSString *)key
                                                  context:(nullable id<MSIDRequestContext>)context
-                                                   error:(NSError*__nullable*__nullable)error
+                                                   error:(NSError*__nullable __autoreleasing*__nullable)error
 {
     NSString *teamId = [[MSIDKeychainUtil sharedInstance] teamId];
 

--- a/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
+++ b/IdentityCore/src/workplacejoin/mac/MSIDWorkPlaceJoinUtil.m
@@ -135,7 +135,7 @@
     return info;
 }
 
-+ (SecIdentityRef)copyWPJIdentityWithAuthorities:(NSArray<NSData *> *)authorities issuer:(NSString **)issuer privateKeyDict:(NSDictionary **)keyDict
++ (SecIdentityRef)copyWPJIdentityWithAuthorities:(NSArray<NSData *> *)authorities issuer:(NSString *__autoreleasing*)issuer privateKeyDict:(NSDictionary *__autoreleasing*)keyDict
 {
     if (![authorities count])
     {
@@ -208,7 +208,7 @@
 
 + (nullable NSString *)getWPJStringDataForIdentifier:(nonnull NSString *)identifier
                                              context:(id<MSIDRequestContext>_Nullable)context
-                                               error:(NSError*__nullable*__nullable)error
+                                               error:(NSError*__nullable __autoreleasing*__nullable)error
 {
     return [self getWPJStringDataForIdentifier:identifier accessGroup:nil context:context error:error];
 }
@@ -217,7 +217,7 @@
                                               identifier:(nonnull NSString *)identifier
                                                      key:(nullable NSString *)key
                                                  context:(nullable id<MSIDRequestContext>)context
-                                                   error:(NSError*__nullable*__nullable)error
+                                                   error:(NSError*__nullable __autoreleasing*__nullable)error
 {
     return [self getWPJStringDataFromV2ForTenantId:tenantId identifier:identifier key:key accessGroup:nil context:context error:error];
 }

--- a/IdentityCore/tests/MSIDJsonSerializableFactoryTests.m
+++ b/IdentityCore/tests/MSIDJsonSerializableFactoryTests.m
@@ -33,7 +33,7 @@
 
 @implementation MSIDJsonSerializableMock
 
-- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError **)error
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(__unused NSError *__autoreleasing*)error
 {
     self = [super init];
     if (self)

--- a/IdentityCore/tests/MSIDThrottlingServiceIntegrationTests.m
+++ b/IdentityCore/tests/MSIDThrottlingServiceIntegrationTests.m
@@ -97,7 +97,7 @@
 - (BOOL)validateAndRemoveRefreshableToken:(MSIDRefreshToken *)token
                            credentialType:(MSIDCredentialType)credentialType
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error;
+                                    error:(NSError *__autoreleasing*)error;
 @end
 
 @implementation MSIDDefaultTokenCacheAccessorForThrottlingTest
@@ -105,7 +105,7 @@
 - (BOOL)validateAndRemoveRefreshableToken:(MSIDRefreshToken *)token
                            credentialType:(MSIDCredentialType)credentialType
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
      return YES;
 }
@@ -144,7 +144,7 @@
 
 - (nullable MSIDTokenResult *)resultWithAccessToken:(MSIDAccessToken *)accessToken
                                        refreshToken:(id<MSIDRefreshableToken>)refreshToken
-                                              error:(__unused NSError * _Nullable * _Nullable)error;
+                                              error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end
 

--- a/IdentityCore/tests/automation/shared/MSIDAutomationErrorResult.m
+++ b/IdentityCore/tests/automation/shared/MSIDAutomationErrorResult.m
@@ -45,7 +45,7 @@ NSString * const MSIDAutomationErrorDescriptionKey = @"MSIDAutomationErrorDescri
 }
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json
-                                 error:(NSError **)error
+                                 error:(NSError *__autoreleasing*)error
 {
     self = [super initWithJSONDictionary:json error:error];
 

--- a/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationOperationAPIRequestHandler.h
+++ b/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationOperationAPIRequestHandler.h
@@ -27,7 +27,7 @@
 @protocol MSIDAutomationOperationAPIResponseHandler <NSObject>
 
 - (id)responseFromData:(NSData *)response
-                 error:(NSError **)error;
+                 error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationOperationResponseHandler.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationOperationResponseHandler.m
@@ -51,7 +51,7 @@
 }
 
 - (id)responseFromData:(NSData *)response
-                 error:(NSError **)error
+                 error:(NSError *__autoreleasing*)error
 {
     id jsonResponse = [NSJSONSerialization JSONObjectWithData:response options:0 error:error];
     

--- a/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationResetOperationResponseHandler.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationResetOperationResponseHandler.m
@@ -26,7 +26,7 @@
 @implementation MSIDAutomationResetOperationResponseHandler
 
 - (id)responseFromData:(NSData *)response
-                 error:(NSError **)error
+                 error:(NSError *__autoreleasing*)error
 {
     NSString *responseString = [[NSString alloc] initWithData:response encoding:NSUTF8StringEncoding];
     // TODO: ask lab to return operation success in a more reasonable way

--- a/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationTemporaryAccountResponseHandler.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationTemporaryAccountResponseHandler.m
@@ -27,7 +27,7 @@
 @implementation MSIDAutomationTemporaryAccountResponseHandler
 
 - (id)responseFromData:(NSData *)response
-                 error:(NSError **)error
+                 error:(NSError *__autoreleasing*)error
 {
     NSDictionary *jsonDictionary = [NSJSONSerialization JSONObjectWithData:response options:0 error:error];
     if (!jsonDictionary)

--- a/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDDefaultAccessorSSOIntegrationTests.m
@@ -64,7 +64,7 @@
 
 - (BOOL)saveToken:(MSIDBaseToken *)token
           context:(id<MSIDRequestContext>)context
-            error:(NSError **)error;
+            error:(NSError *__autoreleasing*)error;
 
 @end
 

--- a/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
+++ b/IdentityCore/tests/mocks/MSIDAccountMetadataCacheAccessorMock.m
@@ -34,7 +34,7 @@
                   clientId:(NSString *)clientId
              instanceAware:(BOOL)instanceAware
                    context:(__unused id<MSIDRequestContext>)context
-                     error:(__unused NSError **)error
+                     error:(__unused NSError *__autoreleasing*)error
 {
     self.getAuthorityURLInvokedCount++;
     
@@ -54,7 +54,7 @@
                   clientId:(NSString *)clientId
              instanceAware:(BOOL)instanceAware
                    context:(__unused id<MSIDRequestContext>)context
-                     error:(__unused NSError **)error
+                     error:(__unused NSError *__autoreleasing*)error
 {
     self.updateAuthorityURLInvokedCount++;
     
@@ -72,14 +72,14 @@
 - (BOOL)clearForHomeAccountId:(__unused NSString *)homeAccountId
                      clientId:(__unused NSString *)clientId
                       context:(__unused id<MSIDRequestContext>)context
-                        error:(__unused NSError **)error
+                        error:(__unused NSError *__autoreleasing*)error
 {
     return YES;
 }
 
 - (MSIDAccountIdentifier *)principalAccountIdForClientId:(__unused NSString *)clientId
                                                  context:(__unused id<MSIDRequestContext>)context
-                                                   error:(NSError **)error
+                                                   error:(NSError *__autoreleasing*)error
 {
     if (error) *error = self.mockedPrincipalAccountIdError;
     return self.mockedPrincipalAccountId;
@@ -89,7 +89,7 @@
                          principalAccountId:(MSIDAccountIdentifier *)principalAccountId
                 principalAccountEnvironment:(NSString *)principalAccountEnvironment
                                     context:(__unused id<MSIDRequestContext>)context
-                                      error:(NSError **)error
+                                      error:(NSError *__autoreleasing*)error
 {
     if (error) *error = self.updatePrincipalAccountIdError;
     
@@ -106,7 +106,7 @@
 
 - (BOOL)removeAccountMetadataForHomeAccountId:(NSString *)homeAccountId
                                       context:(__unused id<MSIDRequestContext>)context
-                                        error:(NSError **)error
+                                        error:(NSError *__autoreleasing*)error
 {
     if (error) *error = self.removeAccountMetadataForHomeAccountIdError;
     
@@ -123,7 +123,7 @@
                                  clientId:(NSString *)clientId
                                     state:(MSIDAccountMetadataState)state
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     self.updateSignInStateForHomeAccountIdInvokedCount++;
     

--- a/IdentityCore/tests/mocks/MSIDClaimsRequestMock.m
+++ b/IdentityCore/tests/mocks/MSIDClaimsRequestMock.m
@@ -25,7 +25,7 @@
 
 @implementation MSIDClaimsRequestMock
 
-- (BOOL)requestClaim:(__unused MSIDIndividualClaimRequest *)request forTarget:(__unused MSIDClaimsRequestTarget)target error:(NSError **)error
+- (BOOL)requestClaim:(__unused MSIDIndividualClaimRequest *)request forTarget:(__unused MSIDClaimsRequestTarget)target error:(NSError *__autoreleasing*)error
 {
     self.requestClaimInvokedCount++;
     
@@ -34,7 +34,7 @@
     return self.resultToReturn;
 }
 
-- (BOOL)removeClaimRequestWithName:(__unused NSString *)name target:(__unused MSIDClaimsRequestTarget)target error:(NSError **)error
+- (BOOL)removeClaimRequestWithName:(__unused NSString *)name target:(__unused MSIDClaimsRequestTarget)target error:(NSError *__autoreleasing*)error
 {
     self.removeClaimRequestWithNameInvokedCount++;
     

--- a/IdentityCore/tests/mocks/MSIDTestBrokerResponseHandler.m
+++ b/IdentityCore/tests/mocks/MSIDTestBrokerResponseHandler.m
@@ -48,7 +48,7 @@
 
 - (nullable MSIDTokenResult *)handleBrokerResponseWithURL:(__unused NSURL *)url
                                         sourceApplication:(__unused  NSString *)sourceApplication
-                                                    error:(NSError * _Nullable * _Nullable)error
+                                                    error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     if (self.testError && error)
     {

--- a/IdentityCore/tests/mocks/MSIDTestTokenRequestProvider.m
+++ b/IdentityCore/tests/mocks/MSIDTestTokenRequestProvider.m
@@ -96,7 +96,7 @@
                                                             brokerKey:(nonnull __unused NSString *)brokerKey
                                                brokerApplicationToken:(__unused NSString * _Nullable )brokerApplicationToken
                                                       sdkCapabilities:(__unused NSArray *)sdkCapabilities
-                                                                error:(NSError * _Nullable * _Nullable)error
+                                                                error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     if (self.testError)
     {

--- a/IdentityCore/tests/mocks/MSIDThrottlingServiceMock.m
+++ b/IdentityCore/tests/mocks/MSIDThrottlingServiceMock.m
@@ -66,7 +66,7 @@
 
 + (BOOL)updateLastRefreshTimeDatasource:(id<MSIDExtendedTokenCacheDataSource>)datasource
                                 context:(id<MSIDRequestContext>)context
-                                  error:(NSError **)error
+                                  error:(NSError *__autoreleasing*)error
 {
     return [super updateLastRefreshTimeDatasource:datasource
                                           context:context
@@ -74,4 +74,3 @@
 }
 
 @end
-

--- a/IdentityCore/tests/util/MSIDTestCacheDataSource.m
+++ b/IdentityCore/tests/util/MSIDTestCacheDataSource.m
@@ -73,7 +73,7 @@
               key:(MSIDCacheKey *)key
        serializer:(id<MSIDCacheItemSerializing>)serializer
           context:(id<MSIDRequestContext>)context
-            error:(NSError **)error
+            error:(NSError *__autoreleasing*)error
 {
     if (!item
         || !key
@@ -99,7 +99,7 @@
 - (MSIDCredentialCacheItem *)tokenWithKey:(MSIDCacheKey *)key
                                serializer:(id<MSIDCacheItemSerializing>)serializer
                                   context:(id<MSIDRequestContext>)context
-                                    error:(NSError **)error
+                                    error:(NSError *__autoreleasing*)error
 {
     if (!serializer)
     {
@@ -123,28 +123,28 @@
 
 - (BOOL)removeTokensWithKey:(MSIDCacheKey *)key
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     return [self removeItemsWithKey:key context:context error:error];
 }
 
 - (BOOL)removeAccountsWithKey:(MSIDCacheKey *)key
                       context:(id<MSIDRequestContext>)context
-                        error:(NSError **)error
+                        error:(NSError *__autoreleasing*)error
 {
     return [self removeItemsWithKey:key context:context error:error];
 }
 
 - (BOOL)removeMetadataItemsWithKey:(MSIDCacheKey *)key
                            context:(id<MSIDRequestContext>)context
-                             error:(NSError **)error
+                             error:(NSError *__autoreleasing*)error
 {
     return [self removeItemsWithKey:key context:context error:error];
 }
 
 - (BOOL)removeItemsWithKey:(MSIDCacheKey *)key
                    context:(__unused id<MSIDRequestContext>)context
-                     error:(NSError **)error
+                     error:(NSError *__autoreleasing*)error
 {
     if (!key)
     {
@@ -183,7 +183,7 @@
 - (NSArray<MSIDCredentialCacheItem *> *)tokensWithKey:(MSIDCacheKey *)key
                                            serializer:(id<MSIDCacheItemSerializing>)serializer
                                               context:(id<MSIDRequestContext>)context
-                                                error:(NSError **)error
+                                                error:(NSError *__autoreleasing*)error
 {
     if (!serializer)
     {
@@ -217,14 +217,14 @@
 }
 
 - (BOOL)saveWipeInfoWithContext:(__unused id<MSIDRequestContext>)context
-                          error:(__unused NSError **)error
+                          error:(__unused NSError *__autoreleasing*)error
 {
     _wipeInfo = @{@"wiped": [NSDate date]};
     return YES;
 }
 
 - (NSDictionary *)wipeInfo:(__unused id<MSIDRequestContext>)context
-                     error:(__unused NSError **)error
+                     error:(__unused NSError *__autoreleasing*)error
 {
     return _wipeInfo;
 }
@@ -233,7 +233,7 @@
                 key:(MSIDCacheKey *)key
          serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
             context:(id<MSIDRequestContext>)context
-              error:(NSError **)error
+              error:(NSError *__autoreleasing*)error
 {
     if (!item
         || !serializer)
@@ -258,7 +258,7 @@
 - (MSIDAccountCacheItem *)accountWithKey:(MSIDCacheKey *)key
                               serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                  context:(id<MSIDRequestContext>)context
-                                   error:(NSError **)error
+                                   error:(NSError *__autoreleasing*)error
 {
     if (!serializer)
     {
@@ -283,7 +283,7 @@
 - (NSArray<MSIDAccountCacheItem *> *)accountsWithKey:(MSIDCacheKey *)key
                                           serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                              context:(id<MSIDRequestContext>)context
-                                               error:(NSError **)error
+                                               error:(NSError *__autoreleasing*)error
 {
     if (!serializer)
     {
@@ -357,7 +357,7 @@
             serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                    key:(MSIDCacheKey *)key
                context:(id<MSIDRequestContext>)context
-                 error:(NSError **)error
+                 error:(NSError *__autoreleasing*)error
 {
     if (!jsonObject || !serializer)
     {
@@ -422,7 +422,7 @@
              keysDictionary:(NSDictionary *)cacheKeys
           contentDictionary:(NSDictionary *)cacheContent
                     context:(id<MSIDRequestContext>)context
-                      error:(NSError **)error
+                      error:(NSError *__autoreleasing*)error
 {
     if (!key || !cacheKeys || !cacheContent)
     {
@@ -454,7 +454,7 @@
            cacheKeys:(NSMutableDictionary *)cacheKeys
         cacheContent:(NSMutableDictionary *)cacheContent
              context:(__unused id<MSIDRequestContext>)context
-               error:(NSError **)error
+               error:(NSError *__autoreleasing*)error
 {
     if (!key || !cacheKeys || !cacheContent)
     {
@@ -502,7 +502,7 @@
                      keysDictionary:(NSDictionary *)cacheKeys
                   contentDictionary:(NSDictionary *)cacheContent
                             context:(__unused id<MSIDRequestContext>)context
-                              error:(NSError **)error
+                              error:(NSError *__autoreleasing*)error
 {
     if (!key
         || !cacheKeys
@@ -569,7 +569,7 @@
     return resultItems;
 }
 
-- (BOOL)clearWithContext:(__unused id<MSIDRequestContext>)context error:(__unused NSError **)error
+- (BOOL)clearWithContext:(__unused id<MSIDRequestContext>)context error:(__unused NSError *__autoreleasing*)error
 {
     [self reset];
     return YES;
@@ -648,7 +648,7 @@
                     key:(MSIDCacheKey *)key
              serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                 context:(id<MSIDRequestContext>)context
-                  error:(NSError **)error
+                  error:(NSError *__autoreleasing*)error
 {
     if (!item
         || !serializer)
@@ -673,7 +673,7 @@
 - (NSArray<MSIDAppMetadataCacheItem *> *)appMetadataEntriesWithKey:(MSIDCacheKey *)key
                                                         serializer:(id<MSIDExtendedCacheItemSerializing>)serializer
                                                            context:(id<MSIDRequestContext>)context
-                                                             error:(NSError **)error
+                                                             error:(NSError *__autoreleasing*)error
 {
     if (!serializer)
     {


### PR DESCRIPTION
## Proposed changes

Requested by Office in [AB#2797114](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2797114/).
OneAuth and MSAL-C++ already enable this warning.

Also fixed a number of capitalization mismatch of `Witherror` vs `WithError`

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

