### PR TITLE
Run common core pipelines against OneAuth instead of MSALCPP

### DIFF
--- a/azure_pipelines/verify_msalcpp_per_pr_ios.yml
+++ b/azure_pipelines/verify_msalcpp_per_pr_ios.yml
@@ -17,15 +17,15 @@ variables:
 
 resources:
  repositories:
-   - repository: microsoft-authentication-library-for-cpp
-     type: github
-     endpoint: 'PipelineConnectionCPP'
-     name: AzureAD/microsoft-authentication-library-for-cpp
-     ref: develop
+   - repository: OneAuth
+     type: git
+     endpoint: 'OfficeADO'
+     name: OneAuth/OneAuth
+     ref: dev
 
 jobs:
 - job: iOS_OnPrCommit
-  displayName: MSAL CPP checks per commit for iOS
+  displayName: OneAuth checks per commit for iOS
   timeoutInMinutes: 40
   cancelTimeoutInMinutes: 1
   workspace:
@@ -34,7 +34,7 @@ jobs:
   steps:
   - checkout: self
     path: CommonCore
-  - checkout: microsoft-authentication-library-for-cpp
+  - checkout: OneAuth
     path: s
 
   - task: UsePythonVersion@0
@@ -47,7 +47,7 @@ jobs:
   - task: PythonScript@0
     displayName: Update subtree and rename files
     inputs:
-     scriptPath: scripts/update_msalobjc_subtree.py
+     scriptPath: msal/scripts/update_msalobjc_subtree.py
      arguments: '--skip-checkout --msal-common-repo $(Agent.BuildDirectory)/CommonCore --remote-ref $(commit_number)'
 
   - task: UsePythonVersion@0
@@ -55,13 +55,13 @@ jobs:
   - script: |
      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_15.4.app"
 
-  - template: azure_pipelines/templates/ios-setup.yml@microsoft-authentication-library-for-cpp
+  - template: msal/azure_pipelines/templates/ios-setup.yml@OneAuth
 
   - task: PythonScript@0
     name: Build
     displayName: 'Build x64 Debug iOS'
     inputs:
-      scriptPath: build.py
+      scriptPath: msal/build.py
       arguments: '--clean --arch x64 --configuration Debug --platform iOS --djinni hashfail --test --test-type unit integration --build-projects tests'
     env:
       MSAL_LAB_VAULT_ACCESS_CERT_LOCATION: $(Agent.TempDirectory)

--- a/azure_pipelines/verify_msalcpp_per_pr_mac.yml
+++ b/azure_pipelines/verify_msalcpp_per_pr_mac.yml
@@ -17,15 +17,15 @@ variables:
 
 resources:
  repositories:
-   - repository: microsoft-authentication-library-for-cpp
-     type: github
-     endpoint: 'PipelineConnectionCPP'
-     name: AzureAD/microsoft-authentication-library-for-cpp
-     ref: develop
+   - repository: OneAuth
+     type: git
+     endpoint: 'OfficeADO'
+     name: OneAuth/OneAuth
+     ref: dev
 
 jobs:
 - job: macOS_OnPrCommit
-  displayName: MSAL CPP checks per commit for macOS
+  displayName: OneAuth checks per commit for macOS
   timeoutInMinutes: 40
   cancelTimeoutInMinutes: 1
   workspace:
@@ -34,7 +34,7 @@ jobs:
   steps:
   - checkout: self
     path: CommonCore
-  - checkout: microsoft-authentication-library-for-cpp
+  - checkout: OneAuth
     path: s
 
   - task: UsePythonVersion@0
@@ -48,7 +48,7 @@ jobs:
   - task: PythonScript@0
     displayName: Update subtree and rename files
     inputs:
-     scriptPath: scripts/update_msalobjc_subtree.py
+     scriptPath: msal/scripts/update_msalobjc_subtree.py
      arguments: '--skip-checkout --msal-common-repo $(Agent.BuildDirectory)/CommonCore --remote-ref $(commit_number)'
 
   - task: UsePythonVersion@0
@@ -56,13 +56,13 @@ jobs:
   - script: |
      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_15.4.app"
 
-  - template: azure_pipelines/templates/macos-setup.yml@microsoft-authentication-library-for-cpp
+  - template: msal/azure_pipelines/templates/macos-setup.yml@OneAuth
 
   - task: PythonScript@0
     name: Build
     displayName: 'Build x64 Debug macOS'
     inputs:
-      scriptPath: build.py
+      scriptPath: msal/build.py
       arguments: '--clean --arch x64 --configuration Debug --platform macOS --djinni hashfail --test --test-type unit integration --build-projects tests'
     env:
       MSAL_LAB_VAULT_ACCESS_CERT_LOCATION: $(Agent.TempDirectory)


### PR DESCRIPTION
## Proposed changes

Fixing MSALCPP pipeline to use OneAuth instead of Microsoft Authentication Library for C++

## Type of change

- [ ] Feature work
- [* ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ *] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Right now these jobs are both failing due to legitimate incompatibilies (a new enum value not handled in an MSALCPP switch statement).
