### PR TITLE
Adding Bound refresh token class and cache item

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -761,6 +761,8 @@
 		72C1EBFC2DEA8199004C40A4 /* MSIDBoundRefreshTokenCacheItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C1EBFB2DEA8185004C40A4 /* MSIDBoundRefreshTokenCacheItem.h */; };
 		72C1EBFE2DEA81A1004C40A4 /* MSIDBoundRefreshTokenCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C1EBFD2DEA819E004C40A4 /* MSIDBoundRefreshTokenCacheItem.m */; };
 		72C1EBFF2DEA81A1004C40A4 /* MSIDBoundRefreshTokenCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C1EBFD2DEA819E004C40A4 /* MSIDBoundRefreshTokenCacheItem.m */; };
+		72C764F92E09CFB800043AB1 /* MSIDBoundRefreshTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C764F82E09CFA400043AB1 /* MSIDBoundRefreshTokenTests.m */; };
+		72C764FA2E09CFB800043AB1 /* MSIDBoundRefreshTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C764F82E09CFA400043AB1 /* MSIDBoundRefreshTokenTests.m */; };
 		72D961AE2DE12F1F005DED66 /* MSIDCachedNonce.h in Headers */ = {isa = PBXBuildFile; fileRef = 72D961AD2DE12F19005DED66 /* MSIDCachedNonce.h */; };
 		72D961B02DE12F30005DED66 /* MSIDCachedNonce.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */; };
 		72D961B12DE12F30005DED66 /* MSIDCachedNonce.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */; };
@@ -2673,6 +2675,7 @@
 		72C1EBF62DE91ACC004C40A4 /* MSIDBoundRefreshToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBoundRefreshToken.m; sourceTree = "<group>"; };
 		72C1EBFB2DEA8185004C40A4 /* MSIDBoundRefreshTokenCacheItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBoundRefreshTokenCacheItem.h; sourceTree = "<group>"; };
 		72C1EBFD2DEA819E004C40A4 /* MSIDBoundRefreshTokenCacheItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBoundRefreshTokenCacheItem.m; sourceTree = "<group>"; };
+		72C764F82E09CFA400043AB1 /* MSIDBoundRefreshTokenTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBoundRefreshTokenTests.m; sourceTree = "<group>"; };
 		72D961AD2DE12F19005DED66 /* MSIDCachedNonce.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCachedNonce.h; sourceTree = "<group>"; };
 		72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCachedNonce.m; sourceTree = "<group>"; };
 		740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCurrentRequestTelemetrySerializedItem.h; sourceTree = "<group>"; };
@@ -5724,6 +5727,7 @@
 		D6DA89731FBA6A4E004C56C7 /* tests */ = {
 			isa = PBXGroup;
 			children = (
+				72C764F82E09CFA400043AB1 /* MSIDBoundRefreshTokenTests.m */,
 				720B5B572DD58A6A00318FE5 /* MSIDJWECryptoTests.m */,
 				729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */,
 				A0410E4F25E88B5E004D80FD /* MSIDThrottlingMetaDataTest.m */,
@@ -7085,6 +7089,7 @@
 				9668B6F72148796A0039AB0A /* MSIDDataExtensionsTests.m in Sources */,
 				B286B9F12389F866007833AD /* MSIDWebviewFactoryTests.m in Sources */,
 				B252913B2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m in Sources */,
+				72C764FA2E09CFB800043AB1 /* MSIDBoundRefreshTokenTests.m in Sources */,
 				B2BE923121A0EFB100F5AB8C /* MSIDDefaultTokenRequestProviderTests.m in Sources */,
 				729357F42DDBD3F80001D03C /* MSIDNonceTokenRequestTest.m in Sources */,
 				23FB5C20225516FB002BF1EB /* MSIDClaimsRequestTests.m in Sources */,
@@ -7764,6 +7769,7 @@
 				B2BE926221A25A8600F5AB8C /* MSIDInteractiveControllerIntegrationTests.m in Sources */,
 				B2BE923521A0F80100F5AB8C /* MSIDLegacyTokenRequestProviderTests.m in Sources */,
 				B48FC0632D7A90FA007B80DB /* MSIDBrokerFlightProviderTests.m in Sources */,
+				72C764F92E09CFB800043AB1 /* MSIDBoundRefreshTokenTests.m in Sources */,
 				23FB5C21225516FB002BF1EB /* MSIDClaimsRequestTests.m in Sources */,
 				E75DD02625D5E474007664A6 /* MSIDThrottlingServiceIntegrationTests.m in Sources */,
 				B286BA07238A110A007833AD /* MSIDOIDCSignoutRequestTests.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -755,6 +755,12 @@
 		7293580E2DDFADDF0001D03C /* MSIDNonceHttpRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7293580D2DDFADC80001D03C /* MSIDNonceHttpRequest.h */; };
 		729358102DDFADE70001D03C /* MSIDNonceHttpRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */; };
 		729358112DDFADE70001D03C /* MSIDNonceHttpRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */; };
+		72C1EBF52DE91AC8004C40A4 /* MSIDBoundRefreshToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C1EBF42DE91ABE004C40A4 /* MSIDBoundRefreshToken.h */; };
+		72C1EBF72DE91AD0004C40A4 /* MSIDBoundRefreshToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C1EBF62DE91ACC004C40A4 /* MSIDBoundRefreshToken.m */; };
+		72C1EBF82DE91AD0004C40A4 /* MSIDBoundRefreshToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C1EBF62DE91ACC004C40A4 /* MSIDBoundRefreshToken.m */; };
+		72C1EBFC2DEA8199004C40A4 /* MSIDBoundRefreshTokenCacheItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C1EBFB2DEA8185004C40A4 /* MSIDBoundRefreshTokenCacheItem.h */; };
+		72C1EBFE2DEA81A1004C40A4 /* MSIDBoundRefreshTokenCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C1EBFD2DEA819E004C40A4 /* MSIDBoundRefreshTokenCacheItem.m */; };
+		72C1EBFF2DEA81A1004C40A4 /* MSIDBoundRefreshTokenCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C1EBFD2DEA819E004C40A4 /* MSIDBoundRefreshTokenCacheItem.m */; };
 		72D961AE2DE12F1F005DED66 /* MSIDCachedNonce.h in Headers */ = {isa = PBXBuildFile; fileRef = 72D961AD2DE12F19005DED66 /* MSIDCachedNonce.h */; };
 		72D961B02DE12F30005DED66 /* MSIDCachedNonce.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */; };
 		72D961B12DE12F30005DED66 /* MSIDCachedNonce.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */; };
@@ -2663,6 +2669,10 @@
 		729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceTokenRequestTest.m; sourceTree = "<group>"; };
 		7293580D2DDFADC80001D03C /* MSIDNonceHttpRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDNonceHttpRequest.h; sourceTree = "<group>"; };
 		7293580F2DDFADE50001D03C /* MSIDNonceHttpRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDNonceHttpRequest.m; sourceTree = "<group>"; };
+		72C1EBF42DE91ABE004C40A4 /* MSIDBoundRefreshToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBoundRefreshToken.h; sourceTree = "<group>"; };
+		72C1EBF62DE91ACC004C40A4 /* MSIDBoundRefreshToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBoundRefreshToken.m; sourceTree = "<group>"; };
+		72C1EBFB2DEA8185004C40A4 /* MSIDBoundRefreshTokenCacheItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBoundRefreshTokenCacheItem.h; sourceTree = "<group>"; };
+		72C1EBFD2DEA819E004C40A4 /* MSIDBoundRefreshTokenCacheItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBoundRefreshTokenCacheItem.m; sourceTree = "<group>"; };
 		72D961AD2DE12F19005DED66 /* MSIDCachedNonce.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCachedNonce.h; sourceTree = "<group>"; };
 		72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDCachedNonce.m; sourceTree = "<group>"; };
 		740340B72460E5C400DFCF27 /* MSIDCurrentRequestTelemetrySerializedItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDCurrentRequestTelemetrySerializedItem.h; sourceTree = "<group>"; };
@@ -4804,6 +4814,8 @@
 		B226D85B1FFB07840012BF8B /* token */ = {
 			isa = PBXGroup;
 			children = (
+				72C1EBFD2DEA819E004C40A4 /* MSIDBoundRefreshTokenCacheItem.m */,
+				72C1EBFB2DEA8185004C40A4 /* MSIDBoundRefreshTokenCacheItem.h */,
 				B4A5ACD021F7F1DF00D2A780 /* Matchers */,
 				0570FE7D219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.h */,
 				0570FE7C219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.m */,
@@ -4906,6 +4918,8 @@
 		B251CC232041050E005E0179 /* token */ = {
 			isa = PBXGroup;
 			children = (
+				72C1EBF62DE91ACC004C40A4 /* MSIDBoundRefreshToken.m */,
+				72C1EBF42DE91ABE004C40A4 /* MSIDBoundRefreshToken.h */,
 				B2675689228CE6FC000F01D7 /* protocols */,
 				B251CC4E204105AD005E0179 /* MSIDCredentialType.h */,
 				B251CC4F204105AD005E0179 /* MSIDCredentialType.m */,
@@ -5098,7 +5112,6 @@
 		B2AF1D29218BCDEF0080C1A0 /* requests */ = {
 			isa = PBXGroup;
 			children = (
-
 				720B5B542DD57D6600318FE5 /* MSIDEcdhApv.m */,
 				720B5B522DD57C3700318FE5 /* MSIDEcdhApv.h */,
 				720B5B4F2DD577C100318FE5 /* MSIDJWECrypto.m */,
@@ -6357,6 +6370,7 @@
 				B2F671EC2467AB4500649855 /* MSIDInteractiveRequestControlling.h in Headers */,
 				B443F0002AD6327700782168 /* MSIDBrokerOperationPasskeyCredentialRequest.h in Headers */,
 				23AE20982342D3BF00108F76 /* MSIDSilentController+Internal.h in Headers */,
+				72C1EBF52DE91AC8004C40A4 /* MSIDBoundRefreshToken.h in Headers */,
 				23B39A8620993572000AA905 /* MSIDAADAuthorityMetadataRequest.h in Headers */,
 				B28D90AA218FD1F800E230D6 /* MSIDDefaultTokenResponseValidator.h in Headers */,
 				B2F671E82467A34400649855 /* MSIDAuthorizationCodeResult.h in Headers */,
@@ -6401,6 +6415,7 @@
 				B286B9CB2389DE9F007833AD /* MSIDKeyGenerator.h in Headers */,
 				B26CEB022367B3B9009E6E54 /* MSIDSystemWebViewControllerFactory.h in Headers */,
 				8878C62929DCA054002F5F4B /* MSIDCIAMOauth2Factory.h in Headers */,
+				72C1EBFC2DEA8199004C40A4 /* MSIDBoundRefreshTokenCacheItem.h in Headers */,
 				B2C7088D2198E48E00D917B8 /* NSData+AES.h in Headers */,
 				2394F2052D4894FF00E44F6E /* MSIDWebUpgradeRegOperation.h in Headers */,
 				B251CC3B2041058D005E0179 /* MSIDRefreshToken.h in Headers */,
@@ -7267,6 +7282,7 @@
 				583BFCA924D87BA40035B901 /* MSIDRedirectUri.m in Sources */,
 				E656E07B2C2627B80011FB23 /* MSIDWebUpgradeRegResponse.m in Sources */,
 				580E2547271A014F003D1795 /* MSIDDeviceHeader.m in Sources */,
+				72C1EBFF2DEA81A1004C40A4 /* MSIDBoundRefreshTokenCacheItem.m in Sources */,
 				583BFCAB24D88CED0035B901 /* MSIDRedirectUriVerifier.m in Sources */,
 				B253152723DD61FB00432133 /* MSIDSSOExtensionGetDeviceInfoRequest.m in Sources */,
 				2A24815F2CB08344006FCB34 /* MSIDXpcSilentTokenRequestController.m in Sources */,
@@ -7297,6 +7313,7 @@
 				1E7DC42A2405A95400740BAD /* MSIDBaseBrokerOperationRequest.m in Sources */,
 				B286B97F2389DC08007833AD /* MSIDBrokerOperationRequest.m in Sources */,
 				23FB5C3122551866002BF1EB /* MSIDClaimsRequest+ClientCapabilities.m in Sources */,
+				72C1EBF72DE91AD0004C40A4 /* MSIDBoundRefreshToken.m in Sources */,
 				23B39ACD209CF317000AA905 /* MSIDAADNetworkConfiguration.m in Sources */,
 				23FB5C462255A135002BF1EB /* MSIDIndividualClaimRequest.m in Sources */,
 				2A2481582CB08050006FCB34 /* MSIDXpcSingleSignOnProvider.m in Sources */,
@@ -7976,6 +7993,7 @@
 				2394F1F92D4890BD00E44F6E /* MSIDWebOAuth2AuthCodeOperation.m in Sources */,
 				238EF03E208FE4740035ABE6 /* MSIDRefreshTokenGrantRequest.m in Sources */,
 				230C2C472CF95DBC00E767B6 /* MSIDSwitchBrowserResumeResponse.m in Sources */,
+				72C1EBFE2DEA81A1004C40A4 /* MSIDBoundRefreshTokenCacheItem.m in Sources */,
 				A0C7DDA425D1EA0D00F5B5B6 /* NSError+MSIDThrottlingExtension.m in Sources */,
 				235480C720DDF81000246F72 /* MSIDAuthorityFactory.m in Sources */,
 				239DF9C920E05847002D428B /* MSIDAADRequestConfigurator.m in Sources */,
@@ -8201,6 +8219,7 @@
 				B286B96323861852007833AD /* MSIDSignoutWebRequestConfiguration.m in Sources */,
 				B49323982AD4DA4800E0CBC0 /* MSIDBrokerOperationGetPasskeyAssertionResponse.m in Sources */,
 				B2C708182195283500D917B8 /* MSIDBrokerTokenRequest.m in Sources */,
+				72C1EBF82DE91AD0004C40A4 /* MSIDBoundRefreshToken.m in Sources */,
 				232173E22182A998009852C6 /* NSDictionary+MSIDJsonSerializable.m in Sources */,
 				B2C707F42192524700D917B8 /* MSIDDefaultTokenRequestProvider.m in Sources */,
 				B20657BE1FC9254800412B7D /* MSIDTelemetryCacheEvent.m in Sources */,

--- a/IdentityCore/src/MSIDOAuth2Constants.h
+++ b/IdentityCore/src/MSIDOAuth2Constants.h
@@ -157,6 +157,7 @@ extern NSString *const MSID_ID_TOKEN_CACHE_TYPE;
 extern NSString *const MSID_LEGACY_ID_TOKEN_CACHE_TYPE;
 extern NSString *const MSID_PRT_TOKEN_CACHE_TYPE;
 extern NSString *const MSID_FRT_TOKEN_CACHE_TYPE;
+extern NSString *const MSID_BOUND_RT_TOKEN_CACHE_TYPE;
 extern NSString *const MSID_GENERAL_TOKEN_CACHE_TYPE;
 extern NSString *const MSID_GENERAL_CACHE_ITEM_TYPE;
 extern NSString *const MSID_APP_METADATA_CACHE_TYPE;
@@ -177,3 +178,4 @@ extern NSString *const MSID_CCS_REQUEST_ID_RESPONSE;
 
 extern NSString *const MSID_CCS_REQUEST_SEQUENCE_KEY;
 extern NSString *const MSID_CCS_REQUEST_SEQUENCE_RESPONSE;
+extern NSString *const MSID_BOUND_DEVICE_ID_CACHE_KEY;

--- a/IdentityCore/src/MSIDOAuth2Constants.m
+++ b/IdentityCore/src/MSIDOAuth2Constants.m
@@ -151,6 +151,7 @@ NSString *const MSID_ID_TOKEN_CACHE_TYPE                 = @"IdToken";
 NSString *const MSID_LEGACY_ID_TOKEN_CACHE_TYPE          = @"V1IdToken";
 NSString *const MSID_PRT_TOKEN_CACHE_TYPE                = @"PrimaryRefreshToken";
 NSString *const MSID_FRT_TOKEN_CACHE_TYPE                = @"FamilyRefreshToken";
+NSString *const MSID_BOUND_RT_TOKEN_CACHE_TYPE           = @"BoundRefreshToken";
 NSString *const MSID_GENERAL_TOKEN_CACHE_TYPE            = @"token";
 NSString *const MSID_GENERAL_CACHE_ITEM_TYPE             = @"general_cache_item";
 NSString *const MSID_APP_METADATA_CACHE_TYPE             = @"appmetadata";
@@ -177,3 +178,5 @@ NSString *const MSID_CCS_REQUEST_ID_RESPONSE             = @"ccs-requestid";
 
 NSString *const MSID_CCS_REQUEST_SEQUENCE_KEY            = @"x-ms-srs";
 NSString *const MSID_CCS_REQUEST_SEQUENCE_RESPONSE       = @"ccs-request-sequence";
+
+NSString *const MSID_BOUND_DEVICE_ID_CACHE_KEY           = @"bound_device_id";

--- a/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDAccountCredentialCache.m
@@ -388,7 +388,7 @@ static BOOL s_disableFRT = NO;
     
     BOOL result = [_dataSource removeTokensWithKey:key context:context error:error];
     
-    if (result && (credential.credentialType == MSIDRefreshTokenType || credential.credentialType == MSIDFamilyRefreshTokenType))
+    if (result && (credential.credentialType == MSIDRefreshTokenType || credential.credentialType == MSIDFamilyRefreshTokenType || credential.credentialType == MSIDBoundRefreshTokenType))
     {
         [_dataSource saveWipeInfoWithContext:context error:nil];
     }

--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -307,7 +307,7 @@
             }
             else
             {
-                credentialTypeString = @"";
+                credentialTypeString = [MSIDCredentialTypeHelpers credentialTypeAsString:credentialType];
             }
             
             MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, context, @"(Default accessor) Found %@refresh token by legacy account id", credentialTypeString);

--- a/IdentityCore/src/cache/token/MSIDBoundRefreshTokenCacheItem.h
+++ b/IdentityCore/src/cache/token/MSIDBoundRefreshTokenCacheItem.h
@@ -1,0 +1,40 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import <Foundation/Foundation.h>
+#import "MSIDLegacyTokenCacheItem.h"
+
+/**
+ * @class MSIDBoundRefreshTokenCacheItem
+ * @brief Represents a bound refresh token cache item that is bound to the device.
+ */
+@interface MSIDBoundRefreshTokenCacheItem : MSIDLegacyTokenCacheItem
+
+/**
+ * @property deviceID
+ * @brief The unique identifier of the device to which the refresh token is bound.
+ */
+@property (atomic) NSString *deviceID;
+
+@end

--- a/IdentityCore/src/cache/token/MSIDBoundRefreshTokenCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDBoundRefreshTokenCacheItem.m
@@ -1,0 +1,112 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import "MSIDBoundRefreshTokenCacheItem.h"
+#import "NSString+MSIDExtensions.h"
+#import "NSData+MSIDExtensions.h"
+
+@implementation MSIDBoundRefreshTokenCacheItem
+
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [super encodeWithCoder:coder];
+    [coder encodeObject:self.deviceID forKey:@"deviceID"];
+}
+
+- (id)initWithCoder:(NSCoder *)decoder
+{
+    self = [super initWithCoder:decoder];
+    if (self)
+    {
+        self.deviceID = [decoder decodeObjectOfClass:[NSString class] forKey:@"deviceID"];
+        self.credentialType = MSIDBoundRefreshTokenType;
+    }
+    return self;
+}
+
+#pragma mark - MSIDJsonSerializable
+
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
+{
+    if (!(self = [super initWithJSONDictionary:json error:error]))
+    {
+        return nil;
+    }
+    
+    _deviceID = [json msidObjectForKey:MSID_DEVICE_ID_CACHE_KEY ofClass:[NSString class]];
+    return self;
+}
+
+- (NSDictionary *)jsonDictionary
+{
+    NSMutableDictionary *dictionary = [[super jsonDictionary] mutableCopy];
+    
+    if (!dictionary)
+    {
+        dictionary = [NSMutableDictionary new];
+    }
+
+    dictionary[MSID_DEVICE_ID_CACHE_KEY] = self.deviceID;
+    return dictionary;
+}
+
+#pragma mark - NSObject
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+    {
+        return YES;
+    }
+    
+    if (![object isKindOfClass:self.class])
+    {
+        return NO;
+    }
+    
+    return [self isEqualToItem:(MSIDBoundRefreshTokenCacheItem *)object];
+}
+
+- (BOOL)isEqualToItem:(MSIDBoundRefreshTokenCacheItem *)item
+{
+    BOOL result = [super isEqualToItem:item];
+    result &= (!self.deviceID && !item.deviceID) || [self.deviceID isEqualToString:item.deviceID];
+    return result;
+}
+
+- (NSUInteger)hash
+{
+    NSUInteger hash = [super hash];
+    hash = hash * 31 + self.deviceID.hash;
+    return hash;
+}
+
+@end

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem+MSIDBaseToken.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem+MSIDBaseToken.m
@@ -34,6 +34,7 @@
 #import "MSIDFamilyRefreshToken.h"
 #import "MSIDV1IdToken.h"
 #import "MSIDAccessTokenWithAuthScheme.h"
+#import "MSIDBoundRefreshToken.h"
 
 @implementation MSIDCredentialCacheItem (MSIDBaseToken)
 
@@ -72,6 +73,10 @@
         case MSIDFamilyRefreshTokenType:
         {
             return [[MSIDFamilyRefreshToken alloc] initWithTokenCacheItem:self];
+        }
+        case MSIDBoundRefreshTokenType:
+        {
+            return [[MSIDBoundRefreshToken alloc] initWithTokenCacheItem:self];
         }
         default:
             return [[MSIDBaseToken alloc] initWithTokenCacheItem:self];

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.h
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.h
@@ -90,6 +90,9 @@
 // Redirect Uri
 @property (atomic, readwrite, nullable) NSString *redirectUri;
 
+// Bound device Id
+@property (atomic, readwrite, nullable) NSString *boundDeviceId;
+
 - (BOOL)isEqualToItem:(nullable MSIDCredentialCacheItem *)item;
 
 - (BOOL)matchesTarget:(nullable NSString *)target comparisonOptions:(MSIDComparisonOptions)comparisonOptions;

--- a/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
+++ b/IdentityCore/src/cache/token/MSIDCredentialCacheItem.m
@@ -51,9 +51,9 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"MSIDCredentialCacheItem: clientId: %@, credentialType: %@, target: %@, realm: %@, environment: %@, expiresOn: %@, extendedExpiresOn: %@, refreshOn: %@, cachedAt: %@, last recovery attempted at: %@, recovery attempt count: %@, last recovery attempt succeeded: %@, familyId: %@, homeAccountId: %@, enrollmentId: %@, speInfo: %@, secret: %@, redirectUri: %@",
+    return [NSString stringWithFormat:@"MSIDCredentialCacheItem: clientId: %@, credentialType: %@, target: %@, realm: %@, environment: %@, expiresOn: %@, extendedExpiresOn: %@, refreshOn: %@, cachedAt: %@, last recovery attempted at: %@, recovery attempt count: %@, last recovery attempt succeeded: %@, familyId: %@, homeAccountId: %@, enrollmentId: %@, speInfo: %@, secret: %@, redirectUri: %@ Bound Device ID: %@",
             self.clientId, [MSIDCredentialTypeHelpers credentialTypeAsString:self.credentialType], self.target, self.realm, self.environment, self.expiresOn,
-            self.extendedExpiresOn, self.refreshOn, self.cachedAt, self.lastRecoveryAttempt, self.recoveryAttemptCount, self.lastRecoveryAttemptFailed, self.familyId, self.homeAccountId, self.enrollmentId, self.speInfo, [self.secret msidSecretLoggingHash], MSID_PII_LOG_TRACKABLE(self.redirectUri)];
+            self.extendedExpiresOn, self.refreshOn, self.cachedAt, self.lastRecoveryAttempt, self.recoveryAttemptCount, self.lastRecoveryAttemptFailed, self.familyId, self.homeAccountId, self.enrollmentId, self.speInfo, [self.secret msidSecretLoggingHash], MSID_PII_LOG_TRACKABLE(self.redirectUri), self.boundDeviceId];
 }
 
 #pragma mark - MSIDCacheItem
@@ -94,6 +94,7 @@
     result &= (!self.kid && !item.kid) || [self.kid isEqual:item.kid];
     result &= (!self.requestedClaims && !item.requestedClaims) || [self.requestedClaims isEqual:item.requestedClaims];
     result &= (!self.redirectUri && !item.redirectUri) || [self.redirectUri isEqual:item.redirectUri];
+    result &= (!self.boundDeviceId && !item.boundDeviceId) || [self.boundDeviceId isEqualToString:item.boundDeviceId];
     // Ignore the lastMod properties (two otherwise-identical items with different
     // last modification informational values should be considered equal)
     return result;
@@ -122,6 +123,7 @@
     hash = hash * 31 + self.kid.hash;
     hash = hash * 31 + self.requestedClaims.hash;
     hash = hash * 31 + self.redirectUri.hash;
+    hash = hash * 31 + self.boundDeviceId.hash;
     return hash;
 }
 
@@ -155,6 +157,7 @@
     item.kid = [self.kid copyWithZone:zone];
     item.requestedClaims = [self.requestedClaims copyWithZone:zone];
     item.redirectUri = [self.redirectUri copyWithZone:zone];
+    item.boundDeviceId = [self.boundDeviceId copyWithZone:zone];
     return item;
 }
 
@@ -212,6 +215,7 @@
     _expiryInterval = [json msidStringObjectForKey:MSID_EXPIRES_IN_CACHE_KEY];
     _requestedClaims = [json msidStringObjectForKey:MSID_REQUESTED_CLAIMS_CACHE_KEY];
     _redirectUri = [json msidStringObjectForKey:MSID_OAUTH2_REDIRECT_URI];
+    _boundDeviceId = [json msidStringObjectForKey:MSID_BOUND_DEVICE_ID_CACHE_KEY];
     return self;
 }
 
@@ -252,6 +256,7 @@
     dictionary[MSID_OAUTH2_TOKEN_TYPE] = _tokenType;
     dictionary[MSID_REQUESTED_CLAIMS_CACHE_KEY] = _requestedClaims;
     dictionary[MSID_OAUTH2_REDIRECT_URI] = _redirectUri;
+    dictionary[MSID_BOUND_DEVICE_ID_CACHE_KEY] = _boundDeviceId;
     return dictionary;
 }
 

--- a/IdentityCore/src/oauth2/token/MSIDBoundRefreshToken.h
+++ b/IdentityCore/src/oauth2/token/MSIDBoundRefreshToken.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @return An initialized instance of MSIDBoundRefreshToken.
  */
--(instancetype)initWithRefreshToken:(MSIDRefreshToken *)refreshToken
+- (instancetype)initWithRefreshToken:(MSIDRefreshToken *)refreshToken
                       boundDeviceId:(NSString *)boundDeviceId;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/IdentityCore/src/oauth2/token/MSIDBoundRefreshToken.h
+++ b/IdentityCore/src/oauth2/token/MSIDBoundRefreshToken.h
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDRefreshToken.h"
+NS_ASSUME_NONNULL_BEGIN
+
+/*!
+ @class MSIDBoundRefreshToken
+ 
+ @brief Represents a refresh token bound to a specific device, extending MSIDRefreshToken.
+ 
+ @discussion MSIDBoundRefreshToken is a specialized refresh token type that includes binding information to current device. This token type is used to satisfy token binding policies by associating the refresh token with the device registration's device key.
+ */
+@interface MSIDBoundRefreshToken : MSIDRefreshToken
+
+/*!
+ @property boundDeviceId
+ 
+ @brief The identifier of the device to which this refresh token is bound.
+ 
+ @discussion This property stores the device ID associated with the bound refresh token. It is meant to be a hint to check if device registration's device id matches this value.
+ */
+@property (nonatomic, copy) NSString *boundDeviceId;
+
+/*!
+ @brief Initializes a new instance of MSIDBoundRefreshToken with the provided refresh token, bound device identifier, and request context.
+ 
+ @param refreshToken The bound refresh token
+ @param boundDeviceId The identifier of the device to which this refresh token is bound.
+ 
+ @return An initialized instance of MSIDBoundRefreshToken.
+ */
+-(instancetype)initWithRefreshToken:(MSIDRefreshToken *)refreshToken
+                      boundDeviceId:(NSString *)boundDeviceId;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/oauth2/token/MSIDBoundRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDBoundRefreshToken.m
@@ -1,0 +1,140 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import "MSIDBoundRefreshToken.h"
+#import "MSIDBoundRefreshTokenCacheItem.h"
+
+@implementation MSIDBoundRefreshToken
+
+- (instancetype)initWithRefreshToken:(MSIDRefreshToken *)refreshToken
+                       boundDeviceId:(NSString *)boundDeviceId
+{
+    if (refreshToken && [refreshToken.class isKindOfClass:MSIDRefreshToken.class] && ![NSString msidIsStringNilOrBlank:boundDeviceId])
+    {
+        MSIDBoundRefreshToken *boundRefreshToken = [MSIDBoundRefreshToken new];
+        boundRefreshToken.refreshToken = refreshToken.refreshToken;
+        boundRefreshToken.boundDeviceId = boundDeviceId;
+        boundRefreshToken.familyId = refreshToken.familyId;
+        boundRefreshToken.storageEnvironment = refreshToken.storageEnvironment;
+        boundRefreshToken.environment = refreshToken.environment;
+        boundRefreshToken.realm = refreshToken.realm;
+        boundRefreshToken.clientId = refreshToken.clientId;
+        boundRefreshToken.additionalServerInfo = refreshToken.additionalServerInfo;
+        boundRefreshToken.accountIdentifier = refreshToken.accountIdentifier;
+        boundRefreshToken.speInfo = refreshToken.speInfo;
+        self = boundRefreshToken;
+    }
+    return self;
+}
+
+- (instancetype)initWithTokenCacheItem:(MSIDCredentialCacheItem *)tokenCacheItem
+{
+    self = [super initWithTokenCacheItem:tokenCacheItem];
+    
+    if (self)
+    {
+        NSDictionary *jsonDictionary = tokenCacheItem.jsonDictionary;
+        _boundDeviceId = [jsonDictionary msidObjectForKey:MSID_DEVICE_ID_CACHE_KEY ofClass:[NSString class]];
+    }
+    
+    return self;
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MSIDBoundRefreshToken *item = [super copyWithZone:zone];
+    item.boundDeviceId = [self.boundDeviceId copyWithZone:zone];
+    return item;
+}
+
+#pragma mark - NSObject
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+    {
+        return YES;
+    }
+
+    if (![object isKindOfClass:MSIDBoundRefreshToken.class])
+    {
+        return NO;
+    }
+
+    return [self isEqualToItem:(MSIDBoundRefreshToken *)object];
+}
+
+- (NSUInteger)hash
+{
+    NSUInteger hash = [super hash];
+    hash = hash * 31 + self.boundDeviceId.hash;
+    return hash;
+}
+
+- (BOOL)isEqualToItem:(MSIDBoundRefreshToken *)token
+{
+    if (!token)
+    {
+        return NO;
+    }
+
+    BOOL result = [super isEqualToItem:token];
+    result &= (!self.boundDeviceId && !token.boundDeviceId) || [self.boundDeviceId isEqualToString:token.boundDeviceId];
+    return result;
+}
+
+#pragma mark - Cache
+
+- (MSIDCredentialCacheItem *)tokenCacheItem
+{
+    MSIDCredentialCacheItem *cacheItem = [super tokenCacheItem];
+    NSError *error;
+    MSIDBoundRefreshTokenCacheItem *boundRtCacheItem = [[MSIDBoundRefreshTokenCacheItem alloc] initWithJSONDictionary:cacheItem.jsonDictionary error:&error];
+    if (!boundRtCacheItem)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create bound refresh token cache item from base cache item: %@", error.description);
+        return nil;
+    }
+    boundRtCacheItem.deviceID = self.boundDeviceId;
+    return boundRtCacheItem;
+}
+
+#pragma mark - Token type
+
+- (MSIDCredentialType)credentialType
+{
+    return MSIDBoundRefreshTokenType;
+}
+
+#pragma mark - Description
+
+- (NSString *)description
+{
+    NSString *baseDescription = [super description];
+    return [baseDescription stringByAppendingFormat:@"(bound refresh token=%@, bound device ID=%@)", [_refreshToken msidSecretLoggingHash], _boundDeviceId];
+}
+
+@end

--- a/IdentityCore/src/oauth2/token/MSIDCredentialType.h
+++ b/IdentityCore/src/oauth2/token/MSIDCredentialType.h
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSInteger, MSIDCredentialType)
     MSIDLegacyIDTokenType = 6,
     MSIDAccessTokenWithAuthSchemeType = 7,
     MSIDFamilyRefreshTokenType = 8,
+    MSIDBoundRefreshTokenType = 9,
     MSIDCredentialTypeLast
 };
 

--- a/IdentityCore/src/oauth2/token/MSIDCredentialType.m
+++ b/IdentityCore/src/oauth2/token/MSIDCredentialType.m
@@ -46,6 +46,9 @@ static NSInteger kCredentialTypePrefix = 2000;
         case MSIDPrimaryRefreshTokenType:
             return MSID_PRT_TOKEN_CACHE_TYPE;
             
+        case MSIDBoundRefreshTokenType:
+            return MSID_BOUND_RT_TOKEN_CACHE_TYPE;
+            
         case MSIDFamilyRefreshTokenType:
             return MSID_FRT_TOKEN_CACHE_TYPE;
             
@@ -74,6 +77,7 @@ static NSDictionary *sCredentialTypes = nil;
                              [MSID_ID_TOKEN_CACHE_TYPE lowercaseString]: @(MSIDIDTokenType),
                              [MSID_PRT_TOKEN_CACHE_TYPE lowercaseString]: @(MSIDPrimaryRefreshTokenType),
                              [MSID_FRT_TOKEN_CACHE_TYPE lowercaseString]: @(MSIDFamilyRefreshTokenType),
+                             [MSID_BOUND_RT_TOKEN_CACHE_TYPE lowercaseString]: @(MSIDBoundRefreshTokenType),
                              [MSID_LEGACY_ID_TOKEN_CACHE_TYPE lowercaseString]: @(MSIDLegacyIDTokenType),
                              [MSID_GENERAL_TOKEN_CACHE_TYPE lowercaseString]: @(MSIDCredentialTypeOther),
                              [MSID_ACCESS_TOKEN_WITH_AUTH_SCHEME_CACHE_TYPE lowercaseString]: @(MSIDAccessTokenWithAuthSchemeType),

--- a/IdentityCore/tests/MSIDBoundRefreshTokenTests.m
+++ b/IdentityCore/tests/MSIDBoundRefreshTokenTests.m
@@ -1,0 +1,232 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import <XCTest/XCTest.h>
+#import "NSDictionary+MSIDTestUtil.h"
+#import "MSIDRefreshToken.h"
+#import "MSIDAuthority.h"
+#import "MSIDAccountIdentifier.h"
+#import "MSIDClientInfo.h"
+#import "MSIDBoundRefreshToken.h"
+
+@interface MSIDBoundRefreshTokenTests : XCTestCase
+
+@end
+
+@implementation MSIDBoundRefreshTokenTests
+
+#pragma mark - Copy tests
+
+- (void)testCopy_whenAllPropertiesAreSet_shouldReturnEqualCopy
+{
+    MSIDBoundRefreshToken *token = [self createToken];
+    MSIDBoundRefreshToken *tokenCopy = [token copy];
+    
+    XCTAssertEqualObjects(tokenCopy, token);
+}
+
+#pragma mark - isEqual tests
+
+- (void)testBoundRefreshTokenIsEqual_whenAllPropertiesAreEqual_shouldReturnTrue
+{
+    MSIDBoundRefreshToken *lhs = [self createToken];
+    MSIDBoundRefreshToken *rhs = [self createToken];
+    
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+#pragma mark - MSIDBoundRefreshToken
+
+- (void)testBoundRefreshTokenIsEqual_whenBoundDeviceIdIsNotEqual_shouldReturnFalse
+{
+    MSIDBoundRefreshToken *lhs = [self createToken];
+    MSIDBoundRefreshToken *rhs = [self createToken];
+    rhs.boundDeviceId = @"different_device_id";
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testBoundRefreshTokenIsEqual_whenBoundDeviceIdIsEqual_shouldReturnTrue
+{
+    MSIDBoundRefreshToken *lhs = [self createToken];
+    MSIDBoundRefreshToken *rhs = [self createToken];
+    lhs.boundDeviceId = @"abcdefgh";
+    rhs.boundDeviceId = @"abcdefgh";
+    XCTAssertEqualObjects(lhs, rhs);
+}
+
+- (void)testBoundRefreshTokenIsEqual_whenRefreshTokenIsNotEqual_shouldReturnFalse
+{
+    MSIDBoundRefreshToken *lhs = [self createToken];
+    MSIDBoundRefreshToken *rhs = [self createToken];
+    rhs.refreshToken = @"different_refresh_token";
+    
+    XCTAssertNotEqualObjects(lhs, rhs);
+}
+
+- (void)testBoundRefreshTokenInitWithRefreshToken_whenValidParameters_shouldCreateBoundRefreshToken
+{
+    MSIDRefreshToken *refreshToken = [self createRefreshToken];
+    MSIDBoundRefreshToken *boundToken = [[MSIDBoundRefreshToken alloc] initWithRefreshToken:refreshToken boundDeviceId:@"device_id"];
+    
+    XCTAssertNotNil(boundToken);
+    XCTAssertEqualObjects(boundToken.refreshToken, refreshToken.refreshToken);
+    XCTAssertEqualObjects(boundToken.boundDeviceId, @"device_id");
+    XCTAssertEqualObjects(boundToken.familyId, refreshToken.familyId);
+    XCTAssertEqualObjects(boundToken.environment, refreshToken.environment);
+    XCTAssertEqualObjects(boundToken.realm, refreshToken.realm);
+    XCTAssertEqualObjects(boundToken.clientId, refreshToken.clientId);
+    XCTAssertEqualObjects(boundToken.accountIdentifier.homeAccountId, refreshToken.accountIdentifier.homeAccountId);
+    XCTAssertNotEqual(boundToken.hash, refreshToken.hash);
+}
+
+- (void)testBoundRefreshTokenInitWithRefreshToken_whenNilDeviceId_shouldReturnNil
+{
+    MSIDRefreshToken *refreshToken = [self createRefreshToken];
+    NSString *deviceId = nil;
+    MSIDBoundRefreshToken *boundToken = [[MSIDBoundRefreshToken alloc] initWithRefreshToken:refreshToken boundDeviceId:deviceId];
+    
+    XCTAssertNil(boundToken);
+}
+
+#pragma mark - Token cache item
+
+- (void)testInitWithTokenCacheItem_whenNilCacheItem_shouldReturnNil
+{
+    MSIDBoundRefreshToken *token = [[MSIDBoundRefreshToken alloc] initWithTokenCacheItem:nil];
+    XCTAssertNil(token);
+}
+
+- (void)testInitWithTokenCacheItem_whenWrongTokenType_shouldReturnNil
+{
+    MSIDCredentialCacheItem *cacheItem = [MSIDCredentialCacheItem new];
+    cacheItem.credentialType = MSIDIDTokenType;
+    
+    MSIDBoundRefreshToken *token = [[MSIDBoundRefreshToken alloc] initWithTokenCacheItem:cacheItem];
+    XCTAssertNil(token);
+}
+
+- (void)testInitWithTokenCacheItem_whenNoRefreshToken_shouldReturnNil
+{
+    MSIDCredentialCacheItem *cacheItem = [MSIDCredentialCacheItem new];
+    cacheItem.credentialType = MSIDBoundRefreshTokenType;
+    cacheItem.environment = @"login.microsoftonline.com";
+    cacheItem.speInfo = @"test";
+    cacheItem.homeAccountId = @"uid.utid";
+    cacheItem.clientId = @"client id";
+    cacheItem.boundDeviceId = @"device id";
+    
+    MSIDBoundRefreshToken *token = [[MSIDBoundRefreshToken alloc] initWithTokenCacheItem:cacheItem];
+    XCTAssertNil(token);
+}
+
+- (void)testInitWithTokenCacheItem_whenNoDeviceId_shouldReturnNil
+{
+    MSIDCredentialCacheItem *cacheItem = [MSIDCredentialCacheItem new];
+    cacheItem.credentialType = MSIDBoundRefreshTokenType;
+    cacheItem.environment = @"login.microsoftonline.com";
+    cacheItem.speInfo = @"test";
+    cacheItem.homeAccountId = @"uid.utid";
+    cacheItem.clientId = @"client id";
+    cacheItem.secret = @"refresh token";
+    
+    MSIDBoundRefreshToken *token = [[MSIDBoundRefreshToken alloc] initWithTokenCacheItem:cacheItem];
+    XCTAssertNil(token);
+}
+
+- (void)testInitWithTokenCacheItem_whenAllFieldsSet_shouldReturnToken
+{
+    MSIDCredentialCacheItem *cacheItem = [MSIDCredentialCacheItem new];
+    cacheItem.credentialType = MSIDBoundRefreshTokenType;
+    cacheItem.environment = @"login.microsoftonline.com";
+    cacheItem.speInfo = @"test";
+    cacheItem.homeAccountId = @"uid.utid";
+    cacheItem.clientId = @"client id";
+    cacheItem.secret = @"refresh token";
+    cacheItem.boundDeviceId = @"device id";
+
+    MSIDBoundRefreshToken *token = [[MSIDBoundRefreshToken alloc] initWithTokenCacheItem:cacheItem];
+    XCTAssertNotNil(token);
+    XCTAssertEqualObjects(token.environment, @"login.microsoftonline.com");
+    XCTAssertNil(token.realm);
+    XCTAssertEqualObjects(token.clientId, @"client id");
+    XCTAssertEqualObjects(token.speInfo, @"test");
+    XCTAssertNil(token.additionalServerInfo);
+    XCTAssertEqualObjects(token.accountIdentifier.homeAccountId, @"uid.utid");
+    XCTAssertEqualObjects(token.refreshToken, @"refresh token");
+    XCTAssertEqualObjects(token.boundDeviceId, @"device id");
+    
+    MSIDCredentialCacheItem *newCacheItem = [token tokenCacheItem];
+    XCTAssertEqualObjects(cacheItem, newCacheItem);
+}
+
+- (void)testTokenCacheItem_whenAllFieldsSet_shouldReturnValidCacheItem
+{
+    MSIDBoundRefreshToken *token = [self createToken];
+    MSIDCredentialCacheItem *cacheItem = [token tokenCacheItem];
+    
+    XCTAssertNotNil(cacheItem);
+    XCTAssertEqual(cacheItem.credentialType, MSIDBoundRefreshTokenType);
+    XCTAssertEqualObjects(cacheItem.environment, @"contoso.com");
+    XCTAssertNil(cacheItem.realm);
+    XCTAssertEqualObjects(cacheItem.clientId, @"some clientId");
+    XCTAssertEqualObjects(cacheItem.secret, @"refreshToken");
+    XCTAssertEqualObjects(cacheItem.homeAccountId, @"uid.utid");
+    XCTAssertEqualObjects(cacheItem.boundDeviceId, @"device_id");
+}
+
+- (void)testCredentialType_shouldReturnBoundRefreshTokenType
+{
+    MSIDBoundRefreshToken *token = [self createToken];
+    XCTAssertEqual([token credentialType], MSIDBoundRefreshTokenType);
+}
+
+#pragma mark - Private
+
+- (MSIDBoundRefreshToken *)createToken
+{
+    MSIDRefreshToken *refreshToken = [self createRefreshToken];
+    return [[MSIDBoundRefreshToken alloc] initWithRefreshToken:refreshToken boundDeviceId:@"device_id"];
+}
+
+- (MSIDRefreshToken *)createRefreshToken
+{
+    MSIDRefreshToken *token = [MSIDRefreshToken new];
+    token.environment = @"contoso.com";
+    token.realm = @"common";
+    token.clientId = @"some clientId";
+    token.additionalServerInfo = @{@"spe_info" : @"value2"};
+    token.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"legacy.id" homeAccountId:@"uid.utid"];
+    token.refreshToken = @"refreshToken";
+    token.familyId = @"familyId";
+    return token;
+}
+
+- (MSIDClientInfo *)createClientInfo:(NSDictionary *)clientInfoDict
+{
+    NSString *base64String = [clientInfoDict msidBase64UrlJson];
+    return [[MSIDClientInfo alloc] initWithRawClientInfo:base64String error:nil];
+}
+
+@end


### PR DESCRIPTION
## Proposed changes

This pull request introduces support for a new "Bound Refresh Token" (BRT) type in the IdentityCore library. It adds all necessary files, constants, and project configuration to handle this new token type, which is designed to be bound to a specific device. The changes ensure that BRTs are properly serialized, cached, and handled throughout the codebase, and include corresponding unit tests for validation.

**Bound Refresh Token (BRT) Support**

* Added new files `MSIDBoundRefreshToken.h`, `MSIDBoundRefreshToken.m`, `MSIDBoundRefreshTokenCacheItem.h`, and `MSIDBoundRefreshTokenCacheItem.m` to define and implement the BRT type and its cache item, including device binding logic and serialization. [[1]](diffhunk://#diff-aa07af328f9a313cae79adbce6098c36c0f1fc94f349fc5c410c044a7e2964faR1-R40) [[2]](diffhunk://#diff-9282947dffa021670f928387104028843a637e116814c10cb730974f9a9cc9c2R1-R112) [[3]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR2674-R2678) [[4]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR4820-R4821) [[5]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR4924-R4925)
* Registered these new files in the Xcode project, including source, header, and test entries, ensuring they are included in builds and test runs. [[1]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR758-R765) [[2]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR5730) [[3]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR6377) [[4]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR6422) [[5]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR7092) [[6]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR7290) [[7]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR7321) [[8]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR7772) [[9]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR8002) [[10]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR8228)

**Constants and Type Handling**

* Added new constants `MSID_BOUND_RT_TOKEN_CACHE_TYPE` and `MSID_BOUND_DEVICE_ID_CACHE_KEY` to `MSIDOAuth2Constants.h` and `.m` for identifying BRTs and their associated device IDs. [[1]](diffhunk://#diff-ccb8d422c5d2ad0564c496ecc9c73413678c9d0052183a067dadc1faf67b8d3aR160) [[2]](diffhunk://#diff-ccb8d422c5d2ad0564c496ecc9c73413678c9d0052183a067dadc1faf67b8d3aR181) [[3]](diffhunk://#diff-e3d03bf21e6ff9b11fdd43e719c81c12a133dfcc6e9767fe00acd4623b6178d8R154) [[4]](diffhunk://#diff-e3d03bf21e6ff9b11fdd43e719c81c12a133dfcc6e9767fe00acd4623b6178d8R181-R182)
* Updated token handling logic to recognize and process the new BRT type, including logging and credential type string handling. [[1]](diffhunk://#diff-8bae7869a933c3487565ad68b54ecb1966e06d513d7d84b3a33253cb9f329c29L310-R310) [[2]](diffhunk://#diff-450839bfa0c737fd8dced222a3dcd07b8dc3d20fe6de8f1e2cee39d02da29e7fR37)

**Cache and Wipe Info Handling**

* Modified cache removal logic to ensure that wiping info is saved when a BRT is removed, similar to existing refresh token types.

**Testing**

* Added `MSIDBoundRefreshTokenTests.m` to validate the new BRT functionality and ensure correctness. [[1]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR5730) [[2]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR7092) [[3]](diffhunk://#diff-ecc6567d3bacb2ed1f4b93b2249973ba63873e2fbcb0db4d9335e66b1d25e08bR7772)

These changes lay the groundwork for securely managing refresh tokens that are bound to specific devices, improving the security and granularity of token management in the library.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

