### PR TITLE
Hotfix/1.12.1

### DIFF
--- a/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
+++ b/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
@@ -70,7 +70,7 @@
 
 - (void)handleXpcWithRequestParams:(NSDictionary *)passedInParams
                    parentViewFrame:(NSRect)frame
-                   completionBlock:(void (^)(NSDictionary<NSString *,id> * _Nonnull, NSDate * _Nonnull, NSString * _Nonnull, NSError * _Nullable))blockName;
+                   completionBlock:(void (^)(NSDictionary<NSString *,id> * _Nullable, NSDate * _Nonnull, NSString * _Nonnull, NSError * _Nullable))blockName;
 
 - (void)canPerformWithMetadata:(NSDictionary *)passedInParams
                completionBlock:(void (^)(BOOL))blockName;
@@ -115,7 +115,7 @@ typedef void (^NSXPCListenerEndpointCompletionBlock)(id<MSIDXpcBrokerInstancePro
             return;
         }
         
-        [xpcService handleXpcWithRequestParams:requestParam parentViewFrame:frame completionBlock:^(NSDictionary<NSString *,id> * _Nonnull replyParam, NSDate * _Nonnull __unused xpcStartDate, NSString * _Nonnull __unused processId, NSError * _Nonnull callbackError) {
+        [xpcService handleXpcWithRequestParams:requestParam parentViewFrame:frame completionBlock:^(NSDictionary<NSString *,id> * _Nullable replyParam, NSDate * _Nonnull __unused xpcStartDate, NSString * _Nonnull __unused processId, NSError * _Nullable callbackError) {
             [directConnection suspend];
             [directConnection invalidate];
             

--- a/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
+++ b/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
@@ -415,8 +415,6 @@ typedef void (^NSXPCListenerEndpointCompletionBlock)(id<MSIDXpcBrokerInstancePro
             continueBlock(nil, nil, xpcError);
             return;
         }
-        
-        if (continueBlock) continueBlock(nil, nil, xpcError);
     }];
     
     id<MSIDXpcBrokerDispatcherProtocol> parentXpcService = [connection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.12.1
+* Remove a line that could cause crash when XPC service refuse to take the incoming connection (#1522)
+* Resolve UBSan issue due to Xpc protocol I/O  (#1522)
+
 Version 1.12.0
 * Add classes to define jwe_crypto and APV (#1522)
 * Add Request class to get nonce from server (#1525)


### PR DESCRIPTION
## Proposed changes


This pull request addresses stability and correctness issues in the XPC communication layer for macOS single sign-on, specifically by improving error handling and resolving a type mismatch that could lead to undefined behavior. The changes ensure safer handling of XPC service replies and prevent potential crashes when connections are refused.

Improvements to XPC error handling:

* Updated the `handleXpcWithRequestParams:parentViewFrame:completionBlock:` protocol and its usage to allow the reply parameter to be nullable, resolving a type mismatch and addressing a UBSan (Undefined Behavior Sanitizer) issue. [[1]](diffhunk://#diff-071f78951861bddb890dd200720f18d597709b29382140548f0b58c391325190L73-R73) [[2]](diffhunk://#diff-071f78951861bddb890dd200720f18d597709b29382140548f0b58c391325190L118-R118)
* Removed a redundant line in `getXpcService:withContinueB` that could cause a crash if the XPC service refused the incoming connection, improving stability.

Documentation:

* Added a changelog entry for version 1.12.1, detailing the crash fix and UBSan resolution.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

