### PR TITLE
Add method to generate jwe crypto from a give EC key

### DIFF
--- a/IdentityCore/src/util/MSIDKeyOperationUtil.h
+++ b/IdentityCore/src/util/MSIDKeyOperationUtil.h
@@ -68,5 +68,21 @@ NS_ASSUME_NONNULL_BEGIN
                                 signingAlgorithm:(SecKeyAlgorithm)algorithm
                                          context:(_Nullable id<MSIDRequestContext>)context
                                            error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+
+/// Generates JWE crypto using the supplied public key and algorithm.
+/// @param publicStk The public session transport key used to generate APV in jwe_crypto.
+/// @param alg The algorithm used for the purpose of the jwe_crypto. Defaults to ECDH-ES
+/// @param enc Encryption algorithm that client wants server to use to encrypt JWE repsonse. Defaults to A256GCM
+/// @param apvPrefix A prefix string attached to APV to differentiate clients.
+/// @param context request context
+/// @param error error
+- (NSDictionary *)generateJweCryptoWithTransportKey:(SecKeyRef _Nonnull)publicStk
+                                                alg:(nullable NSString *)alg
+                                                enc:(nullable NSString *)enc
+                                          apvPrefix:(nonnull NSString *)apvPrefix
+                                            context:(_Nullable id<MSIDRequestContext>)context
+                                              error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+                                               
 @end
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/util/MSIDKeyOperationUtil.m
+++ b/IdentityCore/src/util/MSIDKeyOperationUtil.m
@@ -135,6 +135,96 @@
     return signature;
 }
 
+- (nonnull NSDictionary *)generateJweCryptoWithTransportKey:(SecKeyRef _Nonnull)publicStk
+                                                        alg:(nullable NSString *)alg
+                                                        enc:(nullable NSString *)enc
+                                                  apvPrefix:(nonnull NSString *)apvPrefix
+                                                    context:(id<MSIDRequestContext> _Nullable)context
+                                                      error:(NSError * _Nullable __autoreleasing * _Nullable)error
+{
+    if (!publicStk)
+    {
+        [self generateErrorWithMessage:@"Public STK provided is not defined." underlyingError:nil context:context error:error];
+        return nil;
+    }
+    
+    NSData *exportedData = CFBridgingRelease(SecKeyCopyExternalRepresentation(publicStk, NULL));
+    if (!exportedData)
+    {
+        [self generateErrorWithMessage:@"Supplied key should be a public EC key." underlyingError:nil context:context error:error];
+        return nil;
+    }
+    
+    if (exportedData.length != 65)
+    {
+        [self generateErrorWithMessage:@"Supplied key is not a EC P-256 key." underlyingError:nil context:context error:error];
+        return nil;
+    }
+    
+    if ([NSString msidIsStringNilOrBlank:alg])
+    {
+        alg = @"ECDH-ES";
+    }
+    
+    if ([NSString msidIsStringNilOrBlank:enc])
+    {
+        enc = @"A256GCM";
+    }
+    
+    if ([NSString msidIsStringNilOrBlank:apvPrefix])
+    {
+        [self generateErrorWithMessage:@"APV prefix is not defined. A prefix must be provided to determine calling application type." underlyingError:nil context:context error:error];
+        return nil;
+    }
+    
+    /* APV is defined as:
+     <Datalen of prefix>||<prefix>||<Datalen of STK Pubkey>||<STK PubKey>||<Datalen of ASCII encoded nonce bytes>||<ASCII encoded nonce bytes>
+     prefix is string defined according to PRTv4.0 protocol for broker client or MSAL client.
+     STK Pubkey is public key of the STK.
+     nonce is client generated nonce for KDF (not AESGCM nonce)
+     => The corresponding "apv":BASE64URLEncode(OtherInfo.PartyVInfo)
+     */
+    
+    NSMutableData *data = [NSMutableData new];
+    
+    int prefixLen = (int)apvPrefix.length;
+    NSData *prefixLenData = [NSData dataWithBytes:&prefixLen length:sizeof(prefixLen)];
+    [data appendData:prefixLenData];
+    [data appendData:[apvPrefix dataUsingEncoding:NSUTF8StringEncoding]];
+    
+    
+    CFErrorRef errorRef = NULL;
+    NSData *stkData = CFBridgingRelease(SecKeyCopyExternalRepresentation(publicStk, &errorRef));
+    
+    if (!stkData)
+    {
+        [self generateErrorWithMessage:@"Failed to get data representation of public STK" underlyingError:CFBridgingRelease(errorRef) context:context error:error];
+        return nil;
+    }
+    
+    int stkLen = (int)stkData.length;
+    NSData *stkLenData = [NSData dataWithBytes:&stkLen length:sizeof(stkLen)];
+    [data appendData:stkLenData];
+    [data appendData:stkData];
+    
+    NSData *nonceData = [[NSUUID UUID].UUIDString dataUsingEncoding:NSASCIIStringEncoding];
+    int nonceLen = (int)nonceData.length;
+    NSData *nonceLenData = [NSData dataWithBytes:&nonceLen length:sizeof(nonceLen)];
+    [data appendData:nonceLenData];
+    [data appendData:nonceData];
+    
+    NSString *apvString = [data msidBase64UrlEncodedString];
+    
+    NSMutableDictionary *jweCrypto = [NSMutableDictionary new];
+    jweCrypto[@"apv"] = apvString;
+    jweCrypto[@"alg"] = alg;
+    jweCrypto[@"enc"] = enc;
+    
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Jwe crypto generated %@", MSID_PII_LOG_MASKABLE(jweCrypto));
+    
+    return jweCrypto;
+}
+
 - (void)generateErrorWithMessage:(NSString *)errorMessage underlyingError:(NSError *)underlyingError context:(id<MSIDRequestContext> _Nullable)context error:(NSError *__autoreleasing*)error
 {
     if (error)


### PR DESCRIPTION
## Proposed changes

Add utility method to allow MSAL/oneAuth clients to generate JWE crypto claim in payload when redeeming a bound refresh token.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

