### PR TITLE
Add new errors for passkey biometric policy mismatch  and invalid pas…

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -334,6 +334,12 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     
     // JIT - Error Handling config invalid or not found
     MSIDErrorJITErrorHandlingConfigNotFound        =   -51839,
+    
+    // Error is thrown when PSSO biometric policy flag mismatches with the config value
+    MSIDErrorPSSOBiometricPolicyMismatch        =   -51840,
+    
+    // Error is thrown when non ENtra passkey extension tries to access the passkey
+    MSIDErrorPSSOInvalidPasskeyExtension        =   -51841,
 
     // Throttling errors
     MSIDErrorThrottleCacheNoRecord = -51900,

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -207,6 +207,8 @@ NSDictionary* MSIDErrorDomainsAndCodes(void)
                       @(MSIDErrorDeviceNotPSSORegistered),
                       @(MSIDErrorPSSOKeyIdMismatch),
                       @(MSIDErrorJITErrorHandlingConfigNotFound),
+                      @(MSIDErrorPSSOBiometricPolicyMismatch),
+                      @(MSIDErrorPSSOInvalidPasskeyExtension),
                       ],
               MSIDOAuthErrorDomain : @[// Server Errors
                       @(MSIDErrorServerOauth),
@@ -415,6 +417,10 @@ NSString *MSIDErrorCodeToString(MSIDErrorCode errorCode)
             return @"MSIDErrorDeviceNotPSSORegistered";
         case MSIDErrorPSSOKeyIdMismatch:
             return @"MSIDErrorPSSOKeyIdMismatch";
+        case MSIDErrorPSSOBiometricPolicyMismatch:
+            return @"MSIDErrorPSSOBiometricPolicyMismatch";
+        case MSIDErrorPSSOInvalidPasskeyExtension:
+            return @"MSIDErrorPSSOInvalidPasskeyExtension";
             // Throttling errors
         case MSIDErrorThrottleCacheNoRecord:
             return @"MSIDErrorThrottleCacheNoRecord";


### PR DESCRIPTION

## Proposed changes

New error codes for passkey biometric policy mismatch and invalid passkey extension have been added 

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

