### PR TITLE
IdentityCore register device with hint - Enable ECC when hint is available

### DIFF
--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
@@ -135,7 +135,7 @@
             NSMutableDictionary *additionalInfo = [NSMutableDictionary new];
             additionalInfo[MSIDUserDisplayableIdkey] = response.upn;
             additionalInfo[MSIDHomeAccountIdkey] = response.clientInfo.accountIdentifier;
-            additionalInfo[MSIDTokenProtectionRequired] = @(response.tokenProtectionRequired);
+            additionalInfo[MSIDTokenProtectionRequired] = response.tokenProtectionRequired ? @(YES) : @(NO);
 
             registrationError = MSIDCreateError(MSIDErrorDomain, MSIDErrorWorkplaceJoinRequired, @"Workplace join is required", nil, nil, nil, self.requestParameters.correlationId, additionalInfo, NO);
         }


### PR DESCRIPTION
## Proposed changes

NSDictionary holds object values of type (id) entries. `NSError additionalInfo[MSIDTokenProtectionRequired]` was set with either  NO  or YES which translates to 0 or 1 because BOOL is tranformed to NO (0) or YES (1) as described [here](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/%5BApple%5D%20Objective%20C%20Style%20Guide/Objectice-C%20Style%20format%20and%20Guide.md&_a=preview&anchor=bool-pitfalls).
While reading, using the following format caused the value of BOOL to be always equals YES
```objc
// tokenProtection was always set to YES as the object exists not evaluating the content of id.
BOOL tokenProtection = error.userInfo[MSIDTokenProtectionRequired];
```
 The proper fix is to use 
`[[error.userInfo objectForKey:MSIDTokenProtectionRequired] boolValue];`

That could have caused ECC to be set always.
Added a feature flag to disable this as well for more protection

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Did you guard your code with an ECS feature flight?

- [x] Yes – you don't need to do anything else
- [ ] No – provide a justification why your code doesn't need a feature flag.

## Additional information
