### PR TITLE
Fix build error in MSAL CPP

### DIFF
--- a/IdentityCore/src/oauth2/MSIDOauth2Factory.m
+++ b/IdentityCore/src/oauth2/MSIDOauth2Factory.m
@@ -418,11 +418,8 @@
 
 - (BOOL)doesResponseHaveBoundAppRefreshToken:(MSIDTokenResponse *)response
 {
-    id bartDeviceIdValue = response.additionalServerInfo[MSID_BART_DEVICE_ID_KEY];
-    NSString *bartDeviceId = [bartDeviceIdValue isKindOfClass:NSString.class] ? (NSString *)bartDeviceIdValue : nil;
-
     return ![NSString msidIsStringNilOrBlank:response.boundAppRefreshTokenDeviceId] ||
-           ![NSString msidIsStringNilOrBlank:bartDeviceId];
+           ![NSString msidIsStringNilOrBlank:response.additionalServerInfo[MSID_BART_DEVICE_ID_KEY]];
 }
 
 #pragma mark - Webview


### PR DESCRIPTION
## Proposed changes

Fix build error: 
`multiple methods named 'length' found [-Wstrict-selector-match] on /src/oauth2/MSIDOauth2Factory.m:422:17`
- https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1576834&view=logs&j=d46b93ad-1be7-5eab-6980-c78d65372179&t=0153d404-5636-5846-4ebd-361eb75124ec
- https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1576833&view=logs&j=ae394acb-13da-583b-0a66-8bef9d5c9830&t=ff952aa1-7e64-5933-ff40-5f21944bb66d

---- 
This pull request makes a targeted improvement to the logic for checking if a response has a bound app refresh token. The change ensures that the value for `MSID_BART_DEVICE_ID_KEY` is validated as a string before checking if it is nil or blank, which increases robustness and prevents potential type errors.

* Improved validation in `doesResponseHaveBoundAppRefreshToken:` by checking if the value for `MSID_BART_DEVICE_ID_KEY` is a string before using it, replacing a previous length check with a more robust nil/blank check.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

