### PR TITLE
Convert "[MSAL] Common core submodule update check" to a yaml file

### DIFF
--- a/azure_pipelines/msal_submodule_check.yaml
+++ b/azure_pipelines/msal_submodule_check.yaml
@@ -1,6 +1,3 @@
-#Your build pipeline references an undefined variable named ‘git rev-parse HEAD’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
-
-
 # Pipeline will be triggered for PR & any updates on the PR on all branches
 pr:
   branches:
@@ -13,6 +10,13 @@ trigger:
     include:
     - main
     - release/*
+
+resources:
+ repositories:
+   - repository: microsoft-authentication-library-for-objc
+     type: github
+     endpoint: 'MSAL ObjC Service Connection'
+     name: AzureAD/microsoft-authentication-library-for-objc
 
 # Define parallel jobs that run build script for specified targets
 jobs:
@@ -62,18 +66,18 @@ jobs:
         fi
       failOnStderr: false
 
-  - checkout: MSAL
+  - checkout: microsoft-authentication-library-for-objc
     displayName: 'Checkout MSAL'
     clean: true
     submodules: true
     fetchTags: true
-    path: '$(Agent.BuildDirectory)'
     persistCredentials: true
 
   - checkout: self
     clean: true
     submodules: false
     fetchDepth: 1
+    path: 's/microsoft-authentication-library-for-objc/MSAL/IdentityCore'
     persistCredentials: false
 
   - task: Bash@3
@@ -81,7 +85,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        cd $(Agent.BuildDirectory)/MSAL/microsoft-authentication-library-for-objc
+        cd $(Agent.BuildDirectory)/s/microsoft-authentication-library-for-objc
         { output=$(./build.py --target $(target) 2>&1 1>&3-) ;} 3>&1
         final_status=$(<./build/status.txt)
         echo "FINAL STATUS  = ${final_status}"
@@ -97,7 +101,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        rm -rf ./build/status.txt
+        rm -rf $(Agent.BuildDirectory)/s/build/status.txt
   - task: PublishTestResults@2
     condition: always()
     displayName: Publish Test Report

--- a/azure_pipelines/msal_submodule_check.yaml
+++ b/azure_pipelines/msal_submodule_check.yaml
@@ -3,11 +3,9 @@
 
 # Pipeline will be triggered for PR & any updates on the PR on all branches
 pr:
-  autoCancel: true
   branches:
     include:
     - '*'
-  drafts: true
 
 # Trigger CI for only main/release branches
 trigger:
@@ -15,8 +13,6 @@ trigger:
     include:
     - main
     - release/*
-    exclude:
-    - '*'
 
 # Define parallel jobs that run build script for specified targets
 jobs:
@@ -65,30 +61,20 @@ jobs:
             echo "Not visionOS job, no download needed"
         fi
       failOnStderr: false
-  - task: Bash@3
-    displayName: Clone MSAL
-    inputs:
-      targetType: 'inline'
-      script: |
-        currentCommit=$(git rev-parse HEAD)
-        cd $(Agent.BuildDirectory)
-        mkdir MSAL
-        cd MSAL
-        git clone https://github.com/AzureAD/microsoft-authentication-library-for-objc.git
-        cd microsoft-authentication-library-for-objc
-        git checkout origin/dev
-        git submodule update --init
-        cd MSAL/IdentityCore
-   
-        if [ -n "$(system.pullRequest.sourceCommitId)" ]; then
-           echo "Using PR validation and checking out $(system.pullRequest.sourceCommitId)"
-           git checkout $(system.pullRequest.sourceCommitId)
-        else
-           echo "First parameter not supplied."
-           echo "Using commit validation and checking out $currentCommit"
-           git checkout $currentCommit
-        fi
-      failOnStderr: false
+
+  - checkout: MSAL
+    displayName: 'Checkout MSAL'
+    clean: true
+    submodules: true
+    fetchTags: true
+    path: '$(Agent.BuildDirectory)'
+    persistCredentials: true
+
+  - checkout: self
+    clean: true
+    submodules: false
+    fetchDepth: 1
+    persistCredentials: false
 
   - task: Bash@3
     displayName: Run Build script & check for Errors

--- a/azure_pipelines/msal_submodule_check.yaml
+++ b/azure_pipelines/msal_submodule_check.yaml
@@ -1,0 +1,122 @@
+#Your build pipeline references an undefined variable named ‘git rev-parse HEAD’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+
+
+# Pipeline will be triggered for PR & any updates on the PR on all branches
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - '*'
+  drafts: true
+
+# Trigger CI for only main/release branches
+trigger:
+  branches:
+    include:
+    - main
+    - release/*
+    exclude:
+    - '*'
+
+# Define parallel jobs that run build script for specified targets
+jobs:
+- job: 'Validate_Pull_Request'
+  strategy:
+    maxParallel: 3
+    matrix:
+      IOS_FRAMEWORK:
+        target: "iosFramework iosTestApp sampleIosApp sampleIosAppSwift"
+      MAC_FRAMEWORK:
+        target: "macFramework"
+      VISION_FRAMEWORK:
+        target: "visionOSFramework"
+  displayName: Validate Pull Request
+  pool:
+    vmImage: 'macOS-14'
+    timeOutInMinutes: 30
+
+  steps:
+  - script: |
+          /bin/bash -c "sudo xcode-select -s /Applications/Xcode_15.4.app"
+    displayName: 'Switch to use Xcode 15.4'
+  - task: CmdLine@2
+    displayName: Installing dependencies
+    inputs:
+      script: |
+        gem install xcpretty slather bundler -N
+      failOnStderr: true
+
+# The following is needed to install the visionOS SDK on macos-14 vm image which
+# doesn't have visionOS installed by default.
+# TODO: Remove when macos-14-arm64 is supported on ADO.
+  - task: Bash@3
+    displayName: download visionOS SDK
+    inputs:
+      targetType: 'inline'
+      script: |
+        echo $(target)
+        if [ $(target) == 'visionOSFramework' ]; then
+            echo "Downloading simulator for visionOS"
+            sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+            defaults write com.apple.dt.Xcode AllowUnsupportedVisionOSHost -bool YES
+            defaults write com.apple.CoreSimulator AllowUnsupportedVisionOSHost -bool YES
+            xcodebuild -downloadPlatform visionOS
+        else
+            echo "Not visionOS job, no download needed"
+        fi
+      failOnStderr: false
+  - task: Bash@3
+    displayName: Clone MSAL
+    inputs:
+      targetType: 'inline'
+      script: |
+        currentCommit=$(git rev-parse HEAD)
+        cd $(Agent.BuildDirectory)
+        mkdir MSAL
+        cd MSAL
+        git clone https://github.com/AzureAD/microsoft-authentication-library-for-objc.git
+        cd microsoft-authentication-library-for-objc
+        git checkout origin/dev
+        git submodule update --init
+        cd MSAL/IdentityCore
+   
+        if [ -n "$(system.pullRequest.sourceCommitId)" ]; then
+           echo "Using PR validation and checking out $(system.pullRequest.sourceCommitId)"
+           git checkout $(system.pullRequest.sourceCommitId)
+        else
+           echo "First parameter not supplied."
+           echo "Using commit validation and checking out $currentCommit"
+           git checkout $currentCommit
+        fi
+      failOnStderr: false
+
+  - task: Bash@3
+    displayName: Run Build script & check for Errors
+    inputs:
+      targetType: 'inline'
+      script: |
+        cd $(Agent.BuildDirectory)/MSAL/microsoft-authentication-library-for-objc
+        { output=$(./build.py --target $(target) 2>&1 1>&3-) ;} 3>&1
+        final_status=$(<./build/status.txt)
+        echo "FINAL STATUS  = ${final_status}"
+        echo "POSSIBLE ERRORS: ${output}"
+        
+        if [ $final_status != "0" ]; then
+          echo "Build & Testing Failed! \n ${output}" >&2
+        fi
+      failOnStderr: true
+  - task: Bash@3
+    condition: always()
+    displayName: Cleanup
+    inputs:
+      targetType: 'inline'
+      script: |
+        rm -rf ./build/status.txt
+  - task: PublishTestResults@2
+    condition: always()
+    displayName: Publish Test Report
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
+      failTaskOnFailedTests: true
+      testRunTitle: 'Test Run - $(target)'


### PR DESCRIPTION
## Proposed changes

Due to consistent failures in the "[MSAL] Common core submodule update check" pipeline since visionOS was added, this PR converts that Azure Pipelines UI pipeline to a yaml-based pipeline. After this PR is merged into dev, I will create an accompanying new pipeline that runs from this yaml file and eventually remove "[MSAL] Common core submodule update check".

The benefit of a yaml based pipeline is that we can run the pipeline from different branches, allowing us to test changes to the pipeline before those changes affect all other pipeline runs.

This pipeline should:
~ Clone MSAL
~ Update the submodule of common core to the specified commit
~ Run the MSAL build.py to verify the common core changes with MSAL dev

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

