### PR TITLE
Add log to print URL protocol in path and stmt when http body is nil

### DIFF
--- a/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/token_request/MSIDBrokerOperationBrowserTokenRequest.m
@@ -57,6 +57,11 @@
         _requestURL = requestURL;
         
         [self printRequestURLInfo:requestURL];
+        if (![httpBody length])
+        {
+            // Apple doesn't provide/expose the HTTP method of the request SSO extension intercepted. If httpBody is nil we assume GET else POST.
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[Browser SSO] Request body is empty or undefined. SSO extension will assume HTTP method to GET.");
+        }
         
         if (![requestValidator shouldHandleURL:_requestURL])
         {
@@ -121,8 +126,8 @@
             return logProtocolNames[keyword];
         }
     }
-    
-    return @"N/A";
+    NSString *lastPathComponent = [requestURL lastPathComponent];
+    return [NSString msidIsStringNilOrBlank:lastPathComponent] ? @"N/A" : lastPathComponent;
 }
 
 - (void)printRequestURLInfo:(NSURL *)requestURL

--- a/IdentityCore/tests/MSIDBrokerOperationBrowserTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationBrowserTokenRequestTests.m
@@ -53,7 +53,7 @@
 
     NSString *result = [MSIDBrokerOperationBrowserTokenRequest protocolLogNameForRequestURL:[NSURL URLWithString:url]];
 
-    XCTAssertEqualObjects(result, @"N/A");
+    XCTAssertEqualObjects(result, @"fido");
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

Print the protocol from URL path in SSO extension logs. 
Add log line when HTTP body of request intercepted by SSO extension is empty or undefined.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

