### PR TITLE
Add flag to indicate to broker that BART is supported by common-core 

### DIFF
--- a/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDBrokerTokenRequest.m
@@ -162,6 +162,10 @@
 #if TARGET_OS_IPHONE
     [queryDictionary msidSetNonEmptyString:self.brokerKey forKey:@"broker_key"];
     [queryDictionary msidSetNonEmptyString:self.brokerNonce forKey:@"broker_nonce"];
+    //if ([MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_IS_BART_SUPPORTED])
+    //{
+        [queryDictionary msidSetNonEmptyString:@"1" forKey:@"bound_rt_redeem"];
+    //}
 #endif
     [queryDictionary msidSetNonEmptyString:[MSIDVersion sdkVersion] forKey:@"client_version"];
     [queryDictionary msidSetNonEmptyString:claimsString forKey:@"claims"];

--- a/IdentityCore/tests/integration/ios/MSIDBrokerTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerTokenRequestTests.m
@@ -191,6 +191,7 @@
                                       @"client_app_version": @"1.0",
                                       @"broker_nonce" : [MSIDTestIgnoreSentinel sentinel],
                                       @"application_token" : @"brokerApplicationToken",
+                                      @"bound_rt_redeem": @"1",
                                       @"client_sku" : [self clientSku],
                                       @"skip_validate_result_account" : @"NO"
                                       };
@@ -238,6 +239,7 @@
                                       @"application_token" : @"brokerApplicationToken",
                                       @"req_cnf" : @"eyJraWQiOiJlQWkyNE9leml1czc5VlRadDhsZlhldFJTejdsR2thSmloWEJFWkIwMnV3In0",
                                       @"token_type" : @"Pop",
+                                      @"bound_rt_redeem": @"1",
                                       @"client_sku" : [self clientSku],
                                       @"skip_validate_result_account" : @"NO"
     };
@@ -290,6 +292,7 @@
                                       @"key_id":@"key_id_value",
                                       @"req_cnf" : [NSString stringWithFormat:@"{\"kty\":\"RSA\",\"n\":\"%@\",\"e\":\"%@\"}", modulus, exponent],
                                       @"token_type" : @"ssh-cert",
+                                      @"bound_rt_redeem": @"1",
                                       @"client_sku" : [self clientSku],
                                       @"skip_validate_result_account" : @"NO"
     };
@@ -339,6 +342,7 @@
                                       @"client_app_version": @"1.0",
                                       @"broker_nonce" : [MSIDTestIgnoreSentinel sentinel],
                                       @"application_token" : @"brokerApplicationToken",
+                                      @"bound_rt_redeem": @"1",
                                       @"client_sku" : [self clientSku],
                                       @"skip_validate_result_account" : @"NO"
                                       };
@@ -376,6 +380,7 @@
                                       @"client_app_version": @"1.0",
                                       @"broker_nonce" : [MSIDTestIgnoreSentinel sentinel],
                                       @"application_token" : @"brokerApplicationToken",
+                                      @"bound_rt_redeem": @"1",
                                       @"client_sku" : [self clientSku],
                                       @"skip_validate_result_account" : @"NO"
                                       };
@@ -422,6 +427,7 @@
                                       @"broker_nonce" : [MSIDTestIgnoreSentinel sentinel],
                                       @"application_token" : @"brokerApplicationToken",
                                       @"sdk_broker_capabilities": @"capability1,capability2",
+                                      @"bound_rt_redeem": @"1",
                                       @"client_sku" : [self clientSku],
                                       @"skip_validate_result_account" : @"NO"
                                       };
@@ -505,6 +511,7 @@
                                       @"client_app_version": @"1.0",
                                       @"broker_nonce" : [MSIDTestIgnoreSentinel sentinel],
                                       @"application_token" : @"brokerApplicationToken",
+                                      @"bound_rt_redeem": @"1",
                                       @"client_sku" : [self clientSku],
                                       @"skip_validate_result_account" : @"NO"
                                       };
@@ -592,6 +599,7 @@
             @"application_token" : @"brokerApplicationToken",
             @"brk_client_id" : @"123-456-7890-123",
             @"brk_redirect_uri" : @"msauth.com.app.id://auth",
+            @"bound_rt_redeem": @"1",
             @"client_sku" : [self clientSku],
             @"skip_validate_result_account" : @"NO"
     };


### PR DESCRIPTION
## Proposed changes

MSAL/Common-core version that indicates to broker that it is capable of handling bound app refresh tokens (BART).
[IMPORTANT] This PR should be merged after PR https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1572
and https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1565


## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

