### PR TITLE
Split broker common submodule check into separate stages

### DIFF
--- a/azure_pipelines/broker_submodule_check.yml
+++ b/azure_pipelines/broker_submodule_check.yml
@@ -37,9 +37,9 @@ stages:
   jobs:
   - job: Validate_Pull_Request_IOS
     displayName: Validate Pull Request (iOS)
+    timeoutInMinutes: 60
     pool:
       vmImage: 'macOS-15'
-      timeOutInMinutes: 30
     variables:
       target: "ios_library"
     steps:
@@ -51,9 +51,9 @@ stages:
   jobs:
   - job: Validate_Pull_Request_MAC
     displayName: Validate Pull Request (Mac)
+    timeoutInMinutes: 60
     pool:
       vmImage: 'macOS-15'
-      timeOutInMinutes: 30
     variables:
       target: "mac_library"
     steps:
@@ -65,9 +65,9 @@ stages:
   jobs:
   - job: Validate_Pull_Request_VISION
     displayName: Validate Pull Request (Vision)
+    timeoutInMinutes: 60
     pool:
       vmImage: 'macOS-15'
-      timeOutInMinutes: 30
     variables:
       target: "vision_library"
     steps:

--- a/azure_pipelines/broker_submodule_steps.yml
+++ b/azure_pipelines/broker_submodule_steps.yml
@@ -44,7 +44,7 @@ steps:
       # GIT_TRACE=1
       # GIT_CURL_VERBOSE=1
       
-      # Note that the resoruce is specified to limit the token to Azure DevOps
+      # Note that the resource is specified to limit the token to Azure DevOps
       $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
       Write-Host "##vso[task.setvariable variable=aadToken;issecret=true]$token"
 - task: Bash@3


### PR DESCRIPTION
## Proposed changes

This converts the pipeline from one Stage with 3 Jobs to 3 Stages with one Job each, allowing us to re-run a failing stage before waiting (30+ minutes) for the other jobs to finish, for example:
<img width="417" height="497" alt="image" src="https://github.com/user-attachments/assets/864a8707-dd28-4b46-bced-d4d8bae79322" />

now becomes:
<img width="337" height="753" alt="image" src="https://github.com/user-attachments/assets/3b18adc3-5fa3-4127-9216-c28f6fb11e91" />


## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

This pull request refactors the Azure Pipelines configuration for validating iOS, Mac, and Vision builds by modularizing the job steps into a reusable template and splitting the validation process into separate pipeline stages for each platform. This improves maintainability and clarity of the pipeline setup.

Key changes:

**Pipeline Structure Improvements:**
* The main pipeline YAML (`broker_submodule_check.yml`) is restructured to define separate stages (`Stage_IOS`, `Stage_MAC`, `Stage_VISION`) for iOS, Mac, and Vision validations, each with its own job and target variable.
* Each validation job now references a new template file (`broker_submodule_steps.yml`) for its steps, reducing duplication and making the pipeline easier to update. [[1]](diffhunk://#diff-273ad8716a34ed63a51f52e0f6d32de2d80fc6a6608f3abec00cccf99ad0ff58R33-R74) [[2]](diffhunk://#diff-524fbea467a63b402e909087f8a1d33a1c2434b6394a4972b3c0871db368f643R1-R142)

**Job Step Modularization:**
* All steps required for checking out repositories, updating submodules, setting up dependencies, and running builds/tests are moved into the new `broker_submodule_steps.yml` template. This includes logic for handling platform-specific requirements like downloading the visionOS SDK.
* Cleanup and setup steps, including dependency installation and environment configuration, are now consistently handled via the shared template.

**Platform-Specific Handling:**
* The process for downloading the visionOS SDK is now encapsulated within the shared template and only runs for the Vision build, improving clarity and reducing unnecessary steps for other platforms.

These changes make the pipeline more modular, easier to maintain, and clearer in its intent for each platform.