### PR TITLE
Update log level for message about FRT status not updated from Error to Info

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
@@ -581,7 +581,7 @@ static BOOL s_disableFRT = NO;
         
         if ([NSString msidIsStringNilOrBlank:flagEnableFRT] || (!shouldEnableFRT && !shouldDisableFRT))
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"FRT flight set to keep current status: %ld", (long)status);
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"FRT flight set to keep current status: %ld", (long)status);
             return status;
         }
         MSIDIsFRTEnabledStatus newStatus = status;


### PR DESCRIPTION
## Proposed changes

Update log level for message about FRT status not updated from Error to Info.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

