### PR TITLE
Automation - Get lab credentials in background thread

### DIFF
--- a/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationOperationAPIRequestHandler.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/lab_api/MSIDAutomationOperationAPIRequestHandler.m
@@ -85,9 +85,16 @@
         return;
     }
     
-    [self getAccessTokenAndCallLabAPI:apiRequest
-                      responseHandler:responseHandler
-                    completionHandler:completionHandler];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self getAccessTokenAndCallLabAPI:apiRequest
+                          responseHandler:responseHandler
+                        completionHandler:^(id result, NSError *error) 
+         {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionHandler(result, error);
+            });
+        }];
+    });
 }
 
 #pragma mark - Get access token


### PR DESCRIPTION
## Proposed changes

Get lab credentials in background thread to prevent error message and avoid possible UI issues.
Error message from pipeline: `This method should not be called on the main thread as it may lead to UI unresponsiveness.`

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

