### PR TITLE
Add flag for PSSO registration in progress to MSDIExternalSSOContext

### DIFF
--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
 @property (nonatomic, nullable, strong) ASAuthorizationProviderExtensionLoginManager *loginManager API_AVAILABLE(macos(13.0));
 @property (nonatomic) BOOL isDeviceRegistered API_AVAILABLE(macos(13.0));
+@property (nonatomic) BOOL isPSSORegistration API_AVAILABLE(macos(13.0));
 #endif
 #endif
 

--- a/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
+++ b/IdentityCore/src/oauth2/MSIDExternalSSOContext.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
 @property (nonatomic, nullable, strong) ASAuthorizationProviderExtensionLoginManager *loginManager API_AVAILABLE(macos(13.0));
 @property (nonatomic) BOOL isDeviceRegistered API_AVAILABLE(macos(13.0));
-@property (nonatomic) BOOL isPSSORegistration API_AVAILABLE(macos(13.0));
+@property (nonatomic) BOOL isPlatformSSORegistrationFlow API_AVAILABLE(macos(13.0));
 #endif
 #endif
 

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.h
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.h
@@ -49,6 +49,7 @@ typedef NS_ENUM(NSInteger, MSIDExternalPRTKeyLocationType)
 @property (nonatomic) MSIDExternalPRTKeyLocationType externalKeyLocationType;
  
 - (BOOL)isDevicelessPRT;
+- (BOOL)isDevicelessPRTv3;
 - (BOOL)shouldRefreshWithInterval:(NSUInteger)refreshInterval;
 - (NSUInteger)prtId;
 

--- a/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDPrimaryRefreshToken.m
@@ -216,6 +216,12 @@ static NSString *kMinSupportedPRTVersion = @"3.0";
     return prtVersion >= 3.0 && [NSString msidIsStringNilOrBlank:self.deviceID];
 }
 
+- (BOOL)isDevicelessPRTv3
+{
+    CGFloat prtVersion = [self.prtProtocolVersion floatValue];
+    return prtVersion == 3.0 && [NSString msidIsStringNilOrBlank:self.deviceID];
+}
+
 - (BOOL)shouldRefreshWithInterval:(NSUInteger)refreshInterval
 {
     if (!self.expiresOn)


### PR DESCRIPTION
## Proposed changes

This PR adds a boolean flag to the MSIDExternalSSOContext to determine if PSSO registration is currently in-progress. It can be checked as the obj is passed through various flows.

This PR also adds a isDevicelessPRTv3 function.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

