### PR TITLE
[minor] [bugfix]: Fix Unviersal Link opening in Embedded Webview

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -32,6 +32,8 @@
 #import "MSIDWebAuthNUtil.h"
 #import "MSIDFlightManager.h"
 #import "MSIDConstants.h"
+#import "MSIDAppExtensionUtil.h"
+#import "MSIDBrokerConstants.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -58,6 +60,20 @@
                      customHeaders:headers
                     platfromParams:platformParams
                            context:context];
+}
+
+- (BOOL)isAuthenticatorAppActivationURL:(NSURL *)url
+{
+    NSString *host = url.host.lowercaseString;
+    NSString *path = url.path.lowercaseString;
+
+    BOOL isAADHost = [host isEqualToString:@"login.microsoftonline.com"] ||
+                     [host isEqualToString:@"login.microsoftonline.us"] ||
+                     [host isEqualToString:@"login.chinacloudapi.cn"];
+
+    BOOL isActivationPath = [path isEqualToString:@"/authenticatorapp/activateaccount"];
+
+    return isAADHost && isActivationPath;
 }
 
 - (BOOL)decidePolicyAADForNavigationAction:(WKNavigationAction *)navigationAction
@@ -134,6 +150,30 @@
                            }];
         return YES;
     }
+    
+#if AD_BROKER && TARGET_OS_IPHONE
+    // Based on https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content,
+    // Universal link won't open Authenticator if it is already in Authetnicatior.
+    // Directly invoke the app delegate's continueUserActivity to handle it in-app.
+    // Only apply when running in the main Authenticator app.
+    if ([MSID_BROKER_APP_BUNDLE_ID isEqualToString:[[NSBundle mainBundle] bundleIdentifier]]
+        && [self isAuthenticatorAppActivationURL:requestURL])
+    {
+        decisionHandler(WKNavigationActionPolicyCancel);
+        NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+        userActivity.webpageURL = requestURL;
+        UIApplication *app = [MSIDAppExtensionUtil sharedApplication];
+        id<UIApplicationDelegate> appDelegate = app.delegate;
+        if ([appDelegate respondsToSelector:@selector(application:continueUserActivity:restorationHandler:)])
+        {
+            [appDelegate application:app
+                continueUserActivity:userActivity
+                  restorationHandler:^(NSArray<id<UIUserActivityRestoring>> * _Nullable _) {}];
+        }
+        return YES;
+    }
+#endif
+
     
     return NO;
 }

--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -72,9 +72,9 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         aadHosts = [NSSet setWithArray:@[
-            @"login.microsoftonline.com",
-            @"login.microsoftonline.us",
-            @"login.chinacloudapi.cn"
+            MSIDTrustedAuthorityWorldWide,
+            MSIDTrustedAuthorityUS,
+            MSIDTrustedAuthorityChina
         ]];
     });
     

--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -64,15 +64,23 @@
 
 - (BOOL)isAuthenticatorAppActivationURL:(NSURL *)url
 {
+    
     NSString *host = url.host.lowercaseString;
     NSString *path = url.path.lowercaseString;
-
-    BOOL isAADHost = [host isEqualToString:@"login.microsoftonline.com"] ||
-                     [host isEqualToString:@"login.microsoftonline.us"] ||
-                     [host isEqualToString:@"login.chinacloudapi.cn"];
-
+    
+    static NSSet<NSString *> *aadHosts = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        aadHosts = [NSSet setWithArray:@[
+            @"login.microsoftonline.com",
+            @"login.microsoftonline.us",
+            @"login.chinacloudapi.cn"
+        ]];
+    });
+    
+    BOOL isAADHost = host && [aadHosts containsObject:host];
     BOOL isActivationPath = [path isEqualToString:@"/authenticatorapp/activateaccount"];
-
+    
     return isAADHost && isActivationPath;
 }
 
@@ -153,7 +161,7 @@
     
 #if AD_BROKER && TARGET_OS_IPHONE
     // Based on https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content,
-    // Universal link won't open Authenticator if it is already in Authetnicatior.
+    // Universal links won't open Authenticator if it is already in Authenticator.
     // Directly invoke the app delegate's continueUserActivity to handle it in-app.
     // Only apply when running in the main Authenticator app.
     if ([MSID_BROKER_APP_BUNDLE_ID isEqualToString:[[NSBundle mainBundle] bundleIdentifier]]
@@ -168,7 +176,11 @@
         {
             [appDelegate application:app
                 continueUserActivity:userActivity
-                  restorationHandler:^(NSArray<id<UIUserActivityRestoring>> * _Nullable _) {}];
+                  restorationHandler:^(NSArray<id<UIUserActivityRestoring>> * _Nullable __unused _) {}];
+        }
+        else
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelWarning, self.context, @"Received MFA activation link in webview but failed to call delegate.");
         }
         return YES;
     }

--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -173,7 +173,6 @@
         return YES;
     }
 #endif
-
     
     return NO;
 }

--- a/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
+++ b/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
@@ -27,8 +27,27 @@
 #import "MSIDAADOAuthEmbeddedWebviewController.h"
 #import "MSIDWKNavigationActionMock.h"
 #import "MSIDWebAuthNUtil.h"
+#import "MSIDTestBundle.h"
 
 #if !MSID_EXCLUDE_WEBKIT
+
+#if AD_BROKER && TARGET_OS_IPHONE
+@interface MSIDMockAppDelegate : NSObject <UIApplicationDelegate>
+@property (nonatomic) XCTestExpectation *continueUserActivityExpectation;
+@property (nonatomic) NSURL *receivedURL;
+@end
+
+@implementation MSIDMockAppDelegate
+- (BOOL)application:(UIApplication *)application
+    continueUserActivity:(NSUserActivity *)userActivity
+      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
+{
+    self.receivedURL = userActivity.webpageURL;
+    [self.continueUserActivityExpectation fulfill];
+    return YES;
+}
+@end
+#endif
 
 @interface MSIDAADOAuthEmbeddedWebviewControllerTests : XCTestCase
 
@@ -256,6 +275,46 @@
 
     XCTAssertFalse(result);
 }
+
+#if AD_BROKER && TARGET_OS_IPHONE
+- (void)testDecidePolicyForNavigationAction_whenActivationURL_shouldCancelActionAndInvokeContinueUserActivity
+{
+    [MSIDTestBundle overrideBundleId:@"com.microsoft.azureauthenticator"];
+
+    MSIDMockAppDelegate *mockDelegate = [MSIDMockAppDelegate new];
+    mockDelegate.continueUserActivityExpectation = [self expectationWithDescription:@"continueUserActivity invoked"];
+
+    id<UIApplicationDelegate> originalDelegate = [UIApplication sharedApplication].delegate;
+    [UIApplication sharedApplication].delegate = mockDelegate;
+
+    MSIDAADOAuthEmbeddedWebviewController *webVC = [[MSIDAADOAuthEmbeddedWebviewController alloc]
+            initWithStartURL:[NSURL URLWithString:@"https://contoso.com/oauth/authorize"]
+                      endURL:[NSURL URLWithString:@"endurl://host"]
+                     webview:nil
+               customHeaders:nil
+              platfromParams:nil
+                     context:nil];
+
+    NSURL *activationURL = [NSURL URLWithString:@"https://login.microsoftonline.com/authenticatorApp/activateAccount"];
+    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:activationURL];
+    MSIDWKNavigationActionMock *action = [[MSIDWKNavigationActionMock alloc] initWithRequest:request];
+
+    XCTestExpectation *decisionExpectation = [self expectationWithDescription:@"decision handler"];
+
+    BOOL result = [webVC decidePolicyAADForNavigationAction:action decisionHandler:^(WKNavigationActionPolicy decision) {
+        XCTAssertEqual(decision, WKNavigationActionPolicyCancel);
+        [decisionExpectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+
+    XCTAssertTrue(result);
+    XCTAssertEqualObjects(mockDelegate.receivedURL, activationURL);
+
+    [UIApplication sharedApplication].delegate = originalDelegate;
+    [MSIDTestBundle reset];
+}
+#endif
 
 @end
 

--- a/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
+++ b/IdentityCore/tests/MSIDAADOAuthEmbeddedWebviewControllerTests.m
@@ -38,9 +38,9 @@
 @end
 
 @implementation MSIDMockAppDelegate
-- (BOOL)application:(UIApplication *)application
+- (BOOL)application:(__unused UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
-      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
+      restorationHandler:(__unused void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
 {
     self.receivedURL = userActivity.webpageURL;
     [self.continueUserActivityExpectation fulfill];


### PR DESCRIPTION


## Proposed changes

Based on https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content, Universal link won't open Authenticator if it is already in Authetnicatior. Directly invoke the app delegate's continueUserActivity to handle it in-app.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

