### PR TITLE
Add deviceId constant and property for BART requests/response

### DIFF
--- a/IdentityCore/src/MSIDBrokerConstants.h
+++ b/IdentityCore/src/MSIDBrokerConstants.h
@@ -99,6 +99,7 @@ extern NSString * _Nonnull const MSID_IS_CALLER_MANAGED_KEY;
 extern NSString * _Nonnull const MSID_BROKER_PREFERRED_AUTH_CONFIGURATION_KEY;
 extern NSString * _Nonnull const MSID_BROKER_CLIENT_FLIGHTS_KEY;
 extern NSString * _Nonnull const MSID_BROKER_SDM_WPJ_ATTEMPTED;
+extern NSString * _Nonnull const MSID_BART_DEVICE_ID_KEY;
 extern NSString * _Nonnull const MSID_EXP_RETRY_ON_NETWORK;
 extern NSString * _Nonnull const MSID_EXP_ENABLE_CONNECTION_CLOSE;
 extern NSString * _Nonnull const MSID_HTTP_CONNECTION;

--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -97,6 +97,7 @@ NSString *const MSID_PLATFORM_SSO_STATUS_KEY = @"platform_sso_status";
 NSString *const MSID_JIT_TROUBLESHOOTING_HOST = @"jit_troubleshooting";
 NSString *const MSID_IS_CALLER_MANAGED_KEY = @"isCallerAppManaged";
 NSString *const MSID_BROKER_SDM_WPJ_ATTEMPTED = @"sdm_reg_attempted";
+NSString *const MSID_BART_DEVICE_ID_KEY = @"bart_device_id";
 NSString *const MSID_FORCE_REFRESH_KEY = @"force_refresh";
 
 // Experiments

--- a/IdentityCore/src/oauth2/MSIDTokenResponse.h
+++ b/IdentityCore/src/oauth2/MSIDTokenResponse.h
@@ -95,6 +95,8 @@
 
 @property (nonatomic) BOOL createdFromCache;
 
+@property (nonatomic, nullable) NSString *boundAppRefreshTokenDeviceId;
+
 - (nullable instancetype)initWithJSONDictionary:(nonnull NSDictionary *)json
                                    refreshToken:(nullable MSIDBaseToken<MSIDRefreshableToken> *)token
                                           error:(NSError * _Nullable __autoreleasing *_Nullable)error;

--- a/IdentityCore/src/oauth2/MSIDTokenResponse.m
+++ b/IdentityCore/src/oauth2/MSIDTokenResponse.m
@@ -170,6 +170,7 @@
         _stsErrorCodes = [json msidArrayOfIntegersForKey: MSID_OAUTH2_ERROR_CODES];
         _errorDescription = [[json msidStringObjectForKey:MSID_OAUTH2_ERROR_DESCRIPTION] msidURLDecode];
         _clientAppVersion = [json msidStringObjectForKey:MSID_BROKER_CLIENT_APP_VERSION_KEY];
+        _boundAppRefreshTokenDeviceId = [json msidStringObjectForKey:MSID_BART_DEVICE_ID_KEY];
         [self setAdditionalServerInfo:json];
     }
     


### PR DESCRIPTION
## Proposed changes

Add deviceId constant and property for BART requests/response

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

