### PR TITLE
[Patch] [bugfix]: Serialize `is_sso_account` as NSString instead of NSNumber in MSIDAccount

### DIFF
--- a/IdentityCore/src/oauth2/account/MSIDAccount.m
+++ b/IdentityCore/src/oauth2/account/MSIDAccount.m
@@ -231,7 +231,7 @@
     json[@"client_info"] = self.clientInfo.rawClientInfo;
     json[@"alternative_account_id"] = self.alternativeAccountId;
     json[@"id_token_claims"] = self.idTokenClaims.jsonDictionary;
-    json[@"is_sso_account"] = @(self.isSSOAccount);
+    json[@"is_sso_account"] = [@(self.isSSOAccount) stringValue];
     [json addEntriesFromDictionary:[self.accountIdentifier jsonDictionary]];
     
     return json;

--- a/IdentityCore/tests/MSIDAccountTests.m
+++ b/IdentityCore/tests/MSIDAccountTests.m
@@ -213,7 +213,7 @@
         @"realm" : @"common",
         @"storage_environment" : @"login.windows2.net",
         @"username" : @"username",
-        @"is_sso_account": @NO, 
+        @"is_sso_account": @"0",
         @"id_token_claims" : @{ @"sub" : @"abc",
                                 @"middle_name" : @"Middle" }
     };
@@ -238,7 +238,8 @@
         @"realm" : @"common",
         @"storage_environment" : @"login.windows2.net",
         @"username" : @"username",
-        @"id_token_claims" : idTokenClaims
+        @"id_token_claims" : idTokenClaims,
+        @"is_sso_account"  : @"1",
     };
     
     NSError *error;
@@ -262,6 +263,7 @@
     XCTAssertEqualObjects(account.idTokenClaims.jsonDictionary, idTokenClaims);
     XCTAssertEqualObjects(account.idTokenClaims.subject, @"abc");
     XCTAssertEqualObjects(account.idTokenClaims.middleName, @"Middle");
+    XCTAssertTrue(account.isSSOAccount);
 }
 
 - (void)testInitWithJSONDictionary_whenAccountIdentifierNotDictionary_shouldReturnNil {

--- a/IdentityCore/tests/MSIDBrokerOperationGetAccountsResponseTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationGetAccountsResponseTests.m
@@ -305,7 +305,7 @@
             @"realm" : @"common",
             @"storage_environment" : @"login.windows2.net",
             @"username" : @"username",
-            @"is_sso_account": @YES
+            @"is_sso_account": @"1"
         },
         @{
             @"home_account_id" : @"uid.utid",
@@ -321,7 +321,7 @@
             @"realm" : @"tenant",
             @"storage_environment" : @"login.windows2.net",
             @"username" : @"username",
-            @"is_sso_account": @NO
+            @"is_sso_account": @"0"
         }
     ];
     

--- a/IdentityCore/tests/MSIDBrokerOperationGetDefaultAccountResponseTests.m
+++ b/IdentityCore/tests/MSIDBrokerOperationGetDefaultAccountResponseTests.m
@@ -61,6 +61,7 @@
         @"realm" : @"common",
         @"storage_environment" : @"login.windows2.net",
         @"username" : @"username",
+        @"is_sso_account" : @"1",
     };
 
     NSError *error;
@@ -86,6 +87,7 @@
     XCTAssertEqualObjects(account.name, @"Eric Middle Last");
     XCTAssertEqualObjects(account.clientInfo.rawClientInfo, [@{@"key" : @"value"} msidBase64UrlJson]);
     XCTAssertEqualObjects(account.alternativeAccountId, @"AltID");
+    XCTAssertTrue(account.isSSOAccount);
 }
 
 - (void)testInitWithJSONDictionary_whenSuccessButAccountInvalid_shouldReturnNil {
@@ -136,6 +138,7 @@
     MSIDClientInfo *clientInfo = [[MSIDClientInfo alloc] initWithRawClientInfo:base64String error:nil];
     account.clientInfo = clientInfo;
     account.alternativeAccountId = @"AltID";
+    account.isSSOAccount = YES;
     
     MSIDBrokerOperationGetDefaultAccountResponse *response = [[MSIDBrokerOperationGetDefaultAccountResponse alloc] initWithDeviceInfo:nil];
     response.account = account;
@@ -153,6 +156,36 @@
     XCTAssertEqualObjects(result[@"username"], @"username");
     XCTAssertEqualObjects(result[@"environment"], @"login.microsoftonline.com");
     XCTAssertEqualObjects(result[@"realm"], @"common");
+    XCTAssertEqualObjects(result[@"is_sso_account"], @"1");
+}
+
+- (void)testJsonDictionary_allValuesMustBeNSString_noNSNumberAllowed
+{
+    MSIDAccount *account = [MSIDAccount new];
+    account.accountType = MSIDAccountTypeMSSTS;
+    account.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com"
+                                                                        homeAccountId:@"uid.utid"];
+    account.localAccountId = @"local";
+    account.environment = @"login.microsoftonline.com";
+    account.realm = @"common";
+    account.isSSOAccount = YES;
+
+    MSIDBrokerOperationGetDefaultAccountResponse *response = [[MSIDBrokerOperationGetDefaultAccountResponse alloc] initWithDeviceInfo:nil];
+    response.account = account;
+    response.operation = @"get_default_account";
+    response.success = YES;
+
+    NSDictionary *result = response.jsonDictionary;
+    XCTAssertNotNil(result);
+
+    [result enumerateKeysAndObjectsUsingBlock:^(id key, id value, __unused BOOL *stop) {
+        // nil values are filtered out by NSDictionary, but nested dicts or arrays
+        // are not valid HTTP header values either — only flat strings are.
+        XCTAssertTrue([value isKindOfClass:[NSString class]],
+                      @"Value for key '%@' must be NSString for NSHTTPURLResponse "
+                       "headerFields compatibility, but got %@ (%@)",
+                      key, NSStringFromClass([value class]), value);
+    }];
 }
 
 #endif

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ TBD
 * Aligned Init Logic for Get Token API With Documentation (#1698)
 * Strip eqp from CIAM authority #1714
 * Add French sovereign cloud authority as a trusted authority (#1731)
+* Serialize `is_sso_account` as NSString instead of NSNumber in MSIDAccount
 
 Version 1.20.0
 * Add token request execution flow logger (#1655)


### PR DESCRIPTION
## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

Updates MSIDAccount serialization to emit is_sso_account as a string ("1"/"0") rather than an NSNumber, aligning with broker operation response/header field string-only conventions.

Changes:
Serialize is_sso_account in MSIDAccount.jsonDictionary as NSString via stringValue.
Update/extend unit tests for account and default-account broker response JSON to expect "1"/"0" and validate isSSOAccount parsing.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

