### PR TITLE
Loading spinner fix - check if webview navigation action targeted to main frame

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -280,7 +280,7 @@ NSString *const CAMERA_CONSENT_PROMPT_SUPPRESS_KEY = @"Microsoft.Broker.Feature.
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelVerbose, self.context, @"-decidePolicyForNavigationAction host: %@", MSID_PII_LOG_TRACKABLE(requestURL.host));
     
-    if ([self shouldSendNavigationNotification:requestURL])
+    if ([self shouldSendNavigationNotification:requestURL navigationAction:navigationAction])
     {
         [MSIDNotifications notifyWebAuthDidStartLoad:requestURL userInfo:webView ? @{@"webview" : webView} : nil];
     }
@@ -550,10 +550,15 @@ initiatedByFrame:(WKFrameInfo *)frame
     [self stopSpinner];
 }
 
-- (BOOL)shouldSendNavigationNotification:(NSURL *)requestURL
+- (BOOL)shouldSendNavigationNotification:(NSURL *)requestURL navigationAction:(WKNavigationAction *)navigationAction
 {
     NSString *requestURLString = [requestURL.absoluteString lowercaseString];
     if ([requestURLString isEqualToString:@"about:blank"] || [requestURLString isEqualToString:@"about:srcdoc"])
+    {
+        return NO;
+    }
+    
+    if (!navigationAction.targetFrame.isMainFrame)
     {
         return NO;
     }


### PR DESCRIPTION
## Proposed changes

This PR stops the navigation notification from triggering when the webview navigation item is not targeting the main frame. When this would happen before, the main frame cannot end the navigation action and the stop notification is not sent. This caused the loading spinner in the webview to stay up even if the main webview content loaded. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

