### PR TITLE
Disable preferred identity in CBA flow

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -214,6 +214,7 @@ extern NSString * _Nonnull const MSID_BROWSER_RESPONSE_SWITCH_BROWSER_RESUME;
 extern NSString * _Nonnull const MSID_FLIGHT_USE_V2_WEB_RESPONSE_FACTORY;
 extern NSString * _Nonnull const MSID_FLIGHT_SUPPORT_DUNA_CBA;
 extern NSString * _Nonnull const MSID_FLIGHT_CLIENT_SFRT_STATUS;
+extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_PREFERRED_IDENTITY_CBA;
 
 /**
  * Flight to indicate if remove account artifacts should be disabled

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -86,6 +86,7 @@ NSString *const MSID_BROWSER_RESPONSE_SWITCH_BROWSER_RESUME = @"switch_browser_r
 NSString *const MSID_FLIGHT_USE_V2_WEB_RESPONSE_FACTORY = @"use_v2_web_response_factory";
 NSString *const MSID_FLIGHT_SUPPORT_DUNA_CBA = @"support_duna_cba_v2";
 NSString *const MSID_FLIGHT_CLIENT_SFRT_STATUS = @"sfrt_v2";
+NSString *const MSID_FLIGHT_DISABLE_PREFERRED_IDENTITY_CBA = @"dis_pre_iden_cba";
 
 // Making the flight string short to avoid legacy broker url size limit
 NSString *const MSID_FLIGHT_DISABLE_REMOVE_ACCOUNT_ARTIFACTS = @"disable_rm_metadata";

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
@@ -107,7 +107,7 @@
 
 + (BOOL)isIdentityPersistenceEnabled
 {
-    return [MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_DISABLE_PREFERRED_IDENTITY_CBA];
+    return ![MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_DISABLE_PREFERRED_IDENTITY_CBA];
 }
 
 + (void)respondCertAuthChallengeWithIdentity:(nonnull SecIdentityRef)identity

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/mac/MSIDCertAuthHandler.m
@@ -25,6 +25,8 @@
 #import "MSIDCertificateChooser.h"
 #import "NSDate+MSIDExtensions.h"
 #import "MSIDKeychainUtil.h"
+#import "MSIDFlightManager.h"
+#import "MSIDConstants.h"
 
 @implementation MSIDCertAuthHandler
 
@@ -40,20 +42,23 @@
 {
     NSString *host = challenge.protectionSpace.host;
     NSArray<NSData*> *distinguishedNames = challenge.protectionSpace.distinguishedNames;
-    
-    // Check if a preferred identity is set for this host
-    SecIdentityRef identity = SecIdentityCopyPreferred((CFStringRef)host, NULL, (CFArrayRef)distinguishedNames);
-    
-    if (!identity)
+    BOOL isIdentityValid = false;
+    SecIdentityRef identity = NULL;
+    if ([self isIdentityPersistenceEnabled])
     {
-        // If there was no identity matched for the exact host, try to match by URL
-        // URL matching is more flexible, as it's doing a wildcard matching for different subdomains
-        // However, we need to do both, because if there's an entry by hostname, matching by URL won't find it
-        identity = SecIdentityCopyPreferred((CFStringRef)webview.URL.absoluteString, NULL, (CFArrayRef)distinguishedNames);
+        // Check if a preferred identity is set for this host
+        identity = SecIdentityCopyPreferred((CFStringRef)host, NULL, (CFArrayRef)distinguishedNames);
+        
+        if (!identity)
+        {
+            // If there was no identity matched for the exact host, try to match by URL
+            // URL matching is more flexible, as it's doing a wildcard matching for different subdomains
+            // However, we need to do both, because if there's an entry by hostname, matching by URL won't find it
+            identity = SecIdentityCopyPreferred((CFStringRef)webview.URL.absoluteString, NULL, (CFArrayRef)distinguishedNames);
+        }
+        isIdentityValid  = [self isIdentityValid:identity context:context];
     }
-    
-    BOOL isIdentityValid = [self isIdentityValid:identity context:context];
-    
+      
     if (isIdentityValid)
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Using preferred identity");
@@ -81,7 +86,7 @@
             // If there is no preferred identity saved, we must set preferred identity certificate using hostname and key usage parameters: kSecAttrCanSign to create digital signature in Keychain and kSecAttrCanEn/Decrypt to specify certain attributes of identity to be stored in encrypted format
             NSArray *arr = @[(__bridge NSString *)kSecAttrCanSign, (__bridge NSString *)kSecAttrCanEncrypt, (__bridge NSString *)kSecAttrCanDecrypt];
             CFArrayRef arrayRef = (__bridge CFArrayRef)arr;
-            if (host)
+            if (host && [self isIdentityPersistenceEnabled])
             {
                 OSStatus status = SecIdentitySetPreferred(selectedIdentity, (CFStringRef)host, arrayRef);
                 if (!status)
@@ -98,6 +103,11 @@
     }
     
     return YES;
+}
+
++ (BOOL)isIdentityPersistenceEnabled
+{
+    return [MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_DISABLE_PREFERRED_IDENTITY_CBA];
 }
 
 + (void)respondCertAuthChallengeWithIdentity:(nonnull SecIdentityRef)identity

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version TBD
 * Fix crash when adding existing RT on interactive calls (#1528)
+* Disable preferred identity in CBA flow (#1529)
 
 Version 1.11.0
 * Use a single family refresh token (#1470)


### PR DESCRIPTION
## Proposed changes

Disable preferred identity save/query in CBA flow to let user choose cert.

```
By design, CBA supports multiple accounts with different certificates on the same device.
The hostname (certauth.login.microsoftonline.com) and distinguished names (list of subject names of all the cert authorities configured in the tenant) are used to find the correct certificate for authentication. There is no user-specific unique ID per certificate because, in CBA, a user can have multiple certificates to authenticate the same UPN, and a certificate can be used to authenticate multiple users (e.g., personal/admin account, etc.).
The way it works relies on the user deciding the correct certificate, so the client needs to present the certificate picker.
The cache problem: We have two cache layers here: internal browser (including embedded webview that our libraries start for interactive requests) and keychain record that common-core/broker owns.
Browser cache saves the certificate picked from the previous session, and next time, if the same challenge and conditions (hostname, distinguished name) are met, it will be sent to the server without showing a prompt.
Keychain cache is permanent, and common-core will prioritize the “preferred identity” instead of showing the prompt to the user. (code snippet at the bottom)
So, in order for the user to choose another certificate, both caches need to be flushed. 

```## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

