### PR TITLE
[CommonCore] Fix issue with legacy keychain on macOS.

### DIFF
--- a/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
+++ b/IdentityCore/src/cache/mac/MSIDMacKeychainTokenCache.m
@@ -557,14 +557,15 @@ static NSString *kLoginKeychainEmptyKey = @"LoginKeychainEmpty";
 
 - (NSArray<MSIDJsonObject *> *)jsonObjectsWithKey:(__unused MSIDCacheKey *)key serializer:(__unused id<MSIDExtendedCacheItemSerializing>)serializer context:(id<MSIDRequestContext>)context error:(NSError *__autoreleasing *)error
 {
-    [self createUnimplementedError:error context:context];
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Skipping jsonObjectsWithKey:serializer:context:error: in MSIDMacKeychainTokenCache.");
     return nil;
 }
 
 
 - (BOOL)saveJsonObject:(__unused MSIDJsonObject *)jsonObject serializer:(__unused id<MSIDExtendedCacheItemSerializing>)serializer key:(__unused MSIDCacheKey *)key context:(id<MSIDRequestContext>)context error:(NSError *__autoreleasing *)error
 {
-    [self createUnimplementedError:error context:context];
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Skipping saveJsonObject:serializer:key:context:error: in MSIDMacKeychainTokenCache.");
+    
     return NO;
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.15.3
+* Fix issue with legacy keychain on macOS.
+
 Version 1.15.2
 * Feature flag gating STK querying and getting rid of category for its setter. (#1586)
 


### PR DESCRIPTION
## Proposed changes

This pull request addresses an issue with the legacy keychain on macOS by updating logging and error handling in the `MSIDMacKeychainTokenCache` implementation. Instead of creating unimplemented errors for certain methods, the code now logs informational messages and returns early, which should improve clarity when these methods are called in unsupported contexts.

Key changes:

**Keychain error handling and logging improvements:**

* Updated `jsonObjectsWithKey:serializer:context:error:` and `saveJsonObject:serializer:key:context:error:` in `MSIDMacKeychainTokenCache.m` to log informational messages instead of generating unimplemented errors, and to return `nil` or `NO` as appropriate.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

