### PR TITLE
[minor][bufix] MSRC 116201 - Validate PKeyAuth SubmitUrl host against trusted Microsoft hosts

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -267,4 +267,7 @@ extern NSString * _Nonnull const MSID_FLIGHT_ENABLE_SKIP_BROKER_CACHE;
 /// Owner: josephpab
 extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_OPEN_NEW_WINDOW_IN_BROWSER;
 
+/// When enabled, validates that the SubmitUrl host in PKeyAuth challenges is a trusted Microsoft host.
+extern NSString * _Nonnull const MSID_FLIGHT_VALIDATE_PKEYAUTH_SUBMIT_HOST;
+
 #define METHODANDLINE   [NSString stringWithFormat:@"%s [Line %d]", __PRETTY_FUNCTION__, __LINE__]

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -121,4 +121,6 @@ NSString *const MSID_FLIGHT_SPINNER_FIX = @"enable_spinner_fix";
 
 NSString *const MSID_FLIGHT_DISABLE_OPEN_NEW_WINDOW_IN_BROWSER = @"disable_open_new_window_in_browser";
 
+NSString *const MSID_FLIGHT_VALIDATE_PKEYAUTH_SUBMIT_HOST = @"validate_pkeyauth_submit_host";
+
 #define METHODANDLINE   [NSString stringWithFormat:@"%s [Line %d]", __PRETTY_FUNCTION__, __LINE__]

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -35,6 +35,7 @@
 #import "MSIDRequestTelemetryConstants.h"
 #endif
 #import "MSIDWorkPlaceJoinUtil.h"
+#import "MSIDAADNetworkConfiguration.h"
 
 @implementation MSIDPKeyAuthHandler
 
@@ -56,6 +57,17 @@
     if (!queryParamsMap || !submitUrl)
     {
         error = MSIDCreateError(MSIDOAuthErrorDomain, MSIDErrorServerOauth, @"Incomplete PKeyAuth challenge received.", nil, nil, nil, context.correlationId, nil, YES);
+        completionHandler(nil, error);
+        return YES;
+    }
+    
+    // Validate that the SubmitUrl host is a trusted Microsoft host
+    NSURL *submitURL = [NSURL URLWithString:submitUrl];
+    NSString *submitUrlHost = submitURL.host.lowercaseString;
+    if (!submitUrlHost || ![[MSIDAADNetworkConfiguration defaultConfiguration].trustedHosts containsObject:submitUrlHost])
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, context, @"PKeyAuth challenge SubmitUrl host is not a trusted Microsoft host: %@", MSID_EUII_ONLY_LOG_MASKABLE(submitUrlHost));
+        error = MSIDCreateError(MSIDOAuthErrorDomain, MSIDErrorServerOauth, @"PKeyAuth challenge SubmitUrl is not a trusted Microsoft host.", nil, nil, nil, context.correlationId, nil, YES);
         completionHandler(nil, error);
         return YES;
     }

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -36,6 +36,7 @@
 #endif
 #import "MSIDWorkPlaceJoinUtil.h"
 #import "MSIDAADNetworkConfiguration.h"
+#import "MSIDFlightManager.h"
 
 @implementation MSIDPKeyAuthHandler
 
@@ -62,14 +63,17 @@
     }
     
     // Validate that the SubmitUrl host is a trusted Microsoft host
-    NSURL *submitURL = [NSURL URLWithString:submitUrl];
-    NSString *submitUrlHost = submitURL.host.lowercaseString;
-    if (!submitUrlHost || ![[MSIDAADNetworkConfiguration defaultConfiguration].trustedHosts containsObject:submitUrlHost])
+    if ([MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_VALIDATE_PKEYAUTH_SUBMIT_HOST])
     {
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, context, @"PKeyAuth challenge SubmitUrl host is not a trusted Microsoft host: %@", MSID_EUII_ONLY_LOG_MASKABLE(submitUrlHost));
-        error = MSIDCreateError(MSIDOAuthErrorDomain, MSIDErrorServerOauth, @"PKeyAuth challenge SubmitUrl is not a trusted Microsoft host.", nil, nil, nil, context.correlationId, nil, YES);
-        completionHandler(nil, error);
-        return YES;
+        NSURL *submitURL = [NSURL URLWithString:submitUrl];
+        NSString *submitUrlHost = submitURL.host.lowercaseString;
+        if (!submitUrlHost || ![[MSIDAADNetworkConfiguration defaultConfiguration].trustedHosts containsObject:submitUrlHost])
+        {
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, context, @"PKeyAuth challenge SubmitUrl host is not a trusted Microsoft host: %@", MSID_EUII_ONLY_LOG_MASKABLE(submitUrlHost));
+            error = MSIDCreateError(MSIDOAuthErrorDomain, MSIDErrorServerOauth, @"PKeyAuth challenge SubmitUrl is not a trusted Microsoft host.", nil, nil, nil, context.correlationId, nil, YES);
+            completionHandler(nil, error);
+            return YES;
+        }
     }
     
     // Extract authority from submit url    

--- a/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
+++ b/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
@@ -32,6 +32,8 @@
 #import "MSIDTestSwizzle.h"
 #import "MSIDInteractiveTokenRequestParameters.h"
 #import "MSIDConstants.h"
+#import "MSIDFlightManager.h"
+#import "MSIDFlightManagerMockProvider.h"
 
 @interface MSIDPKeyAuthHandlerTests : XCTestCase
 
@@ -47,6 +49,7 @@
 - (void)tearDown
 {
     [MSIDTestSwizzle reset];
+    [MSIDFlightManager sharedInstance].flightProvider = nil;
 }
 
 #pragma mark - Tests
@@ -201,6 +204,8 @@
 
 - (void)testHandleChallenge_whenSubmitUrlIsUntrustedHost_shouldReturnError
 {
+    [self enableSubmitUrlValidationFlight];
+
     __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2fevil.contoso.com%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
 
     __auto_type *context = [MSIDInteractiveTokenRequestParameters new];
@@ -222,6 +227,7 @@
 
 - (void)testHandleChallenge_whenSubmitUrlIsTrustedHost_shouldSucceed
 {
+    [self enableSubmitUrlValidationFlight];
     [self makeAppV2GroupEntitled:YES];
 
     __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2flogin.microsoftonline.us%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
@@ -243,6 +249,7 @@
 
 - (void)testHandleChallenge_whenSubmitUrlIsChinaCloud_shouldSucceed
 {
+    [self enableSubmitUrlValidationFlight];
     [self makeAppV2GroupEntitled:YES];
 
     __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2flogin.chinacloudapi.cn%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
@@ -260,6 +267,34 @@
     }];
     XCTAssertTrue(callback);
     XCTAssertTrue(handleResult);
+}
+
+- (void)testHandleChallenge_whenFlightDisabledAndUntrustedHost_shouldSucceed
+{
+    [self makeAppV2GroupEntitled:YES];
+
+    __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2fevil.contoso.com%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+
+    __auto_type *context = [MSIDInteractiveTokenRequestParameters new];
+    __block BOOL callback = NO;
+    BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
+                                                     context:context
+                                               customHeaders:nil
+                                          externalSSOContext:nil
+                                           completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
+        XCTAssertNotNil(challengeResponse);
+        XCTAssertNil(error);
+        callback = YES;
+    }];
+    XCTAssertTrue(callback);
+    XCTAssertTrue(handleResult);
+}
+
+- (void)enableSubmitUrlValidationFlight
+{
+    MSIDFlightManagerMockProvider *mockProvider = [MSIDFlightManagerMockProvider new];
+    mockProvider.boolForKeyContainer = @{ MSID_FLIGHT_VALIDATE_PKEYAUTH_SUBMIT_HOST : @YES };
+    [MSIDFlightManager sharedInstance].flightProvider = mockProvider;
 }
 
 - (void)makeAppV2GroupEntitled:(BOOL)entitled

--- a/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
+++ b/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
@@ -31,6 +31,7 @@
 #import "MSIDBasicContext.h"
 #import "MSIDTestSwizzle.h"
 #import "MSIDInteractiveTokenRequestParameters.h"
+#import "MSIDConstants.h"
 
 @interface MSIDPKeyAuthHandlerTests : XCTestCase
 
@@ -191,6 +192,69 @@
         XCTAssertNil([[challengeResponse allHTTPHeaderFields] objectForKey:MSID_REFRESH_TOKEN_CREDENTIAL], @"RefreshToken should be nil");
         NSString *currentTelemetry = [[challengeResponse allHTTPHeaderFields] objectForKey:@"x-client-current-telemetry"];
         XCTAssertEqualObjects(currentTelemetry, @"4|0,0|wpj-v1");
+        XCTAssertNil(error);
+        callback = YES;
+    }];
+    XCTAssertTrue(callback);
+    XCTAssertTrue(handleResult);
+}
+
+- (void)testHandleChallenge_whenSubmitUrlIsUntrustedHost_shouldReturnError
+{
+    __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2fevil.contoso.com%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+
+    __auto_type *context = [MSIDInteractiveTokenRequestParameters new];
+    __block BOOL callback = NO;
+    BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
+                                                     context:context
+                                               customHeaders:nil
+                                          externalSSOContext:nil
+                                           completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
+        XCTAssertNil(challengeResponse);
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.domain, MSIDOAuthErrorDomain);
+        XCTAssertTrue([error.userInfo[MSIDErrorDescriptionKey] containsString:@"not a trusted Microsoft host"]);
+        callback = YES;
+    }];
+    XCTAssertTrue(callback);
+    XCTAssertTrue(handleResult);
+}
+
+- (void)testHandleChallenge_whenSubmitUrlIsTrustedHost_shouldSucceed
+{
+    [self makeAppV2GroupEntitled:YES];
+
+    __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2flogin.microsoftonline.us%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+
+    __auto_type *context = [MSIDInteractiveTokenRequestParameters new];
+    __block BOOL callback = NO;
+    BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
+                                                     context:context
+                                               customHeaders:nil
+                                          externalSSOContext:nil
+                                           completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
+        XCTAssertNotNil(challengeResponse);
+        XCTAssertNil(error);
+        callback = YES;
+    }];
+    XCTAssertTrue(callback);
+    XCTAssertTrue(handleResult);
+}
+
+- (void)testHandleChallenge_whenSubmitUrlIsChinaCloud_shouldSucceed
+{
+    [self makeAppV2GroupEntitled:YES];
+
+    __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2flogin.chinacloudapi.cn%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+
+    __auto_type *context = [MSIDInteractiveTokenRequestParameters new];
+    __block BOOL callback = NO;
+    BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
+                                                     context:context
+                                               customHeaders:nil
+                                          externalSSOContext:nil
+                                           completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
+        XCTAssertNotNil(challengeResponse);
         XCTAssertNil(error);
         callback = YES;
     }];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 TBD
 * Add device token grant request/response handlers. (#1801)
 * Improve UI tests performance #1805
+* Validate PKeyAuth challenge SubmitUrl host against trusted Microsoft hosts, gated behind MSID_FLIGHT_VALIDATE_PKEYAUTH_SUBMIT_HOST flight
 
 Version 1.23.0
 * Clean up the experiment bag for HTTP requests and attempt to resolve the reported crash. (#1757)


### PR DESCRIPTION
Reject PKeyAuth challenges where the SubmitUrl host is not in the MSIDAADNetworkConfiguration trusted hosts set. This prevents potential abuse where a malicious challenge could redirect device auth responses to an untrusted server.

## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [x] Appropriate reviewers are assigned
- [x] PR reviewed by code owner (required if Copilot-generated)
- [x] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

