### PR TITLE
Add early return in if block

### DIFF
--- a/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
+++ b/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
@@ -413,6 +413,7 @@ typedef void (^NSXPCListenerEndpointCompletionBlock)(id<MSIDXpcBrokerInstancePro
         {
             isConnectionErroredOut = YES;
             continueBlock(nil, nil, xpcError);
+            return;
         }
         
         if (continueBlock) continueBlock(nil, nil, xpcError);


### PR DESCRIPTION
## Proposed changes

This is to add an early return when falls into if block instead of continuing the completion handler after that

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

