### PR TITLE
Add new error mapping for http error code 403 and 404

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -171,6 +171,8 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
      */
 
     MSIDErrorServerUnhandledResponse    = -51500,
+    // http status Code 403 or 404
+    MSIDErrorUnExpectedHttpResponse     = -51501,
     
     /*!
      =========================================================

--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -172,7 +172,7 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
 
     MSIDErrorServerUnhandledResponse    = -51500,
     // http status Code 403 or 404
-    MSIDErrorUnExpectedHttpResponse     = -51501,
+    MSIDErrorUnexpectedHttpResponse     = -51501,
     
     /*!
      =========================================================

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -225,7 +225,7 @@ NSDictionary* MSIDErrorDomainsAndCodes(void)
                       ],
               MSIDHttpErrorCodeDomain : @[
                       @(MSIDErrorServerUnhandledResponse),
-                      @(MSIDErrorUnExpectedHttpResponse)
+                      @(MSIDErrorUnexpectedHttpResponse)
                       ]
 
               // TODO: add new codes here
@@ -302,8 +302,8 @@ NSString *MSIDErrorCodeToString(MSIDErrorCode errorCode)
             // HTTP errors
         case MSIDErrorServerUnhandledResponse:
             return @"MSIDErrorServerUnhandledResponse";
-        case MSIDErrorUnExpectedHttpResponse:
-            return @"MSIDErrorUnExpectedHttpResponse";
+        case MSIDErrorUnexpectedHttpResponse:
+            return @"MSIDErrorUnexpectedHttpResponse";
             // Authority validation errors
         case MSIDErrorAuthorityValidation:
             return @"MSIDErrorAuthorityValidation";

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -224,7 +224,8 @@ NSDictionary* MSIDErrorDomainsAndCodes(void)
                       @(MSIDErrorServerError),
                       ],
               MSIDHttpErrorCodeDomain : @[
-                      @(MSIDErrorServerUnhandledResponse)
+                      @(MSIDErrorServerUnhandledResponse),
+                      @(MSIDErrorUnExpectedHttpResponse)
                       ]
 
               // TODO: add new codes here
@@ -301,6 +302,8 @@ NSString *MSIDErrorCodeToString(MSIDErrorCode errorCode)
             // HTTP errors
         case MSIDErrorServerUnhandledResponse:
             return @"MSIDErrorServerUnhandledResponse";
+        case MSIDErrorUnExpectedHttpResponse:
+            return @"MSIDErrorUnExpectedHttpResponse";
             // Authority validation errors
         case MSIDErrorAuthorityValidation:
             return @"MSIDErrorAuthorityValidation";

--- a/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
+++ b/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
@@ -150,7 +150,13 @@
         }
     }
     
-    NSError *httpError = MSIDCreateError(MSIDHttpErrorCodeDomain, MSIDErrorServerUnhandledResponse, errorDescription, nil, nil, nil, context.correlationId, additionalInfo, YES);
+    NSError *httpUnderlyingError = nil;
+    if (httpResponse.statusCode == 403 || httpResponse.statusCode == 404)
+    {
+        httpUnderlyingError = MSIDCreateError(MSIDHttpErrorCodeDomain, MSIDErrorUnExpectedHttpResponse, errorDescription, nil, nil, nil, context.correlationId, nil, YES);
+    }
+
+    NSError *httpError = MSIDCreateError(MSIDHttpErrorCodeDomain, MSIDErrorServerUnhandledResponse, errorDescription, nil, nil, httpUnderlyingError, context.correlationId, additionalInfo, YES);
     
     if (completionBlock) completionBlock(nil, httpError);
 }

--- a/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
+++ b/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
@@ -153,7 +153,7 @@
     NSError *httpUnderlyingError = nil;
     if (httpResponse.statusCode == 403 || httpResponse.statusCode == 404)
     {
-        httpUnderlyingError = MSIDCreateError(MSIDHttpErrorCodeDomain, MSIDErrorUnExpectedHttpResponse, errorDescription, nil, nil, nil, context.correlationId, nil, YES);
+        httpUnderlyingError = MSIDCreateError(MSIDHttpErrorCodeDomain, MSIDErrorUnexpectedHttpResponse, errorDescription, nil, nil, nil, context.correlationId, nil, YES);
     }
 
     NSError *httpError = MSIDCreateError(MSIDHttpErrorCodeDomain, MSIDErrorServerUnhandledResponse, errorDescription, nil, nil, httpUnderlyingError, context.correlationId, additionalInfo, YES);

--- a/IdentityCore/tests/MSIDAADRequestErrorHandlerTests.m
+++ b/IdentityCore/tests/MSIDAADRequestErrorHandlerTests.m
@@ -191,6 +191,8 @@
 
     XCTAssertEqualObjects(returnError.domain, MSIDHttpErrorCodeDomain);
     XCTAssertEqual(returnError.code, MSIDErrorServerUnhandledResponse);
+    NSError *underlyingError = returnError.userInfo[NSUnderlyingErrorKey];
+    XCTAssertEqual(underlyingError.code, MSIDErrorUnExpectedHttpResponse);
     XCTAssertEqualObjects(returnError.userInfo[MSIDHTTPHeadersKey], @{@"headerKey":@"headerValue"});
 
     XCTAssertNil(errorResponse);
@@ -275,6 +277,8 @@
 
     XCTAssertEqualObjects(returnError.domain, MSIDHttpErrorCodeDomain);
     XCTAssertEqual(returnError.code, MSIDErrorServerUnhandledResponse);
+    NSError *underlyingError = returnError.userInfo[NSUnderlyingErrorKey];
+    XCTAssertEqual(underlyingError.code, MSIDErrorUnExpectedHttpResponse);
     XCTAssertEqualObjects(returnError.userInfo[MSIDHTTPResponseCodeKey], @"404");
 }
 

--- a/IdentityCore/tests/MSIDAADRequestErrorHandlerTests.m
+++ b/IdentityCore/tests/MSIDAADRequestErrorHandlerTests.m
@@ -192,7 +192,7 @@
     XCTAssertEqualObjects(returnError.domain, MSIDHttpErrorCodeDomain);
     XCTAssertEqual(returnError.code, MSIDErrorServerUnhandledResponse);
     NSError *underlyingError = returnError.userInfo[NSUnderlyingErrorKey];
-    XCTAssertEqual(underlyingError.code, MSIDErrorUnExpectedHttpResponse);
+    XCTAssertEqual(underlyingError.code, MSIDErrorUnexpectedHttpResponse);
     XCTAssertEqualObjects(returnError.userInfo[MSIDHTTPHeadersKey], @{@"headerKey":@"headerValue"});
 
     XCTAssertNil(errorResponse);
@@ -278,7 +278,7 @@
     XCTAssertEqualObjects(returnError.domain, MSIDHttpErrorCodeDomain);
     XCTAssertEqual(returnError.code, MSIDErrorServerUnhandledResponse);
     NSError *underlyingError = returnError.userInfo[NSUnderlyingErrorKey];
-    XCTAssertEqual(underlyingError.code, MSIDErrorUnExpectedHttpResponse);
+    XCTAssertEqual(underlyingError.code, MSIDErrorUnexpectedHttpResponse);
     XCTAssertEqualObjects(returnError.userInfo[MSIDHTTPResponseCodeKey], @"404");
 }
 

--- a/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
@@ -1389,6 +1389,8 @@
         XCTAssertNotNil(error);
         XCTAssertNil(result);
         XCTAssertEqual(error.code, MSIDErrorServerUnhandledResponse);
+        NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+        XCTAssertEqual(underlyingError.code, MSIDErrorUnexpectedHttpResponse);
         XCTAssertEqualObjects(error.domain, MSIDHttpErrorCodeDomain);
         XCTAssertEqualObjects(error.userInfo[MSIDHTTPResponseCodeKey], @"403");
         [expectation fulfill];


### PR DESCRIPTION
## Proposed changes

When token request fails with http error code 403 and 404 , we currently return MSIDErrorServerUnHandledResponse. This PR will add a new error MSIDErrorUnexpectedHttpResponse in case of http error code 403 or 404 and add this as an underlying error in the MSIDErrorServerUnHandledResponse error returned.

## Type of change

- [x ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

