### PR TITLE
Modify the MSID telemetry reset logic

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -524,6 +524,9 @@
 		23FB5C452255A11D002BF1EB /* MSIDClaimsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C24225517AA002BF1EB /* MSIDClaimsRequest.m */; };
 		23FB5C462255A135002BF1EB /* MSIDIndividualClaimRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C29225517AA002BF1EB /* MSIDIndividualClaimRequest.m */; };
 		23FB5C472255A13A002BF1EB /* MSIDIndividualClaimRequestAdditionalInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FB5C27225517AA002BF1EB /* MSIDIndividualClaimRequestAdditionalInfo.m */; };
+		2A0278912D6E3216005655B4 /* MSIDAADTokenRequestServerTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A0278902D6E3216005655B4 /* MSIDAADTokenRequestServerTelemetryTests.m */; };
+		2A0278922D6E3216005655B4 /* MSIDAADTokenRequestServerTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A0278902D6E3216005655B4 /* MSIDAADTokenRequestServerTelemetryTests.m */; };
+		2A0278A32D6E3787005655B4 /* MSIDLastRequestTelemetry+Tests.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A0278A22D6E3787005655B4 /* MSIDLastRequestTelemetry+Tests.h */; };
 		580E25402719FD10003D1795 /* MSIDPrtHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 580E253E2719FD10003D1795 /* MSIDPrtHeader.h */; };
 		580E25412719FD10003D1795 /* MSIDPrtHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 580E253F2719FD10003D1795 /* MSIDPrtHeader.m */; };
 		580E25422719FD10003D1795 /* MSIDPrtHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 580E253F2719FD10003D1795 /* MSIDPrtHeader.m */; };
@@ -2392,6 +2395,8 @@
 		23FB5C2E22551866002BF1EB /* MSIDClaimsRequest+ClientCapabilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDClaimsRequest+ClientCapabilities.m"; sourceTree = "<group>"; };
 		23FB5C32225585E6002BF1EB /* MSIDClaimsRequestMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDClaimsRequestMock.h; sourceTree = "<group>"; };
 		23FB5C33225585E6002BF1EB /* MSIDClaimsRequestMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDClaimsRequestMock.m; sourceTree = "<group>"; };
+		2A0278902D6E3216005655B4 /* MSIDAADTokenRequestServerTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAADTokenRequestServerTelemetryTests.m; sourceTree = "<group>"; };
+		2A0278A22D6E3787005655B4 /* MSIDLastRequestTelemetry+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDLastRequestTelemetry+Tests.h"; sourceTree = "<group>"; };
 		51E364572863C0F300A97F82 /* MSIDTelemetryConditionalCompile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIDTelemetryConditionalCompile.h; sourceTree = "<group>"; };
 		580E253E2719FD10003D1795 /* MSIDPrtHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDPrtHeader.h; sourceTree = "<group>"; };
 		580E253F2719FD10003D1795 /* MSIDPrtHeader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDPrtHeader.m; sourceTree = "<group>"; };
@@ -3712,6 +3717,7 @@
 				B431B5322AF1C3AA0020CD3D /* MSIDSSOExtensionPasskeyAssertionRequestMock.m */,
 				B431B5352AF1C3BD0020CD3D /* MSIDSSOExtensionPasskeyCredentialRequestMock.h */,
 				B431B5362AF1C3C60020CD3D /* MSIDSSOExtensionPasskeyCredentialRequestMock.m */,
+				2A0278A22D6E3787005655B4 /* MSIDLastRequestTelemetry+Tests.h */,
 			);
 			path = mocks;
 			sourceTree = "<group>";
@@ -5717,6 +5723,7 @@
 				2347D6652D5415EB00372D20 /* MSIDSwitchBrowserResumeResponseTest.swift */,
 				2347D6682D5453A400372D20 /* MSIDSwitchBrowserOperationTest.swift */,
 				237034432D56AA7F00D6A70B /* MSIDSwitchBrowserResumeOperationTest.swift */,
+				2A0278902D6E3216005655B4 /* MSIDAADTokenRequestServerTelemetryTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -6261,6 +6268,7 @@
 				B217861823A57ED800839CE8 /* MSIDAuthorizationControllerMock.h in Headers */,
 				B2E4A07B24DDE5D7007CE642 /* NSUUID+MSIDTestUtil.h in Headers */,
 				B217862923A5839300839CE8 /* MSIDSSOExtensionSignoutRequestMock.h in Headers */,
+				2A0278A32D6E3787005655B4 /* MSIDLastRequestTelemetry+Tests.h in Headers */,
 				969CCB5622A9EB0300A55515 /* MSIDTestCacheDataSource.h in Headers */,
 				B28AC66421A0BB9D00A1FC4A /* MSIDTestBrokerResponseHelper.h in Headers */,
 				B23ECF031FF30BB90015FC1D /* MSIDTestIdentifiers.h in Headers */,
@@ -6822,6 +6830,7 @@
 				23AE9D9D213A06EF00B285F3 /* MSIDAadAuthorityCacheTests.m in Sources */,
 				58EB18382729BB8B00F4DD73 /* MSIDSSOExtensionGetSsoCookiesRequestTests.m in Sources */,
 				B2BE926F21A2668600F5AB8C /* MSIDBrokerInteractiveControllerIntegrationTests.m in Sources */,
+				2A0278912D6E3216005655B4 /* MSIDAADTokenRequestServerTelemetryTests.m in Sources */,
 				23AE9DAC21409A3800B285F3 /* MSIDWebMSAuthResponseTests.m in Sources */,
 				23985AB72391F8D100942308 /* MSIDBrokerOperationInteractiveTokenRequestTests.m in Sources */,
 				968871E920AD0397009D6FC3 /* MSIDWebAADAuthResponseTests.m in Sources */,
@@ -7584,6 +7593,7 @@
 				B26A0B972072B9CB006BD95A /* MSIDAADV1Oauth2FactoryTests.m in Sources */,
 				B208854C29ADC0FD00A50B88 /* MSIDPkeyAuthHelperTests.m in Sources */,
 				5837A7DD28F4977C007B3F4E /* MSIDLegacyTokenCacheKey+UTest.m in Sources */,
+				2A0278922D6E3216005655B4 /* MSIDAADTokenRequestServerTelemetryTests.m in Sources */,
 				B2DD5BA2204761660084313F /* MSIDLegacySingleResourceTokenTests.m in Sources */,
 				239DF9C020E04BC9002D428B /* MSIDAADAuthorityTests.m in Sources */,
 				D6D9A4BF1FBE712900EFA430 /* MSIDStringExtensionsTests.m in Sources */,

--- a/IdentityCore/src/network/request_server_telemetry/MSIDAADTokenRequestServerTelemetry.m
+++ b/IdentityCore/src/network/request_server_telemetry/MSIDAADTokenRequestServerTelemetry.m
@@ -51,26 +51,10 @@
             context:(id<MSIDRequestContext>)context
 {
     if (error == nil) {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to handle telemetry. Error is nil");
-        return;
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Error is nil, reset MSID telemetry");
     }
 
     NSString *errorString = [error msidServerTelemetryErrorString];
-    
-    [self handleError:error
-          errorString:errorString
-              context:context];
-}
-
-- (void)handleError:(nullable NSError *)error
-        errorString:(NSString *)errorString
-            context:(id<MSIDRequestContext>)context
-{
-    if (error == nil) {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to handle telemetry. Error is nil");
-        return;
-    }
-
     [self.lastRequestTelemetry updateWithApiId:self.currentRequestTelemetry.apiId
                                    errorString:errorString
                                        context:context];

--- a/IdentityCore/src/network/request_server_telemetry/MSIDAADTokenRequestServerTelemetry.m
+++ b/IdentityCore/src/network/request_server_telemetry/MSIDAADTokenRequestServerTelemetry.m
@@ -54,7 +54,19 @@
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Error is nil, reset MSID telemetry");
     }
 
-    NSString *errorString = [error msidServerTelemetryErrorString];
+    [self.lastRequestTelemetry updateWithApiId:self.currentRequestTelemetry.apiId
+                                   errorString:[error msidServerTelemetryErrorString]
+                                       context:context];
+}
+
+- (void)handleError:(nullable NSError *)error
+        errorString:(NSString *)errorString
+            context:(id<MSIDRequestContext>)context
+{
+    if (error == nil) {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Error is nil, reset MSID telemetry");
+    }
+    
     [self.lastRequestTelemetry updateWithApiId:self.currentRequestTelemetry.apiId
                                    errorString:errorString
                                        context:context];

--- a/IdentityCore/src/network/request_server_telemetry/MSIDHttpRequestServerTelemetryHandling.h
+++ b/IdentityCore/src/network/request_server_telemetry/MSIDHttpRequestServerTelemetryHandling.h
@@ -32,6 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleError:(nullable NSError *)error
             context:(id<MSIDRequestContext>)context;
 
+- (void)handleError:(nullable NSError *)error
+        errorString:(NSString *)errorString
+            context:(id<MSIDRequestContext>)context;
+
 - (void)setTelemetryToRequest:(id<MSIDHttpRequestProtocol>)request;
 
 @end

--- a/IdentityCore/src/network/request_server_telemetry/MSIDHttpRequestServerTelemetryHandling.h
+++ b/IdentityCore/src/network/request_server_telemetry/MSIDHttpRequestServerTelemetryHandling.h
@@ -32,10 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleError:(nullable NSError *)error
             context:(id<MSIDRequestContext>)context;
 
-- (void)handleError:(nullable NSError *)error
-        errorString:(NSString *)errorString
-            context:(id<MSIDRequestContext>)context;
-
 - (void)setTelemetryToRequest:(id<MSIDHttpRequestProtocol>)request;
 
 @end

--- a/IdentityCore/tests/MSIDAADTokenRequestServerTelemetryTests.m
+++ b/IdentityCore/tests/MSIDAADTokenRequestServerTelemetryTests.m
@@ -1,0 +1,158 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import <XCTest/XCTest.h>
+#import "MSIDLastRequestTelemetry+Tests.h"
+#import "MSIDAADTokenRequestServerTelemetry.h"
+#import "MSIDTestSwizzle.h"
+#import "MSIDTestContext.h"
+
+@interface MSIDAADTokenRequestServerTelemetryTests : XCTestCase
+
+@property (nonatomic) MSIDTestContext *context;
+
+@end
+
+@implementation MSIDAADTokenRequestServerTelemetryTests
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    [MSIDTestSwizzle reset];
+    __auto_type context = [MSIDTestContext new];
+    context.correlationId = [[NSUUID alloc] initWithUUIDString:@"00000000-0000-0000-0000-000000000001"];
+    self.context = context;
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [MSIDTestSwizzle reset];
+}
+
+- (void)test_whenNoError_passIn_handleErrorWithContext_shouldResetTelemetry
+{
+    MSIDAADTokenRequestServerTelemetry *telemetry = [MSIDAADTokenRequestServerTelemetry new];
+    MSIDLastRequestTelemetry *telemetryObject = [MSIDLastRequestTelemetry sharedInstance];
+    [telemetry setValue:telemetryObject forKey:@"lastRequestTelemetry"];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"resetTelemetry triggerred"];
+    [MSIDTestSwizzle instanceMethod:@selector(resetTelemetry)
+                              class:[MSIDLastRequestTelemetry class]
+                              block:(id)^(void)
+     {
+        [expectation fulfill];
+
+     }];
+    
+    [MSIDTestSwizzle instanceMethod:@selector(addErrorInfo:)
+                              class:[MSIDLastRequestTelemetry class]
+                              block:(id)^(void)
+     {
+        XCTFail(@"addErrorInfo should not be triggerred");
+     }];
+    
+    [telemetry handleError:nil context:self.context];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)test_whenError_passIn_handleErrorWithContext_shouldAddErrorInfo
+{
+    MSIDAADTokenRequestServerTelemetry *telemetry = [MSIDAADTokenRequestServerTelemetry new];
+    MSIDLastRequestTelemetry *telemetryObject = [MSIDLastRequestTelemetry sharedInstance];
+    [telemetry setValue:telemetryObject forKey:@"lastRequestTelemetry"];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"addErrorInfo triggerred"];
+    [MSIDTestSwizzle instanceMethod:@selector(resetTelemetry)
+                              class:[MSIDLastRequestTelemetry class]
+                              block:(id)^(void)
+     {
+        XCTFail(@"resetTelemetry should not be triggerred");
+     }];
+    
+    [MSIDTestSwizzle instanceMethod:@selector(addErrorInfo:)
+                              class:[MSIDLastRequestTelemetry class]
+                              block:(id)^(void)
+     {
+        [expectation fulfill];
+     }];
+    
+    [telemetry handleError:[NSError new] context:self.context];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)test_whenNoError_passIn_handleErrorWithMessageAndContext_shouldAddErrorInfo
+{
+    MSIDAADTokenRequestServerTelemetry *telemetry = [MSIDAADTokenRequestServerTelemetry new];
+    MSIDLastRequestTelemetry *telemetryObject = [MSIDLastRequestTelemetry sharedInstance];
+    [telemetry setValue:telemetryObject forKey:@"lastRequestTelemetry"];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"resetTelemetry triggerred"];
+    [MSIDTestSwizzle instanceMethod:@selector(resetTelemetry)
+                              class:[MSIDLastRequestTelemetry class]
+                              block:(id)^(void)
+     {
+        XCTFail(@"resetTelemetry should not be triggerred");
+     }];
+    
+    [MSIDTestSwizzle instanceMethod:@selector(addErrorInfo:)
+                              class:[MSIDLastRequestTelemetry class]
+                              block:(id)^(void)
+     {
+        [expectation fulfill];
+     }];
+    
+    [telemetry handleError:nil errorString:@"error string" context:self.context];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)test_whenError_passIn_handleErrorWithMessageAndContext_shouldAddErrorInfo
+{
+    MSIDAADTokenRequestServerTelemetry *telemetry = [MSIDAADTokenRequestServerTelemetry new];
+    MSIDLastRequestTelemetry *telemetryObject = [MSIDLastRequestTelemetry sharedInstance];
+    [telemetry setValue:telemetryObject forKey:@"lastRequestTelemetry"];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"resetTelemetry triggerred"];
+    [MSIDTestSwizzle instanceMethod:@selector(resetTelemetry)
+                              class:[MSIDLastRequestTelemetry class]
+                              block:(id)^(void)
+     {
+        XCTFail(@"resetTelemetry should not be triggerred");
+     }];
+    
+    [MSIDTestSwizzle instanceMethod:@selector(addErrorInfo:)
+                              class:[MSIDLastRequestTelemetry class]
+                              block:(id)^(void)
+     {
+        [expectation fulfill];
+     }];
+    
+    [telemetry handleError:[NSError new] errorString:@"error string" context:self.context];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+@end

--- a/IdentityCore/tests/mocks/MSIDLastRequestTelemetry+Tests.h
+++ b/IdentityCore/tests/mocks/MSIDLastRequestTelemetry+Tests.h
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import "MSIDLastRequestTelemetry.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDLastRequestTelemetry ()
+
+- (void)resetTelemetry;
+
+- (void)addErrorInfo:(MSIDRequestTelemetryErrorInfo *)errorInfo;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Update resetting MSID telemetry logic to make sure reset happens correctly when in no error cases. Previous accumulated errors should be sent through a successful session

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

