### PR TITLE
Check for both possible camera consent suppression flags in user defaults

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -499,28 +499,31 @@ initiatedByFrame:(WKFrameInfo *)frame
             type:(WKMediaCaptureType)type
  decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler API_AVAILABLE(ios(15.0), macos(12.0))
 {
-    
-    NSUserDefaults *userDefaults = [[NSUserDefaults alloc] initWithSuiteName:SSO_EXTENSION_USER_DEFAULTS_KEY];
-    id cameraConsentValue = [userDefaults objectForKey:CAMERA_CONSENT_PROMPT_SUPPRESS_KEY];
-    id sdmCameraConsentValue = [userDefaults objectForKey:SDM_CAMERA_CONSENT_PROMPT_SUPPRESS_KEY];
-    
-    if (cameraConsentValue && ([cameraConsentValue isKindOfClass:NSNumber.class] || [cameraConsentValue isKindOfClass:NSString.class]))
+    // Prompt suppression is only allowed for the camera
+    if (type == WKMediaCaptureTypeCamera)
     {
-        if ([cameraConsentValue boolValue] && type == WKMediaCaptureTypeCamera)
+        NSUserDefaults *userDefaults = [[NSUserDefaults alloc] initWithSuiteName:SSO_EXTENSION_USER_DEFAULTS_KEY];
+        id cameraConsentValue = [userDefaults objectForKey:CAMERA_CONSENT_PROMPT_SUPPRESS_KEY];
+        id sdmCameraConsentValue = [userDefaults objectForKey:SDM_CAMERA_CONSENT_PROMPT_SUPPRESS_KEY];
+        
+        if (cameraConsentValue && ([cameraConsentValue isKindOfClass:NSNumber.class] || [cameraConsentValue isKindOfClass:NSString.class]))
         {
-            decisionHandler(WKPermissionDecisionGrant);
-            return;
+            if ([cameraConsentValue boolValue])
+            {
+                decisionHandler(WKPermissionDecisionGrant);
+                return;
+            }
+        }
+        else if (sdmCameraConsentValue && ([sdmCameraConsentValue isKindOfClass:NSNumber.class] || [sdmCameraConsentValue isKindOfClass:NSString.class]))
+        {
+            if ([sdmCameraConsentValue boolValue])
+            {
+                decisionHandler(WKPermissionDecisionGrant);
+                return;
+            }
         }
     }
-    else if (sdmCameraConsentValue && ([sdmCameraConsentValue isKindOfClass:NSNumber.class] || [sdmCameraConsentValue isKindOfClass:NSString.class]))
-    {
-        if ([sdmCameraConsentValue boolValue] && type == WKMediaCaptureTypeCamera)
-        {
-            decisionHandler(WKPermissionDecisionGrant);
-            return;
-        }
-    }
-    
+
     decisionHandler(WKPermissionDecisionPrompt);
 }
 #endif

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -65,7 +65,8 @@
 
 #if AD_BROKER
 NSString *const SSO_EXTENSION_USER_DEFAULTS_KEY = @"group.com.microsoft.azureauthenticator.sso";
-NSString *const CAMERA_CONSENT_PROMPT_SUPPRESS_KEY = @"Microsoft.Broker.Feature.sdm_suppress_camera_consent";
+NSString *const CAMERA_CONSENT_PROMPT_SUPPRESS_KEY = @"Microsoft.Broker.Feature.suppress_camera_consent";
+NSString *const SDM_CAMERA_CONSENT_PROMPT_SUPPRESS_KEY = @"Microsoft.Broker.Feature.sdm_suppress_camera_consent";
 #endif
 
 - (id)initWithStartURL:(NSURL *)startURL
@@ -501,10 +502,19 @@ initiatedByFrame:(WKFrameInfo *)frame
     
     NSUserDefaults *userDefaults = [[NSUserDefaults alloc] initWithSuiteName:SSO_EXTENSION_USER_DEFAULTS_KEY];
     id cameraConsentValue = [userDefaults objectForKey:CAMERA_CONSENT_PROMPT_SUPPRESS_KEY];
+    id sdmCameraConsentValue = [userDefaults objectForKey:SDM_CAMERA_CONSENT_PROMPT_SUPPRESS_KEY];
     
     if (cameraConsentValue && ([cameraConsentValue isKindOfClass:NSNumber.class] || [cameraConsentValue isKindOfClass:NSString.class]))
     {
         if ([cameraConsentValue boolValue] && type == WKMediaCaptureTypeCamera)
+        {
+            decisionHandler(WKPermissionDecisionGrant);
+            return;
+        }
+    }
+    else if (sdmCameraConsentValue && ([sdmCameraConsentValue isKindOfClass:NSNumber.class] || [sdmCameraConsentValue isKindOfClass:NSString.class]))
+    {
+        if ([sdmCameraConsentValue boolValue] && type == WKMediaCaptureTypeCamera)
         {
             decisionHandler(WKPermissionDecisionGrant);
             return;


### PR DESCRIPTION
## Proposed changes

There are now 2 possible camera consent suppression flags possible in the SSO extension config. This PR adds a check for the 2nd flag.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

