### PR TITLE
Make upn hash case insensitive

### DIFF
--- a/IdentityCore/src/logger/MSIDMaskedUsernameLogParameter.m
+++ b/IdentityCore/src/logger/MSIDMaskedUsernameLogParameter.m
@@ -49,7 +49,7 @@
             domain = [stringValue substringFromIndex:emailIndex.location + 1];
         }
         
-        return [NSString stringWithFormat:@"auth.placeholder-%@__%@", [username msidSecretLoggingHash], domain];
+        return [NSString stringWithFormat:@"auth.placeholder-%@__%@", [username.lowercaseString msidSecretLoggingHash], domain.lowercaseString];
     }
     
     return [self.parameterValue msidSecretLoggingHash];

--- a/IdentityCore/tests/MSIDMaskedUsernameLogParameterTests.m
+++ b/IdentityCore/tests/MSIDMaskedUsernameLogParameterTests.m
@@ -88,4 +88,15 @@
     XCTAssertEqualObjects(description, @"auth.placeholder-9f86d081__ ");
 }
 
+- (void)testDescription_whenPIINotEnabled_andEmailParameterWithDomain_shouldReturnSameMaskedValueForDifferentCase
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
+    MSIDMaskedUsernameLogParameter *logParameter = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"username@domain.com"];
+    MSIDMaskedUsernameLogParameter *logParameter1 = [[MSIDMaskedUsernameLogParameter alloc] initWithParameterValue:@"UserNamE@domAIN.com"];
+    NSString *description = [logParameter description];
+    NSString *description1 = [logParameter1 description];
+    XCTAssertEqualObjects(description, @"auth.placeholder-16f78a7d__domain.com");
+    XCTAssertEqualObjects(description, description1);
+}
+
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version TBD
+* Make hashed ups in logs case insensitive (#1446)
+
 Version 1.7.43
 * Support web_page_uri #1440
 * Save error received from ESTS, and return it to the client on silent broker calls (#1438)


### PR DESCRIPTION
## Proposed changes

MSID_PII_LOG_EMAIL() returns different hash values for the same email address with different cases.
This can cause confusion in log if caller passes UPN in request parameters without case conversion.
This PR aims to log UPN hash in a case-insensitive manner to avoid confusion in logs.

There is no change in functionality for keychain queries using upn because we already lower case before making keychain query.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

