### PR TITLE
Update device register to include a new hint for Token protection

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -31,6 +31,7 @@ extern NSString * _Nonnull MSIDHTTPHeadersKey;
 extern NSString * _Nonnull MSIDHTTPResponseCodeKey;
 extern NSString * _Nonnull MSIDUserDisplayableIdkey;
 extern NSString * _Nonnull MSIDHomeAccountIdkey;
+extern NSString * _Nonnull MSIDTokenProtectionRequired;
 extern NSString * _Nonnull MSIDBrokerVersionKey;
 
 /*!

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -33,6 +33,7 @@ NSString *MSIDDeclinedScopesKey = @"MSIDDeclinedScopesKey";
 NSString *MSIDGrantedScopesKey = @"MSIDGrantedScopesKey";
 NSString *MSIDUserDisplayableIdkey = @"MSIDUserDisplayableIdkey";
 NSString *MSIDHomeAccountIdkey = @"MSIDHomeAccountIdkey";
+NSString *MSIDTokenProtectionRequired = @"MSIDTokenProtectionRequired";
 NSString *MSIDBrokerVersionKey = @"MSIDBrokerVersionKey";
 NSString *MSIDServerUnavailableStatusKey = @"MSIDServerUnavailableStatusKey";
 

--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
@@ -135,7 +135,8 @@
             NSMutableDictionary *additionalInfo = [NSMutableDictionary new];
             additionalInfo[MSIDUserDisplayableIdkey] = response.upn;
             additionalInfo[MSIDHomeAccountIdkey] = response.clientInfo.accountIdentifier;
-            
+            additionalInfo[MSIDTokenProtectionRequired] = @(response.tokenProtectionRequired);
+
             registrationError = MSIDCreateError(MSIDErrorDomain, MSIDErrorWorkplaceJoinRequired, @"Workplace join is required", nil, nil, nil, self.requestParameters.correlationId, additionalInfo, NO);
         }
         else

--- a/IdentityCore/src/webview/response/MSIDWebWPJResponse.h
+++ b/IdentityCore/src/webview/response/MSIDWebWPJResponse.h
@@ -34,5 +34,6 @@
 @property (atomic, readonly) NSString *upn;
 @property (atomic, readonly) NSString *appInstallLink;
 @property (atomic, readonly) MSIDClientInfo *clientInfo;
+@property (atomic, readonly) BOOL tokenProtectionRequired;
 
 @end

--- a/IdentityCore/src/webview/response/MSIDWebWPJResponse.m
+++ b/IdentityCore/src/webview/response/MSIDWebWPJResponse.m
@@ -69,6 +69,8 @@
     self = [super initWithURL:url context:context error:error];
     if (self)
     {
+        NSString *tokenProtection = self.parameters[@"token_protection_required"];
+        _tokenProtectionRequired = [tokenProtection isEqualToString:@"true"];
         _appInstallLink = self.parameters[@"app_link"];
         _upn = self.parameters[@"username"];
         

--- a/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
@@ -206,6 +206,60 @@
     
     NSError *error = nil;
     
+    NSURL *url = [NSURL URLWithString:@"msauth.com.microsoft.myapp://auth/msauth/wpj?app_link=app.link&username=XXX@upn.com&token_protection_required=true"];
+    __auto_type response = [factory oAuthResponseWithURL:url requestState:nil ignoreInvalidState:YES context:nil error:&error];
+    
+    XCTAssertTrue([response isKindOfClass:MSIDWebWPJResponse.class]);
+    XCTAssertNil(error);
+    
+    MSIDWebWPJResponse *wpjResponse = (MSIDWebWPJResponse *)response;
+    XCTAssertEqualObjects(wpjResponse.appInstallLink, @"app.link");
+    XCTAssertEqualObjects(wpjResponse.upn, @"XXX@upn.com");
+    XCTAssertTrue(wpjResponse.tokenProtectionRequired);
+}
+
+- (void)testResponseWithURL_whenBrokerInstallResponseInSystemBrowser_withStrongerAuthFalse_shouldReturnUseStrongerAuthFalse
+{
+    MSIDAADWebviewFactory *factory = [MSIDAADWebviewFactory new];
+    
+    NSError *error = nil;
+    
+    NSURL *url = [NSURL URLWithString:@"msauth.com.microsoft.myapp://auth/msauth/wpj?app_link=app.link&username=XXX@upn.com&token_protection_required=false"];
+    __auto_type response = [factory oAuthResponseWithURL:url requestState:nil ignoreInvalidState:YES context:nil error:&error];
+    
+    XCTAssertTrue([response isKindOfClass:MSIDWebWPJResponse.class]);
+    XCTAssertNil(error);
+    
+    MSIDWebWPJResponse *wpjResponse = (MSIDWebWPJResponse *)response;
+    XCTAssertEqualObjects(wpjResponse.appInstallLink, @"app.link");
+    XCTAssertEqualObjects(wpjResponse.upn, @"XXX@upn.com");
+    XCTAssertFalse(wpjResponse.tokenProtectionRequired);
+}
+
+- (void)testResponseWithURL_whenBrokerInstallResponseInSystemBrowser_withStrongerAuthEqualsTRUE_shouldReturnUseStrongerAuthFalse
+{
+    MSIDAADWebviewFactory *factory = [MSIDAADWebviewFactory new];
+    
+    NSError *error = nil;
+    
+    NSURL *url = [NSURL URLWithString:@"msauth.com.microsoft.myapp://auth/msauth/wpj?app_link=app.link&username=XXX@upn.com&token_protection_required=TRUE"];
+    __auto_type response = [factory oAuthResponseWithURL:url requestState:nil ignoreInvalidState:YES context:nil error:&error];
+    
+    XCTAssertTrue([response isKindOfClass:MSIDWebWPJResponse.class]);
+    XCTAssertNil(error);
+    
+    MSIDWebWPJResponse *wpjResponse = (MSIDWebWPJResponse *)response;
+    XCTAssertEqualObjects(wpjResponse.appInstallLink, @"app.link");
+    XCTAssertEqualObjects(wpjResponse.upn, @"XXX@upn.com");
+    XCTAssertFalse(wpjResponse.tokenProtectionRequired);
+}
+
+- (void)testResponseWithURL_whenBrokerInstallResponseInSystemBrowser_withStrongerAuthNotExist_shouldReturnUseStrongerAuthFalse
+{
+    MSIDAADWebviewFactory *factory = [MSIDAADWebviewFactory new];
+    
+    NSError *error = nil;
+    
     NSURL *url = [NSURL URLWithString:@"msauth.com.microsoft.myapp://auth/msauth/wpj?app_link=app.link&username=XXX@upn.com"];
     __auto_type response = [factory oAuthResponseWithURL:url requestState:nil ignoreInvalidState:YES context:nil error:&error];
     
@@ -215,6 +269,7 @@
     MSIDWebWPJResponse *wpjResponse = (MSIDWebWPJResponse *)response;
     XCTAssertEqualObjects(wpjResponse.appInstallLink, @"app.link");
     XCTAssertEqualObjects(wpjResponse.upn, @"XXX@upn.com");
+    XCTAssertFalse(wpjResponse.tokenProtectionRequired);
 }
 
 - (void)testResponseWithURL_whenBrokerUpgradeRegResponseInSystemBrowser_shouldReturnUpgradeRegResponse
@@ -242,7 +297,7 @@
     
     NSError *error = nil;
     
-    NSURL *url = [NSURL URLWithString:@"https://localhost/msauth/wpj?app_link=app.link&username=XXX@upn.com"];
+    NSURL *url = [NSURL URLWithString:@"https://localhost/msauth/wpj?app_link=app.link&username=XXX@upn.com&token_protection_required=true"];
     __auto_type response = [factory oAuthResponseWithURL:url requestState:nil ignoreInvalidState:YES context:nil error:&error];
     
     XCTAssertTrue([response isKindOfClass:MSIDWebWPJResponse.class]);
@@ -251,6 +306,7 @@
     MSIDWebWPJResponse *wpjResponse = (MSIDWebWPJResponse *)response;
     XCTAssertEqualObjects(wpjResponse.appInstallLink, @"app.link");
     XCTAssertEqualObjects(wpjResponse.upn, @"XXX@upn.com");
+    XCTAssertTrue(wpjResponse.tokenProtectionRequired);
 }
 
 - (void)testResponseWithURL_whenBrokerUpgradeResponseInSystemBrowser_andLocalhostRedirectUri_shouldReturnUpgradeRegResponse
@@ -278,7 +334,7 @@
     
     NSError *error = nil;
     
-    NSURL *url = [NSURL URLWithString:@"https://localhost//msauth/wpj?app_link=app.link&username=XXX@upn.com"];
+    NSURL *url = [NSURL URLWithString:@"https://localhost//msauth/wpj?app_link=app.link&username=XXX@upn.com&token_protection_required=true"];
     __auto_type response = [factory oAuthResponseWithURL:url requestState:nil ignoreInvalidState:YES context:nil error:&error];
     
     XCTAssertTrue([response isKindOfClass:MSIDWebWPJResponse.class]);
@@ -287,6 +343,7 @@
     MSIDWebWPJResponse *wpjResponse = (MSIDWebWPJResponse *)response;
     XCTAssertEqualObjects(wpjResponse.appInstallLink, @"app.link");
     XCTAssertEqualObjects(wpjResponse.upn, @"XXX@upn.com");
+    XCTAssertTrue(wpjResponse.tokenProtectionRequired);
 }
 
 - (void)testResponseWithURL_whenURLSchemeNotMsauth_shouldReturnAADAuthResponse

--- a/IdentityCore/tests/MSIDWebMSAuthResponseTests.m
+++ b/IdentityCore/tests/MSIDWebMSAuthResponseTests.m
@@ -55,7 +55,7 @@
 - (void)testInit_whenMSAuthScheme_shouldReturnResponsewithNoError
 {
     NSError *error = nil;
-    MSIDWebWPJResponse *response = [[MSIDWebWPJResponse alloc] initWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"msauth://wpj?app_link=applink&username=user"]]
+    MSIDWebWPJResponse *response = [[MSIDWebWPJResponse alloc] initWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"msauth://wpj?app_link=applink&username=user&token_protection_required=true"]]
                                                                            context:nil
                                                                              error:&error];
 
@@ -64,6 +64,7 @@
 
     XCTAssertEqualObjects(response.upn, @"user");
     XCTAssertEqualObjects(response.appInstallLink, @"applink");
+    XCTAssertTrue(response.tokenProtectionRequired);
 
 }
 

--- a/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
@@ -703,7 +703,7 @@
                                MSIDWebviewAuthCompletionHandler completionHandler)
     {
 
-         NSString *responseString = @"msauth://wpj?app_link=https://login.microsoftonline.appinstall.test";
+         NSString *responseString = @"msauth://wpj?app_link=https://login.microsoftonline.appinstall.test&token_protection_required=true";
 
          MSIDWebWPJResponse *msauthResponse = [[MSIDWebWPJResponse alloc] initWithURL:[NSURL URLWithString:responseString] context:nil error:nil];
          completionHandler(msauthResponse, nil);
@@ -724,6 +724,7 @@
         XCTAssertNil(error);
         XCTAssertNotNil(installBrokerResponse);
         XCTAssertEqualObjects(installBrokerResponse.appInstallLink, @"https://login.microsoftonline.appinstall.test");
+        XCTAssertTrue(installBrokerResponse.tokenProtectionRequired);
 
         [expectation fulfill];
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 [TBD]
 * Migrate existing devices using UpgradeReg API - Error definitions (#1376)
+* Update device register to include a new hint for Token protection (#1394)
 
 Version 1.7.36
 * Add platform sequence telemetry param. (#1378)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 [TBD]
 * Migrate existing devices using UpgradeReg API - Error definitions (#1376)
-* Update device register to include a new hint for Token protection (#1394)
+* Update device register to include a new hint for token protection (#1394)
 
 Version 1.7.36
 * Add platform sequence telemetry param. (#1378)


### PR DESCRIPTION
## Proposed changes

Add a new hint to indicate that the registration requires token protection i.e passing a flag to WPJ to set using most_secure_storage to true.
This part is in common core to set the flags in additionalInfo. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

