### PR TITLE
Fix condition to log error when getting RT for SFRT

### DIFF
--- a/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDInteractiveTokenRequest.m
@@ -149,11 +149,11 @@
         {
             NSError *error = nil;
             MSIDIsFRTEnabledStatus frtEnabledStatus = [credentialCache checkFRTEnabled:self.requestParameters error:&error];
+            enableFRT = (frtEnabledStatus == MSIDIsFRTEnabledStatusEnabled);
             
-            if (!error)
+            if (error)
             {
                 MSID_LOG_WITH_CTX(MSIDLogLevelError, self.requestParameters, @"Error when checking if FRT is enabled: error code: %@", error);
-                enableFRT = (frtEnabledStatus == MSIDIsFRTEnabledStatusEnabled);
             }
         }
     }


### PR DESCRIPTION
## Proposed changes

Fix condition to log error when getting RT for SFRT

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

