### PR TITLE
Replace deprecated method UIApplication.openURL(_:) for all targets

### DIFF
--- a/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
+++ b/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
@@ -77,7 +77,20 @@ static BOOL s_isRunningInCompliantExtension = NO;
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
     
     [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
+#if defined TARGET_OS_VISION && TARGET_OS_VISION
         [[self sharedApplication] openURL:url options:@{} completionHandler:nil];
+#else
+        [self sharedApplicationOpenURL:url
+                               options:nil
+                     completionHandler:^(BOOL success)
+         {
+            if (!success)
+            {
+                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Error when trying to open url: %@", [url msidPIINullifiedURL]);
+            }
+        }];
+#endif
+
     }];
 #pragma clang diagnostic pop
 }

--- a/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
+++ b/IdentityCore/src/util/ios/MSIDAppExtensionUtil.m
@@ -77,11 +77,7 @@ static BOOL s_isRunningInCompliantExtension = NO;
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
     
     [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
-#if defined TARGET_OS_VISION && TARGET_OS_VISION
         [[self sharedApplication] openURL:url options:@{} completionHandler:nil];
-#else
-        [[self sharedApplication] performSelector:NSSelectorFromString(@"openURL:") withObject:url];
-#endif
     }];
 #pragma clang diagnostic pop
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 [TBD]
+* Replace deprecated method UIApplication.openURL(_:) (#1424)
+
+[TBD]
 * VisionOS support added to IdentityCore (#1412)
 * Increased macOS minimum version to 10.15 (#2220)
 * Parse and add STS error codes in token error result (#1417)


### PR DESCRIPTION
## Proposed changes

Apple has begun force-returning false for any calls to the deprecated [openURL](https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl?language=objc) method for apps/frameworks compiled with Xcode 16.

This is documented in the iOS 18 release notes at https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-18-release-notes

> Fixed: Applications built with iOS 18, iPadOS 18, Mac Catalyst 18, or tvOS 18 SDKs will call to the deprecated method
UIApplication.openURL(_:). The specified URL will not open and will always return false. (125695759)

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

