### PR TITLE
fix an issue where the SsoExt anchor window is based on its VC, which…

### DIFF
--- a/IdentityCore/src/requests/broker/MSIDSSOExtensionInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSOExtensionInteractiveTokenRequest.m
@@ -126,7 +126,7 @@
     }
     
     __typeof__(self.requestParameters.parentViewController) parentViewController = self.requestParameters.parentViewController;
-    return parentViewController.view.window ? : self.requestParameters.presentationAnchorWindow;
+    return parentViewController.view.window ? parentViewController.view.window : self.requestParameters.presentationAnchorWindow;
 }
 
 #pragma mark - Dealloc


### PR DESCRIPTION
… is not accurate

## Proposed changes

This pull request makes a minor change to how the presentation anchor window is selected in the `MSIDSSOExtensionInteractiveTokenRequest.m` file. The update simplifies the conditional logic for returning the window.

* Simplified the return statement in `presentationAnchor` to use the window of `parentViewController` if available, otherwise falling back to `presentationAnchorWindow`.
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

