### PR TITLE
Code Review Feedback: ameyapat/add-get-device-token-api

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
+++ b/IdentityCore/src/cache/accessor/MSIDDefaultTokenCacheAccessor.m
@@ -990,6 +990,7 @@
 }
 
 #pragma mark - Internal
+
 - (BOOL)saveAccessTokenWithConfiguration:(MSIDConfiguration *)configuration
                                 response:(MSIDTokenResponse *)response
                                  factory:(MSIDOauth2Factory *)factory

--- a/IdentityCore/src/requests/MSIDDeviceTokenGrantRequest.h
+++ b/IdentityCore/src/requests/MSIDDeviceTokenGrantRequest.h
@@ -23,7 +23,6 @@
 // THE SOFTWARE.
 
 #import "MSIDTokenRequest.h"
-#import "MSIDThumbprintCalculatable.h"
 #import "MSIDWPJKeyPairWithCert.h"
 #import "MSIDConstants.h"
 
@@ -35,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) MSIDWPJKeyPairWithCert *wpjInfo;
 
-- (instancetype _Nullable )initWithEndpoint:(nonnull NSURL *)endpoint
+- (instancetype _Nullable)initWithEndpoint:(nonnull NSURL *)endpoint
                           requestParameters:(nonnull MSIDRequestParameters *)requestParameters
                                      scopes:(nullable NSString *)scope
                     registrationInformation:(nonnull MSIDWPJKeyPairWithCert *)registrationInformation
@@ -43,8 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
                                enrollmentId:(nullable NSString *)enrollmentId
                             extraParameters:(nullable NSDictionary *)extraParameters
                                  ssoContext:(nullable MSIDExternalSSOContext *)ssoContext
-                     tokenResponseHandler:(nonnull MSIDDeviceTokenResponseHandler *)tokenResponseValidator
-                                      error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+                    tokenResponseHandler:(nonnull MSIDDeviceTokenResponseHandler *)tokenResponseHandler
+                                     error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 - (instancetype _Nullable)initWithEndpoint:(nonnull NSURL *)endpoint
                                 authScheme:(nonnull MSIDAuthenticationScheme *)authScheme

--- a/IdentityCore/src/requests/MSIDDeviceTokenGrantRequest.m
+++ b/IdentityCore/src/requests/MSIDDeviceTokenGrantRequest.m
@@ -49,7 +49,7 @@
 @property (nonatomic) NSSet *scopesSet;
 @property (nonatomic) MSIDRequestParameters *requestParameters;
 
-@property (nonatomic) MSIDTokenResponseHandler *tokenResponseHandler;
+@property (nonatomic) MSIDDeviceTokenResponseHandler *tokenResponseHandler;
 
 @end
 
@@ -141,17 +141,24 @@
     // Passing blank accountId details as device token is not associated with a specific account. This is required to bypass cache look up in nonce request and directly request new nonce from server.
     nonceReqParams.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"" homeAccountId:@""];
     MSIDNonceTokenRequest *nonceRequest = [[MSIDNonceTokenRequest alloc] initWithRequestParameters:nonceReqParams];
+    __weak typeof(self) weakSelf = self;
     [nonceRequest executeRequestWithCompletion:^(NSString * _Nullable resultNonce, NSError * _Nullable error)
     {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf)
+        {
+            return;
+        }
+        
         if (!resultNonce || error)
         {
-            NSError *nonceError = error ?: MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"Failed to retrieve nonce for device token request: nonce is nil.", nil, nil, nil, self.context.correlationId, nil, YES);
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"Failed to retrieve nonce for device token request: %@", nonceError);
+            NSError *nonceError = error ?: MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"Failed to retrieve nonce for device token request: nonce is nil.", nil, nil, nil, strongSelf.context.correlationId, nil, YES);
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, strongSelf.context, @"Failed to retrieve nonce for device token request: %@", nonceError);
             completionBlock(nil, nonceError);
             return;
         }
-        self.nonce = resultNonce;
-        [self tokenRequestWithCompletionBlock:completionBlock];
+        strongSelf.nonce = resultNonce;
+        [strongSelf tokenRequestWithCompletionBlock:completionBlock];
     }];
 }
 
@@ -191,18 +198,25 @@
     requestParameters[@"request"] = jwt;
 
     self.parameters = requestParameters;
+    __weak typeof(self) weakSelf = self;
     [self sendWithBlock:^(NSDictionary *tokenJsonResponse, NSError *tokenError)
     {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf)
+        {
+            return;
+        }
+        
         if (tokenError)
         {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, self.context, @"Failed to retrieve device token: %@", tokenError);
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, strongSelf.context, @"Failed to retrieve device token: %@", tokenError);
             completionBlock(nil, tokenError);
             return;
-            
         }
-        MSIDDeviceTokenResponseHandler *tokenResponseHandler = (MSIDDeviceTokenResponseHandler *)self.tokenResponseHandler;
+        
+        MSIDDeviceTokenResponseHandler *tokenResponseHandler = strongSelf.tokenResponseHandler;
         [tokenResponseHandler handleTokenResponse:tokenJsonResponse
-                                          context:self.requestParameters
+                                          context:strongSelf.requestParameters
                                             error:nil
                                   completionBlock:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
             completionBlock(result, error);

--- a/IdentityCore/src/requests/MSIDDeviceTokenResponseHandler.h
+++ b/IdentityCore/src/requests/MSIDDeviceTokenResponseHandler.h
@@ -40,10 +40,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithRequestParameters:(MSIDRequestParameters *)requestParameters
                              oauthFactory:(MSIDOauth2Factory *)oauthFactory NS_DESIGNATED_INITIALIZER;
 
--(void)handleTokenResponse:(NSDictionary *)tokenJsonresponse
-                   context:(id<MSIDRequestContext>)context
-                     error:(NSError *)error
-           completionBlock:(MSIDRequestCompletionBlock)completionBlock;
+- (void)handleTokenResponse:(NSDictionary *)tokenJsonResponse
+                    context:(id<MSIDRequestContext>)context
+                      error:(NSError *)error
+            completionBlock:(MSIDRequestCompletionBlock)completionBlock;
 
 @end
 

--- a/IdentityCore/src/requests/MSIDDeviceTokenResponseHandler.m
+++ b/IdentityCore/src/requests/MSIDDeviceTokenResponseHandler.m
@@ -26,7 +26,7 @@
 #import "MSIDRequestParameters.h"
 #import "MSIDOauth2Factory.h"
 #import "MSIDTokenResponseValidator.h"
-@class MSIDCacheAccessor;
+@protocol MSIDCacheAccessor;
 
 @interface MSIDDeviceTokenResponseHandler ()
 
@@ -67,6 +67,13 @@
     MSIDTokenResponse *serializedTokenResponse = [self.oauthFactory tokenResponseFromJSON:tokenJsonResponse
                                                                                    context:context
                                                                                      error:&error];
+    
+    if (!serializedTokenResponse)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Failed to deserialize device token response.");
+        completionBlock(nil, error);
+        return;
+    }
     
     MSIDTokenResponseValidator *tokenResponseValidator = [MSIDTokenResponseValidator new];
     // Since device associated access tokens are not tied to a user identity, there is account related information to use as key in the token cache. We will skip cache lookup and cache saving for device tokens by setting the following flag on request parameters. This will ensure that device tokens are always requested from the service and not cached on the client.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Code review feedback: fix retain cycles, nil-check deserialized response, correct @class→@protocol, restore style conventions in device token grant request
 * Import the right bridging header when common-core is consumed as submodule 
 * Add retry logic when bound app refresh token redemption fails.
 * Captures the x-ms-clientData HTTP response header from ESTS & MSTS and supports client data from redirect uri (#1699)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 TBD
-* Code review feedback: fix retain cycles, nil-check deserialized response, correct @class→@protocol, restore style conventions in device token grant request
+* Code review feedback: fix retain cycles, nil-check deserialized response, correct @class→@protocol, restore style conventions in device token grant request (#1800)
 * Import the right bridging header when common-core is consumed as submodule 
 * Add retry logic when bound app refresh token redemption fails.
 * Captures the x-ms-clientData HTTP response header from ESTS & MSTS and supports client data from redirect uri (#1699)


### PR DESCRIPTION
## Code Review Summary

**Branch reviewed:** `ameyapat/add-get-device-token-api` vs `dev`
**Files reviewed:** 8 changed files (4 new, 4 modified)

### Findings: 8 issues (4 warnings, 4 suggestions)

#### Warnings (fixed)

| # | File | Issue |
|---|------|-------|
| 1 | `MSIDDeviceTokenGrantRequest.m` | **Retain cycle in nonce completion block** — `self` captured strongly in async completion block without `weakSelf/strongSelf` pattern. Could prevent deallocation of the request object. |
| 2 | `MSIDDeviceTokenGrantRequest.m` | **Retain cycle in sendWithBlock completion** — Same strong-self capture issue in the token request completion block. |
| 3 | `MSIDDeviceTokenResponseHandler.m` | **Missing nil check on deserialized token response** — If `tokenResponseFromJSON:` returns nil, the code proceeds to `validateAndSaveTokenResponse:` with a nil response, which could crash or produce unexpected behavior. |
| 4 | `MSIDDeviceTokenResponseHandler.m` | **`@class MSIDCacheAccessor` used for a protocol** — `MSIDCacheAccessor` is a protocol, not a class. Forward declaration should use `@protocol`. |

#### Suggestions (fixed)

| # | File | Issue |
|---|------|-------|
| 5 | `MSIDDeviceTokenGrantRequest.h` | **Unused import** — `MSIDThumbprintCalculatable.h` imported but class does not conform to the protocol. |
| 6 | `MSIDDeviceTokenGrantRequest.h` | **Parameter name mismatch** — `tokenResponseValidator` parameter was named misleadingly; it is a handler, not a validator. Renamed to `tokenResponseHandler`. |
| 7 | `MSIDDeviceTokenGrantRequest.m` | **Property typed as parent class** — `tokenResponseHandler` property was typed as `MSIDTokenResponseHandler *` but always stores `MSIDDeviceTokenResponseHandler *`, requiring unnecessary downcasts. |
| 8 | `MSIDDefaultTokenCacheAccessor.m` | **Missing blank line before `#pragma mark`** — Accidental removal of the blank line between method and `#pragma mark - Internal` violates code style. |

#### Additional Suggestions (not auto-fixed — require design decisions)

| # | File | Issue | Recommendation |
|---|------|-------|----------------|
| 9 | `MSIDDeviceTokenGrantRequest.m` | **Init returns nil without setting NSError out-param** — Multiple validation failures return nil but never populate the `error` parameter, leaving the caller with no error information. | Populate `*error` with a descriptive `MSIDCreateError()` for each validation failure. |
| 10 | `MSIDDeviceTokenGrantRequest.h` | **Missing unit tests** — No corresponding `MSIDDeviceTokenGrantRequestTests.m` or `MSIDDeviceTokenResponseHandlerTests.m` found. | Add unit tests for the new request and response handler. |

### Credential Scan
No credentials, secrets, tokens, or PII detected.