### PR TITLE
Retry network requests on NSURLErrorNotConnectedToInternet after exte…

### DIFF
--- a/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
+++ b/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
@@ -50,7 +50,7 @@
         {
             // Networking errors (-1001, -1003. -1004. -1005. -1009)
             shouldRetryNetworkingFailure = [self shouldRetryNetworkingFailure:error.code];
-            if (error.code == NSURLErrorNotConnectedToInternet)
+            if (shouldRetryNetworkingFailure && error.code == NSURLErrorNotConnectedToInternet)
             {
                 // For handling the NSURLErrorNotConnectedToInternet error, retry the network request after a longer delay.
                 httpRequest.retryInterval = 2.0;

--- a/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
+++ b/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
@@ -50,6 +50,11 @@
         {
             // Networking errors (-1001, -1003. -1004. -1005. -1009)
             shouldRetryNetworkingFailure = [self shouldRetryNetworkingFailure:error.code];
+            if (error.code == NSURLErrorNotConnectedToInternet)
+            {
+                // For handling the NSURLErrorNotConnectedToInternet error, retry the network request after a longer delay.
+                httpRequest.retryInterval = 2.0;
+            }
         }
 
         shouldRetry &= shouldRetryNetworkingFailure;


### PR DESCRIPTION
…nded delay

## Proposed changes

We still have -1009 error in broker but later resolved in OneAuth. Extend the delay for retrying for no network connection case. 

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

