### PR TITLE
Add support to attach cross domain PRT in embedded webview

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -621,6 +621,7 @@
 		6078EB51226DA97200235498 /* MSIDTestCacheUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 6078EB4D226DA73600235498 /* MSIDTestCacheUtil.m */; };
 		607A788D23294D6F00A1F74D /* MSIDAccountMetadataCacheAccessorMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 607A788C23294D6F00A1F74D /* MSIDAccountMetadataCacheAccessorMock.m */; };
 		607A788E23294D6F00A1F74D /* MSIDAccountMetadataCacheAccessorMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 607A788C23294D6F00A1F74D /* MSIDAccountMetadataCacheAccessorMock.m */; };
+		607E6A8C2CAF04D700948365 /* MSIDCustomHeaderProviding.h in Headers */ = {isa = PBXBuildFile; fileRef = 607E6A8B2CAF04D700948365 /* MSIDCustomHeaderProviding.h */; };
 		6080B97A2384BD17009B1322 /* MSIDAccountMetadataCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 6080B9792384BD17009B1322 /* MSIDAccountMetadataCacheItem.m */; };
 		6080B97B2384BD17009B1322 /* MSIDAccountMetadataCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 6080B9792384BD17009B1322 /* MSIDAccountMetadataCacheItem.m */; };
 		6080B9A523886DD9009B1322 /* MSIDBrokerOperationGetDeviceInfoRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6080B9A423886DD9009B1322 /* MSIDBrokerOperationGetDeviceInfoRequestTests.m */; };
@@ -2455,6 +2456,7 @@
 		6078EB4D226DA73600235498 /* MSIDTestCacheUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTestCacheUtil.m; sourceTree = "<group>"; };
 		607A788B23294D2400A1F74D /* MSIDAccountMetadataCacheAccessorMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountMetadataCacheAccessorMock.h; sourceTree = "<group>"; };
 		607A788C23294D6F00A1F74D /* MSIDAccountMetadataCacheAccessorMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountMetadataCacheAccessorMock.m; sourceTree = "<group>"; };
+		607E6A8B2CAF04D700948365 /* MSIDCustomHeaderProviding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCustomHeaderProviding.h; sourceTree = "<group>"; };
 		6080B9782384BD01009B1322 /* MSIDAccountMetadataCacheItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAccountMetadataCacheItem.h; sourceTree = "<group>"; };
 		6080B9792384BD17009B1322 /* MSIDAccountMetadataCacheItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAccountMetadataCacheItem.m; sourceTree = "<group>"; };
 		6080B9A423886DD9009B1322 /* MSIDBrokerOperationGetDeviceInfoRequestTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBrokerOperationGetDeviceInfoRequestTests.m; sourceTree = "<group>"; };
@@ -4088,6 +4090,14 @@
 			path = account_request;
 			sourceTree = "<group>";
 		};
+		607E6A872CAF03C400948365 /* customHeaderProviding */ = {
+			isa = PBXGroup;
+			children = (
+				607E6A8B2CAF04D700948365 /* MSIDCustomHeaderProviding.h */,
+			);
+			path = customHeaderProviding;
+			sourceTree = "<group>";
+		};
 		609E74BA228CA3C2005E3FED /* metadata */ = {
 			isa = PBXGroup;
 			children = (
@@ -4323,6 +4333,7 @@
 				6057EE8F20B5FDF8007976EB /* MSIDAADOAuthEmbeddedWebviewController.m */,
 				60B3856D20AB3CDC00D546D0 /* ui */,
 				96235FA0207D786A007EAB36 /* challangeHandlers */,
+				607E6A872CAF03C400948365 /* customHeaderProviding */,
 			);
 			path = embeddedWebview;
 			sourceTree = "<group>";
@@ -6076,6 +6087,7 @@
 				B26A0B8C2071B763006BD95A /* MSIDAADV1Oauth2Factory.h in Headers */,
 				B2C708B4219A620E00D917B8 /* MSIDBrokerCryptoProvider.h in Headers */,
 				B2CDB5791FE33A46003A4B5C /* MSIDAccount.h in Headers */,
+				607E6A8C2CAF04D700948365 /* MSIDCustomHeaderProviding.h in Headers */,
 				B2AF1D40218BD10A0080C1A0 /* MSIDRequestParameters.h in Headers */,
 				B2C7089721991D0000D917B8 /* MSIDAADV2BrokerResponse.h in Headers */,
 				E733EDEF25C0A49500ACB79A /* MSIDThumbprintCalculator.h in Headers */,

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.h
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.h
@@ -108,6 +108,7 @@
                                             error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDPrimaryRefreshToken *> *)getPrimaryRefreshTokensForConfiguration:(MSIDConfiguration *)configuration
+                                                                        account:(MSIDAccountIdentifier *)accountIdentifier
                                                                         context:(id<MSIDRequestContext>)context
                                                                           error:(NSError *__autoreleasing*)error;
 

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.h
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.h
@@ -108,6 +108,10 @@
                                             error:(NSError *__autoreleasing*)error;
 
 - (NSArray<MSIDPrimaryRefreshToken *> *)getPrimaryRefreshTokensForConfiguration:(MSIDConfiguration *)configuration
+                                                                        context:(id<MSIDRequestContext>)context
+                                                                          error:(NSError *__autoreleasing*)error;
+
+- (NSArray<MSIDPrimaryRefreshToken *> *)getPrimaryRefreshTokensForConfiguration:(MSIDConfiguration *)configuration
                                                                         account:(MSIDAccountIdentifier *)accountIdentifier
                                                                         context:(id<MSIDRequestContext>)context
                                                                           error:(NSError *__autoreleasing*)error;

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -191,6 +191,13 @@
 }
 
 - (NSArray<MSIDPrimaryRefreshToken *> *)getPrimaryRefreshTokensForConfiguration:(MSIDConfiguration *)configuration
+                                                                        context:(id<MSIDRequestContext>)context
+                                                                          error:(NSError *__autoreleasing*)error
+{
+    return [self getPrimaryRefreshTokensForConfiguration:configuration account:nil context:context error:error];
+}
+
+- (NSArray<MSIDPrimaryRefreshToken *> *)getPrimaryRefreshTokensForConfiguration:(MSIDConfiguration *)configuration
                                                                         account:(MSIDAccountIdentifier *)accountIdentifier
                                                                         context:(id<MSIDRequestContext>)context
                                                                           error:(NSError *__autoreleasing*)error

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -191,12 +191,14 @@
 }
 
 - (NSArray<MSIDPrimaryRefreshToken *> *)getPrimaryRefreshTokensForConfiguration:(MSIDConfiguration *)configuration
+                                                                        account:(MSIDAccountIdentifier *)accountIdentifier
                                                                         context:(id<MSIDRequestContext>)context
                                                                           error:(NSError *__autoreleasing*)error
 {
     MSIDDefaultCredentialCacheQuery *query = [MSIDDefaultCredentialCacheQuery new];
     query.environmentAliases = [configuration.authority defaultCacheEnvironmentAliases];
     query.credentialType = MSIDPrimaryRefreshTokenType;
+    query.homeAccountId = accountIdentifier.homeAccountId;
 
     NSArray<MSIDPrimaryRefreshToken *> *refreshTokens = (NSArray<MSIDPrimaryRefreshToken *> *)[self getTokensWithEnvironment:configuration.authority.environment cacheQuery:query context:context error:error];
     return refreshTokens;

--- a/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.h
+++ b/IdentityCore/src/configuration/webview/MSIDBaseWebRequestConfiguration.h
@@ -27,6 +27,7 @@
 
 #import <Foundation/Foundation.h>
 #import "MSIDConstants.h"
+#import "MSIDCustomHeaderProviding.h"
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -45,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Embedded webview
 @property (nonatomic, readwrite) NSDictionary<NSString *, NSString *> *customHeaders;
+@property (nonatomic) id<MSIDCustomHeaderProviding> customHeaderProvider; // provide extra headers for subsequent requests rather than the intial request
 
 @property (nonatomic, weak) MSIDViewController *parentController;
 @property (nonatomic) BOOL prefersEphemeralWebBrowserSession;

--- a/IdentityCore/src/oauth2/MSIDWebviewFactory.m
+++ b/IdentityCore/src/oauth2/MSIDWebviewFactory.m
@@ -301,6 +301,7 @@
     configuration.customHeaders = parameters.customWebviewHeaders;
     configuration.parentController = parameters.parentViewController;
     configuration.prefersEphemeralWebBrowserSession = parameters.prefersEphemeralWebBrowserSession;
+    configuration.customHeaderProvider = parameters.crossDomainHeaderProvider;
     
 #if TARGET_OS_IPHONE
     configuration.presentationType = parameters.presentationType;

--- a/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
@@ -129,6 +129,7 @@
 #endif
     
     embeddedWebviewController.externalDecidePolicyForBrowserAction = externalDecidePolicyForBrowserAction;
+    embeddedWebviewController.customHeaderProvider = configuration.customHeaderProvider;
 
     return embeddedWebviewController;
 }

--- a/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.h
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import "MSIDInteractiveRequestParameters.h"
+#import "MSIDCustomHeaderProviding.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSDictionary *extraAuthorizeURLQueryParameters;
 @property (nonatomic) BOOL enablePkce;
 @property (nonatomic) MSIDBrokerInvocationOptions *brokerInvocationOptions;
+@property (nonatomic) id<MSIDCustomHeaderProviding> crossDomainHeaderProvider;
 
 - (NSOrderedSet *)allAuthorizeRequestScopes;
 - (NSDictionary *)allAuthorizeRequestExtraParameters DEPRECATED_MSG_ATTRIBUTE("Use -allAuthorizeRequestExtraParametersWithMetadata: instead");

--- a/IdentityCore/src/validation/MSIDAADAuthority.m
+++ b/IdentityCore/src/validation/MSIDAADAuthority.m
@@ -140,6 +140,11 @@
     return self.url;
 }
 
+- (nullable NSSet<NSString *> *)allCloudNetworkEnvironments
+{
+    return self.authorityCache.allCloudNetworkEnvironments;
+}
+
 - (nonnull NSArray<NSURL *> *)legacyRefreshTokenLookupAliases
 {
     if (self.tenant.type == MSIDAADTenantTypeConsumers)

--- a/IdentityCore/src/validation/MSIDAadAuthorityCache.h
+++ b/IdentityCore/src/validation/MSIDAadAuthorityCache.h
@@ -33,6 +33,8 @@
 
 @interface MSIDAadAuthorityCache : MSIDCache
 
+@property (nonatomic) NSSet<NSString *> *allCloudNetworkEnvironments;
+
 + (MSIDAadAuthorityCache *)sharedInstance;
 
 - (NSURL *)networkUrlForAuthority:(MSIDAADAuthority *)authority

--- a/IdentityCore/src/validation/MSIDAadAuthorityCache.m
+++ b/IdentityCore/src/validation/MSIDAadAuthorityCache.m
@@ -124,6 +124,7 @@ openIdConfigEndpoint:(NSURL *)openIdConfigEndpoint
     }
     
     NSMutableArray<MSIDAadAuthorityCacheRecord *> *recordsToAdd = [NSMutableArray new];
+    NSMutableSet<NSString *> *cloudNetworkEnvironments = [NSMutableSet new];
     
     for (NSDictionary *environment in metadata)
     {
@@ -152,7 +153,14 @@ openIdConfigEndpoint:(NSURL *)openIdConfigEndpoint
         record.openIdConfigurationEndpoint = openIdConfigEndpoint;
 
         [recordsToAdd addObject:record];
+        
+        if (![NSString msidIsStringNilOrBlank:networkHost])
+        {
+            [cloudNetworkEnvironments addObject:networkHost];
+        }
     }
+    
+    _allCloudNetworkEnvironments = cloudNetworkEnvironments;
     
     for (MSIDAadAuthorityCacheRecord *record in recordsToAdd)
     {

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
@@ -33,6 +33,7 @@
 #import "MSIDWebviewUIController.h"
 #import "MSIDAuthorizeWebRequestConfiguration.h"
 #import "MSIDWebViewPlatformParams.h"
+#import "MSIDCustomHeaderProviding.h"
 
 typedef void (^MSIDNavigationResponseBlock)(NSHTTPURLResponse *response);
 
@@ -60,6 +61,7 @@ typedef NSURLRequest *(^MSIDExternalDecidePolicyForBrowserActionBlock)(MSIDOAuth
 @property (nonatomic, readonly) NSDictionary<NSString *, NSString *> *customHeaders;
 @property (nonatomic, copy) MSIDNavigationResponseBlock navigationResponseBlock;
 @property (nonatomic, copy) MSIDExternalDecidePolicyForBrowserActionBlock externalDecidePolicyForBrowserAction;
+@property (nonatomic) id<MSIDCustomHeaderProviding> customHeaderProvider;
 #if MSAL_JS_AUTOMATION
 @property (nonatomic) NSString *clientAutomationScript;
 #endif

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -456,7 +456,9 @@
             }
             
             if (error)
+            {
                 MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, nil, @"Error received while getting custom headers in embedded webview: %@", MSID_PII_LOG_MASKABLE(error));
+            }
             
             decisionHandler(WKNavigationActionPolicyAllow);
             return;

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -433,7 +433,36 @@
         return;
     }
     
-    decisionHandler(WKNavigationActionPolicyAllow);
+    if (self.customHeaderProvider)
+    {
+        [self.customHeaderProvider getCustomHeaders:navigationAction.request
+                                                    forHost:requestURL.host
+                                            completionBlock:^(NSDictionary<NSString *, NSString *> *extraHeaders, __unused NSError *error){
+            if (extraHeaders && extraHeaders.count > 0)
+            {
+                NSMutableURLRequest *newUrlRequest = [navigationAction.request mutableCopy];
+                
+                for (NSString *headerKey in extraHeaders)
+                {
+                    if (![NSString msidIsStringNilOrBlank:extraHeaders[headerKey]])
+                    {
+                        [newUrlRequest setValue:extraHeaders[headerKey] forHTTPHeaderField:headerKey];
+                    }
+                }
+                
+                decisionHandler(WKNavigationActionPolicyCancel);
+                [self loadRequest:newUrlRequest];
+                return;
+            }
+            
+            decisionHandler(WKNavigationActionPolicyAllow);
+            return;
+        }];
+    }
+    else
+    {
+        decisionHandler(WKNavigationActionPolicyAllow);
+    }
 }
 
 - (void)webView:(WKWebView *)webView didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -437,7 +437,7 @@
     {
         [self.customHeaderProvider getCustomHeaders:navigationAction.request
                                                     forHost:requestURL.host
-                                            completionBlock:^(NSDictionary<NSString *, NSString *> *extraHeaders, __unused NSError *error){
+                                            completionBlock:^(NSDictionary<NSString *, NSString *> *extraHeaders, NSError *error){
             if (extraHeaders && extraHeaders.count > 0)
             {
                 NSMutableURLRequest *newUrlRequest = [navigationAction.request mutableCopy];
@@ -454,6 +454,9 @@
                 [self loadRequest:newUrlRequest];
                 return;
             }
+            
+            if (error)
+                MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, nil, @"Error received while getting custom headers in embedded webview: %@", MSID_PII_LOG_MASKABLE(error));
             
             decisionHandler(WKNavigationActionPolicyAllow);
             return;

--- a/IdentityCore/src/webview/embeddedWebview/customHeaderProviding/MSIDCustomHeaderProviding.h
+++ b/IdentityCore/src/webview/embeddedWebview/customHeaderProviding/MSIDCustomHeaderProviding.h
@@ -1,3 +1,4 @@
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -19,29 +20,15 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-#import "MSIDAuthority.h"
-#import "MSIDAADTenant.h"
+#import <Foundation/Foundation.h>
 
-@interface MSIDAADAuthority : MSIDAuthority
+typedef void(^MSIDCustomHeaderBlock)(NSDictionary<NSString *, NSString *> *headers, NSError *error);
 
-- (nullable instancetype)initWithURL:(nonnull NSURL *)url
-                           rawTenant:(nullable NSString *)rawTenant
-                             context:(nullable id<MSIDRequestContext>)context
-                               error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+@protocol MSIDCustomHeaderProviding <NSObject>
 
-- (nullable NSSet<NSString *> *)allCloudNetworkEnvironments;
-
-@property (nonatomic, readonly, nonnull) MSIDAADTenant *tenant;
-
-+ (nullable instancetype)aadAuthorityWithEnvironment:(nonnull NSString *)environment
-                                           rawTenant:(nullable NSString *)rawTenant
-                                             context:(nullable id<MSIDRequestContext>)context
-                                               error:(NSError * _Nullable __autoreleasing * _Nullable)error;
-
-+ (nullable NSURL *)normalizedAuthorityUrl:(nonnull NSURL *)url
-                                        context:(nullable id<MSIDRequestContext>)context
-                                          error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+- (void)getCustomHeaders:(NSURLRequest *)request forHost:(NSString *)host completionBlock:(MSIDCustomHeaderBlock)completionBlock;;
 
 @end
+

--- a/IdentityCore/tests/MSIDAadAuthorityCacheTests.m
+++ b/IdentityCore/tests/MSIDAadAuthorityCacheTests.m
@@ -846,5 +846,37 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)testAllCloudNetworkEnvironments_whenNoRecord_shouldReturnNil
+{
+    MSIDAadAuthorityCache *cache = [[MSIDAadAuthorityCache alloc] init];
+    
+    XCTAssertNil(cache.allCloudNetworkEnvironments);
+}
+
+- (void)testAllCloudNetworkEnvironments_AfterParsingRecords_shouldReturnValidSet
+{
+    MSIDAadAuthorityCache *cache = [[MSIDAadAuthorityCache alloc] init];
+    
+    NSArray *metadata = @[ @{ @"preferred_network" : @"cloudA",
+                              @"preferred_cache" :  @"cloudA",
+                              @"aliases" : @[@"cloudA1", @"cloudA2"] },
+                            @{ @"preferred_network" : @"cloudB",
+                                                      @"preferred_cache" :  @"cloudB",
+                                                      @"aliases" : @[@"cloudB1", @"cloudB2"] }];
+    NSURL *authorityUrl = [NSURL URLWithString:@"https://fakeauthority.com/v2/oauth/endpoint"];
+    __auto_type authority = [[MSIDAADAuthority alloc] initWithURL:authorityUrl context:nil error:nil];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Process Metadata."];
+    [cache processMetadata:metadata openIdConfigEndpoint:nil authority:authority context:nil completion:^(__unused BOOL result, __unused NSError *error)
+     {
+        NSSet *expectedEnvironments = [[NSSet alloc] initWithArray:@[@"cloudA", @"cloudB"]];
+        XCTAssertTrue([cache.allCloudNetworkEnvironments isEqualToSet:expectedEnvironments]);
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
 @end
 

--- a/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
+++ b/IdentityCore/tests/integration/MSIDAuthorityIntegrationTests.m
@@ -447,7 +447,7 @@
          [expectation fulfill];
      }];
 
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:3 handler:nil];
 
     XCTAssertTrue([MSIDTestURLSession noResponsesLeft]);
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version TBD
 * Support extra query parameters on signout (#1243)
 * Wrap ASAuthorizationProviderExtensionAuthorizationRequest methods (#1427)
 * Replace deprecated method UIApplication.openURL(_:) (#1424)
+* Add support to attach PRT during cross cloud authentication (#1431)
 
 Version 1.7.41
 * VisionOS support added to IdentityCore (#1412)


### PR DESCRIPTION
## Proposed changes

Add support in common to allow broker to attach cross domain PRT headers in webview. 
More details, please see here:
https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/1703


## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

