### PR TITLE
 Handle account removed suberror in brokers and MSALs

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1890,6 +1890,7 @@
 		E656E07A2C2627B80011FB23 /* MSIDWebUpgradeRegResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E656E0792C2627B80011FB23 /* MSIDWebUpgradeRegResponse.m */; };
 		E656E07B2C2627B80011FB23 /* MSIDWebUpgradeRegResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E656E0792C2627B80011FB23 /* MSIDWebUpgradeRegResponse.m */; };
 		E656E07D2C2627FB0011FB23 /* MSIDWebUpgradeRegResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E656E07C2C2627FB0011FB23 /* MSIDWebUpgradeRegResponse.h */; };
+		E6B895AD2DD2AEE1000879AE /* MSIDSilentTokenRequest+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = E6B895AC2DD2AEC2000879AE /* MSIDSilentTokenRequest+Internal.h */; };
 		E70C49F1258D662F00A7A07E /* MSIDLRUCache.m in Sources */ = {isa = PBXBuildFile; fileRef = E70C49F0258D662F00A7A07E /* MSIDLRUCache.m */; };
 		E70C49F2258D662F00A7A07E /* MSIDLRUCache.m in Sources */ = {isa = PBXBuildFile; fileRef = E70C49F0258D662F00A7A07E /* MSIDLRUCache.m */; };
 		E70C4A30258D68D900A7A07E /* MSIDThrottlingCacheRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = E70C4A2F258D68D900A7A07E /* MSIDThrottlingCacheRecord.m */; };
@@ -3366,6 +3367,7 @@
 		D6D9A4BB1FBE712900EFA430 /* MSIDStringExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDStringExtensionsTests.m; sourceTree = "<group>"; };
 		E656E0792C2627B80011FB23 /* MSIDWebUpgradeRegResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWebUpgradeRegResponse.m; sourceTree = "<group>"; };
 		E656E07C2C2627FB0011FB23 /* MSIDWebUpgradeRegResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDWebUpgradeRegResponse.h; sourceTree = "<group>"; };
+		E6B895AC2DD2AEC2000879AE /* MSIDSilentTokenRequest+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDSilentTokenRequest+Internal.h"; sourceTree = "<group>"; };
 		E6FABC0A2C2A110900611378 /* MSIDWebWPJResponse+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDWebWPJResponse+Internal.h"; sourceTree = "<group>"; };
 		E70C49F0258D662F00A7A07E /* MSIDLRUCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLRUCache.m; sourceTree = "<group>"; };
 		E70C4A2F258D68D900A7A07E /* MSIDThrottlingCacheRecord.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDThrottlingCacheRecord.m; sourceTree = "<group>"; };
@@ -5045,6 +5047,7 @@
 				23B01884235548C000207FEC /* MSIDInteractiveTokenRequest+Internal.h */,
 				B2AF1D2D218BCEDE0080C1A0 /* MSIDInteractiveTokenRequest.m */,
 				B2F671EB2467AB4500649855 /* MSIDInteractiveRequestControlling.h */,
+				E6B895AC2DD2AEC2000879AE /* MSIDSilentTokenRequest+Internal.h */,
 				B2AF1D31218BCEEB0080C1A0 /* MSIDSilentTokenRequest.h */,
 				B2AF1D32218BCEEB0080C1A0 /* MSIDSilentTokenRequest.m */,
 				B286B9542385F01A007833AD /* MSIDOIDCSignoutRequest.h */,
@@ -6126,6 +6129,7 @@
 				23C898162C8928DD00071482 /* MSIDBrowserNativeMessageGetSupportedContractsRequest.h in Headers */,
 				238E19E12086FE28004DF483 /* MSIDAuthorizationCodeGrantRequest.h in Headers */,
 				238EF038208FDBA20035ABE6 /* MSIDAADV1RefreshTokenGrantRequest.h in Headers */,
+				E6B895AD2DD2AEE1000879AE /* MSIDSilentTokenRequest+Internal.h in Headers */,
 				589BDB272718F18800BF3799 /* MSIDCredentialHeader.h in Headers */,
 				235480C620DDF81000246F72 /* MSIDADFSAuthority.h in Headers */,
 				96CE53E920C73E3A002E24C9 /* MSIDWebviewFactory.h in Headers */,

--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -215,4 +215,15 @@ extern NSString * _Nonnull const MSID_FLIGHT_USE_V2_WEB_RESPONSE_FACTORY;
 extern NSString * _Nonnull const MSID_FLIGHT_SUPPORT_DUNA_CBA;
 extern NSString * _Nonnull const MSID_FLIGHT_CLIENT_SFRT_STATUS;
 
+/**
+ * Flight to indicate if remove account artifacts should be disabled
+ * Owner: Antonio
+ * Link: N/A - No ECS flag created as this is a disable flight to be created on demand
+ * Created Date: N/A
+ * Status: Not started
+ * Fully Allocated: Not Started
+ * WorkItem: 3168316
+ */
+extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_REMOVE_ACCOUNT_ARTIFACTS;
+
 #define METHODANDLINE   [NSString stringWithFormat:@"%s [Line %d]", __PRETTY_FUNCTION__, __LINE__]

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -87,5 +87,7 @@ NSString *const MSID_FLIGHT_USE_V2_WEB_RESPONSE_FACTORY = @"use_v2_web_response_
 NSString *const MSID_FLIGHT_SUPPORT_DUNA_CBA = @"support_duna_cba_v2";
 NSString *const MSID_FLIGHT_CLIENT_SFRT_STATUS = @"sfrt_status";
 
+NSString *const MSID_FLIGHT_DISABLE_REMOVE_ACCOUNT_ARTIFACTS = @"disable_remove_account_artifacts";
+
 
 #define METHODANDLINE   [NSString stringWithFormat:@"%s [Line %d]", __PRETTY_FUNCTION__, __LINE__]

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -87,7 +87,8 @@ NSString *const MSID_FLIGHT_USE_V2_WEB_RESPONSE_FACTORY = @"use_v2_web_response_
 NSString *const MSID_FLIGHT_SUPPORT_DUNA_CBA = @"support_duna_cba_v2";
 NSString *const MSID_FLIGHT_CLIENT_SFRT_STATUS = @"sfrt_status";
 
-NSString *const MSID_FLIGHT_DISABLE_REMOVE_ACCOUNT_ARTIFACTS = @"disable_remove_account_artifacts";
+// Making the flight string short to avoid legacy broker url size limit
+NSString *const MSID_FLIGHT_DISABLE_REMOVE_ACCOUNT_ARTIFACTS = @"disable_rm_metadata";
 
 
 #define METHODANDLINE   [NSString stringWithFormat:@"%s [Line %d]", __PRETTY_FUNCTION__, __LINE__]

--- a/IdentityCore/src/MSIDOAuth2Constants.h
+++ b/IdentityCore/src/MSIDOAuth2Constants.h
@@ -170,6 +170,7 @@ extern NSString *const MSID_PREFERRED_USERNAME_MISSING;
 
 extern NSString *const MSIDServerErrorClientMismatch;
 extern NSString *const MSIDServerErrorBadToken;
+extern NSString *const MSIDServerErrorUserAccountDeleted;
 
 extern NSString *const MSID_CCS_REQUEST_ID_KEY;
 extern NSString *const MSID_CCS_REQUEST_ID_RESPONSE;

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -170,6 +170,7 @@ NSString *const MSID_PREFERRED_USERNAME_MISSING          = @"Missing from the to
 
 NSString *const MSIDServerErrorClientMismatch            = @"client_mismatch";
 NSString *const MSIDServerErrorBadToken                  = @"bad_token";
+NSString *const MSIDServerErrorUserAccountDeleted        = @"user_account_deleted";
 
 NSString *const MSID_CCS_REQUEST_ID_KEY                  = @"x-ms-ccs-requestid";
 NSString *const MSID_CCS_REQUEST_ID_RESPONSE             = @"ccs-requestid";

--- a/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.h
+++ b/IdentityCore/src/cache/metadata/MSIDAccountMetadataCacheAccessor.h
@@ -77,4 +77,9 @@
 - (MSIDAccountMetadataCacheItem *)retrieveAccountMetadataCacheItemForClientId:(NSString *)clientId
                                                                       context:(id<MSIDRequestContext>)context
                                                                         error:(NSError *__autoreleasing*)error;
+
+- (BOOL)removeAccountMetadataForHomeAccountId:(NSString *)homeAccountId
+                                      context:(id<MSIDRequestContext>)context
+                                        error:(NSError *__autoreleasing*)error;
+
 @end

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest+Internal.h
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest+Internal.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDCacheAccessor.h"
+#import "MSIDConstants.h"
+#import "MSIDThrottlingService.h"
+
+@interface MSIDSilentTokenRequest (Internal)
+
+- (BOOL)shouldRemoveAccountArtifacts:(nonnull NSError *)serverError;
+
+@end
+

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -699,10 +699,12 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
     return NO;
 }
 
-- (BOOL)shouldRemoveAccountArtifacts:(__unused NSError *)serverError
+- (BOOL)shouldRemoveAccountArtifacts:(nonnull NSError *)serverError
 {
-    NSAssert(NO, @"Abstract method. Should be implemented in a subclass");
-    return NO;
+    // Removing account artifacts on invalid_grant + user_deleted_account suberror combination
+    MSIDErrorCode oauthError = MSIDErrorCodeForOAuthError(serverError.msidOauthError, MSIDErrorInternal);
+    NSString *subError = serverError.msidSubError;
+    return oauthError == MSIDErrorServerInvalidGrant && [subError isEqualToString:MSIDServerErrorUserAccountDeleted];
 }
 
 - (id<MSIDCacheAccessor>)tokenCache

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -41,6 +41,7 @@
 #import "MSIDLastRequestTelemetry.h"
 #import "MSIDCurrentRequestTelemetry.h"
 #import "MSIDAccountMetadataCacheItem.h"
+#import "MSIDFlightManager.h"
 
 #if TARGET_OS_OSX && !EXCLUDE_FROM_MSALCPP
 #import "MSIDExternalAADCacheSeeder.h"
@@ -617,8 +618,11 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
                     MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, self.requestParameters, @"Failed to remove invalid refresh token with error %@", MSID_PII_LOG_MASKABLE(removalError));
                 }
             }
+            
+            BOOL disableRemoveAccountArtifacts = [MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_DISABLE_REMOVE_ACCOUNT_ARTIFACTS];
 
-            if (!result && [self shouldRemoveAccountArtifacts:localError])
+            // remove account artifacts only if we test flight feature is not disabled
+            if (!result && !disableRemoveAccountArtifacts && [self shouldRemoveAccountArtifacts:localError])
             {
                 MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Account deleted, Removing any user account artifacts from device...");
                 [self removeAccountArtifacts:self.requestParameters];

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacySilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacySilentTokenRequest.m
@@ -28,6 +28,7 @@
 #import "MSIDAccessToken.h"
 #import "NSError+MSIDExtensions.h"
 #import "MSIDAccountMetadataCacheAccessor.h"
+#import "MSIDSilentTokenRequest+Internal.h"
 
 @interface MSIDLegacySilentTokenRequest()
 
@@ -102,10 +103,7 @@
 
 - (BOOL)shouldRemoveAccountArtifacts:(NSError *)serverError
 {
-    // Removing account artifacts on invalid_grant + user_deleted_account suberror combination
-    MSIDErrorCode oauthError = MSIDErrorCodeForOAuthError(serverError.msidOauthError, MSIDErrorInternal);
-    NSString *subError = serverError.msidSubError;
-    return oauthError == MSIDErrorServerInvalidGrant && [subError isEqualToString:MSIDServerErrorUserAccountDeleted];
+    return [super shouldRemoveAccountArtifacts:serverError];
 }
 
 - (id<MSIDCacheAccessor>)tokenCache

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacySilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacySilentTokenRequest.m
@@ -100,6 +100,14 @@
     return oauthError == MSIDErrorServerInvalidGrant;
 }
 
+- (BOOL)shouldRemoveAccountArtifacts:(NSError *)serverError
+{
+    // MSAL removes Account artifacts on invalid_grant + bad token combination
+    MSIDErrorCode oauthError = MSIDErrorCodeForOAuthError(serverError.msidOauthError, MSIDErrorInternal);
+    NSString *subError = serverError.msidSubError;
+    return oauthError == MSIDErrorServerInvalidGrant && [subError isEqualToString:MSIDServerErrorUserAccountDeleted];
+}
+
 - (id<MSIDCacheAccessor>)tokenCache
 {
     return self.legacyAccessor;

--- a/IdentityCore/src/requests/sdk/adal/MSIDLegacySilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/adal/MSIDLegacySilentTokenRequest.m
@@ -102,7 +102,7 @@
 
 - (BOOL)shouldRemoveAccountArtifacts:(NSError *)serverError
 {
-    // MSAL removes Account artifacts on invalid_grant + bad token combination
+    // Removing account artifacts on invalid_grant + user_deleted_account suberror combination
     MSIDErrorCode oauthError = MSIDErrorCodeForOAuthError(serverError.msidOauthError, MSIDErrorInternal);
     NSString *subError = serverError.msidSubError;
     return oauthError == MSIDErrorServerInvalidGrant && [subError isEqualToString:MSIDServerErrorUserAccountDeleted];

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
@@ -37,6 +37,7 @@
 #import "MSIDAccountMetadataCacheAccessor.h"
 #import "MSIDTokenResponse.h"
 #import "MSIDThrottlingService.h"
+#import "MSIDSilentTokenRequest+Internal.h"
 
 @interface MSIDDefaultSilentTokenRequest()
 
@@ -228,10 +229,7 @@
 
 - (BOOL)shouldRemoveAccountArtifacts:(NSError *)serverError
 {
-    // Removing account artifacts on invalid_grant + user_deleted_account suberror combination
-    MSIDErrorCode oauthError = MSIDErrorCodeForOAuthError(serverError.msidOauthError, MSIDErrorInternal);
-    NSString *subError = serverError.msidSubError;
-    return oauthError == MSIDErrorServerInvalidGrant && [subError isEqualToString:MSIDServerErrorUserAccountDeleted];
+    return [super shouldRemoveAccountArtifacts:serverError];
 }
 
 - (id<MSIDCacheAccessor>)tokenCache

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
@@ -228,7 +228,7 @@
 
 - (BOOL)shouldRemoveAccountArtifacts:(NSError *)serverError
 {
-    // MSAL removes Account artifacts on invalid_grant + bad token combination
+    // Removing account artifacts on invalid_grant + user_deleted_account suberror combination
     MSIDErrorCode oauthError = MSIDErrorCodeForOAuthError(serverError.msidOauthError, MSIDErrorInternal);
     NSString *subError = serverError.msidSubError;
     return oauthError == MSIDErrorServerInvalidGrant && [subError isEqualToString:MSIDServerErrorUserAccountDeleted];

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
@@ -226,6 +226,14 @@
     return oauthError == MSIDErrorServerInvalidGrant && [subError isEqualToString:MSIDServerErrorBadToken];
 }
 
+- (BOOL)shouldRemoveAccountArtifacts:(NSError *)serverError
+{
+    // MSAL removes Account artifacts on invalid_grant + bad token combination
+    MSIDErrorCode oauthError = MSIDErrorCodeForOAuthError(serverError.msidOauthError, MSIDErrorInternal);
+    NSString *subError = serverError.msidSubError;
+    return oauthError == MSIDErrorServerInvalidGrant && [subError isEqualToString:MSIDServerErrorUserAccountDeleted];
+}
+
 - (id<MSIDCacheAccessor>)tokenCache
 {
     return self.defaultAccessor;

--- a/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
@@ -821,6 +821,12 @@
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"silent request"];
 
+    MSIDAccessToken *accessToken = [tokenCache getAccessTokenForAccount:accountIdentifier configuration:silentParameters.msidConfiguration context:nil error:nil];
+    XCTAssertNotNil(accessToken);
+    
+    MSIDRefreshToken *refreshToken = [tokenCache getRefreshTokenWithAccount:accountIdentifier familyId:nil configuration:silentParameters.msidConfiguration context:nil error:nil];
+    XCTAssertNotNil(refreshToken);
+    
     [silentRequest executeRequestWithCompletion:^(__unused MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
 
         XCTAssertNotNil(error);
@@ -832,11 +838,11 @@
 
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 
-    MSIDAccessToken *accessToken = [tokenCache getAccessTokenForAccount:accountIdentifier configuration:silentParameters.msidConfiguration context:nil error:nil];
-    XCTAssertNil(accessToken);
+    accessToken = [tokenCache getAccessTokenForAccount:accountIdentifier configuration:silentParameters.msidConfiguration context:nil error:nil];
+    XCTAssertNil(accessToken, "AT have removed access token from cache");
 
-    MSIDRefreshToken *refreshToken = [tokenCache getRefreshTokenWithAccount:accountIdentifier familyId:nil configuration:silentParameters.msidConfiguration context:nil error:nil];
-    XCTAssertNil(refreshToken);
+    refreshToken = [tokenCache getRefreshTokenWithAccount:accountIdentifier familyId:nil configuration:silentParameters.msidConfiguration context:nil error:nil];
+    XCTAssertNil(refreshToken, "RT have removed access token from cache");
     
     accountMetadataCacheItem = [self.accountMetadataCache retrieveAccountMetadataCacheItemForClientId:silentParameters.clientId
                                                                                               context:nil

--- a/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
@@ -52,6 +52,7 @@
 #import "NSString+MSIDTestUtil.h"
 #import "MSIDIdToken.h"
 #import "MSIDLRUCache.h"
+#import "MSIDAccountMetadataCacheItem.h"
 
 @interface MSIDDefaultSilentTokenRequestTests : XCTestCase
 
@@ -764,6 +765,86 @@
 
     MSIDRefreshToken *refreshToken = [tokenCache getRefreshTokenWithAccount:accountIdentifier familyId:nil configuration:silentParameters.msidConfiguration context:nil error:nil];
     XCTAssertNil(refreshToken);
+}
+
+- (void)testAcquireTokenSilent_whenATExpired_AndFailedToRefreshTokenWithUserAccountDeleted_shouldReturnError_AndRemoveAccountMetadata_AndRemoveRefreshTokenInCache
+{
+    MSIDRequestParameters *silentParameters = [self silentRequestParameters];
+    MSIDDefaultTokenCacheAccessor *tokenCache = self.tokenCache;
+
+    MSIDAccountIdentifier *accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:DEFAULT_TEST_ID_TOKEN_USERNAME homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
+    silentParameters.accountIdentifier = accountIdentifier;
+    [self saveExpiredTokensInCache:tokenCache configuration:silentParameters.msidConfiguration];
+    
+    NSError *updateError = nil;
+    [self.accountMetadataCache updateSignInStateForHomeAccountId:silentParameters.accountIdentifier.homeAccountId
+                                                        clientId:silentParameters.clientId
+                                                           state:MSIDAccountMetadataStateSignedIn
+                                                         context:nil
+                                                           error:&updateError];
+    XCTAssertNil(updateError);
+    
+    NSError *metadataCacheError;
+    MSIDAccountMetadataCacheItem *accountMetadataCacheItem = [self.accountMetadataCache retrieveAccountMetadataCacheItemForClientId:silentParameters.clientId
+                                                                                                                            context:nil
+                                                                                                                              error:&metadataCacheError];
+    XCTAssertNil(metadataCacheError);
+    XCTAssertEqualObjects(silentParameters.clientId, accountMetadataCacheItem.clientId, "Valid item should be in the metadata cache");
+    MSIDAccountMetadata *accountMetadata = [accountMetadataCacheItem accountMetadataForHomeAccountId:silentParameters.accountIdentifier.homeAccountId];
+    XCTAssertNil(metadataCacheError);
+    XCTAssertNotNil(accountMetadata);
+
+    NSString *authority = DEFAULT_TEST_AUTHORITY_GUID;
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:authority];
+    [MSIDTestURLSession addResponse:oidcResponse];
+
+    MSIDTestURLResponse *tokenResponse = [MSIDTestURLResponse errorRefreshTokenGrantResponseWithRT:DEFAULT_TEST_REFRESH_TOKEN
+                                                                                     requestClaims:nil
+                                                                                     requestScopes:@"user.read tasks.read openid profile offline_access"
+                                                                                     responseError:@"invalid_grant"
+                                                                                       description:@"test"
+                                                                                          subError:@"user_account_deleted"
+                                                                                               url:DEFAULT_TEST_TOKEN_ENDPOINT_GUID
+                                                                                      responseCode:200];
+
+    [MSIDTestURLSession addResponse:tokenResponse];
+
+    MSIDDefaultSilentTokenRequest *silentRequest = [[MSIDDefaultSilentTokenRequest alloc] initWithRequestParameters:silentParameters
+                                                                                                       forceRefresh:NO
+                                                                                                       oauthFactory:[MSIDAADV2Oauth2Factory new]
+                                                                                             tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]
+                                                                                                         tokenCache:tokenCache
+                                                                                                      accountMetadataCache:self.accountMetadataCache];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"silent request"];
+
+    [silentRequest executeRequestWithCompletion:^(__unused MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
+
+        XCTAssertNotNil(error);
+        XCTAssertEqual(error.code, MSIDErrorInteractionRequired);
+        XCTAssertEqualObjects(error.userInfo[MSIDOAuthErrorKey], @"invalid_grant");
+        XCTAssertEqualObjects(error.userInfo[MSIDOAuthSubErrorKey], @"user_account_deleted");
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+
+    MSIDAccessToken *accessToken = [tokenCache getAccessTokenForAccount:accountIdentifier configuration:silentParameters.msidConfiguration context:nil error:nil];
+    XCTAssertNil(accessToken);
+
+    MSIDRefreshToken *refreshToken = [tokenCache getRefreshTokenWithAccount:accountIdentifier familyId:nil configuration:silentParameters.msidConfiguration context:nil error:nil];
+    XCTAssertNil(refreshToken);
+    
+    accountMetadataCacheItem = [self.accountMetadataCache retrieveAccountMetadataCacheItemForClientId:silentParameters.clientId
+                                                                                              context:nil
+                                                                                                error:&metadataCacheError];
+    XCTAssertNil(metadataCacheError);
+    accountMetadata = [accountMetadataCacheItem accountMetadataForHomeAccountId:silentParameters.accountIdentifier.homeAccountId];
+    XCTAssertNil(metadataCacheError);
+    XCTAssertNil(accountMetadata, "Account metadata should have been removed from cache");
 }
 
 - (void)testAcquireTokenSilent_whenATExpiresIn50WithinExpirationBuffer100_shouldReAcquireToken


### PR DESCRIPTION
## Proposed changes

Ensuring that any remaining artifacts on the device for deleted user accounts are removed when ESTS returns the suberror=user_account_deleted. This fix should be applied in the common core where Brokers and MSALs are addressed.
Added TestFlight entry: "disable_rm_metadata"
## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

WILink: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3168316
