### PR TITLE
Update MSAL CPP check to 90 minutes for macOS

### DIFF
--- a/azure_pipelines/verify_msalcpp_per_pr_mac.yml
+++ b/azure_pipelines/verify_msalcpp_per_pr_mac.yml
@@ -26,7 +26,7 @@ resources:
 jobs:
 - job: macOS_OnPrCommit
   displayName: OneAuth checks per commit for macOS
-  timeoutInMinutes: 60
+  timeoutInMinutes: 90
   cancelTimeoutInMinutes: 1
   workspace:
     clean: all


### PR DESCRIPTION
For `[MSAL C++] Common core subtree update check macOS` pipeline.

This pull request makes a minor adjustment to the Azure Pipelines configuration by increasing the job timeout for macOS OneAuth checks.

- Increased the `timeoutInMinutes` for the `macOS_OnPrCommit` job in `azure_pipelines/verify_msalcpp_per_pr_mac.yml` from 60 to 90 minutes to allow more time for job completion.