### PR TITLE
[minor] [improvement]: Remove 4-hour XPC canPerform status cache and XPC roundtrip

### DIFF
--- a/IdentityCore/src/util/mac/MSIDXpcProviderCache.m
+++ b/IdentityCore/src/util/mac/MSIDXpcProviderCache.m
@@ -25,17 +25,12 @@
 
 #import "MSIDXpcProviderCache.h"
 #import "NSString+MSIDExtensions.h"
-#import "NSDate+MSIDExtensions.h"
 #import "MSIDDeviceInfo.h"
 #import "MSIDXpcConfiguration.h"
 #import "MSIDLogger+Internal.h"
 
 NSString *const MSID_XPC_CACHE_QUEUE_NAME = @"com.microsoft.msidxpcprovidercache";
 NSString *const MSID_XPC_PROVIDER_TYPE_KEY = @"xpc_provider_type";
-NSString *const MSID_XPC_LAST_UPDATE_TIME = @"last_update_time";
-NSString *const MSID_XPC_LAST_UPDATE_TIME_DESCRIPTION = @"last_update_time_description";
-NSString *const MSID_XPC_STATUS = @"xpc_status";
-NSTimeInterval const MSID_XPC_STATUS_EXPIRATION_TIME = 14400.0;
 
 @interface MSIDXpcProviderCache ()
 
@@ -178,84 +173,19 @@ NSTimeInterval const MSID_XPC_STATUS_EXPIRATION_TIME = 14400.0;
     return NO;
 }
 
-- (BOOL)shouldReturnCachedXpcStatus
-{
-    __block BOOL result = YES;
-    dispatch_sync(self.synchronizationQueue, ^{
-        
-        if (!self.xpcConfiguration)
-        {
-            result = NO;
-        }
-        else
-        {
-            NSDictionary *xpcInfo = [[NSUserDefaults standardUserDefaults] dictionaryForKey:self.xpcConfiguration.xpcMachServiceName];
-            if (!xpcInfo)
-            {
-                result = NO;
-            }
-            else
-            {
-                NSDate *lastUpdatedTime = [NSDate msidDateFromTimeStamp:xpcInfo[MSID_XPC_LAST_UPDATE_TIME]];
-                NSTimeInterval timeDifference = [[NSDate date] timeIntervalSinceDate:lastUpdatedTime];
-
-                // cached Broker Xpc status expired after 4 hours
-                if (!lastUpdatedTime || timeDifference > MSID_XPC_STATUS_EXPIRATION_TIME)
-                {
-                    result = NO;
-                }
-            }
-        }
-    });
-    
-    return result;
-}
-
-- (BOOL)cachedCanPerformRequestsStatus
-{
-    __block BOOL result = NO;
-    dispatch_sync(self.synchronizationQueue, ^{
-        if (!self.xpcConfiguration)
-        {
-            result = NO;
-        }
-        else
-        {
-            NSDictionary *xpcInfo = [[NSUserDefaults standardUserDefaults] dictionaryForKey:self.xpcConfiguration.xpcMachServiceName];
-            if ([xpcInfo[MSID_XPC_STATUS] respondsToSelector:@selector(boolValue)])
-            {
-                result = [xpcInfo[MSID_XPC_STATUS] boolValue];
-            }
-        }
-    });
-    
-    return result;
-}
-
-- (void)setCachedCanPerformRequestsStatus:(BOOL)cachedCanPerformRequestsStatus
-{
-    dispatch_barrier_sync(self.synchronizationQueue, ^{
-        if (!self.xpcConfiguration)
-        {
-            return;
-        }
-        
-        NSDate *currentTime = [NSDate date];
-        NSDictionary *xpcInfo = @{MSID_XPC_LAST_UPDATE_TIME:[currentTime msidDateToTimestamp], MSID_XPC_LAST_UPDATE_TIME_DESCRIPTION:[currentTime msidToString], MSID_XPC_STATUS:@(cachedCanPerformRequestsStatus)};
-        [self.userDefaults setObject:xpcInfo forKey:self.xpcConfiguration.xpcMachServiceName];
-    });
-}
-
 - (MSIDXpcConfiguration *)xpcConfiguration
 {
-    @synchronized (self) {
+    __block MSIDXpcConfiguration *config = nil;
+    dispatch_barrier_sync(self.synchronizationQueue, ^{
         if (!_xpcConfiguration)
         {
-            _xpcConfiguration = [[MSIDXpcConfiguration alloc] initWithXpcProviderType:self.cachedXpcProviderType];
+            NSInteger providerType = [self.userDefaults integerForKey:MSID_XPC_PROVIDER_TYPE_KEY];
+            _xpcConfiguration = [[MSIDXpcConfiguration alloc] initWithXpcProviderType:providerType];
         }
-        
-        return _xpcConfiguration;
-    }
+        config = _xpcConfiguration;
+    });
+    
+    return config;
 }
 
 @end

--- a/IdentityCore/src/util/mac/MSIDXpcProviderCaching.h
+++ b/IdentityCore/src/util/mac/MSIDXpcProviderCaching.h
@@ -35,15 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
 // cachedXpcProvider is the Xpc provider's identifier from cache. This value can be updated through SsoExtension request
 @property (nonatomic) MSIDSsoProviderType cachedXpcProviderType;
 
-// cachedCanPerformRequestsStatus is the Xpc provider's status from cache.
-@property (nonatomic) BOOL cachedCanPerformRequestsStatus;
-
-// xpcConfigurationwill be used for the Xpc flow, the value will be determined based on the cachedXpcProvider
+// xpcConfiguration will be used for the Xpc flow, the value will be determined based on the cachedXpcProvider
 @property (nonatomic) MSIDXpcConfiguration *xpcConfiguration;
 
 - (BOOL)isXpcProviderInstalledOnDevice;
 - (BOOL)validateCacheXpcProvider;
-- (BOOL)shouldReturnCachedXpcStatus;
 
 @end
 

--- a/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
+++ b/IdentityCore/src/util/mac/MSIDXpcSingleSignOnProvider.m
@@ -152,14 +152,12 @@ typedef void (^NSXPCListenerEndpointCompletionBlock)(id<MSIDXpcBrokerInstancePro
     // Step 1: Read from the userDefaults cache to find the correct XPC configuration based on the active SsoExtension.
         // Step 1.1: If the XPC configuration is found, validate the existence of the corresponding XPC component based on the configuration.
             // Step 1.1.1: If the XPC component no longer exists on the device, return false (this is unlikely to happen in a short time period).
-            // Step 1.1.2: If the XPC component exists on the device, proceed to Step 2.
+            // Step 1.1.2: If the XPC component exists on the device, return true.
         // Step 1.2: If the cache is not found, perform a handshake with the SsoExtension (canPerformRequest -> getDeviceInfo).
             // Step 1.2.1: If the handshake succeeds, update the XPC provider cache and configuration, then go to Step 1.1.
             // Step 1.2.2: If the handshake fails because canPerformRequest returns NO, use predefined logic to decide the XPC provider/configuration (use the XPC component from the MacBrokerApp first, then from the CompanyPortal App).
-                // Step 1.2.2.1: If using the XPC provider from the MacBroker App, proceed to Step 2.
-                // Step 1.2.2.2: If using the XPC provider from the CompanyPortal App, proceed to Step 2.
-    // Step 2: Check canPerformRequest from the XPC service.
-        // XPC status caching logic: https://microsoft-my.sharepoint-df.com/:w:/p/kasong/EeTyTIf6TbNIvquOtT80q6kBr38-nRx1Q_ssIxDzVXg88w?e=tG63sP
+                // Step 1.2.2.1: If using the XPC provider from the MacBroker App, return true.
+                // Step 1.2.2.2: If using the XPC provider from the CompanyPortal App, return true.
     
     /* Step 0 Start*/
     if (!xpcProviderCache.isXpcProviderInstalledOnDevice)
@@ -228,46 +226,7 @@ typedef void (^NSXPCListenerEndpointCompletionBlock)(id<MSIDXpcBrokerInstancePro
     
     /* Step 1 Finish */
     
-    /* Step 2 Start: Check Xpc status */
-    if ([xpcProviderCache shouldReturnCachedXpcStatus])
-    {
-        return xpcProviderCache.cachedCanPerformRequestsStatus;
-    }
-    
-    dispatch_group_t xpcGroup = dispatch_group_create();
-    dispatch_group_enter(xpcGroup);
-    
-    __block BOOL result = NO;
-    MSIDXpcSingleSignOnProvider *xpcSingleSignOnProvider = [MSIDXpcSingleSignOnProvider new];
-    
-    // Check canPerformAuthorization through real broker Xpc service
-    [xpcSingleSignOnProvider getXpcService:xpcProviderCache withContinueBlock:^(id<MSIDXpcBrokerInstanceProtocol> __unused xpcService, NSXPCConnection *directConnection, NSError *error)
-     {
-        if (!xpcService || error)
-        {
-            dispatch_group_leave(xpcGroup);
-            return;
-        }
-        
-        // For now, we are intentionally pass an empty dictionary.
-        // We can expand the param for Xpc service for further validation. e.g. (Authority url, tenant_id/upn)
-        [xpcService canPerformWithMetadata:@{} completionBlock:^(BOOL canPerformRequest) {
-            [directConnection suspend];
-            [directConnection invalidate];
-            
-            result = canPerformRequest;
-            xpcProviderCache.cachedCanPerformRequestsStatus = result;
-            dispatch_group_leave(xpcGroup);
-        }];
-    }];
-    
-    // waiting expired in 1 sec
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC);
-    dispatch_group_wait(xpcGroup, timeout);
-    
-    return result;
-    
-    /* Step 2 End */
+    return YES;
 }
 
 #pragma mark - Helpers

--- a/IdentityCore/tests/mac/MSIDXpcSingleSignOnProviderTest.m
+++ b/IdentityCore/tests/mac/MSIDXpcSingleSignOnProviderTest.m
@@ -49,12 +49,11 @@
 - (void)testNoXpcComponentInstalledOnDevice_canPerformRequest_returnsFalse
 {
     MSIDXpcProviderCacheMock *xpcProviderCacheMock = [[MSIDXpcProviderCacheMock alloc] initWithXpcInstallationStatus:NO
-                                                                                                      isXpcValidated:NO
-                                                                                         shouldReturnCachedXpcStatus:NO];
+                                                                                                      isXpcValidated:NO];
     XCTAssertFalse([MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCacheMock]);
 }
 
-- (void)testXpcComponentInstalledOnDevice_ssoExtentionDisabled_hasValidCachedXpcConfiguration_canPerformRequest_returnsCachedStatus
+- (void)testXpcComponentInstalledOnDevice_ssoExtentionDisabled_hasValidXpcConfiguration_canPerformRequest_returnsTrue
 {
     
     SEL selectorForMSIDSSOExtensionGetDeviceInfoRequest = NSSelectorFromString(@"canPerformRequest");
@@ -65,22 +64,13 @@
         return NO;
     }];
     
-    MSIDXpcProviderCacheMock *xpcProviderCachedFalseMock = [[MSIDXpcProviderCacheMock alloc] initWithXpcInstallationStatus:YES
-                                                                                                            isXpcValidated:YES
-                                                                                               shouldReturnCachedXpcStatus:YES];
-    xpcProviderCachedFalseMock.cachedCanPerformRequestsStatus = NO;
-    XCTAssertFalse([MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCachedFalseMock]);
-    
-    MSIDXpcProviderCacheMock *xpcProviderCachedTrueMock = [[MSIDXpcProviderCacheMock alloc] initWithXpcInstallationStatus:YES
-                                                                                                           isXpcValidated:YES
-                                                                                              shouldReturnCachedXpcStatus:YES];
-    xpcProviderCachedTrueMock.cachedCanPerformRequestsStatus = YES;
-    XCTAssertTrue([MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCachedTrueMock]);
+    MSIDXpcProviderCacheMock *xpcProviderCacheMock = [[MSIDXpcProviderCacheMock alloc] initWithXpcInstallationStatus:YES
+                                                                                                      isXpcValidated:YES];
+    XCTAssertTrue([MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCacheMock]);
 }
 
-- (void)testXpcComponentInstalledOnDevice_ssoExtentionDisabled_hasInvalidCachedXpcConfiguration_andValidXpcValidation_canPerformRequest_shouldCallRemoteXpcService
+- (void)testXpcComponentInstalledOnDevice_ssoExtentionDisabled_hasValidXpcConfiguration_canPerformRequest_doesNotCallRemoteXpcService
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Remote Xpc service will be called for canPerformRequest"];
     SEL selectorForMSIDSSOExtensionGetDeviceInfoRequest = NSSelectorFromString(@"canPerformRequest");
     [MSIDTestSwizzle classMethod:selectorForMSIDSSOExtensionGetDeviceInfoRequest
                            class:[MSIDSSOExtensionGetDeviceInfoRequest class]
@@ -89,23 +79,22 @@
         return NO;
     }];
     
+    __block BOOL xpcServiceCalled = NO;
     SEL selectorForMSIDXpcSingleSignOnProvider = NSSelectorFromString(@"getXpcService:withContinueBlock:");
     [MSIDTestSwizzle instanceMethod:selectorForMSIDXpcSingleSignOnProvider
                               class:[MSIDXpcSingleSignOnProvider class]
                               block:(id)^(void)
      {
-        [expectation fulfill];
+        xpcServiceCalled = YES;
      }];
     
-    MSIDXpcProviderCacheMock *xpcProviderCachedMock = [[MSIDXpcProviderCacheMock alloc]
-                                                       initWithXpcInstallationStatus:YES
-                                                       isXpcValidated:YES
-                                                       shouldReturnCachedXpcStatus:NO];
-    [MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCachedMock];
-    [self waitForExpectations:@[expectation] timeout:2.0];
+    MSIDXpcProviderCacheMock *xpcProviderCacheMock = [[MSIDXpcProviderCacheMock alloc] initWithXpcInstallationStatus:YES
+                                                                                                      isXpcValidated:YES];
+    [MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCacheMock];
+    XCTAssertFalse(xpcServiceCalled, @"getXpcService should not be called from canPerformRequest");
 }
 
-- (void)testXpcComponentInstalledOnDevice_ssoExtentionDisabled_hasInvalidCachedXpcStatus_cannotValidateXpc_canPerformRequest_returnsFalse
+- (void)testXpcComponentInstalledOnDevice_ssoExtentionDisabled_hasInvalidXpcValidation_canPerformRequest_returnsFalse
 {
     SEL selectorForMSIDSSOExtensionGetDeviceInfoRequest = NSSelectorFromString(@"canPerformRequest");
     [MSIDTestSwizzle classMethod:selectorForMSIDSSOExtensionGetDeviceInfoRequest
@@ -117,13 +106,12 @@
     
     MSIDXpcProviderCacheMock *xpcProviderCachedMock = [[MSIDXpcProviderCacheMock alloc]
                                                        initWithXpcInstallationStatus:YES
-                                                       isXpcValidated:NO
-                                                       shouldReturnCachedXpcStatus:NO];
+                                                       isXpcValidated:NO];
     
     XCTAssertFalse([MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCachedMock]);
 }
 
-- (void)testNoXpcComponentInstalledOnDevice_ssoExtentionEnabled_hasInvalidCachedXpcStatus_canPerformRequest_ssoExtensionShouldTrigger
+- (void)testNoXpcComponentInstalledOnDevice_ssoExtentionEnabled_hasInvalidXpcValidation_canPerformRequest_ssoExtensionShouldTrigger
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"SsoExtension will be triggered for to get device info"];
 
@@ -145,8 +133,7 @@
     
     MSIDXpcProviderCacheMock *xpcProviderCachedMock = [[MSIDXpcProviderCacheMock alloc]
                                                        initWithXpcInstallationStatus:YES
-                                                       isXpcValidated:NO
-                                                       shouldReturnCachedXpcStatus:NO];
+                                                       isXpcValidated:NO];
     [MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCachedMock];
     [self waitForExpectations:@[expectation] timeout:2.0];
 }

--- a/IdentityCore/tests/mac/MSIDXpcSingleSignOnProviderTest.m
+++ b/IdentityCore/tests/mac/MSIDXpcSingleSignOnProviderTest.m
@@ -53,7 +53,7 @@
     XCTAssertFalse([MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCacheMock]);
 }
 
-- (void)testXpcComponentInstalledOnDevice_ssoExtentionDisabled_hasValidXpcConfiguration_canPerformRequest_returnsTrue
+- (void)testXpcComponentInstalledOnDevice_ssoExtensionDisabled_hasValidXpcConfiguration_canPerformRequest_returnsTrue
 {
     
     SEL selectorForMSIDSSOExtensionGetDeviceInfoRequest = NSSelectorFromString(@"canPerformRequest");
@@ -69,7 +69,7 @@
     XCTAssertTrue([MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCacheMock]);
 }
 
-- (void)testXpcComponentInstalledOnDevice_ssoExtentionDisabled_hasValidXpcConfiguration_canPerformRequest_doesNotCallRemoteXpcService
+- (void)testXpcComponentInstalledOnDevice_ssoExtensionDisabled_hasValidXpcConfiguration_canPerformRequest_doesNotCallRemoteXpcService
 {
     SEL selectorForMSIDSSOExtensionGetDeviceInfoRequest = NSSelectorFromString(@"canPerformRequest");
     [MSIDTestSwizzle classMethod:selectorForMSIDSSOExtensionGetDeviceInfoRequest
@@ -94,7 +94,7 @@
     XCTAssertFalse(xpcServiceCalled, @"getXpcService should not be called from canPerformRequest");
 }
 
-- (void)testXpcComponentInstalledOnDevice_ssoExtentionDisabled_hasInvalidXpcValidation_canPerformRequest_returnsFalse
+- (void)testXpcComponentInstalledOnDevice_ssoExtensionDisabled_hasInvalidXpcValidation_canPerformRequest_returnsFalse
 {
     SEL selectorForMSIDSSOExtensionGetDeviceInfoRequest = NSSelectorFromString(@"canPerformRequest");
     [MSIDTestSwizzle classMethod:selectorForMSIDSSOExtensionGetDeviceInfoRequest
@@ -111,7 +111,7 @@
     XCTAssertFalse([MSIDXpcSingleSignOnProvider canPerformRequest:xpcProviderCachedMock]);
 }
 
-- (void)testNoXpcComponentInstalledOnDevice_ssoExtentionEnabled_hasInvalidXpcValidation_canPerformRequest_ssoExtensionShouldTrigger
+- (void)testNoXpcComponentInstalledOnDevice_ssoExtensionEnabled_hasInvalidXpcValidation_canPerformRequest_ssoExtensionShouldTrigger
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"SsoExtension will be triggered for to get device info"];
 

--- a/IdentityCore/tests/mocks/MSIDXpcProviderCacheMock.h
+++ b/IdentityCore/tests/mocks/MSIDXpcProviderCacheMock.h
@@ -30,8 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MSIDXpcProviderCacheMock : NSObject <MSIDXpcProviderCaching>
 
 - (instancetype)initWithXpcInstallationStatus:(BOOL)xpcInstallationStatus
-                               isXpcValidated:(BOOL)isXpcValidated
-                  shouldReturnCachedXpcStatus:(BOOL)shouldReturnCachedXpcStatus;
+                               isXpcValidated:(BOOL)isXpcValidated;
 
 @end
 

--- a/IdentityCore/tests/mocks/MSIDXpcProviderCacheMock.m
+++ b/IdentityCore/tests/mocks/MSIDXpcProviderCacheMock.m
@@ -29,24 +29,21 @@
 
 @property (nonatomic) BOOL isXpcProviderInstalledOnDevice;
 @property (nonatomic) BOOL isXpcValidated;
-@property (nonatomic) BOOL shouldReturnCachedXpcStatus;
 
 @end
 
 @implementation MSIDXpcProviderCacheMock
 
-@synthesize cachedCanPerformRequestsStatus, xpcConfiguration, cachedXpcProviderType;
+@synthesize xpcConfiguration, cachedXpcProviderType;
 
 - (instancetype)initWithXpcInstallationStatus:(BOOL)xpcInstallationStatus
                                isXpcValidated:(BOOL)isXpcValidated
-                  shouldReturnCachedXpcStatus:(BOOL)shouldReturnCachedXpcStatus
 {
     self = [super init];
     if (self)
     {
         self.isXpcProviderInstalledOnDevice = xpcInstallationStatus;
         self.isXpcValidated = isXpcValidated;
-        self.shouldReturnCachedXpcStatus = shouldReturnCachedXpcStatus;
         
         return self;
     }
@@ -62,11 +59,6 @@
 - (BOOL)isXpcProviderInstalledOnDevice
 {
     return _isXpcProviderInstalledOnDevice;
-}
-
-- (BOOL)shouldReturnCachedXpcStatus
-{
-    return _shouldReturnCachedXpcStatus;
 }
 
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@ Version 1.22.0
 * Serialize `is_sso_account` as NSString instead of NSNumber in MSIDAccount
 * Clean up the experiment bag for HTTP requests and attempt to resolve the reported crash.
 * Remove 4-hour XPC canPerform status cache and XPC roundtrip (#1771) 
-* Add HttpRequest interceptor #1759
+* Add HttpRequest interceptor #1759 
 
 Version 1.21.0
 * Import the right bridging header when common-core is consumed as submodule  (#1678)

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@ Version 1.22.0
 * Add French sovereign cloud authority as a trusted authority (#1731)
 * Serialize `is_sso_account` as NSString instead of NSNumber in MSIDAccount
 * Clean up the experiment bag for HTTP requests and attempt to resolve the reported crash.
-* Remove 4-hour XPC canPerform status cache and XPC roundtrip (#1771)
+* Remove 4-hour XPC canPerform status cache and XPC roundtrip (#1771) 
 * Add HttpRequest interceptor #1759
 
 Version 1.21.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Version 1.22.0
 * Add French sovereign cloud authority as a trusted authority (#1731)
 * Serialize `is_sso_account` as NSString instead of NSNumber in MSIDAccount
 * Clean up the experiment bag for HTTP requests and attempt to resolve the reported crash.
+* Remove 4-hour XPC canPerform status cache and XPC roundtrip (#1771)
 
 Version 1.21.0
 * Import the right bridging header when common-core is consumed as submodule  (#1678)


### PR DESCRIPTION
canPerformRequest: now returns YES once the XPC provider is installed and validated (Step 0 + Step 1), without making a blocking XPC call to canPerformWithMetadata:. This eliminates up to 1s of latency and the stale 4-hour NSUserDefaults cache that could lock out broker auth after transient failures.

Changes:
- Remove MSID_XPC_STATUS_EXPIRATION_TIME and related UserDefaults keys
- Remove shouldReturnCachedXpcStatus, cachedCanPerformRequestsStatus
- Fix Bug F: unify xpcConfiguration synchronization under dispatch_barrier_sync (was mixed @synchronized + dispatch_barrier)
- Add regression test: getXpcService is not called from canPerformRequest

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

This pull request simplifies and streamlines the XPC provider status caching logic in the macOS identity core. It removes the previous mechanism for caching the XPC provider's ability to perform requests, opting instead for a direct validation approach. This impacts both the production code and the associated tests and mocks.

**Caching and status logic simplification:**
* Removed all logic related to caching the XPC provider's "can perform requests" status, including the `shouldReturnCachedXpcStatus` and `cachedCanPerformRequestsStatus` properties and their usage in `MSIDXpcProviderCache` and related files. Now, if the XPC component exists and is validated, `canPerformRequest` returns `YES` without checking or updating any cached status. [[1]](diffhunk://#diff-9b8de3a283dd9082811e4e6224b835f1dc16cd2a3e35eaa856c50c70e382a9f0L28-L38) [[2]](diffhunk://#diff-9b8de3a283dd9082811e4e6224b835f1dc16cd2a3e35eaa856c50c70e382a9f0L181-R188) [[3]](diffhunk://#diff-c41de115d3fcb7911920d4bd665c01162e5675650fd851b72978e48174a8efedL38-L46) [[4]](diffhunk://#diff-071f78951861bddb890dd200720f18d597709b29382140548f0b58c391325190L155-R160) [[5]](diffhunk://#diff-071f78951861bddb890dd200720f18d597709b29382140548f0b58c391325190L231-R229)

**Test and mock updates:**
* Updated tests in `MSIDXpcSingleSignOnProviderTest.m` to reflect the removal of cached status logic. Tests now directly check the validation and installation status, and no longer pass or assert on cached status values. [[1]](diffhunk://#diff-6526277f24be701a521b169852aefeb897981c00a6181430d9e057bbb4e1047dL52-R56) [[2]](diffhunk://#diff-6526277f24be701a521b169852aefeb897981c00a6181430d9e057bbb4e1047dL68-L83) [[3]](diffhunk://#diff-6526277f24be701a521b169852aefeb897981c00a6181430d9e057bbb4e1047dR82-R97) [[4]](diffhunk://#diff-6526277f24be701a521b169852aefeb897981c00a6181430d9e057bbb4e1047dL120-R114) [[5]](diffhunk://#diff-6526277f24be701a521b169852aefeb897981c00a6181430d9e057bbb4e1047dL148-R136)
* Simplified the `MSIDXpcProviderCacheMock` interface and implementation by removing the `shouldReturnCachedXpcStatus` parameter and property, as well as the `cachedCanPerformRequestsStatus` property. [[1]](diffhunk://#diff-fb16185e9d4c261474524f856439aba96730642ad2cb6facc3032efeee34a9daL33-R33) [[2]](diffhunk://#diff-82046664b591972e05765c88af4e1d17f2cc935efa2b4d197a0a4999215e6b2dL32-L49) [[3]](diffhunk://#diff-82046664b591972e05765c88af4e1d17f2cc935efa2b4d197a0a4999215e6b2dL67-L71)

These changes reduce complexity, eliminate potential inconsistencies with cached XPC status, and ensure that the provider's ability to perform requests is always checked in real-time.
## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

