### PR TITLE
Use parent anchor window as a fallback for presenting the xpc sign-in…

### DIFF
--- a/IdentityCore/src/requests/broker/mac/MSIDSSOXpcInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/broker/mac/MSIDSSOXpcInteractiveTokenRequest.m
@@ -20,7 +20,7 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.  
+// THE SOFTWARE.
 
 
 #import "MSIDSSOXpcInteractiveTokenRequest.h"
@@ -96,13 +96,26 @@
 
     // Retrieve the bundle identifier
     NSString *bundleIdentifier = [mainBundle bundleIdentifier];
+
+    // Use parentViewController frame if available, otherwise fall back to presentationAnchorWindow frame.
+    // This is also aligned when providing anchor window for the SSO Extension
+    CGRect xpcAnchorFrame = CGRectZero;
+    MSIDViewController *strongParentViewController = self.requestParameters.parentViewController;
+    if (strongParentViewController) {
+        xpcAnchorFrame = strongParentViewController.view.window.frame;
+    } else if (self.requestParameters.presentationAnchorWindow) {
+        xpcAnchorFrame = self.requestParameters.presentationAnchorWindow.frame;
+    }
+    
+    // If there is no xpcAnchorFrame at this moment, the xpc window will try best effort to be presented on the screen with default size and position.
+
     NSDictionary *parameters = @{@"source_application": bundleIdentifier,
                                  @"sso_request_param": xpcRequest,
                                  @"is_silent": @(NO),
                                  @"sso_request_operation": [self.operationRequest.class operation],
                                  @"sso_request_id": [[NSUUID UUID] UUIDString]};
     [self.xpcSingleSignOnProvider handleRequestParam:parameters
-                                     parentViewFrame:self.requestParameters.parentViewController.view.window.frame
+                                     parentViewFrame:xpcAnchorFrame
                            assertKindOfResponseClass:MSIDBrokerOperationTokenResponse.class
                                     xpcProviderCache:MSIDXpcProviderCache.sharedInstance
                                              context:self.context


### PR DESCRIPTION
… window

## Proposed changes

This pull request improves how the anchor window frame is determined for presenting the XPC request window in the SSO flow on macOS. The update ensures that the frame used for presentation is chosen more reliably, improving alignment with how the anchor window is provided for the SSO Extension.

Enhancements to anchor window frame selection:

* In `MSIDSSOXpcInteractiveTokenRequest.m`, the code now checks if a `parentViewController` is available and uses its window frame for the XPC anchor. If not, it falls back to the `presentationAnchorWindow` frame. If neither is available, it defaults to a zero rect, allowing best-effort presentation. This logic ensures better consistency and reliability in window positioning.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

