### PR TITLE
Hotfix/1.7.37

### DIFF
--- a/IdentityCore/src/oauth2/account/MSIDAccountType.h
+++ b/IdentityCore/src/oauth2/account/MSIDAccountType.h
@@ -28,7 +28,8 @@ typedef NS_ENUM(NSInteger, MSIDAccountType)
     MSIDAccountTypeOther,
     MSIDAccountTypeAADV1,
     MSIDAccountTypeMSA,
-    MSIDAccountTypeMSSTS
+    MSIDAccountTypeMSSTS,
+    MSIDAccountTypeADFS
 };
 
 @interface MSIDAccountTypeHelpers : NSObject

--- a/IdentityCore/src/oauth2/account/MSIDAccountType.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccountType.m
@@ -37,6 +37,9 @@
             
         case MSIDAccountTypeMSSTS:
             return @"MSSTS";
+
+	case MSIDAccountTypeADFS:
+	    return @"ADFS";
             
         default:
             return @"Other";
@@ -53,7 +56,8 @@ static NSDictionary *sAccountTypes = nil;
         
         sAccountTypes = @{@"aad": @(MSIDAccountTypeAADV1),
                           @"msa": @(MSIDAccountTypeMSA),
-                          @"mssts": @(MSIDAccountTypeMSSTS)};
+                          @"mssts": @(MSIDAccountTypeMSSTS),
+			  @"adfs": @(MSIDAccountTypeADFS)};
     });
     
     NSNumber *accountType = sAccountTypes[type.lowercaseString];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.7.37
+* Added new account type to handle On-prem ADFS scenarios. (#1397)
+
 Version 1.7.36
 * Add platform sequence telemetry param. (#1378)
 * Update broker automations lab API. (#1377)


### PR DESCRIPTION
## Proposed changes


This pull request primarily involves the addition of a new account type, `MSIDAccountTypeADFS`, to handle On-prem ADFS scenarios in the IdentityCore library. The changes are reflected in the enumeration `MSIDAccountType` and the associated account type handling methods. The changelog has also been updated to reflect this new feature.

Here are the key changes:

* [`IdentityCore/src/oauth2/account/MSIDAccountType.h`](diffhunk://#diff-ab60f783f8d4d5a5ce323b360f27a31cef2e462a0d20ad5012be075dff87540bL31-R32): Added `MSIDAccountTypeADFS` to the `MSIDAccountType` enumeration.
* [`IdentityCore/src/oauth2/account/MSIDAccountType.m`](diffhunk://#diff-34e0fe798dd5ea79235995d27c17643e0f43435cdbc1de950e9a1884c541d09cR41-R43): Updated the `accountTypeAsString:` method to return "ADFS" when the account type is `MSIDAccountTypeADFS`.
* [`IdentityCore/src/oauth2/account/MSIDAccountType.m`](diffhunk://#diff-34e0fe798dd5ea79235995d27c17643e0f43435cdbc1de950e9a1884c541d09cL56-R60): Updated the `accountTypeFromString:` method to map the string "adfs" to `MSIDAccountTypeADFS`.
* [`changelog.txt`](diffhunk://#diff-b40cd67182487ef24807d9c9268329d35fbd96aa2b0a9cae69e2e0d746b1c666R1-R3): Added a changelog entry for the new feature in version 1.7.37.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

