### PR TITLE
Add new account type to handle On-prem ADFS scenarios

### DIFF
--- a/IdentityCore/src/oauth2/account/MSIDAccountType.h
+++ b/IdentityCore/src/oauth2/account/MSIDAccountType.h
@@ -28,7 +28,8 @@ typedef NS_ENUM(NSInteger, MSIDAccountType)
     MSIDAccountTypeOther,
     MSIDAccountTypeAADV1,
     MSIDAccountTypeMSA,
-    MSIDAccountTypeMSSTS
+    MSIDAccountTypeMSSTS,
+    MSIDAccountTypeADFS
 };
 
 @interface MSIDAccountTypeHelpers : NSObject

--- a/IdentityCore/src/oauth2/account/MSIDAccountType.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccountType.m
@@ -37,6 +37,9 @@
             
         case MSIDAccountTypeMSSTS:
             return @"MSSTS";
+
+	case MSIDAccountTypeADFS:
+	    return @"ADFS";
             
         default:
             return @"Other";
@@ -53,7 +56,8 @@ static NSDictionary *sAccountTypes = nil;
         
         sAccountTypes = @{@"aad": @(MSIDAccountTypeAADV1),
                           @"msa": @(MSIDAccountTypeMSA),
-                          @"mssts": @(MSIDAccountTypeMSSTS)};
+                          @"mssts": @(MSIDAccountTypeMSSTS),
+			  @"adfs": @(MSIDAccountTypeADFS)};
     });
     
     NSNumber *accountType = sAccountTypes[type.lowercaseString];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
-[TBD]
-* Migrate existing devices using UpgradeReg API - Error definitions (#1376)
-* Update device register to include a new hint for token protection (#1394)
+Version 1.7.37
+* Added new account type to handle On-prem ADFS scenarios. (#1397)
 
 Version 1.7.36
 * Add platform sequence telemetry param. (#1378)


### PR DESCRIPTION
## Proposed changes
Update MSIDAccountType enum to include "ADFS" as new account type. Correspondingly update implementation as well

Describe what this PR is trying to do.
When ADFS account type is presented to Identity Core then it is defaulted to type "Other" causing ADFS on prem flow to fail for Outlook macOS. Hence added "adfs" account type.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk
Migration of existing ADFS accounts will not work. This is expected by OneAuth-MSAL.

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Tested these changes locally along with Outlook mac and OneAuth-MSAL code and end to end flow works as expected.
