### PR TITLE
[MSAL2.x]Ensure valid broker capable redirect URI is required for AAD scenarios

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -119,6 +119,8 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     MSIDErrorMismatchedAccount          = -51117,
     
     MSIDErrorRedirectSchemeNotRegistered = -51118,
+    
+    MSIDErrorInvalidRedirectURI         = -51119,
 
     /*!
     =========================================================

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -271,6 +271,8 @@ NSString *MSIDErrorCodeToString(MSIDErrorCode errorCode)
             return @"MSIDErrorMismatchedAccount";
         case MSIDErrorRedirectSchemeNotRegistered:
             return @"MSIDErrorRedirectSchemeNotRegistered";
+        case MSIDErrorInvalidRedirectURI:
+            return @"MSIDErrorInvalidRedirectURI";
             // Cache errors
         case MSIDErrorCacheMultipleUsers:
             return @"MSIDErrorCacheMultipleUsers";

--- a/IdentityCore/src/util/MSIDRedirectUri.h
+++ b/IdentityCore/src/util/MSIDRedirectUri.h
@@ -68,7 +68,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSURL *)defaultBrokerCapableRedirectUri;
 
-+ (MSIDRedirectUriValidationResult)redirectUriIsBrokerCapable:(NSURL *)redirectUri;
++ (MSIDRedirectUriValidationResult)redirectUriIsBrokerCapable:(NSURL *)redirectUri
+                                                        error:(NSError * __autoreleasing *)error;
 
 @end
 

--- a/IdentityCore/src/util/MSIDRedirectUri.m
+++ b/IdentityCore/src/util/MSIDRedirectUri.m
@@ -73,9 +73,15 @@
 + (MSIDRedirectUriValidationResult)redirectUriIsBrokerCapable:(NSURL *)redirectUri
                                                         error:(NSError * __autoreleasing *)error
 {
+    NSString *scheme = [NSString msidIsStringNilOrBlank:redirectUri.scheme] ? @"<custom_scheme>" : redirectUri.scheme;
+    NSString *bundleID = [NSString msidIsStringNilOrBlank:[[NSBundle mainBundle] bundleIdentifier]] ? @"[bundle_id]" : [[NSBundle mainBundle] bundleIdentifier];
+    
+    NSString *msalFormat = [NSString stringWithFormat:@"msauth.%@://auth", bundleID];
+    NSString *adalFormat = [NSString stringWithFormat:@"%@://%@", scheme, bundleID];
+    
     if ([NSString msidIsStringNilOrBlank:redirectUri.absoluteString])
     {
-        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, @"The provided redirect URI is nil or empty. Please use one of the following valid formats instead:\n- MSAL: msauth.[bundle_id]://auth\n- ADAL: <custom_scheme>://[bundle_id]", nil);
+        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, [NSString stringWithFormat:@"The provided redirect URI is nil or empty. Please use one of the following valid formats instead:\n- MSAL: %@\n- ADAL: %@", msalFormat, adalFormat], nil);
         return MSIDRedirectUriValidationResultNilOrEmpty;
     }
     
@@ -97,36 +103,36 @@
     // Add extra validation on why redirect_uri is not capable
     if ([redirectUri.scheme isEqualToString:@"http"] || [redirectUri.scheme isEqualToString:@"https"])
     {
-        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, @"The provided redirect URI uses an unsupported scheme (http(s)://host). Please use one of the following valid formats instead:\n- MSAL: msauth.[bundle_id]://auth\n- ADAL: <custom_scheme>://[bundle_id]", nil);
+        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, [NSString stringWithFormat:@"The provided redirect URI uses an unsupported scheme (http(s)://host). Please use one of the following valid formats instead:\n- MSAL: %@\n- ADAL: %@", msalFormat, adalFormat], nil);
         return MSIDRedirectUriValidationResultHttpFormatNotSupport;
     }
     else if ([redirectUri.host isEqualToString:@"auth"] && [redirectUri.absoluteString hasPrefix:@"msauth"])
     {
-        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, @"The provided redirect URI uses MSAL format (msauth.[bundle_id]://auth) but the bundle ID does not match the app’s bundle ID. Please ensure the scheme matches your app’s bundle ID.\nValid format: msauth.<bundle_id>://auth", nil);
+        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, [NSString stringWithFormat:@"The provided redirect URI uses MSAL format (%@) but the bundle ID does not match the app’s bundle ID. Please ensure the scheme matches your app’s bundle ID.\nValid format: %@", msalFormat, msalFormat], nil);
         return MSIDRedirectUriValidationResultMSALFormatBundleIdMismatched;
     }
     else if ([redirectUri.absoluteString hasPrefix:@"msauth"])
     {
-        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, @"The provided redirect URI uses MSAL scheme (msauth.<bundle_id>) but is missing the required host component \"auth\". Please ensure the URI follows the valid format: msauth.<bundle_id>://auth", nil);
+        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, [NSString stringWithFormat:@"The provided redirect URI uses MSAL scheme (msauth.<bundle_id>) but is missing the required host component \"auth\". Please ensure the URI follows the valid format: %@", msalFormat], nil);
         return MSIDRedirectUriValidationResultMSALFormatHostNilOrEmpty;
     }
     else if ([NSString msidIsStringNilOrBlank:redirectUri.scheme])
     {
-        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, @"The provided redirect URI is missing a scheme. Please use one of the following valid formats instead:\n- MSAL: msauth.[bundle_id]://auth\n- ADAL: <custom_scheme>://[bundle_id].\nRegister your scheme in Info.plist under CFBundleURLSchemes.", nil);
+        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, [NSString stringWithFormat:@"The provided redirect URI is missing a scheme. Please use one of the following valid formats instead:\n- MSAL: %@\n- ADAL: %@\nRegister your scheme in Info.plist under CFBundleURLSchemes.", msalFormat, adalFormat], nil);
         return MSIDRedirectUriValidationResultSchemeNilOrEmpty;
     }
     else if ([redirectUri.absoluteString isEqualToString:@"urn:ietf:wg:oauth:2.0:oob"])
     {
-        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, @"The provided redirect URI 'urn:ietf:wg:oauth:2.0:oob' is not supported. Please use one of the following valid formats instead:\n- MSAL: msauth.[bundle_id]://auth\n- ADAL: <custom_scheme>://[bundle_id]", nil);
+        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, [NSString stringWithFormat:@"The provided redirect URI 'urn:ietf:wg:oauth:2.0:oob' is not supported. Please use one of the following valid formats instead:\n- MSAL: %@\n- ADAL: %@", msalFormat, adalFormat], nil);
         return MSIDRedirectUriValidationResultoauth20FormatNotSupport;
     }
     else if ([NSString msidIsStringNilOrBlank:redirectUri.host])
     {
-        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, @"The provided redirect URI is missing a host. Please use one of the following valid formats instead:\n- MSAL: msauth.[bundle_id]://auth\n- ADAL: <custom_scheme>://[bundle_id]", nil);
+        MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, [NSString stringWithFormat:@"The provided redirect URI is missing a host. Please use one of the following valid formats instead:\n- MSAL: %@\n- ADAL: %@", msalFormat, adalFormat], nil);
         return MSIDRedirectUriValidationResultHostNilOrEmpty;
     }
 
-    MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, @"The provided redirect URI is invalid. Please use one of the following valid formats instead:\n- MSAL: msauth.[bundle_id]://auth\n- ADAL: <custom_scheme>://[bundle_id]", nil);
+    MSIDFillAndLogError(error, MSIDErrorInvalidRedirectURI, [NSString stringWithFormat:@"The provided redirect URI is invalid. Please use one of the following valid formats instead:\n- MSAL: %@\n- ADAL: %@", msalFormat, adalFormat], nil);
     return MSIDRedirectUriValidationResultUnknownNotMatched;
 }
 

--- a/IdentityCore/src/util/ios/MSIDRedirectUriVerifier.m
+++ b/IdentityCore/src/util/ios/MSIDRedirectUriVerifier.m
@@ -59,9 +59,16 @@
         }
         
         NSError *redirectError = nil;
-        MSIDRedirectUriValidationResult validationResult = [MSIDRedirectUri redirectUriIsBrokerCapable:redirectURI
-                                                                                                  error:&redirectError];
-        BOOL brokerCapable = !bypassRedirectValidation && (validationResult == MSIDRedirectUriValidationResultMatched);
+        BOOL brokerCapable = NO;
+
+        if (!bypassRedirectValidation)
+        {
+            MSIDRedirectUriValidationResult validationResult = [MSIDRedirectUri redirectUriIsBrokerCapable:redirectURI
+                                                                                                     error:&redirectError];
+            
+            brokerCapable = (validationResult == MSIDRedirectUriValidationResultMatched);
+        }
+        
         if (error)
         {
             *error = redirectError;

--- a/IdentityCore/src/util/ios/MSIDRedirectUriVerifier.m
+++ b/IdentityCore/src/util/ios/MSIDRedirectUriVerifier.m
@@ -58,7 +58,14 @@
             return nil;
         }
         
-        BOOL brokerCapable = !bypassRedirectValidation && [MSIDRedirectUri redirectUriIsBrokerCapable:redirectURI] == MSIDRedirectUriValidationResultMatched;
+        NSError *redirectError = nil;
+        MSIDRedirectUriValidationResult validationResult = [MSIDRedirectUri redirectUriIsBrokerCapable:redirectURI
+                                                                                                  error:&redirectError];
+        BOOL brokerCapable = !bypassRedirectValidation && (validationResult == MSIDRedirectUriValidationResultMatched);
+        if (error)
+        {
+            *error = redirectError;
+        }
         
         MSIDRedirectUri *redirectUri = [[MSIDRedirectUri alloc] initWithRedirectUri:redirectURI
                                                                       brokerCapable:brokerCapable];

--- a/IdentityCore/src/util/mac/MSIDRedirectUriVerifier.m
+++ b/IdentityCore/src/util/mac/MSIDRedirectUriVerifier.m
@@ -42,7 +42,9 @@
             return nil;
         }
         
-        BOOL isBrokerCapable = [MSIDRedirectUri redirectUriIsBrokerCapable:customRedirectURL] == MSIDRedirectUriValidationResultMatched || bypassRedirectValidation;
+        MSIDRedirectUriValidationResult validationResult = [MSIDRedirectUri redirectUriIsBrokerCapable:customRedirectURL
+                                                                                                 error:error];
+        BOOL isBrokerCapable = validationResult == MSIDRedirectUriValidationResultMatched || bypassRedirectValidation;
         return [[MSIDRedirectUri alloc] initWithRedirectUri:customRedirectURL
                                               brokerCapable:isBrokerCapable];
     }

--- a/IdentityCore/tests/MSIDBrokerRedirectUriTest.m
+++ b/IdentityCore/tests/MSIDBrokerRedirectUriTest.m
@@ -53,12 +53,26 @@
 
 - (void)test_check_empty_redirectUri
 {
-    XCTAssertTrue([MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@""]] == MSIDRedirectUriValidationResultNilOrEmpty);
+    NSError *error = nil;
+    MSIDRedirectUriValidationResult result = [MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@""] error:&error];
+    
+    XCTAssertEqual(result, MSIDRedirectUriValidationResultNilOrEmpty);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
 }
 
 - (void)test_redirectUri_is_broker_capable_with_https_url
 {
-    XCTAssertTrue([MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@"https://fakeurl.contoso.com"]] == MSIDRedirectUriValidationResultHttpFormatNotSupport);
+    NSError *error = nil;
+    MSIDRedirectUriValidationResult result = [MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@"https://fakeurl.contoso.com"] error:&error];
+    
+    XCTAssertEqual(result, MSIDRedirectUriValidationResultHttpFormatNotSupport);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
 }
 
 - (void)test_check_default_redirect_msal_format
@@ -69,7 +83,10 @@
 #else
     url = [NSURL URLWithString:@"msauth.com.apple.dt.xctest.tool://auth"];
 #endif
-    XCTAssertTrue([MSIDRedirectUri redirectUriIsBrokerCapable:url] == MSIDRedirectUriValidationResultMatched);
+
+    NSError *error = nil;
+    XCTAssertEqual([MSIDRedirectUri redirectUriIsBrokerCapable:url error:&error], MSIDRedirectUriValidationResultMatched);
+    XCTAssertNil(error);
 
 }
 
@@ -81,8 +98,10 @@
 #else
     url = [NSURL URLWithString:@"myscheme://com.apple.dt.xctest.tool"];
 #endif
-    XCTAssertTrue([MSIDRedirectUri redirectUriIsBrokerCapable:url] == MSIDRedirectUriValidationResultMatched);
 
+    NSError *error = nil;
+    XCTAssertEqual([MSIDRedirectUri redirectUriIsBrokerCapable:url error:&error], MSIDRedirectUriValidationResultMatched);
+    XCTAssertNil(error);
 }
 
 - (void)test_check_default_redirect_adal_format_without_scheme
@@ -93,23 +112,44 @@
 #else
     url = [NSURL URLWithString:@"com.apple.dt.xctest.tool"];
 #endif
-    XCTAssertTrue([MSIDRedirectUri redirectUriIsBrokerCapable:url] == MSIDRedirectUriValidationResultSchemeNilOrEmpty);
+
+    NSError *error = nil;
+    XCTAssertEqual([MSIDRedirectUri redirectUriIsBrokerCapable:url error:&error], MSIDRedirectUriValidationResultSchemeNilOrEmpty);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
 
 }
 
 - (void)test_checkRedirect_uri_miss_host
 {
-    XCTAssertTrue([MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@"myscheme://"]] == MSIDRedirectUriValidationResultHostNilOrEmpty);
+    NSError *error = nil;
+    XCTAssertEqual([MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@"myscheme://"] error:&error], MSIDRedirectUriValidationResultHostNilOrEmpty);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
 }
 
 - (void)test_checkRedirect_uri_msal_format_miss_host
 {
-    XCTAssertTrue([MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@"msauth.com.microsoft.MSIDTestsHostApp://"]] == MSIDRedirectUriValidationResultMSALFormatHostNilOrEmpty);
+    NSError *error = nil;
+    XCTAssertEqual([MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@"msauth.com.microsoft.MSIDTestsHostApp://"] error:&error], MSIDRedirectUriValidationResultMSALFormatHostNilOrEmpty);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
 }
 
 - (void)test_checkRedirect_uri_msal_format_miss_scheme
 {
-    XCTAssertTrue([MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@"://auth"]] == MSIDRedirectUriValidationResultSchemeNilOrEmpty);
+    NSError *error = nil;
+    XCTAssertEqual([MSIDRedirectUri redirectUriIsBrokerCapable:[NSURL URLWithString:@"://auth"] error:&error], MSIDRedirectUriValidationResultSchemeNilOrEmpty);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
 }
 
 @end

--- a/IdentityCore/tests/MSIDBrokerRedirectUriTest.m
+++ b/IdentityCore/tests/MSIDBrokerRedirectUriTest.m
@@ -60,7 +60,7 @@
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
     XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
-    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
 }
 
 - (void)test_redirectUri_is_broker_capable_with_https_url
@@ -72,7 +72,7 @@
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
     XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
-    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
 }
 
 - (void)test_check_default_redirect_msal_format
@@ -118,7 +118,7 @@
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
     XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
-    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
 
 }
 
@@ -129,7 +129,7 @@
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
     XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
-    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
 }
 
 - (void)test_checkRedirect_uri_msal_format_miss_host
@@ -139,7 +139,7 @@
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
     XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
-    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
 }
 
 - (void)test_checkRedirect_uri_msal_format_miss_scheme
@@ -149,7 +149,7 @@
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
     XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
-    XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
 }
 
 @end

--- a/IdentityCore/tests/MSIDRedirectUriVerifierTests.m
+++ b/IdentityCore/tests/MSIDRedirectUriVerifierTests.m
@@ -63,7 +63,10 @@
     XCTAssertNotNil(result);
     XCTAssertEqualObjects(result.url.absoluteString, redirectUri);
     XCTAssertFalse(result.brokerCapable);
-    XCTAssertNil(error);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
 }
 
 - (void)testMSIDRedirectUri_whenCustomRedirectUri_andBrokerCapable_shouldReturnUriBrokerCapableYes
@@ -232,6 +235,103 @@
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
     XCTAssertEqual(error.code, MSIDErrorRedirectSchemeNotRegistered);
+}
+
+
+- (void)testMSIDRedirectUri_whenCustomRedirectUri_withUnsupportedScheme_shouldReturnNonBrokerCapableUri
+{
+    NSArray *urlTypes = @[@{@"CFBundleURLSchemes": @[@"unsupportedScheme"]}];
+    [MSIDTestBundle overrideObject:urlTypes forKey:@"CFBundleURLTypes"];
+    [MSIDTestBundle overrideBundleId:@"test.bundle.identifier"];
+    
+    NSString *redirectUri = @"unsupportedScheme://auth";
+    NSString *clientId = @"msidclient";
+    NSError *error = nil;
+    
+    MSIDRedirectUri *result = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:redirectUri
+                                                                           clientId:clientId
+                                                           bypassRedirectValidation:NO
+                                                                              error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertEqualObjects(result.url.absoluteString, redirectUri);
+    XCTAssertFalse(result.brokerCapable);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
+}
+
+- (void)testMSIDRedirectUri_whenCustomRedirectUri_withHttpsScheme_shouldReturnNonBrokerCapableUri 
+{
+    NSArray *urlTypes = @[@{@"CFBundleURLSchemes": @[@"myapp"]}];
+    [MSIDTestBundle overrideObject:urlTypes forKey:@"CFBundleURLTypes"];
+    [MSIDTestBundle overrideBundleId:@"test.bundle.identifier"];
+    
+    NSString *redirectUri = @"https://example.com";
+    NSString *clientId = @"msidclient";
+    
+    NSError *error = nil;
+    MSIDRedirectUri *result = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:redirectUri
+                                                                           clientId:clientId
+                                                           bypassRedirectValidation:NO
+                                                                              error:&error];
+    
+    XCTAssertNotNil(result);
+    XCTAssertEqualObjects(result.url.absoluteString, redirectUri);
+    XCTAssertFalse(result.brokerCapable);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
+}
+
+- (void)testMSIDRedirectUri_whenCustomRedirectUri_withMissingHost_shouldReturnNonBrokerCapableUri 
+{
+    NSArray *urlTypes = @[@{@"CFBundleURLSchemes": @[@"myapp"]}];
+    [MSIDTestBundle overrideObject:urlTypes forKey:@"CFBundleURLTypes"];
+    [MSIDTestBundle overrideBundleId:@"test.bundle.identifier"];
+    
+    NSString *redirectUri = @"myapp://";
+    NSString *clientId = @"msidclient";
+    
+    NSError *error = nil;
+    
+    MSIDRedirectUri *result = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:redirectUri
+                                                                           clientId:clientId
+                                                           bypassRedirectValidation:NO
+                                                                              error:&error];
+    
+    XCTAssertNotNil(result);
+    XCTAssertEqualObjects(result.url.absoluteString, redirectUri);
+    XCTAssertFalse(result.brokerCapable);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
+}
+
+- (void)testMSIDRedirectUri_whenCustomRedirectUri_withNonRegisteredScheme_shouldReturnNilAndFillError 
+{
+    NSArray *urlTypes = @[@{@"CFBundleURLSchemes": @[@"myapp"]}];
+    [MSIDTestBundle overrideObject:urlTypes forKey:@"CFBundleURLTypes"];
+    [MSIDTestBundle overrideBundleId:@"test.bundle.identifier"];
+    
+    NSString *redirectUri = @"myapp://auth";
+    NSString *clientId = @"msidclient";
+    
+    NSError *error = nil;
+    
+    MSIDRedirectUri *result = [MSIDRedirectUriVerifier msidRedirectUriWithCustomUri:redirectUri
+                                                                           clientId:clientId
+                                                           bypassRedirectValidation:NO
+                                                                              error:&error];
+    
+    XCTAssertNotNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertFalse(result.brokerCapable);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertNotNil(error.userInfo[MSIDErrorDescriptionKey]);
+    XCTAssertEqual(error.code, MSIDErrorInvalidRedirectURI);
 }
 
 @end

--- a/IdentityCore/tests/mac/MSIDRedirectUriVerifierMacTests.m
+++ b/IdentityCore/tests/mac/MSIDRedirectUriVerifierMacTests.m
@@ -62,7 +62,7 @@
                                                                                    error:&error];
     
     XCTAssertNotNil(redirectUri);
-    XCTAssertNil(error);
+    XCTAssertNotNil(error);
     XCTAssertFalse(redirectUri.brokerCapable);
 }
 
@@ -89,7 +89,7 @@
                                                                                    error:&error];
     
     XCTAssertNotNil(redirectUri);
-    XCTAssertNil(error);
+    XCTAssertNotNil(error);
     XCTAssertTrue(redirectUri.brokerCapable);
 }
 
@@ -116,7 +116,7 @@
                                                                                    error:&error];
     
     XCTAssertNotNil(redirectUri);
-    XCTAssertNil(error);
+    XCTAssertNotNil(error);
     XCTAssertTrue(redirectUri.brokerCapable);
 }
 


### PR DESCRIPTION
## Proposed changes

Ensure valid broker capable redirect URI is required for AAD scenarios
Related MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/2592
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

