### PR TITLE
Shift nonce acquisition code from broker to common-core

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -744,6 +744,9 @@
 		729357F02DDBCBAE0001D03C /* MSIDNonceTokenRequestMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 729357EE2DDBCBAB0001D03C /* MSIDNonceTokenRequestMock.m */; };
 		729357F32DDBD3F80001D03C /* MSIDNonceTokenRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */; };
 		729357F42DDBD3F80001D03C /* MSIDNonceTokenRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */; };
+		7293580E2DDFADDF0001D03C /* MSIDNonceHttpRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7293580D2DDFADC80001D03C /* MSIDNonceHttpRequest.h */; };
+		729358102DDFADE70001D03C /* MSIDNonceHttpRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */; };
+		729358112DDFADE70001D03C /* MSIDNonceHttpRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */; };
 		740340B92460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */; };
 		740340BA2460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */; };
 		740340BB2460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */; };
@@ -2642,6 +2645,8 @@
 		729357EC2DDBCB930001D03C /* MSIDNonceTokenRequestMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDNonceTokenRequestMock.h; sourceTree = "<group>"; };
 		729357EE2DDBCBAB0001D03C /* MSIDNonceTokenRequestMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceTokenRequestMock.m; sourceTree = "<group>"; };
 		729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceTokenRequestTest.m; sourceTree = "<group>"; };
+		7293580D2DDFADC80001D03C /* MSIDNonceHttpRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDNonceHttpRequest.h; sourceTree = "<group>"; };
+		7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceHttpRequest.m; sourceTree = "<group>"; };
 		740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCurrentRequestTelemetrySerializedItem.h; sourceTree = "<group>"; };
 		740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCurrentRequestTelemetrySerializedItem.m; sourceTree = "<group>"; };
 		74043F7C245CC84B00D3E7C1 /* MSIDCurrentRequestTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCurrentRequestTelemetryTests.m; sourceTree = "<group>"; };
@@ -3896,6 +3901,8 @@
 		238E19CF2086FE28004DF483 /* request */ = {
 			isa = PBXGroup;
 			children = (
+				7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */,
+				7293580D2DDFADC80001D03C /* MSIDNonceHttpRequest.h */,
 				238E19D12086FE28004DF483 /* MSIDTokenRequest.h */,
 				238E19D42086FE28004DF483 /* MSIDTokenRequest.m */,
 				238EF03B208FE4730035ABE6 /* MSIDRefreshTokenGrantRequest.h */,
@@ -6239,6 +6246,7 @@
 				23AE9DB72148529A00B285F3 /* NSError+MSIDExtensions.h in Headers */,
 				23AD4A32237E298C0094B87E /* NSBundle+MSIDExtensions.h in Headers */,
 				23AE209A2342DD3F00108F76 /* MSIDLocalInteractiveController+Internal.h in Headers */,
+				7293580E2DDFADDF0001D03C /* MSIDNonceHttpRequest.h in Headers */,
 				B2C07492246B735B0008D701 /* MSIDAssymetricKeyKeychainGenerator.h in Headers */,
 				B2EB3AE022F7C74300FA400E /* MSIDBrokerInvocationOptions.h in Headers */,
 				B286B9B22389DD75007833AD /* MSIDWebOAuth2AuthCodeResponse.h in Headers */,
@@ -7521,6 +7529,7 @@
 				A0E541B125CDC5F10016E167 /* MSIDThrottlingMetaData.m in Sources */,
 				B443F0032AD6328700782168 /* MSIDBrokerOperationPasskeyCredentialRequest.m in Sources */,
 				B27ACAAA22EE9FE60049ACE0 /* MSIDIntuneApplicationStateManager.m in Sources */,
+				729358112DDFADE70001D03C /* MSIDNonceHttpRequest.m in Sources */,
 				2385DD902D13A5C80075D080 /* MSIDSwitchBrowserResumeResponse.m in Sources */,
 				B20657CA1FC926B200412B7D /* MSIDTelemetryHttpEvent.m in Sources */,
 				58E2A1F824E47D610027A28A /* MSIDWebOpenBrowserResponseOperation.m in Sources */,
@@ -8102,6 +8111,7 @@
 				2392229E2432A65F009736C4 /* NSError+MSIDServerTelemetryError.m in Sources */,
 				600D199E20963B020004CD43 /* MSIDNTLMUIPrompt.m in Sources */,
 				235C2B022D6FAF7900DEFEFB /* MSIDSwitchBrowserResumeOperation.m in Sources */,
+				729358102DDFADE70001D03C /* MSIDNonceHttpRequest.m in Sources */,
 				235C2B032D6FAF7900DEFEFB /* MSIDSwitchBrowserOperation.m in Sources */,
 				B2C708732198C42200D917B8 /* MSIDLegacyBrokerResponseHandler.m in Sources */,
 				886F517029CCA84200F09471 /* MSIDCIAMAuthorityResolver.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -747,6 +747,9 @@
 		7293580E2DDFADDF0001D03C /* MSIDNonceHttpRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7293580D2DDFADC80001D03C /* MSIDNonceHttpRequest.h */; };
 		729358102DDFADE70001D03C /* MSIDNonceHttpRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */; };
 		729358112DDFADE70001D03C /* MSIDNonceHttpRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */; };
+		72D961AE2DE12F1F005DED66 /* MSIDCachedNonce.h in Headers */ = {isa = PBXBuildFile; fileRef = 72D961AD2DE12F19005DED66 /* MSIDCachedNonce.h */; };
+		72D961B02DE12F30005DED66 /* MSIDCachedNonce.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */; };
+		72D961B12DE12F30005DED66 /* MSIDCachedNonce.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */; };
 		740340B92460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */; };
 		740340BA2460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */; };
 		740340BB2460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */; };
@@ -2647,6 +2650,8 @@
 		729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceTokenRequestTest.m; sourceTree = "<group>"; };
 		7293580D2DDFADC80001D03C /* MSIDNonceHttpRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDNonceHttpRequest.h; sourceTree = "<group>"; };
 		7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceHttpRequest.m; sourceTree = "<group>"; };
+		72D961AD2DE12F19005DED66 /* MSIDCachedNonce.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCachedNonce.h; sourceTree = "<group>"; };
+		72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCachedNonce.m; sourceTree = "<group>"; };
 		740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCurrentRequestTelemetrySerializedItem.h; sourceTree = "<group>"; };
 		740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCurrentRequestTelemetrySerializedItem.m; sourceTree = "<group>"; };
 		74043F7C245CC84B00D3E7C1 /* MSIDCurrentRequestTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCurrentRequestTelemetryTests.m; sourceTree = "<group>"; };
@@ -4426,6 +4431,8 @@
 		9641B4FF1FCF3E1400AFA0EC /* cache */ = {
 			isa = PBXGroup;
 			children = (
+				72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */,
+				72D961AD2DE12F19005DED66 /* MSIDCachedNonce.h */,
 				B2C0747E246B70DC0008D701 /* crypto */,
 				609E74BA228CA3C2005E3FED /* metadata */,
 				B226D85B1FFB07840012BF8B /* token */,
@@ -6386,6 +6393,7 @@
 				580E25402719FD10003D1795 /* MSIDPrtHeader.h in Headers */,
 				23B39AB7209BC705000AA905 /* MSIDOpenIdProviderMetadata.h in Headers */,
 				1E707FE32407338000716148 /* MSIDBrokerOperationResponseHandling.h in Headers */,
+				72D961AE2DE12F1F005DED66 /* MSIDCachedNonce.h in Headers */,
 				23391BD62B17F2FD00EB121B /* MSIDBrowserNativeMessageSignOutRequest.h in Headers */,
 				238A04932089A3C800989EE0 /* MSIDHttpRequestTelemetry.h in Headers */,
 				B286B9C62389DE7B007833AD /* MSIDAccountMetadataCacheKey.h in Headers */,
@@ -7331,6 +7339,7 @@
 				232173EF2182B195009852C6 /* MSIDIntuneInMemoryCacheDataSource.m in Sources */,
 				239E3BC023E1004F00F7A50A /* MSIDClientSDKType.m in Sources */,
 				B20E3CAE1FC4F14B0029C097 /* MSIDDeviceId.m in Sources */,
+				72D961B12DE12F30005DED66 /* MSIDCachedNonce.m in Sources */,
 				600D19B720964D2F0004CD43 /* MSIDWorkPlaceJoinConstants.m in Sources */,
 				886F517129CCA84200F09471 /* MSIDCIAMAuthorityResolver.m in Sources */,
 				96F94A3520817C1A0034676C /* MSIDNTLMHandler.m in Sources */,
@@ -7980,6 +7989,7 @@
 				238E19E22086FE28004DF483 /* MSIDAADAuthorizationCodeRequest.m in Sources */,
 				B2964BE2205103920000BC95 /* MSIDTokenFilteringHelper.m in Sources */,
 				233E96EE22652B00007FCE2A /* MSIDDefaultDispatcher.m in Sources */,
+				72D961B02DE12F30005DED66 /* MSIDCachedNonce.m in Sources */,
 				B28BDA7B217E961F003E5670 /* MSIDB2COauth2Factory.m in Sources */,
 				B26CEB032367B3B9009E6E54 /* MSIDSystemWebViewControllerFactory.m in Sources */,
 				2370B5FB217FA5E400DEEBEA /* MSIDIntuneMAMResourcesCache.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -736,6 +736,14 @@
 		728D9E4628245DD7001D990F /* MSIDTestSecureEnclaveKeyPairGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 728D9E4528245DD7001D990F /* MSIDTestSecureEnclaveKeyPairGenerator.m */; };
 		728D9E4728245DD7001D990F /* MSIDTestSecureEnclaveKeyPairGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 728D9E4528245DD7001D990F /* MSIDTestSecureEnclaveKeyPairGenerator.m */; };
 		728D9E492824A323001D990F /* MSIDPkeyAuthHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23CA0C5E220A68D400768729 /* MSIDPkeyAuthHelperTests.m */; };
+		729357E82DD810CA0001D03C /* MSIDNonceTokenRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 729357E72DD810C70001D03C /* MSIDNonceTokenRequest.h */; };
+		729357EA2DD810D00001D03C /* MSIDNonceTokenRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 729357E92DD810CD0001D03C /* MSIDNonceTokenRequest.m */; };
+		729357EB2DD810D00001D03C /* MSIDNonceTokenRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 729357E92DD810CD0001D03C /* MSIDNonceTokenRequest.m */; };
+		729357ED2DDBCBA60001D03C /* MSIDNonceTokenRequestMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 729357EC2DDBCB930001D03C /* MSIDNonceTokenRequestMock.h */; };
+		729357EF2DDBCBAE0001D03C /* MSIDNonceTokenRequestMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 729357EE2DDBCBAB0001D03C /* MSIDNonceTokenRequestMock.m */; };
+		729357F02DDBCBAE0001D03C /* MSIDNonceTokenRequestMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 729357EE2DDBCBAB0001D03C /* MSIDNonceTokenRequestMock.m */; };
+		729357F32DDBD3F80001D03C /* MSIDNonceTokenRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */; };
+		729357F42DDBD3F80001D03C /* MSIDNonceTokenRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */; };
 		740340B92460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */; };
 		740340BA2460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */; };
 		740340BB2460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */; };
@@ -2629,6 +2637,11 @@
 		728209D32702AE9300B5F018 /* MSIDBackgroundTaskManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBackgroundTaskManagerTests.m; sourceTree = "<group>"; };
 		728D9E4528245DD7001D990F /* MSIDTestSecureEnclaveKeyPairGenerator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTestSecureEnclaveKeyPairGenerator.m; sourceTree = "<group>"; };
 		728D9E4828247D4C001D990F /* MSIDTestSecureEnclaveKeyPairGenerator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTestSecureEnclaveKeyPairGenerator.h; sourceTree = "<group>"; };
+		729357E72DD810C70001D03C /* MSIDNonceTokenRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDNonceTokenRequest.h; sourceTree = "<group>"; };
+		729357E92DD810CD0001D03C /* MSIDNonceTokenRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceTokenRequest.m; sourceTree = "<group>"; };
+		729357EC2DDBCB930001D03C /* MSIDNonceTokenRequestMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDNonceTokenRequestMock.h; sourceTree = "<group>"; };
+		729357EE2DDBCBAB0001D03C /* MSIDNonceTokenRequestMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceTokenRequestMock.m; sourceTree = "<group>"; };
+		729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceTokenRequestTest.m; sourceTree = "<group>"; };
 		740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCurrentRequestTelemetrySerializedItem.h; sourceTree = "<group>"; };
 		740340B82460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCurrentRequestTelemetrySerializedItem.m; sourceTree = "<group>"; };
 		74043F7C245CC84B00D3E7C1 /* MSIDCurrentRequestTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCurrentRequestTelemetryTests.m; sourceTree = "<group>"; };
@@ -3749,6 +3762,8 @@
 		23642AB32187D88C00F97009 /* mocks */ = {
 			isa = PBXGroup;
 			children = (
+				729357EE2DDBCBAB0001D03C /* MSIDNonceTokenRequestMock.m */,
+				729357EC2DDBCB930001D03C /* MSIDNonceTokenRequestMock.h */,
 				23FB5C32225585E6002BF1EB /* MSIDClaimsRequestMock.h */,
 				23FB5C33225585E6002BF1EB /* MSIDClaimsRequestMock.m */,
 				23642AB52187D88C00F97009 /* MSIDAuthorityMock.h */,
@@ -5056,6 +5071,8 @@
 		B2AF1D29218BCDEF0080C1A0 /* requests */ = {
 			isa = PBXGroup;
 			children = (
+				729357E92DD810CD0001D03C /* MSIDNonceTokenRequest.m */,
+				729357E72DD810C70001D03C /* MSIDNonceTokenRequest.h */,
 				B2C708A0219A55CB00D917B8 /* sdk */,
 				B2C7087F2198DE0000D917B8 /* broker */,
 				B28D90BC218FE9FA00E230D6 /* result */,
@@ -5662,6 +5679,7 @@
 		D6DA89731FBA6A4E004C56C7 /* tests */ = {
 			isa = PBXGroup;
 			children = (
+				729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */,
 				A0410E4F25E88B5E004D80FD /* MSIDThrottlingMetaDataTest.m */,
 				A0410E1925E87E1A004D80FD /* MSIDThrottlingModelNonRecoverableServerError.m */,
 				A0410E0725E81C5D004D80FD /* MSIDThrottlingModel429Test.m */,
@@ -6121,6 +6139,7 @@
 				B251CC202040F6C6005E0179 /* MSIDDefaultCredentialCacheKey.h in Headers */,
 				B286B9C02389DE38007833AD /* MSIDPrimaryRefreshToken.h in Headers */,
 				9686480420C7711400EF7E73 /* MSIDAADV1WebviewFactory.h in Headers */,
+				729357E82DD810CA0001D03C /* MSIDNonceTokenRequest.h in Headers */,
 				58BC23BC271F6B9D008A77BE /* MSIDSSOExtensionGetDataBaseRequest.h in Headers */,
 				580E254A271A0236003D1795 /* MSIDBrokerOperationGetSsoCookiesResponse.h in Headers */,
 				B286B9A72389DD2E007833AD /* MSIDAADOAuthEmbeddedWebviewController.h in Headers */,
@@ -6426,6 +6445,7 @@
 				2A366B7B2D9EF78600774DD4 /* MSIDXpcProviderCacheMock.h in Headers */,
 				B4C8501829E79E250055B0D3 /* MSIDTestURLSessionUploadTask.h in Headers */,
 				D626FFF91FBD200A00EE4487 /* MSIDTestURLSession.h in Headers */,
+				729357ED2DDBCBA60001D03C /* MSIDNonceTokenRequestMock.h in Headers */,
 				B2E4A07224DDE56A007CE642 /* MSIDTestCacheAccessorHelper.h in Headers */,
 				B245C2F92106ABDC00CD5A52 /* MSIDTestIdTokenUtil.h in Headers */,
 				1E0B145024CF5ADD00825143 /* MSIDAssymetricKeyPair+Test.h in Headers */,
@@ -7014,6 +7034,7 @@
 				B286B9F12389F866007833AD /* MSIDWebviewFactoryTests.m in Sources */,
 				B252913B2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m in Sources */,
 				B2BE923121A0EFB100F5AB8C /* MSIDDefaultTokenRequestProviderTests.m in Sources */,
+				729357F42DDBD3F80001D03C /* MSIDNonceTokenRequestTest.m in Sources */,
 				23FB5C20225516FB002BF1EB /* MSIDClaimsRequestTests.m in Sources */,
 				656E666129BD81B000368F0A /* MSIDAADEndpointProviderTests.m in Sources */,
 				1E65C47B2177DC8B00694293 /* MSIDAppMetadataCacheKeyTests.m in Sources */,
@@ -7254,6 +7275,7 @@
 				B2C7089421991CED00D917B8 /* MSIDAADV1BrokerResponse.m in Sources */,
 				B229841629A9C2930005F83D /* MSIDExternalSSOContext.m in Sources */,
 				B2C07483246B70F70008D701 /* MSIDAssymetricKeyPair.m in Sources */,
+				729357EB2DD810D00001D03C /* MSIDNonceTokenRequest.m in Sources */,
 				B266903F243706DB00FB0117 /* MSIDBrokerBrowserOperationResponse.m in Sources */,
 				B2AF1D3A218BCF140080C1A0 /* MSIDRequestControllerFactory.m in Sources */,
 				B28BDAC1221F7F230055FFE6 /* MSIDCBAWebAADAuthResponse.m in Sources */,
@@ -7720,6 +7742,7 @@
 				B280800B204CD81400944D89 /* MSIDLegacyCacheKeyTests.m in Sources */,
 				B210F44F1FDDF5D2005A8F76 /* MSIDClientInfoTests.m in Sources */,
 				9668B6F82148796A0039AB0A /* MSIDDataExtensionsTests.m in Sources */,
+				729357F32DDBD3F80001D03C /* MSIDNonceTokenRequestTest.m in Sources */,
 				B2936F7D20ABF9570050C585 /* MSIDLegacyRefreshTokenTests.m in Sources */,
 				B253BD7A20487C8A00D07F31 /* MSIDLegacyTokenCacheIntegrationTests.m in Sources */,
 				B2544EEC21684B2B00B4C108 /* MSIDCacheSchemaValidationTests.m in Sources */,
@@ -7789,6 +7812,7 @@
 				B2BE925421A24B8200F5AB8C /* MSIDTestTokenRequestProvider.m in Sources */,
 				23FB5C3A225588D0002BF1EB /* MSIDClaimsRequestMock.m in Sources */,
 				B217861A23A57EDC00839CE8 /* MSIDAuthorizationControllerMock.m in Sources */,
+				729357EF2DDBCBAE0001D03C /* MSIDNonceTokenRequestMock.m in Sources */,
 				B2BE926921A25F8300F5AB8C /* MSIDTestBrokerResponseHandler.m in Sources */,
 				583BFCB624D908980035B901 /* MSIDTestBundle.m in Sources */,
 				58D1514324A6888D001DD18A /* MSIDHttpRequest+OverrideCacheSave.m in Sources */,
@@ -7846,6 +7870,7 @@
 				B2E4A06E24DDE559007CE642 /* MSIDTestContext.m in Sources */,
 				B245C2FB2106ABDC00CD5A52 /* MSIDTestIdTokenUtil.m in Sources */,
 				B2E4A07124DDE568007CE642 /* MSIDTestCacheAccessorHelper.m in Sources */,
+				729357F02DDBCBAE0001D03C /* MSIDNonceTokenRequestMock.m in Sources */,
 				B233F8BC219CE03F00DC90E3 /* MSIDTestURLResponse+Util.m in Sources */,
 				B2968CA922F67B4C005AFC33 /* MSIDTestLocalInteractiveController.m in Sources */,
 				B2BE923D21A0FD2B00F5AB8C /* MSIDTestSwizzle.m in Sources */,
@@ -8046,6 +8071,7 @@
 				23BDA67A1FCE693800FE14BE /* MSIDKeychainUtil.m in Sources */,
 				23AB37EA235151E5003A6E6C /* ASAuthorizationSingleSignOnProvider+MSIDExtensions.m in Sources */,
 				B2AF1D4B218BD12E0080C1A0 /* MSIDInteractiveRequestParameters.m in Sources */,
+				729357EA2DD810D00001D03C /* MSIDNonceTokenRequest.m in Sources */,
 				B2C707FE2192530E00D917B8 /* MSIDDefaultSilentTokenRequest.m in Sources */,
 				23B5DF77234030B2002C530F /* MSIDRequestParameters+Broker.m in Sources */,
 				23B37D1B20C9ECFB0018722F /* MSIDCache.m in Sources */,

--- a/IdentityCore/src/cache/MSIDCachedNonce.h
+++ b/IdentityCore/src/cache/MSIDCachedNonce.h
@@ -22,19 +22,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-@class MSIDRequestParameters;
-typedef void (^MSIDNonceRequestCompletion)(NSString * _Nullable resultNonce, NSError * _Nullable error);
-
 NS_ASSUME_NONNULL_BEGIN
+@interface MSIDCachedNonce : NSObject
 
-@interface MSIDNonceTokenRequest : NSObject
+@property (nonatomic, readonly, nonnull) NSString *nonce;
+@property (nonatomic, readonly, nonnull) NSDate *cachedDate;
 
-@property (nonatomic, readonly, nonnull) MSIDRequestParameters *requestParameters;
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDNonceRequestCompletion)completionBlock;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)initWithNonce:(nonnull NSString *)nonce;
 
 @end
-
 NS_ASSUME_NONNULL_END
+

--- a/IdentityCore/src/cache/MSIDCachedNonce.m
+++ b/IdentityCore/src/cache/MSIDCachedNonce.m
@@ -22,19 +22,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-@class MSIDRequestParameters;
-typedef void (^MSIDNonceRequestCompletion)(NSString * _Nullable resultNonce, NSError * _Nullable error);
+#import "MSIDCachedNonce.h"
+@implementation MSIDCachedNonce
 
-NS_ASSUME_NONNULL_BEGIN
-
-@interface MSIDNonceTokenRequest : NSObject
-
-@property (nonatomic, readonly, nonnull) MSIDRequestParameters *requestParameters;
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDNonceRequestCompletion)completionBlock;
-
+- (instancetype)initWithNonce:(NSString *)nonce
+{
+    self = [super init];
+    if (self)
+    {
+        _nonce = nonce;
+        _cachedDate = [NSDate date];
+    }
+    return self;
+}
 @end
-
-NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/network/request/MSIDNonceHttpRequest.h
+++ b/IdentityCore/src/network/request/MSIDNonceHttpRequest.h
@@ -20,34 +20,14 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.  
+// THE SOFTWARE.
 
-@class MSIDRequestParameters;
+#import "MSIDHttpRequest.h"
+
 NS_ASSUME_NONNULL_BEGIN
-@interface MSIDCachedNonce : NSObject
-
-@property (nonatomic, readonly, nonnull) NSString *nonce;
-@property (nonatomic, readonly, nonnull) NSDate *cachedDate;
-
+@interface MSIDNonceHttpRequest : MSIDHttpRequest
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-- (instancetype)initWithNonce:(nonnull NSString *)nonce;
-
+- (instancetype) initWithTokenEndpoint:(NSURL *)tokenEndpoint context:(id<MSIDRequestContext>)context;
 @end
-NS_ASSUME_NONNULL_END
-
-typedef void (^MSIDNonceRequestCompletion)(NSString * _Nullable resultNonce, NSError * _Nullable error);
-
-NS_ASSUME_NONNULL_BEGIN
-
-@interface MSIDNonceTokenRequest : NSObject
-
-@property (nonatomic, readonly, nonnull) MSIDRequestParameters *requestParameters;
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDNonceRequestCompletion)completionBlock;
-
-@end
-
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/network/request/MSIDNonceHttpRequest.m
+++ b/IdentityCore/src/network/request/MSIDNonceHttpRequest.m
@@ -20,34 +20,34 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.  
+// THE SOFTWARE.
+#import "MSIDNonceHttpRequest.h"
+#import "MSIDAADRequestConfigurator.h"
 
-@class MSIDRequestParameters;
-NS_ASSUME_NONNULL_BEGIN
-@interface MSIDCachedNonce : NSObject
+@implementation MSIDNonceHttpRequest
 
-@property (nonatomic, readonly, nonnull) NSString *nonce;
-@property (nonatomic, readonly, nonnull) NSDate *cachedDate;
+- (nonnull instancetype)initWithTokenEndpoint:(nonnull NSURL *)tokenEndpoint context:(nonnull id<MSIDRequestContext>)context
+{
+    self = [super init];
+    if (self)
+    {
+        if (!tokenEndpoint)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"No endpoint provided to get nonce from!");
+            NSParameterAssert(tokenEndpoint);
+            return nil;
+        }
+        NSMutableURLRequest *urlRequest = [NSMutableURLRequest new];
+        urlRequest.URL = tokenEndpoint;
+        urlRequest.HTTPMethod = @"POST";
+        _urlRequest = urlRequest;
+        
+        __auto_type requestConfigurator = [MSIDAADRequestConfigurator new];
+        [requestConfigurator configure:self];
+        _parameters = @{MSID_OAUTH2_GRANT_TYPE : @"srv_challenge"};
+    }
 
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-- (instancetype)initWithNonce:(nonnull NSString *)nonce;
+    return self;
+}
 
 @end
-NS_ASSUME_NONNULL_END
-
-typedef void (^MSIDNonceRequestCompletion)(NSString * _Nullable resultNonce, NSError * _Nullable error);
-
-NS_ASSUME_NONNULL_BEGIN
-
-@interface MSIDNonceTokenRequest : NSObject
-
-@property (nonatomic, readonly, nonnull) MSIDRequestParameters *requestParameters;
-
-- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters;
-
-- (void)executeRequestWithCompletion:(nonnull MSIDNonceRequestCompletion)completionBlock;
-
-@end
-
-NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/requests/MSIDNonceTokenRequest.h
+++ b/IdentityCore/src/requests/MSIDNonceTokenRequest.h
@@ -1,0 +1,53 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+@class MSIDRequestParameters;
+const static NSUInteger kMSIDNonceLifetimeInSeconds = 180;
+
+@interface MSIDCachedNonce : NSObject
+
+@property (nonatomic, readonly, nonnull) NSString *nonce;
+@property (nonatomic, readonly, nonnull) NSDate *cachedDate;
+
+- (_Nonnull instancetype)init NS_UNAVAILABLE;
++ (_Nonnull instancetype)new NS_UNAVAILABLE;
+- (_Nonnull instancetype)initWithNonce:(nonnull NSString *)nonce;
+
+@end
+
+typedef void (^MSIDNonceRequestCompletion)(NSString * _Nullable resultNonce, NSError * _Nullable error);
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDNonceTokenRequest : NSObject
+
+@property (nonatomic, readonly, nonnull) MSIDRequestParameters *requestParameters;
+
+- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters;
+
+- (void)executeRequestWithCompletion:(nonnull MSIDNonceRequestCompletion)completionBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/requests/MSIDNonceTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDNonceTokenRequest.m
@@ -1,0 +1,207 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import "MSIDNonceTokenRequest.h"
+#import "MSIDRequestParameters.h"
+#import "MSIDAuthority.h"
+#import "MSIDOpenIdProviderMetadata.h"
+#import "MSIDAccountIdentifier.h"
+#import "MSIDHttpRequest.h"
+#import "MSIDAADRequestConfigurator.h"
+
+@implementation MSIDNonceTokenRequest
+
+- (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
+{
+    self = [super init];
+    
+    if (self)
+    {
+        _requestParameters = parameters;
+    }
+    
+    return self;
+}
+
+- (void)executeRequestWithCompletion:(nonnull MSIDNonceRequestCompletion)completionBlock
+{
+    MSIDCachedNonce *cachedNonce = [self.class getCachedNonceForKey:_requestParameters.authority.environment];
+    if (cachedNonce)
+    {
+        completionBlock(cachedNonce.nonce, nil);
+        return;
+    }
+
+    if (_requestParameters.authority.metadata.tokenEndpoint)
+    {
+        [self executeNetworkRequestWithCompletion:completionBlock];
+        return;
+    }
+    
+    [_requestParameters.authority resolveAndValidate:YES
+                                   userPrincipalName:_requestParameters.accountIdentifier.displayableId
+                                             context:_requestParameters
+                                     completionBlock:^(NSURL __unused *openIdConfigurationEndpoint, BOOL __unused validated, NSError *error)
+    {
+        if (error)
+        {
+            completionBlock(nil, error);
+            return;
+        }
+        
+        [self->_requestParameters.authority loadOpenIdMetadataWithContext:self->_requestParameters
+                                                    completionBlock:^(__unused MSIDOpenIdProviderMetadata *metadata, NSError *openIdError)
+         {
+             
+             if (openIdError)
+             {
+                 completionBlock(nil, openIdError);
+                 return;
+             }
+             
+             [self executeNetworkRequestWithCompletion:completionBlock];
+         }];
+    }];
+}
+
+- (void)executeNetworkRequestWithCompletion:(nonnull MSIDNonceRequestCompletion)completionBlock
+{
+    MSIDHttpRequest *nonceRequest = [self configureNonceNetworkRequestForEndpoint:self.requestParameters.tokenEndpoint context:self.requestParameters];
+    [nonceRequest sendWithBlock:^(NSDictionary *response, NSError *error) {
+        
+        if (error)
+        {
+            if (completionBlock) completionBlock(nil, error);
+            return;
+        }
+        
+        if (![response isKindOfClass:[NSDictionary class]])
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, self.requestParameters, @"Unexpected nonce response received");
+            NSError *nwError = MSIDCreateError(MSIDErrorDomain, MSIDErrorServerInvalidResponse, @"Unexpected nonce response", nil, nil, nil, nil, nil, YES);
+            if (completionBlock) completionBlock(nil, nwError);
+            return;
+        }
+        
+        NSString *nonce = [response msidStringObjectForKey:@"Nonce"];
+        
+        if ([NSString msidIsStringNilOrBlank:nonce])
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, self.requestParameters, @"Didn't receive valid nonce in response");
+            NSError *nwError = MSIDCreateError(MSIDErrorDomain, MSIDErrorServerInvalidResponse, @"Didn't receive valid nonce in response", nil, nil, nil, nil, nil, YES);
+            if (completionBlock) completionBlock(nil, nwError);
+            return;
+        }
+        
+        [self.class cacheNonceForKey:self.requestParameters.authority.environment nonce:nonce];
+        if (completionBlock)
+        {
+            completionBlock(nonce, nil);
+        }
+    }];
+}
+
+- (MSIDHttpRequest *)configureNonceNetworkRequestForEndpoint:(NSURL *)endpoint context:(id<MSIDRequestContext>)context
+{
+    if (!endpoint)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"No endpoint provided to get nonce from!");
+        NSParameterAssert(endpoint);
+        return nil;
+    }
+    
+    MSIDHttpRequest *request = [[MSIDHttpRequest alloc] init];
+    NSMutableURLRequest *urlRequest = [NSMutableURLRequest new];
+    urlRequest.URL = endpoint;
+    urlRequest.HTTPMethod = @"POST";
+    request.urlRequest = urlRequest;
+    
+    __auto_type requestConfigurator = [MSIDAADRequestConfigurator new];
+    [requestConfigurator configure:request];
+    
+    NSMutableDictionary *parameters = [NSMutableDictionary new];
+    
+    parameters[MSID_OAUTH2_GRANT_TYPE] = @"srv_challenge";
+    [parameters addEntriesFromDictionary:parameters];
+    request.parameters = parameters;
+    request.urlRequest = urlRequest;
+    return request;
+}
+
+
+#pragma mark - Cache
+
++ (MSIDCache *)nonceCache
+{
+    static MSIDCache *k_nonceCache;
+    static dispatch_once_t once_token;
+    dispatch_once(&once_token, ^{
+        k_nonceCache = [MSIDCache new];
+    });
+    
+    return k_nonceCache;
+}
+
++ (nullable MSIDCachedNonce *)getCachedNonceForKey:(NSString *)key
+{
+    MSIDCache *cache = [self.class nonceCache];
+    MSIDCachedNonce *cachedNonce = [cache objectForKey:key];
+    if (cachedNonce)
+    {
+        NSTimeInterval ti = [[NSDate date] timeIntervalSinceDate:cachedNonce.cachedDate];
+        if (ti > 0 && ti < kMSIDNonceLifetimeInSeconds)
+        {
+            return cachedNonce;
+        }
+    }
+    
+    return nil;
+}
+
++ (BOOL)cacheNonceForKey:(NSString *)key nonce:(NSString *)nonce
+{
+    if (!nonce || !key)
+    {
+        return NO;
+    }
+    
+    MSIDCachedNonce *cachedNonce = [[MSIDCachedNonce alloc] initWithNonce:nonce];
+    [self.class.nonceCache setObject:cachedNonce forKey:key];
+    return YES;
+}
+@end
+
+@implementation MSIDCachedNonce
+
+- (instancetype)initWithNonce:(NSString *)nonce
+{
+    self = [super init];
+    if (self)
+    {
+        _nonce = nonce;
+        _cachedDate = [NSDate date];
+    }
+    return self;
+}
+@end

--- a/IdentityCore/src/requests/MSIDNonceTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDNonceTokenRequest.m
@@ -28,6 +28,7 @@
 #import "MSIDOpenIdProviderMetadata.h"
 #import "MSIDAccountIdentifier.h"
 #import "MSIDNonceHttpRequest.h"
+#import "MSIDCachedNonce.h"
 
 const static NSUInteger kMSIDNonceLifetimeInSeconds = 180;
 @implementation MSIDNonceTokenRequest
@@ -160,19 +161,5 @@ const static NSUInteger kMSIDNonceLifetimeInSeconds = 180;
     MSIDCachedNonce *cachedNonce = [[MSIDCachedNonce alloc] initWithNonce:nonce];
     [self.class.nonceCache setObject:cachedNonce forKey:key];
     return YES;
-}
-@end
-
-@implementation MSIDCachedNonce
-
-- (instancetype)initWithNonce:(NSString *)nonce
-{
-    self = [super init];
-    if (self)
-    {
-        _nonce = nonce;
-        _cachedDate = [NSDate date];
-    }
-    return self;
 }
 @end

--- a/IdentityCore/src/requests/MSIDNonceTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDNonceTokenRequest.m
@@ -35,12 +35,10 @@
 - (nullable instancetype)initWithRequestParameters:(nonnull MSIDRequestParameters *)parameters
 {
     self = [super init];
-    
     if (self)
     {
         _requestParameters = parameters;
     }
-    
     return self;
 }
 
@@ -88,8 +86,8 @@
 - (void)executeNetworkRequestWithCompletion:(nonnull MSIDNonceRequestCompletion)completionBlock
 {
     MSIDHttpRequest *nonceRequest = [self configureNonceNetworkRequestForEndpoint:self.requestParameters.tokenEndpoint context:self.requestParameters];
-    [nonceRequest sendWithBlock:^(NSDictionary *response, NSError *error) {
-        
+    [nonceRequest sendWithBlock:^(NSDictionary *response, NSError *error)
+    {
         if (error)
         {
             if (completionBlock) completionBlock(nil, error);

--- a/IdentityCore/tests/MSIDNonceTokenRequestTest.m
+++ b/IdentityCore/tests/MSIDNonceTokenRequestTest.m
@@ -44,8 +44,18 @@
 
 - (void)setUp
 {
+    [super setUp];
     MSIDCache *nonceCache = [MSIDNonceTokenRequest.class nonceCache];
     [nonceCache removeAllObjects];
+    [MSIDTestURLSession clearResponses];
+}
+
+-(void)tearDown
+{
+    [super tearDown];
+    [MSIDAADNetworkConfiguration.defaultConfiguration setValue:nil forKey:@"aadApiVersion"];
+    [MSIDTestURLSession clearResponses];
+    [MSIDAuthority.openIdConfigurationCache removeAllObjects];
 }
 
 - (void)testExecuteRequestWithCompletion_whenCachedNonceExists_shouldReturnCachedNonce
@@ -307,15 +317,14 @@
     
     MSIDNonceTokenRequestMock *request = [[MSIDNonceTokenRequestMock alloc] initWithRequestParameters:parameters];
     request.openIdMetadataToUpdateInAuthority = parameters.authority.metadata;
-    request.shouldLoadopenIdMetadata = YES;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire new Nonce."];
     
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:parameters.authority.url.absoluteString];
-    discoveryResponse->_requestHeaders = [self mockedRequestHeaders];
+    discoveryResponse.requestHeaders = [self mockedRequestHeaders];
     [MSIDTestURLSession addResponse:discoveryResponse];
 
     MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:parameters.authority.url.absoluteString];
-    oidcResponse->_requestHeaders = [self mockedRequestHeaders];
+    oidcResponse.requestHeaders = [self mockedRequestHeaders];
     [MSIDTestURLSession addResponse:oidcResponse];
     
     request.openIdMetadataToUpdateInAuthority.tokenEndpoint = nil;

--- a/IdentityCore/tests/MSIDNonceTokenRequestTest.m
+++ b/IdentityCore/tests/MSIDNonceTokenRequestTest.m
@@ -96,6 +96,7 @@
     
     [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
         
+        XCTAssertNotNil(resultNonce);
         XCTAssertNil(error);
         XCTAssertEqualObjects(resultNonce, @"1234_nonce_abcd");
         
@@ -128,6 +129,7 @@
     
     [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
         
+        XCTAssertNil(resultNonce);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Could not get nonce from server.");
         
@@ -159,6 +161,7 @@
     
     [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
         
+        XCTAssertNil(resultNonce);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Didn't receive valid nonce in response");
         
@@ -176,6 +179,7 @@
     
     [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
         
+        XCTAssertNil(resultNonce);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Response is not of the expected type: NSDictionary.");
         
@@ -193,6 +197,7 @@
     
     [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
         
+        XCTAssertNil(resultNonce);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Didn't receive valid nonce in response");
         

--- a/IdentityCore/tests/MSIDNonceTokenRequestTest.m
+++ b/IdentityCore/tests/MSIDNonceTokenRequestTest.m
@@ -36,6 +36,7 @@
 #import "NSDictionary+MSIDTestUtil.h"
 #import "MSIDTestURLResponse+Util.h"
 #import "MSIDAADNetworkConfiguration.h"
+#import "MSIDCachedNonce.h"
 
 @interface MSIDNonceTokenRequestTest: XCTestCase
 @end

--- a/IdentityCore/tests/MSIDNonceTokenRequestTest.m
+++ b/IdentityCore/tests/MSIDNonceTokenRequestTest.m
@@ -1,0 +1,363 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import "XCTest/XCTest.h"
+#import "MSIDNonceTokenRequestMock.h"
+#import "MSIDInteractiveTokenRequestParameters.h"
+#import "MSIDTestURLResponse.h"
+#import "MSIDCache.h"
+#import "MSIDInteractiveTokenRequestParameters.h"
+#import "MSIDOpenIdProviderMetadata.h"
+#import "MSIDAuthority+Internal.h"
+#import "MSIDAADAuthority.h"
+#import "MSIDTestURLSession.h"
+#import "MSIDTestURLResponse.h"
+#import "NSDictionary+MSIDTestUtil.h"
+#import "MSIDTestURLResponse+Util.h"
+#import "MSIDAADNetworkConfiguration.h"
+
+@interface MSIDNonceTokenRequestTest: XCTestCase
+@end
+
+@implementation MSIDNonceTokenRequestTest
+
+- (void)setUp
+{
+    MSIDCache *nonceCache = [MSIDNonceTokenRequest.class nonceCache];
+    [nonceCache removeAllObjects];
+}
+
+- (void)testExecuteRequestWithCompletion_whenCachedNonceExists_shouldReturnCachedNonce
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self testRequestParameters];
+    
+    MSIDCachedNonce *cachedNonce = [[MSIDCachedNonce alloc] initWithNonce:@"my-nonce"];
+    MSIDCache *nonceCache = [MSIDNonceTokenRequest.class nonceCache];
+    [nonceCache setObject:cachedNonce forKey:parameters.authority.environment];
+    
+    MSIDNonceTokenRequest *request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Return cached Nonce."];
+    
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
+        
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(resultNonce, @"my-nonce");
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+
+- (void)testExecuteRequestWithCompletion_whenNoCachedNonceExists_shouldGetNonceAndCacheIt
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self testRequestParameters];
+    
+    NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL new] statusCode:200 HTTPVersion:nil headerFields:nil];
+    MSIDTestURLResponse *nonceResponse = [MSIDTestURLResponse request:parameters.authority.metadata.tokenEndpoint
+                                                              reponse:httpResponse];
+    
+    
+    nonceResponse->_requestHeaders = [self mockedRequestHeaders];
+    
+    __auto_type nonceResponseJson = @{
+        @"Nonce": @"1234_nonce_abcd"
+    };
+    
+    [nonceResponse setResponseJSON:nonceResponseJson];
+    [MSIDTestURLSession addResponse:nonceResponse];
+    
+    MSIDNonceTokenRequest *request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire Nonce."];
+    
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
+        
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(resultNonce, @"1234_nonce_abcd");
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    MSIDCache *nonceCache = [MSIDNonceTokenRequest.class nonceCache];
+    XCTAssertNotNil(nonceCache);
+    MSIDCachedNonce *cachedNonce = [nonceCache objectForKey:parameters.authority.environment];
+    XCTAssertEqualObjects(cachedNonce.nonce, @"1234_nonce_abcd");
+}
+
+- (void)testExecuteRequestWithCompletion_whenNoCachedNonceExists_whenNonceResponseReturnsError
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self testRequestParameters];
+    NSError *nonceError = [[NSError alloc] initWithDomain:@"Test domain" code:-1 userInfo:@{@"MSIDErrorDescriptionKey": @"Could not get nonce from server."}];
+    
+    MSIDTestURLResponse *nonceResponse = [MSIDTestURLResponse request:parameters.authority.metadata.tokenEndpoint
+                                                              respondWithError:nonceError];
+    
+    
+    nonceResponse->_requestHeaders = [self mockedRequestHeaders];
+    [MSIDTestURLSession addResponse:nonceResponse];
+    
+    MSIDNonceTokenRequest *request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire Nonce."];
+    
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
+        
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Could not get nonce from server.");
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testExecuteRequestWithCompletion_whenNoCachedNonceExists_InvalidNonceObtainedFromServer
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self testRequestParameters];
+    
+    NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL new] statusCode:200 HTTPVersion:nil headerFields:nil];
+    MSIDTestURLResponse *nonceResponse = [MSIDTestURLResponse request:parameters.authority.metadata.tokenEndpoint
+                                                              reponse:httpResponse];
+    
+    
+    nonceResponse->_requestHeaders = [self mockedRequestHeaders];
+    
+    __auto_type nonceResponseJson = @{};
+    
+    [nonceResponse setResponseJSON:nonceResponseJson];
+    [MSIDTestURLSession addResponse:nonceResponse];
+    
+    MSIDNonceTokenRequest *request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire Nonce for invalid nonce."];
+    
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
+        
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Didn't receive valid nonce in response");
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    [nonceResponse setResponseJSON:@[]];
+    [MSIDTestURLSession addResponse:nonceResponse];
+    
+    request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
+    
+    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Acquire Nonce for invalid nonce."];
+    
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
+        
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Response is not of the expected type: NSDictionary.");
+        
+        [expectation1 fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    [nonceResponse setResponseJSON:@{@"nonce": @""}];
+    [MSIDTestURLSession addResponse:nonceResponse];
+    
+    request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
+    
+    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Acquire Nonce for invalid nonce."];
+    
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
+        
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Didn't receive valid nonce in response");
+        
+        [expectation2 fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testExecuteRequestWithCompletion_whenExpiredCachedNonce_shouldGetNewNonceAndCacheIt
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self testRequestParameters];
+    
+    MSIDCachedNonce *cachedNonce = [[MSIDCachedNonce alloc] initWithNonce:@"my-nonce"];
+    [cachedNonce setValue:[[NSDate new] dateByAddingTimeInterval:-200] forKey:@"cachedDate"]; // Expired nonce
+    MSIDCache *nonceCache = [MSIDNonceTokenRequest.class nonceCache];
+    [nonceCache setObject:cachedNonce forKey:parameters.authority.environment];
+    
+    NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL new] statusCode:200 HTTPVersion:nil headerFields:nil];
+    MSIDTestURLResponse *nonceResponse = [MSIDTestURLResponse request:parameters.authority.metadata.tokenEndpoint
+                                                              reponse:httpResponse];
+    
+    nonceResponse->_requestHeaders = [self mockedRequestHeaders];
+    
+    __auto_type nonceResponseJson = @{
+        @"Nonce": @"1234_nonce_abcd"
+    };
+    
+    [nonceResponse setResponseJSON:nonceResponseJson];
+    [MSIDTestURLSession addResponse:nonceResponse];
+    
+    MSIDNonceTokenRequest *request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire new Nonce."];
+    
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
+        
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(resultNonce, @"1234_nonce_abcd");
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    MSIDCachedNonce *newCachedNonce = [nonceCache objectForKey:parameters.authority.environment];
+    XCTAssertEqualObjects(newCachedNonce.nonce, @"1234_nonce_abcd");
+}
+
+- (void)testExecuteRequestWithCompletion_whenCachedNonceSetInFuture_shouldGetNewNonceAndCacheIt
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self testRequestParameters];
+    
+    MSIDCachedNonce *cachedNonce = [[MSIDCachedNonce alloc] initWithNonce:@"my-nonce"];
+    [cachedNonce setValue:[[NSDate new] dateByAddingTimeInterval:300] forKey:@"cachedDate"]; // Nonce incorrectly cached in the future
+    MSIDCache *nonceCache = [MSIDNonceTokenRequest.class nonceCache];
+    [nonceCache setObject:cachedNonce forKey:parameters.authority.environment];
+    
+    NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL new] statusCode:200 HTTPVersion:nil headerFields:nil];
+    MSIDTestURLResponse *nonceResponse = [MSIDTestURLResponse request:parameters.authority.metadata.tokenEndpoint
+                                                              reponse:httpResponse];
+    
+    nonceResponse->_requestHeaders = [self mockedRequestHeaders];
+    
+    __auto_type nonceResponseJson = @{
+        @"Nonce": @"1234_nonce_abcd"
+    };
+    
+    [nonceResponse setResponseJSON:nonceResponseJson];
+    [MSIDTestURLSession addResponse:nonceResponse];
+    
+    MSIDNonceTokenRequest *request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire new Nonce."];
+    
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
+        
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(resultNonce, @"1234_nonce_abcd");
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    MSIDCachedNonce *newCachedNonce = [nonceCache objectForKey:parameters.authority.environment];
+    XCTAssertEqualObjects(newCachedNonce.nonce, @"1234_nonce_abcd");
+}
+
+- (void)testExecuteRequestWithCompletion_whenOpenIdMetadataIsNotLoaded
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self testRequestParameters];
+    NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL new] statusCode:200 HTTPVersion:nil headerFields:nil];
+    MSIDTestURLResponse *nonceResponse = [MSIDTestURLResponse request:parameters.authority.metadata.tokenEndpoint
+                                                              reponse:httpResponse];
+    
+    nonceResponse->_requestHeaders = [self mockedRequestHeaders];
+    
+    __auto_type nonceResponseJson = @{
+        @"Nonce": @"1234_nonce_abcd"
+    };
+    
+    [MSIDAADNetworkConfiguration.defaultConfiguration setValue:@"v2.0" forKey:@"aadApiVersion"];
+    
+    [nonceResponse setResponseJSON:nonceResponseJson];
+    [MSIDTestURLSession addResponse:nonceResponse];
+    
+    MSIDNonceTokenRequestMock *request = [[MSIDNonceTokenRequestMock alloc] initWithRequestParameters:parameters];
+    request.openIdMetadataToUpdateInAuthority = parameters.authority.metadata;
+    request.shouldLoadopenIdMetadata = YES;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire new Nonce."];
+    
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:parameters.authority.url.absoluteString];
+    discoveryResponse->_requestHeaders = [self mockedRequestHeaders];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:parameters.authority.url.absoluteString];
+    oidcResponse->_requestHeaders = [self mockedRequestHeaders];
+    [MSIDTestURLSession addResponse:oidcResponse];
+    
+    request.openIdMetadataToUpdateInAuthority.tokenEndpoint = nil;
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
+        
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(resultNonce, @"1234_nonce_abcd");
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+#pragma mark - Utils
+
+- (MSIDInteractiveTokenRequestParameters *)testRequestParameters
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [MSIDInteractiveTokenRequestParameters new];
+    parameters.authority = [[MSIDAADAuthority alloc] initWithURL:[NSURL URLWithString:@"https://login.microsoftonline.com/1234567"] rawTenant:nil context:nil error:nil];
+    parameters.authority.metadata = [MSIDOpenIdProviderMetadata new];
+    parameters.authority.metadata.tokenEndpoint = [[NSURL alloc] initWithString:@"https://login.microsoftonline.com/1234567/oauth2/v2.0/token"];
+    parameters.providedAuthority = parameters.authority;
+    parameters.clientId = @"29d9ed98-a469-4536-ade2-f981bc1d605e";
+    parameters.redirectUri = @"redirect_uri";
+    return parameters;
+}
+
+- (NSMutableDictionary *)mockedRequestHeaders
+{
+    NSDictionary *requestHeaders =
+    @{
+            @"Accept" : [[MSIDTestIgnoreSentinel alloc] init],
+            @"Content-Length" : [[MSIDTestIgnoreSentinel alloc] init],
+            @"Content-Type" : [[MSIDTestIgnoreSentinel alloc] init],
+            @"User-Agent" : [[MSIDTestIgnoreSentinel alloc] init],
+            @"x-client-SKU": [[MSIDTestIgnoreSentinel alloc] init],
+            @"x-client-OS": [[MSIDTestIgnoreSentinel alloc] init],
+            @"x-app-name": [[MSIDTestIgnoreSentinel alloc] init],
+            @"x-ms-PkeyAuth+": [[MSIDTestIgnoreSentinel alloc] init],
+            @"x-client-Ver": [[MSIDTestIgnoreSentinel alloc] init],
+            @"x-client-CPU": [[MSIDTestIgnoreSentinel alloc] init],
+            @"x-app-ver": [[MSIDTestIgnoreSentinel alloc] init],
+            @"x-client-DM": [[MSIDTestIgnoreSentinel alloc] init],
+            @"Connection": [MSIDTestIgnoreSentinel sentinel],
+    };
+    
+    return [requestHeaders mutableCopy];
+}
+@end

--- a/IdentityCore/tests/MSIDNonceTokenRequestTest.m
+++ b/IdentityCore/tests/MSIDNonceTokenRequestTest.m
@@ -70,11 +70,10 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Return cached Nonce."];
     
-    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
-        
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
+    {
         XCTAssertNil(error);
         XCTAssertEqualObjects(resultNonce, @"my-nonce");
-        
         [expectation fulfill];
     }];
     
@@ -104,12 +103,11 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire Nonce."];
     
-    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
-        
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
+    {
         XCTAssertNotNil(resultNonce);
         XCTAssertNil(error);
         XCTAssertEqualObjects(resultNonce, @"1234_nonce_abcd");
-        
         [expectation fulfill];
     }];
     
@@ -127,8 +125,7 @@
     NSError *nonceError = [[NSError alloc] initWithDomain:@"Test domain" code:-1 userInfo:@{@"MSIDErrorDescriptionKey": @"Could not get nonce from server."}];
     
     MSIDTestURLResponse *nonceResponse = [MSIDTestURLResponse request:parameters.authority.metadata.tokenEndpoint
-                                                              respondWithError:nonceError];
-    
+                                                     respondWithError:nonceError];
     
     nonceResponse->_requestHeaders = [self mockedRequestHeaders];
     [MSIDTestURLSession addResponse:nonceResponse];
@@ -137,12 +134,11 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire Nonce."];
     
-    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
-        
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
+    {
         XCTAssertNil(resultNonce);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Could not get nonce from server.");
-        
         [expectation fulfill];
     }];
     
@@ -169,12 +165,11 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire Nonce for invalid nonce."];
     
-    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
-        
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
+    {
         XCTAssertNil(resultNonce);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Didn't receive valid nonce in response");
-        
         [expectation fulfill];
     }];
     
@@ -186,13 +181,11 @@
     request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
     
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"Acquire Nonce for invalid nonce."];
-    
-    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
-        
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
+    {
         XCTAssertNil(resultNonce);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Response is not of the expected type: NSDictionary.");
-        
         [expectation1 fulfill];
     }];
     
@@ -205,12 +198,11 @@
     
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"Acquire Nonce for invalid nonce."];
     
-    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
-        
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
+    {
         XCTAssertNil(resultNonce);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.userInfo[@"MSIDErrorDescriptionKey"], @"Didn't receive valid nonce in response");
-        
         [expectation2 fulfill];
     }];
     
@@ -243,11 +235,10 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire new Nonce."];
     
-    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
-        
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
+    {
         XCTAssertNil(error);
         XCTAssertEqualObjects(resultNonce, @"1234_nonce_abcd");
-        
         [expectation fulfill];
     }];
     
@@ -282,12 +273,10 @@
     MSIDNonceTokenRequest *request = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:parameters];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire new Nonce."];
-    
-    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
-        
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
+    {
         XCTAssertNil(error);
         XCTAssertEqualObjects(resultNonce, @"1234_nonce_abcd");
-        
         [expectation fulfill];
     }];
     
@@ -328,11 +317,10 @@
     [MSIDTestURLSession addResponse:oidcResponse];
     
     request.openIdMetadataToUpdateInAuthority.tokenEndpoint = nil;
-    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error) {
-        
+    [request executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
+    {
         XCTAssertNil(error);
         XCTAssertEqualObjects(resultNonce, @"1234_nonce_abcd");
-        
         [expectation fulfill];
     }];
     
@@ -344,7 +332,10 @@
 - (MSIDInteractiveTokenRequestParameters *)testRequestParameters
 {
     MSIDInteractiveTokenRequestParameters *parameters = [MSIDInteractiveTokenRequestParameters new];
-    parameters.authority = [[MSIDAADAuthority alloc] initWithURL:[NSURL URLWithString:@"https://login.microsoftonline.com/1234567"] rawTenant:nil context:nil error:nil];
+    parameters.authority = [[MSIDAADAuthority alloc] initWithURL:[NSURL URLWithString:@"https://login.microsoftonline.com/1234567"]
+                                                       rawTenant:nil
+                                                         context:nil
+                                                           error:nil];
     parameters.authority.metadata = [MSIDOpenIdProviderMetadata new];
     parameters.authority.metadata.tokenEndpoint = [[NSURL alloc] initWithString:@"https://login.microsoftonline.com/1234567/oauth2/v2.0/token"];
     parameters.providedAuthority = parameters.authority;

--- a/IdentityCore/tests/integration/MSIDOIDCSignoutRequestTests.m
+++ b/IdentityCore/tests/integration/MSIDOIDCSignoutRequestTests.m
@@ -98,6 +98,7 @@
         XCTAssertNil(error);
         XCTAssertTrue(success);
         [expectation fulfill];
+        [MSIDTestURLSession clearResponses];
     }];
 
     [self waitForExpectationsWithTimeout:1 handler:nil];
@@ -142,6 +143,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Run request."];
     
     [logoutRequest executeRequestWithCompletion:^(BOOL success, NSError * _Nullable error) {
+        [MSIDTestURLSession clearResponses];
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.domain, MSIDOAuthErrorDomain);
         XCTAssertEqual(error.code, MSIDErrorServerInvalidState);

--- a/IdentityCore/tests/mocks/MSIDNonceTokenRequestMock.h
+++ b/IdentityCore/tests/mocks/MSIDNonceTokenRequestMock.h
@@ -38,7 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSInteger executeRequestInvokedCount;
 @property (nonatomic) MSIDOpenIdProviderMetadata *openIdMetadataToUpdateInAuthority;
-@property (nonatomic) BOOL shouldLoadopenIdMetadata;
 
 @end
 

--- a/IdentityCore/tests/mocks/MSIDNonceTokenRequestMock.h
+++ b/IdentityCore/tests/mocks/MSIDNonceTokenRequestMock.h
@@ -1,0 +1,46 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import "MSIDNonceTokenRequest.h"
+
+@class MSIDCache;
+@class MSIDOpenIdProviderMetadata;
+@interface MSIDNonceTokenRequest()
+
++ (nonnull MSIDCache *)nonceCache;
+
+@end
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDNonceTokenRequestMock : MSIDNonceTokenRequest
+
+@property (nonatomic) NSInteger executeRequestInvokedCount;
+@property (nonatomic) MSIDOpenIdProviderMetadata *openIdMetadataToUpdateInAuthority;
+@property (nonatomic) BOOL shouldLoadopenIdMetadata;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/IdentityCore/tests/mocks/MSIDNonceTokenRequestMock.m
+++ b/IdentityCore/tests/mocks/MSIDNonceTokenRequestMock.m
@@ -1,0 +1,34 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import "MSIDNonceTokenRequestMock.h"
+
+@implementation MSIDNonceTokenRequestMock
+
+- (void)executeRequestWithCompletion:(nonnull MSIDNonceRequestCompletion)completionBlock
+{
+    self.executeRequestInvokedCount++;
+    [super executeRequestWithCompletion:completionBlock];
+}
+@end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+TBD
+
+* Add Request class to get nonce from server (#1525)
+
 Version 1.11.0
 * Use a single family refresh token (#1470)
 * Improve browser core logs #1506


### PR DESCRIPTION
## Proposed changes

This PR aims to shift code to obtain nonce from broker to common-core so that it can also be used for bound refresh token acquisition by non-broker apps.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

