### PR TITLE
JIT troubleshooting in legacy auth flow

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -213,6 +213,7 @@ extern NSString * _Nonnull const MSID_BROWSER_RESPONSE_SWITCH_BROWSER_RESUME;
 
 extern NSString * _Nonnull const MSID_FLIGHT_USE_V2_WEB_RESPONSE_FACTORY;
 extern NSString * _Nonnull const MSID_FLIGHT_SUPPORT_DUNA_CBA;
+extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_JIT_TROUBLESHOOTING_LEGACY_AUTH;
 extern NSString * _Nonnull const MSID_FLIGHT_CLIENT_SFRT_STATUS;
 extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_PREFERRED_IDENTITY_CBA;
 

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -85,6 +85,7 @@ NSString *const MSID_BROWSER_RESPONSE_SWITCH_BROWSER_RESUME = @"switch_browser_r
 
 NSString *const MSID_FLIGHT_USE_V2_WEB_RESPONSE_FACTORY = @"use_v2_web_response_factory";
 NSString *const MSID_FLIGHT_SUPPORT_DUNA_CBA = @"support_duna_cba_v2";
+NSString *const MSID_FLIGHT_DISABLE_JIT_TROUBLESHOOTING_LEGACY_AUTH = @"disable_jit_remediation_legacy_auth";
 NSString *const MSID_FLIGHT_CLIENT_SFRT_STATUS = @"sfrt_v2";
 NSString *const MSID_FLIGHT_DISABLE_PREFERRED_IDENTITY_CBA = @"dis_pre_iden_cba";
 

--- a/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
+++ b/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
@@ -235,6 +235,26 @@
     XCTAssertTrue(result);
 }
 
+- (void)testDecidePolicyForNavigationAction_whenExternalDecidePolicyForBrowserActionLegacyFlowNonHttps_shouldCancelActionAndReturnNoAndCallExternalMethod
+{
+    [MSIDWebAuthNUtil setAmIRunningInExtension:NO];
+    
+    MSIDAADOAuthEmbeddedWebviewController *webVC = [[MSIDAADOAuthEmbeddedWebviewController alloc]
+            initWithStartURL:[NSURL URLWithString:@"https://contoso.com/oauth/authorize"]
+                      endURL:[NSURL URLWithString:@"endurl://host"]
+                     webview:nil
+               customHeaders:nil
+              platfromParams:nil
+                     context:nil];
+
+    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[[NSURL alloc] initWithString:@"http://www.web-cp.com/check"]];
+    MSIDWKNavigationActionMock *action = [[MSIDWKNavigationActionMock alloc] initWithRequest:request];
+
+    BOOL result = [webVC decidePolicyAADForNavigationAction:action decisionHandler:^(WKNavigationActionPolicy decision) { }];
+
+    XCTAssertFalse(result);
+}
+
 @end
 
 #endif

--- a/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
+++ b/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
@@ -250,7 +250,9 @@
     NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[[NSURL alloc] initWithString:@"http://www.web-cp.com/check"]];
     MSIDWKNavigationActionMock *action = [[MSIDWKNavigationActionMock alloc] initWithRequest:request];
 
-    BOOL result = [webVC decidePolicyAADForNavigationAction:action decisionHandler:^(WKNavigationActionPolicy decision) { }];
+    BOOL result = [webVC decidePolicyAADForNavigationAction:action decisionHandler:^(WKNavigationActionPolicy decision) {
+        XCTAssertEqual(decision, WKNavigationActionPolicyCancel);
+    }];
 
     XCTAssertFalse(result);
 }

--- a/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
+++ b/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
@@ -26,6 +26,7 @@
 #import <XCTest/XCTest.h>
 #import "MSIDAADOAuthEmbeddedWebviewController.h"
 #import "MSIDWKNavigationActionMock.h"
+#import "MSIDWebAuthNUtil.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -169,6 +170,45 @@
                      context:nil];
 
     NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[[NSURL alloc] initWithString:@"browser://www.web-cp.com/check"]];
+    MSIDWKNavigationActionMock *action = [[MSIDWKNavigationActionMock alloc] initWithRequest:request];
+
+    XCTestExpectation *expectationExternalDecisionHandler = [self expectationWithDescription:@"external decision handler"];
+    XCTestExpectation *expectationDecisionHandler = [self expectationWithDescription:@"decision handler"];
+
+    webVC.externalDecidePolicyForBrowserAction = ^NSURLRequest *(MSIDOAuth2EmbeddedWebviewController *webView, NSURL *url) {
+
+        XCTAssertNotNil(webView);
+        XCTAssertEqualObjects([url absoluteString], @"browser://www.web-cp.com/check");
+        [expectationExternalDecisionHandler fulfill];
+
+        return [[NSURLRequest alloc] initWithURL:url];
+    };
+
+
+    BOOL result = [webVC decidePolicyAADForNavigationAction:action decisionHandler:^(WKNavigationActionPolicy decision) {
+
+        XCTAssertEqual(decision, WKNavigationActionPolicyCancel);
+        [expectationDecisionHandler fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testDecidePolicyForNavigationAction_whenExternalDecidePolicyForBrowserActionLegacyFlow_shouldCancelActionAndReturnYesAndCallExternalMethod
+{
+    [MSIDWebAuthNUtil setAmIRunningInExtension:NO];
+    
+    MSIDAADOAuthEmbeddedWebviewController *webVC = [[MSIDAADOAuthEmbeddedWebviewController alloc]
+            initWithStartURL:[NSURL URLWithString:@"https://contoso.com/oauth/authorize"]
+                      endURL:[NSURL URLWithString:@"endurl://host"]
+                     webview:nil
+               customHeaders:nil
+              platfromParams:nil
+                     context:nil];
+
+    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[[NSURL alloc] initWithString:@"https://www.web-cp.com/check"]];
     MSIDWKNavigationActionMock *action = [[MSIDWKNavigationActionMock alloc] initWithRequest:request];
 
     XCTestExpectation *expectationExternalDecisionHandler = [self expectationWithDescription:@"external decision handler"];


### PR DESCRIPTION
## Proposed changes

Calling `externalDecidePolicyForBrowserAction` will be done when running in legacy auth flow to decide to intercept the URL redirect or not.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

