### PR TITLE
Attempt to fix an ios crash for MSAL at MSIDLastRequestTelemetry

### DIFF
--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.h
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.h
@@ -26,7 +26,7 @@
 #import <Foundation/Foundation.h>
 #import "MSIDTelemetryStringSerializable.h"
 
-@interface MSIDRequestTelemetryErrorInfo : NSObject <NSSecureCoding>
+@interface MSIDRequestTelemetryErrorInfo : NSObject <NSSecureCoding, NSCopying>
 
 @property (nonatomic) NSInteger apiId;
 @property (nonatomic, nullable) NSUUID *correlationId;

--- a/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
+++ b/IdentityCore/src/telemetry/request_telemetry/MSIDLastRequestTelemetry.m
@@ -97,6 +97,15 @@
     return YES;
 }
 
+- (nonnull id)copyWithZone:(nullable NSZone *)zone 
+{
+    MSIDRequestTelemetryErrorInfo *errorInfo = [[MSIDRequestTelemetryErrorInfo allocWithZone:zone] init];
+    errorInfo.apiId = self.apiId;
+    errorInfo.correlationId = [self.correlationId copyWithZone:zone];
+    errorInfo.error = [self.error copyWithZone:zone];
+    return errorInfo;
+}
+
 @end
 
 NSString * _Nonnull const MSID_PERF_TELEMETRY_SILENT_TYPE = @"silent";
@@ -484,7 +493,7 @@ static int maxErrorCountToArchive = 75;
 {
     __block NSArray *errorsInfoCopy;
     dispatch_sync(self.synchronizationQueue, ^{
-        errorsInfoCopy = [_errorsInfo copy];
+        errorsInfoCopy = [[NSArray alloc] initWithArray:_errorsInfo copyItems:YES];
     });
     return errorsInfoCopy;
 }


### PR DESCRIPTION
## Proposed changes

Reported in [AppCenter crash](https://appcenter.ms/orgs/thomas-olsen-er92/apps/Skype-Teams-iOS-Store/crashes/errors/659814541u/reports/2516770165280009999-eb69eb07-8a16-41eb-9c54-40bd5f14b4e6/raw) tracking. There seems to be a crash that shows more often at this call stack
```objc
libobjc.A.dylib objc_release 
CoreFoundation -[__NSArrayM dealloc]
CoreFoundation cow_cleanup
CoreFoundation -[__NSDictionaryM dealloc]
CoreFoundation __RELEASE_OBJECTS_IN_THE_ARRAY__
CoreFoundation -[__NSArrayM dealloc]
TeamSpaceApp -[MSIDLastRequestTelemetry saveTelemetryToDisk] MSIDLastRequestTelemetry.m:440
```
From this stack. It is more obvious that NSArrayM dealloc is crashing either because that object is already deallocated or nil. Looking at the source code. We had an operation for [NSArray copy] which does a shallow copy. Replacing it with `[[NSArray alloc] initWithArray:_errorsInfo copyItems:YES];` to create another instance of the array and copy its contents.


## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

