### PR TITLE
Fix duplicated symbol error [automation]

### DIFF
--- a/IdentityCore/src/requests/MSIDEcdhApv.m
+++ b/IdentityCore/src/requests/MSIDEcdhApv.m
@@ -27,13 +27,13 @@
 
 @implementation MSIDEcdhApv
 
-const NSUInteger kExpectedECP256KeyLength = 65;
-
 - (instancetype)initWithKey:(SecKeyRef)publicKey
                   apvPrefix:(NSString *)apvPrefix
                     context:(id<MSIDRequestContext> _Nullable)context
                       error:(NSError * _Nullable __autoreleasing *)error
 {
+    const NSUInteger kExpectedECP256KeyLength = 65;
+    
     if (publicKey == NULL)
     {
         if (error) *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Public STK provided is not defined.", nil, nil, nil, context.correlationId, nil, NO);


### PR DESCRIPTION
## Proposed changes

Move constant to smaller scope to prevent duplicate symbol error during build automation tests.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

