### PR TITLE
[minor][bugfix]: Include User FIC token in URL-scheme broker request payload

### DIFF
--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerTokenRequest.m
@@ -27,6 +27,7 @@
 #import "NSMutableDictionary+MSIDExtensions.h"
 #import "MSIDPromptType_Internal.h"
 #import "MSIDAuthority.h"
+#import "MSIDConstants.h"
 
 @implementation MSIDDefaultBrokerTokenRequest
 
@@ -58,6 +59,7 @@
     NSString *promptParam = MSIDPromptParamFromType(self.requestParameters.promptType);
     [contents msidSetNonEmptyString:promptParam forKey:MSID_BROKER_PROMPT_KEY];
     [contents setValue:@(MSID_BROKER_PROTOCOL_VERSION_3) forKey:MSID_BROKER_PROTOCOL_VERSION_KEY];
+    [contents msidSetNonEmptyString:self.requestParameters.userFederatedIdentityToken forKey:MSID_USER_FEDERATED_IDENTITY_CREDENTIAL_KEY];
     
     return contents;
 }

--- a/IdentityCore/tests/integration/ios/MSIDBrokerTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerTokenRequestTests.m
@@ -37,6 +37,7 @@
 #import "MSIDAuthenticationSchemePop.h"
 #import "MSIDAuthenticationSchemeSshCert.h"
 #import "MSIDBartFeatureUtil.h"
+#import "MSIDDefaultBrokerTokenRequest.h"
 @interface MSIDBrokerTokenRequestTests : XCTestCase
 
 @end
@@ -665,6 +666,36 @@
     NSString *expectedUrlString = [NSString stringWithFormat:@"msauthv2://broker?%@", [expectedRequest msidURLEncode]];
     NSURL *expectedURL = [NSURL URLWithString:expectedUrlString];
     XCTAssertTrue([expectedURL matchesURL:actualURL]);
+}
+
+- (void)testInitBrokerRequest_whenUserFederatedIdentityTokenSet_shouldIncludeFICInPayload
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self defaultTestParameters];
+    parameters.userFederatedIdentityToken = @"test-fic-token-value";
+
+    NSError *error = nil;
+    MSIDDefaultBrokerTokenRequest *request = [[MSIDDefaultBrokerTokenRequest alloc] initWithRequestParameters:parameters brokerKey:@"brokerKey" brokerApplicationToken:@"brokerApplicationToken" sdkCapabilities:nil error:&error];
+    XCTAssertNotNil(request);
+    XCTAssertNil(error);
+
+    NSURL *actualURL = request.brokerRequestURL;
+    NSDictionary *queryParams = [actualURL msidQueryParameters];
+    XCTAssertEqualObjects(queryParams[@"x-ms-UserFederatedIdentityCredential"], @"test-fic-token-value");
+}
+
+- (void)testInitBrokerRequest_whenUserFederatedIdentityTokenNil_shouldNotIncludeFICInPayload
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self defaultTestParameters];
+    parameters.userFederatedIdentityToken = nil;
+
+    NSError *error = nil;
+    MSIDDefaultBrokerTokenRequest *request = [[MSIDDefaultBrokerTokenRequest alloc] initWithRequestParameters:parameters brokerKey:@"brokerKey" brokerApplicationToken:@"brokerApplicationToken" sdkCapabilities:nil error:&error];
+    XCTAssertNotNil(request);
+    XCTAssertNil(error);
+
+    NSURL *actualURL = request.brokerRequestURL;
+    NSDictionary *queryParams = [actualURL msidQueryParameters];
+    XCTAssertNil(queryParams[@"x-ms-UserFederatedIdentityCredential"]);
 }
 
 - (void)setBoundAppRefreshTokenFlight


### PR DESCRIPTION


## PR Checklist (must be completed before review)

- [X] All tests pass locally
- [ ] PR size is <= 500 LOC per PR Size Check policy
- [ ] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

Description

The User FIC token (x-ms-UserFederatedIdentityCredential) was not being included in the URL-scheme broker request payload built by MSIDDefaultBrokerTokenRequest. This meant the iOS URL-scheme path (used by ADBTestApp and legacy clients) never sent FIC to the broker, even when it was set on the request parameters.

User FIC will eventuall reach the web view headers because Legacy URL-scheme path eventually reaches MSIDInteractiveTokenRequestParameters+ADBroker which builds params from request (including fic) then gets set into custom web view headers.

The SSO Extension path was unaffected since MSIDBrokerOperationInteractiveTokenRequest already serialized FIC into its JSON payload.

Changes

 - Added userFederatedIdentityToken to protocolPayloadContentsWithError: in MSIDDefaultBrokerTokenRequest.m
 - Added unit tests for both FIC-set and FIC-nil cases

## Type of change

- [X] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

