### PR TITLE
Remove a line that could cause crash when XPC service refuse to take the incoming connection

### DIFF
--- a/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
+++ b/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
@@ -70,7 +70,7 @@
 
 - (void)handleXpcWithRequestParams:(NSDictionary *)passedInParams
                    parentViewFrame:(NSRect)frame
-                   completionBlock:(void (^)(NSDictionary<NSString *,id> * _Nonnull, NSDate * _Nonnull, NSString * _Nonnull, NSError * _Nullable))blockName;
+                   completionBlock:(void (^)(NSDictionary<NSString *,id> * _Nullable, NSDate * _Nonnull, NSString * _Nonnull, NSError * _Nullable))blockName;
 
 - (void)canPerformWithMetadata:(NSDictionary *)passedInParams
                completionBlock:(void (^)(BOOL))blockName;
@@ -115,7 +115,7 @@ typedef void (^NSXPCListenerEndpointCompletionBlock)(id<MSIDXpcBrokerInstancePro
             return;
         }
         
-        [xpcService handleXpcWithRequestParams:requestParam parentViewFrame:frame completionBlock:^(NSDictionary<NSString *,id> * _Nonnull replyParam, NSDate * _Nonnull __unused xpcStartDate, NSString * _Nonnull __unused processId, NSError * _Nonnull callbackError) {
+        [xpcService handleXpcWithRequestParams:requestParam parentViewFrame:frame completionBlock:^(NSDictionary<NSString *,id> * _Nullable replyParam, NSDate * _Nonnull __unused xpcStartDate, NSString * _Nonnull __unused processId, NSError * _Nullable callbackError) {
             [directConnection suspend];
             [directConnection invalidate];
             


### PR DESCRIPTION
## Proposed changes

This pull request makes minor adjustments to the XPC broker protocol and its usage in `MSIDXpcSingleSignOnProvider.m` to improve error handling and clarify the nullability of callback parameters.

Protocol and method signature updates:

* Updated the `completionBlock` signature in `handleXpcWithRequestParams` to allow the reply dictionary to be nullable, improving clarity around possible error cases.
* Updated the callback in `handleRequestParam:` to match the new nullable reply parameter and error type, ensuring consistency with the protocol change.

Error handling cleanup:

* Removed redundant error handling code in `getXpcService:withContinueB`, as the error is already handled by the preceding block.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

