### PR TITLE
Uninstall xcpretty version 0.4.0 before installing version 0.3.0 [CommonCore]

### DIFF
--- a/azure_pipelines/msal_submodule_check.yaml
+++ b/azure_pipelines/msal_submodule_check.yaml
@@ -40,7 +40,13 @@ jobs:
           /bin/bash -c "sudo xcode-select -s /Applications/Xcode_15.4.app"
     displayName: 'Switch to use Xcode 15.4'
   - task: CmdLine@2
-    displayName: Installing xcpretty
+    displayName: Uninstalling xcpretty v0.4.0
+    inputs:
+      script: |
+        gem uninstall xcpretty -I --version 0.4.0
+      failOnStderr: false
+  - task: CmdLine@2
+    displayName: Installing xcpretty v0.3.0
     inputs:
       script: |
         gem install xcpretty -N -v 0.3.0

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -29,7 +29,13 @@ jobs:
 
   steps:
   - task: CmdLine@2
-    displayName: Installing xcpretty
+    displayName: Uninstalling xcpretty v0.4.0
+    inputs:
+      script: |
+        gem uninstall xcpretty -I --version 0.4.0
+      failOnStderr: false
+  - task: CmdLine@2
+    displayName: Installing xcpretty v0.3.0
     inputs:
       script: |
         gem install xcpretty -N -v 0.3.0


### PR DESCRIPTION
## Proposed changes

Uninstall xcpretty version 0.4.0 before installing version 0.3.0

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

