### PR TITLE
Kasong/improve UI element checker

### DIFF
--- a/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
@@ -494,12 +494,12 @@ static MSIDTestConfigurationProvider *s_confProvider;
     return object1.exists ? object1 : object2;
 }
 
-- (XCTWaiterResult)waitForElementsAndContinue:(XCUIElement *)object
+- (XCTWaiterResult)waitForElementsAndContinueIfNotAppear:(XCUIElement *)object
 {
     NSPredicate *existsPredicate = [NSPredicate predicateWithFormat:@"%@.exists == 1" argumentArray:@[object]];
 
-    XCTestExpectation *expectation = [[XCTNSPredicateExpectation alloc] initWithPredicate:existsPredicate object:object];//[self expectationForPredicate:existsPredicate evaluatedWithObject:nil handler:nil];
-    return [XCTWaiter waitForExpectations:@[expectation] timeout:10.0f enforceOrder:YES];
+    XCTestExpectation *expectation = [[XCTNSPredicateExpectation alloc] initWithPredicate:existsPredicate object:object];
+    return [XCTWaiter waitForExpectations:@[expectation] timeout:30.0f enforceOrder:YES];
 }
 
 - (void)tapElementAndWaitForKeyboardToAppear:(XCUIElement *)element

--- a/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
@@ -315,7 +315,7 @@ static MSIDTestConfigurationProvider *s_confProvider;
     XCUIElement *passwordSecureTextField = [application.secureTextFields elementBoundByIndex:0];
     // This is explicitly to check the new screen where to ask user to signin with the following 2 options. This caused several automation failures
     
-    XCTWaiterResult result = [self waitForElementsAndContinue:passwordSecureTextField];
+    XCTWaiterResult result = [self waitForElementsAndContinueIfNotAppear:passwordSecureTextField];
     if (result == XCTWaiterResultCompleted)
     {
         [self tapElementAndWaitForKeyboardToAppear:passwordSecureTextField app:application];
@@ -327,7 +327,7 @@ static MSIDTestConfigurationProvider *s_confProvider;
         // 1. Use my password
         // 2. Sign in to an orgnization
         XCUIElement *useMyPasswordButton = application.buttons[@"Use my password"];
-        result = [self waitForElementsAndContinue:useMyPasswordButton];
+        result = [self waitForElementsAndContinueIfNotAppear:useMyPasswordButton];
         if (result == XCTWaiterResultCompleted)
         {
             [useMyPasswordButton tap];


### PR DESCRIPTION
## Proposed changes

This is to improve the stability of checking the existing of 2 potential elements on the same screen. The old way may cause race conditions, and unexpected results in the and. In this new implementation, the automation code will check the elements one by one

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

