### PR TITLE
Dismiss Spinner when Auth in Webview is Done

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -237,6 +237,10 @@ extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_REMOVE_ACCOUNT_ARTIFACTS;
 /// ECS configuration id: /1678824
 extern NSString * _Nonnull const MSID_FLIGHT_IS_BART_SUPPORTED;
 
+/// Flight to enable embedded webview spinner fix
+/// Owner: zeyong
+extern NSString * _Nonnull const MSID_FLIGHT_SPINNER_FIX;
+
 extern NSString * _Nonnull const MSID_FLIGHT_ENABLE_QUERYING_STK;
 extern NSString * _Nonnull const MSID_FLIGHT_USE_AUTOLAYOUT_FOR_LOADING_INDICATOR;
 

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -108,5 +108,6 @@ NSString *const MSID_FLIGHT_ENABLE_THREAD_STARVATION = @"ts_en";
 
 NSString *const MSID_FLIGHT_IS_BART_SUPPORTED = @"is_bound_app_rt_supported";
 
+NSString *const MSID_FLIGHT_SPINNER_FIX = @"enable_spinner_fix";
 
 #define METHODANDLINE   [NSString stringWithFormat:@"%s [Line %d]", __PRETTY_FUNCTION__, __LINE__]

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -38,6 +38,7 @@
 #import "MSIDTelemetryEventStrings.h"
 #import "MSIDMainThreadUtil.h"
 #import "MSIDAppExtensionUtil.h"
+#import "MSIDFlightManager.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -208,6 +209,13 @@ NSString *const SDM_CAMERA_CONSENT_PROMPT_SUPPRESS_KEY = @"Microsoft.Broker.Feat
         return;
     }
     self.complete = YES;
+    
+    BOOL enableSpinnerFix = [MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_SPINNER_FIX];
+    
+    if (enableSpinnerFix)
+    {
+        [self stopSpinner];
+    }
     
     if (error)
     {


### PR DESCRIPTION
## Proposed changes

We are going to dismiss the loading spinner when the auth is done in embedded webview. Previously it is ok because the webview is going to be dismissed anyway. But in the scenario of concurrent SSO extension requests being loaded one after another, spinner from the previous request needs to be stopped otherwise it will affect the next request coming in.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

