### PR TITLE
Add mapping for MSIDServerInvalidRequest suberror

### DIFF
--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -368,8 +368,8 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     // Broker Xpc internal error
     MSIDErrorBrokerXpcUnexpectedError = -52001,
     
-    // MSIDServerInvalidRequest suberror to bubble up to OneAuth and map to InteractionRequired
-    MSIDErrorServerInvalidRequestWithSuberror = -50142
+    // Error thrown when oauth error = MSIDServerInvalidRequest and suberror = 50142 (SecureChangePasswordDueToConditionalAccess)
+    MSIDErrorServerInvalidRequestResetPasswordRequired = -50142
 
 };
 

--- a/IdentityCore/src/MSIDError.h
+++ b/IdentityCore/src/MSIDError.h
@@ -367,6 +367,9 @@ typedef NS_ENUM(NSInteger, MSIDErrorCode)
     
     // Broker Xpc internal error
     MSIDErrorBrokerXpcUnexpectedError = -52001,
+    
+    // MSIDServerInvalidRequest suberror to bubble up to OneAuth and map to InteractionRequired
+    MSIDErrorServerInvalidRequestWithSuberror = -50142
 
 };
 

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -124,7 +124,7 @@ MSIDErrorCode MSIDErrorCodeForOAuthErrorWithSubErrorCode(NSString *oauthError, M
     }
     if (oauthError && [oauthError caseInsensitiveCompare:@"invalid_request"]  == NSOrderedSame && [subError caseInsensitiveCompare:@"50142"] == NSOrderedSame)
     {
-        return MSIDErrorServerInvalidRequestWithSuberror;
+        return MSIDErrorServerInvalidRequestResetPasswordRequired;
     }
     if (oauthError && [oauthError caseInsensitiveCompare:@"invalid_grant"] == NSOrderedSame && [subError caseInsensitiveCompare:@"transfer_token_expired"] == NSOrderedSame)
     {   // When account Transfter Token is expired.
@@ -454,8 +454,8 @@ NSString *MSIDErrorCodeToString(MSIDErrorCode errorCode)
             // Broker Xpc internal error
         case MSIDErrorBrokerXpcUnexpectedError:
             return @"MSIDErrorBrokerXpcUnexpectedError";
-        case MSIDErrorServerInvalidRequestWithSuberror:
-            return @"MSIDErrorServerInvalidRequestWithSuberror";
+        case MSIDErrorServerInvalidRequestResetPasswordRequired:
+            return @"MSIDErrorServerInvalidRequestResetPasswordRequired";
     }
     
     return [NSString stringWithFormat:@"Unknown: %@", @(errorCode)];

--- a/IdentityCore/src/MSIDError.m
+++ b/IdentityCore/src/MSIDError.m
@@ -122,6 +122,10 @@ MSIDErrorCode MSIDErrorCodeForOAuthErrorWithSubErrorCode(NSString *oauthError, M
     {
         return MSIDErrorCodeForOAuthError(oauthError, defaultCode);
     }
+    if (oauthError && [oauthError caseInsensitiveCompare:@"invalid_request"]  == NSOrderedSame && [subError caseInsensitiveCompare:@"50142"] == NSOrderedSame)
+    {
+        return MSIDErrorServerInvalidRequestWithSuberror;
+    }
     if (oauthError && [oauthError caseInsensitiveCompare:@"invalid_grant"] == NSOrderedSame && [subError caseInsensitiveCompare:@"transfer_token_expired"] == NSOrderedSame)
     {   // When account Transfter Token is expired.
         return MSIDErrorUserCancel;
@@ -450,6 +454,8 @@ NSString *MSIDErrorCodeToString(MSIDErrorCode errorCode)
             // Broker Xpc internal error
         case MSIDErrorBrokerXpcUnexpectedError:
             return @"MSIDErrorBrokerXpcUnexpectedError";
+        case MSIDErrorServerInvalidRequestWithSuberror:
+            return @"MSIDErrorServerInvalidRequestWithSuberror";
     }
     
     return [NSString stringWithFormat:@"Unknown: %@", @(errorCode)];

--- a/IdentityCore/tests/MSIDErrorTests.m
+++ b/IdentityCore/tests/MSIDErrorTests.m
@@ -194,5 +194,12 @@
     NSError *errorWithInvalidGrantWithOutTransferTokenExpired = MSIDCreateError(@"TestDomain", -5555, @"Test description", @"invalid_grant", @"test_sub_error", nil, nil, nil, NO);
     XCTAssertEqual(MSIDErrorCodeForOAuthErrorWithSubErrorCode(errorWithInvalidGrantWithOutTransferTokenExpired.userInfo[MSIDOAuthErrorKey], MSIDErrorUserCancel,errorWithInvalidGrantWithOutTransferTokenExpired.userInfo[MSIDOAuthSubErrorKey]), MSIDErrorServerInvalidGrant);
 }
+- (void)testMSIDErrorWithInvalidRequestAndSubErrorShouldReturnMSIDServerInvalidRequestResetPasswordRequired
+{
+    NSError *errorInvalidRequestWithResetPasswordRequired = MSIDCreateError(@"TestDomain", -5555, @"Test description", @"invalid_request", @"50142", nil, nil, nil, NO);
+    XCTAssertEqual(MSIDErrorCodeForOAuthErrorWithSubErrorCode(errorInvalidRequestWithResetPasswordRequired.userInfo[MSIDOAuthErrorKey],
+                                                              MSIDErrorServerInvalidRequestResetPasswordRequired,
+                                                              errorInvalidRequestWithResetPasswordRequired.userInfo[MSIDOAuthSubErrorKey]), MSIDErrorServerInvalidRequestResetPasswordRequired);
+}
 
 @end


### PR DESCRIPTION
## Proposed changes

ESTS returns sub error 50142 for invalid_request, which needs to be mapped for OneAuth layer error handling

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

