### PR TITLE
Added ephemeral browser session to duna

### DIFF
--- a/IdentityCore/src/webview/MSIDCertAuthManager.h
+++ b/IdentityCore/src/webview/MSIDCertAuthManager.h
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startWithURL:(NSURL *)startURL
     parentController:(MSIDViewController *)parentViewController
              context:(id<MSIDRequestContext>)context
+ephemeralWebBrowserSession:(BOOL)ephemeralWebBrowserSession
      completionBlock:(MSIDWebUICompletionHandler)completionBlock;
 
 - (BOOL)completeWithCallbackURL:(NSURL *)url;

--- a/IdentityCore/src/webview/MSIDCertAuthManager.m
+++ b/IdentityCore/src/webview/MSIDCertAuthManager.m
@@ -79,6 +79,7 @@
 - (void)startWithURL:(NSURL *)startURL
     parentController:(MSIDViewController *)parentViewController
              context:(id<MSIDRequestContext>)context
+   ephemeralWebBrowserSession:(BOOL)ephemeralWebBrowserSession
      completionBlock:(MSIDWebUICompletionHandler)completionBlock
 {
     [MSIDMainThreadUtil executeOnMainThreadIfNeeded:^{
@@ -113,7 +114,7 @@
                                                                             parentController:parentViewController
                                                                     useAuthenticationSession:self.useAuthSession
                                                                    allowSafariViewController:YES
-                                                                  ephemeralWebBrowserSession:YES
+                                                                  ephemeralWebBrowserSession:ephemeralWebBrowserSession
                                                                                      context:context];
         
         self.systemWebViewController.appActivities = self.activities;

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
@@ -96,6 +96,7 @@ static BOOL s_disableCertBasedAuth = NO;
     [MSIDCertAuthManager.sharedInstance startWithURL:requestURL
                                     parentController:parentViewController
                                              context:context
+                          ephemeralWebBrowserSession:YES
                                      completionBlock:^(NSURL *callbackURL, NSError *error)
      {
         MSIDWebviewSession *session = [MSIDWebviewAuthorization currentSession];

--- a/IdentityCore/src/webview/operations/ios/MSIDSwitchBrowserOperation.m
+++ b/IdentityCore/src/webview/operations/ios/MSIDSwitchBrowserOperation.m
@@ -86,10 +86,17 @@
     NSURLComponents *requestURLComponents = [[NSURLComponents alloc] initWithString:self.switchBrowserResponse.actionUri];
     requestURLComponents.percentEncodedQuery = [queryItems msidURLEncode];
     NSURL *startURL = requestURLComponents.URL;
+    BOOL usePrivateSession = YES;
+
+    if (self.switchBrowserResponse.bitMask)
+    {
+        usePrivateSession = (self.switchBrowserResponse.bitMask & (1 << 0)) != 0;
+    }
     
     [self.certAuthManager startWithURL:startURL
                       parentController:requestParameters.parentViewController
                                context:requestParameters
+            ephemeralWebBrowserSession:usePrivateSession
                        completionBlock:^(NSURL *callbackURL, NSError *error)
      {
         [self.certAuthManager resetState];

--- a/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.h
+++ b/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.h
@@ -29,6 +29,7 @@
 
 @property (nonatomic, readonly) NSString *actionUri;
 @property (nonatomic, readonly) NSString *switchBrowserSessionToken;
+@property (nonatomic, readonly) NSInteger bitMask;
 
 - (instancetype )init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.m
+++ b/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.m
@@ -49,6 +49,8 @@
         if (![self isMyUrl:url redirectUri:redirectUri]) return nil;
         
         _actionUri = self.parameters[@"action_uri"];
+        _bitMask = [self.parameters[@"browser_modes"] integerValue];
+        
         if ([NSString msidIsStringNilOrBlank:_actionUri])
         {
             if (error) *error = MSIDCreateError(MSIDOAuthErrorDomain, MSIDErrorServerInvalidResponse, @"action_uri is nil.", nil, nil, nil, context.correlationId, nil, YES);


### PR DESCRIPTION
## Proposed changes

When ESTS redirects back to MSAL at /switch_browser, it will add a new query parameter called browser_modes. This parameter is defined as a base64 encoded int that can be extended in the future with multiple options. The integer is the sum of multiple flags that can be summed together to indicate one or more options. The flag PrivateSession = 1 << 0 which if present indicates that the system browser should be opened in a private session/ephemeral mode if supported. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

