### PR TITLE
Adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug Report
+description: Broken or unintended behavior with the library.
+labels: 'bug-unconfirmed'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Before Submitting Your Issue
+        Our GitHub issues are meant exclusively for bug reports and feature requests. For questions about using the library for iOS and macOS, please refer to the [common issues and FAQ](https://github.com/AzureAD/microsoft-authentication-library-for-objc/wiki#getting-help-common-issues-and-faq). If your question is not addressed there, we encourage you to utilize Chat with Copilot for further assistance.
+        
+        For issues affecting your app in production, please create a support ticket with your Microsoft representative.
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Issue Details
+
+  - type: input
+    attributes:
+      label: Library Version
+      description: "Please enter the latest the library version where the issue can be reproduced."
+      placeholder: "1.9.1"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: "Briefly describe the issue."
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Error Details
+      description: |
+        Provide any error messages, stack traces, or unexpected behavior.
+        
+        **⚠️ Do not include sensitive information (PII, credentials, secrets, tokens).**
+    validations:
+     required: true
+
+  - type: textarea
+    attributes:
+      label: Logs
+      description: |
+        Share [verbose or trace level log messages](https://learn.microsoft.com/en-us/entra/msal/objc/logging-ios?tabs=objc#logging-levels) from the library. For detailed instructions on collecting the library logs, refer to our [Logging Guide](https://learn.microsoft.com/en-us/entra/msal/objc/logging-ios?tabs=objc).
+        
+        **⚠️ Do not include sensitive information (PII, credentials, secrets, tokens).**
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reproduction Steps
+      description: "Provide steps to reproduce the issue."
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: "Describe the expected behavior."
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Regression
+      description: "If this behavior worked previously, provide the last working the library version(s)."
+      placeholder: "1.9.0"
+
+  - type: textarea
+    attributes:
+      label: Screenshots & Screen Recordings
+      description: "If applicable, add screenshots or screen recordings to help illustrate the issue."
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: "Add any additional context about the issue."
+
+  - type: markdown
+    attributes:
+      value: "## Security Reporting"
+
+  - type: markdown
+    attributes:
+      value: |
+        For **privacy/security** issues, please follow the instructions [here](https://github.com/AzureAD/microsoft-authentication-library-for-objc?tab=readme-ov-file#security-reporting)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+# *OPTIONAL* Disables the ability to open blank issues without selecting a template
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,21 @@
+name: Documentation
+description: Issues with documentation for the library.
+labels: 'documentation-update-needed'
+body:
+
+  - type: input
+    attributes:
+      label: Documentation Location
+      description: "Please provide a link to the documentation related to this issue."
+      placeholder: "learn.microsoft.com"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: "Please briefly describe your issue."
+      placeholder: "Describe the issue clearly, including any errors or missing details."
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: Feature request
+description: Suggest a new feature for the library.
+labels: 'feature-unconfirmed'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Before Submitting Your Issue
+        Our GitHub issues are meant exclusively for bug reports and feature requests. For questions about using the library for iOS and macOS, please refer to the [common issues and FAQ](https://github.com/AzureAD/microsoft-authentication-library-for-objc/wiki#getting-help-common-issues-and-faq). If your question is not addressed there, we encourage you to utilize Chat with Copilot for further assistance.
+
+        If this feature is essential for your app in production, please create a support ticket with your Microsoft representative.
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: "Please briefly describe the feature you are requesting."
+    validations:
+      required: true


### PR DESCRIPTION
## Proposed changes

Adding Issue templates. Took references from MSALJS and MSAL Android

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Please feel to provide any suggestions regarding the template fields, structure, grammatical mistakes or any other.
To view templates:
Bug Report:
https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/blob/swagup/issue_templates/.github/ISSUE_TEMPLATE/bug_report.yml 
Feature Request:
https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/blob/swagup/issue_templates/.github/ISSUE_TEMPLATE/feature_request.yml 
Documentation:
https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/blob/swagup/issue_templates/.github/ISSUE_TEMPLATE/documentation.yml 
