### PR TITLE
Fix MSAL automation test

### DIFF
--- a/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
@@ -370,6 +370,18 @@ static MSIDTestConfigurationProvider *s_confProvider;
                 [self enterPassword:password
                                 app:application
                           isMainApp:isMainApp];
+                
+                return;
+            }
+            
+            useMyPasswordButton = application.buttons[@"Use my password"];
+            if (useMyPasswordButton.exists)
+            {
+                [useMyPasswordButton tap];
+                [self enterPassword:password
+                                app:application
+                          isMainApp:isMainApp];
+                return;
             }
         }
     }


### PR DESCRIPTION
## Proposed changes

Try to use "Use my password" button after "Other ways to sign in".

--- 
This pull request updates the password entry logic in the `MSIDBaseUITest.m` UI test helper to improve support for different authentication flows. The main change is adding handling for a "Use my password" button if it appears during the authentication process.

Improvements to authentication UI automation:

* Updated the `enterPassword:app:isMainApp:` method to detect and tap a "Use my password" button if present, then proceed with password entry, allowing the test to handle additional authentication screens that may appear.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

Reference failing pipeline: https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1582223&view=logs&j=72f45d07-90a4-5538-97c9-e537f287170d&t=7503d787-9df7-5f61-1bfb-425c8f826735&s=d654deb9-056d-50a2-1717-90c08683d50a 
