### PR TITLE
Add nullable to crossDomainHeaderProvider

### DIFF
--- a/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSDictionary *extraAuthorizeURLQueryParameters;
 @property (nonatomic) BOOL enablePkce;
 @property (nonatomic) MSIDBrokerInvocationOptions *brokerInvocationOptions;
-@property (nonatomic) id<MSIDCustomHeaderProviding> crossDomainHeaderProvider;
+@property (nullable, nonatomic) id<MSIDCustomHeaderProviding> crossDomainHeaderProvider;
 
 - (NSOrderedSet *)allAuthorizeRequestScopes;
 - (NSDictionary *)allAuthorizeRequestExtraParameters DEPRECATED_MSG_ATTRIBUTE("Use -allAuthorizeRequestExtraParametersWithMetadata: instead");


### PR DESCRIPTION
## Proposed changes

`crossDomainHeaderProvider` can be null for `MSIDInteractiveTokenRequestParameters`. Add the specifier "nullable" to the property.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

