### PR TITLE
[minor][feature]: Excluding MSIDAesGcmDecryptor and MSIDConcatKdfProvider swift files f…

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -447,8 +447,6 @@
 		23B3A4562187BA79009070B2 /* MSIDIntuneEnrollmentIdsCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B3A4542187BA79009070B2 /* MSIDIntuneEnrollmentIdsCacheTests.m */; };
 		23B3A4582187BB31009070B2 /* MSIDIntuneMAMResourcesCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B3A4572187BB31009070B2 /* MSIDIntuneMAMResourcesCacheTests.m */; };
 		23B3A4592187BB31009070B2 /* MSIDIntuneMAMResourcesCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B3A4572187BB31009070B2 /* MSIDIntuneMAMResourcesCacheTests.m */; };
-		B41DD0A92FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B41DD0A62FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m */; };
-		B41DD0AA2FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B41DD0A62FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m */; };
 		23B4CC6F2181680600DBDBCE /* MSIDIntuneEnrollmentIdsCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 23B4CC6D2181680600DBDBCE /* MSIDIntuneEnrollmentIdsCache.h */; };
 		23B4CC702181680600DBDBCE /* MSIDIntuneEnrollmentIdsCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B4CC6E2181680600DBDBCE /* MSIDIntuneEnrollmentIdsCache.m */; };
 		23B4CC712181680600DBDBCE /* MSIDIntuneEnrollmentIdsCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B4CC6E2181680600DBDBCE /* MSIDIntuneEnrollmentIdsCache.m */; };
@@ -822,7 +820,6 @@
 		724C9E0E2E6F9F2A0039BAA0 /* NSData+MSIDEccSecKeyRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 724C9E0D2E6F9F030039BAA0 /* NSData+MSIDEccSecKeyRef.h */; };
 		724C9E102E6F9F430039BAA0 /* NSData+MSIDEccSecKeyRef.m in Sources */ = {isa = PBXBuildFile; fileRef = 724C9E0F2E6F9F410039BAA0 /* NSData+MSIDEccSecKeyRef.m */; };
 		724C9E112E6F9F430039BAA0 /* NSData+MSIDEccSecKeyRef.m in Sources */ = {isa = PBXBuildFile; fileRef = 724C9E0F2E6F9F410039BAA0 /* NSData+MSIDEccSecKeyRef.m */; };
-		724C9E322E6FAB170039BAA0 /* MSIDConcatKdfProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724C9E312E6FAB170039BAA0 /* MSIDConcatKdfProvider.swift */; };
 		724C9E332E6FAB170039BAA0 /* MSIDConcatKdfProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724C9E312E6FAB170039BAA0 /* MSIDConcatKdfProvider.swift */; };
 		724C9E592E6FE6310039BAA0 /* MSIDJweResponseDecryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 724C9E582E6FE6300039BAA0 /* MSIDJweResponseDecryptionTests.m */; };
 		724C9E5A2E6FE6310039BAA0 /* MSIDJweResponseDecryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 724C9E582E6FE6300039BAA0 /* MSIDJweResponseDecryptionTests.m */; };
@@ -1934,6 +1931,8 @@
 		B41DD0A22FB4187500F81A9A /* MSIDIntuneDeviceIdCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B41DD0A12FB4187200F81A9A /* MSIDIntuneDeviceIdCache.h */; };
 		B41DD0A42FB4187B00F81A9A /* MSIDIntuneDeviceIdCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B41DD0A32FB4187900F81A9A /* MSIDIntuneDeviceIdCache.m */; };
 		B41DD0A52FB4187B00F81A9A /* MSIDIntuneDeviceIdCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B41DD0A32FB4187900F81A9A /* MSIDIntuneDeviceIdCache.m */; };
+		B41DD0A92FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B41DD0A62FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m */; };
+		B41DD0AA2FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B41DD0A62FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m */; };
 		B41F0CD62F871F260029E631 /* MSIDWebMDMEnrollmentCompletionResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = B41F0CD52F871F230029E631 /* MSIDWebMDMEnrollmentCompletionResponse.h */; };
 		B41F0CD82F871F320029E631 /* MSIDWebMDMEnrollmentCompletionResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B41F0CD72F871F2E0029E631 /* MSIDWebMDMEnrollmentCompletionResponse.m */; };
 		B41F0CD92F871F320029E631 /* MSIDWebMDMEnrollmentCompletionResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B41F0CD72F871F2E0029E631 /* MSIDWebMDMEnrollmentCompletionResponse.m */; };
@@ -2011,7 +2010,6 @@
 		B4EC850E2EF65C58005567DA /* MSIDAesGcmDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EC850A2EF65C58005567DA /* MSIDAesGcmDecryptor.swift */; };
 		B4EC850F2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m in Sources */ = {isa = PBXBuildFile; fileRef = B4EC850C2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m */; };
 		B4EC85102EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.h in Headers */ = {isa = PBXBuildFile; fileRef = B4EC850B2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.h */; };
-		B4EC85112EF65C58005567DA /* MSIDAesGcmDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EC850A2EF65C58005567DA /* MSIDAesGcmDecryptor.swift */; };
 		B4EC85122EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m in Sources */ = {isa = PBXBuildFile; fileRef = B4EC850C2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m */; };
 		B500F7322F1144A900E64911 /* MSIDBrokerOperationGetDefaultAccountRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B500F7302F1144A900E64911 /* MSIDBrokerOperationGetDefaultAccountRequestTests.m */; };
 		B500F7332F1144A900E64911 /* MSIDBrokerOperationGetDefaultAccountResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B500F7312F1144A900E64911 /* MSIDBrokerOperationGetDefaultAccountResponseTests.m */; };
@@ -2538,7 +2536,6 @@
 		23B3A4502187AFD3009070B2 /* MSIDJsonSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDJsonSerializer.m; sourceTree = "<group>"; };
 		23B3A4542187BA79009070B2 /* MSIDIntuneEnrollmentIdsCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIntuneEnrollmentIdsCacheTests.m; sourceTree = "<group>"; };
 		23B3A4572187BB31009070B2 /* MSIDIntuneMAMResourcesCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIntuneMAMResourcesCacheTests.m; sourceTree = "<group>"; };
-		B41DD0A62FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIntuneDeviceIdCacheTests.m; sourceTree = "<group>"; };
 		23B4CC6D2181680600DBDBCE /* MSIDIntuneEnrollmentIdsCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDIntuneEnrollmentIdsCache.h; sourceTree = "<group>"; };
 		23B4CC6E2181680600DBDBCE /* MSIDIntuneEnrollmentIdsCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIntuneEnrollmentIdsCache.m; sourceTree = "<group>"; };
 		23B5DF74234030B2002C530F /* MSIDRequestParameters+Broker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDRequestParameters+Broker.h"; sourceTree = "<group>"; };
@@ -3546,6 +3543,7 @@
 		B41163BB29BAC9DE00E64619 /* MSIDWKNavigationActionMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDWKNavigationActionMock.h; sourceTree = "<group>"; };
 		B41DD0A12FB4187200F81A9A /* MSIDIntuneDeviceIdCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDIntuneDeviceIdCache.h; sourceTree = "<group>"; };
 		B41DD0A32FB4187900F81A9A /* MSIDIntuneDeviceIdCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIntuneDeviceIdCache.m; sourceTree = "<group>"; };
+		B41DD0A62FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIntuneDeviceIdCacheTests.m; sourceTree = "<group>"; };
 		B41F0CD52F871F230029E631 /* MSIDWebMDMEnrollmentCompletionResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDWebMDMEnrollmentCompletionResponse.h; sourceTree = "<group>"; };
 		B41F0CD72F871F2E0029E631 /* MSIDWebMDMEnrollmentCompletionResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDWebMDMEnrollmentCompletionResponse.m; sourceTree = "<group>"; };
 		B42C16002CE7E53800553316 /* MSIDFamilyRefreshToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDFamilyRefreshToken.h; sourceTree = "<group>"; };
@@ -7846,7 +7844,6 @@
 				B2AF1D42218BD10A0080C1A0 /* MSIDRequestParameters.m in Sources */,
 				B41F0CD92F871F320029E631 /* MSIDWebMDMEnrollmentCompletionResponse.m in Sources */,
 				04D32CB31FD62141000B123E /* MSIDError.m in Sources */,
-				B4EC85112EF65C58005567DA /* MSIDAesGcmDecryptor.swift in Sources */,
 				B4EC85122EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m in Sources */,
 				05566D112204BB8A002DBA40 /* MSIDMacKeychainTokenCache.m in Sources */,
 				23D2049021D1B499009B5975 /* MSIDAADJsonResponsePreprocessor.m in Sources */,
@@ -7918,7 +7915,6 @@
 				B2C708B5219A621100D917B8 /* MSIDBrokerCryptoProvider.m in Sources */,
 				B286B98D2389DC34007833AD /* MSIDBrokerOperationTokenResponse.m in Sources */,
 				2394F1FA2D4890BD00E44F6E /* MSIDWebOAuth2AuthCodeOperation.m in Sources */,
-				724C9E322E6FAB170039BAA0 /* MSIDConcatKdfProvider.swift in Sources */,
 				B286B9832389DC15007833AD /* MSIDBrokerOperationInteractiveTokenRequest.m in Sources */,
 				1EE42FF1248825CE00899491 /* MSIDAccessTokenWithAuthScheme.m in Sources */,
 				606830062098ACED00CCA6AB /* MSIDNegotiateHandler.m in Sources */,

--- a/IdentityCore/src/JWEResponse/MSIDAesGcmDecryptor.swift
+++ b/IdentityCore/src/JWEResponse/MSIDAesGcmDecryptor.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-
+#if !os(macOS)
 import Foundation
 import CryptoKit
 
@@ -37,3 +37,4 @@ public class MSIDAesGcmDecryptor: NSObject {
         return try AES.GCM.open(sealedBox, using: key, authenticating: aad)
     }
 }
+#endif

--- a/IdentityCore/src/JWEResponse/MSIDJweResponse+EcdhAesGcm.h
+++ b/IdentityCore/src/JWEResponse/MSIDJweResponse+EcdhAesGcm.h
@@ -36,9 +36,11 @@ extern MSIDJWECryptoKeyResponseEncryptionAlgorithm const _Nonnull MSID_RESPONSE_
 
 NS_ASSUME_NONNULL_BEGIN
 @interface MSIDJweResponse (EcdhAesGcm)
+#if !TARGET_OS_OSX
 - (BOOL)IsJweResponseAlgorithmSupported:(NSError * _Nullable __autoreleasing * _Nullable)error;
 - (nullable NSDictionary *)decryptJweResponseWithPrivateStk:(SecKeyRef)privateStk
                                                   jweCrypto:(MSIDJWECrypto *)jweCrypto
                                                       error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+#endif
 @end
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/JWEResponse/MSIDJweResponse+EcdhAesGcm.m
+++ b/IdentityCore/src/JWEResponse/MSIDJweResponse+EcdhAesGcm.m
@@ -40,6 +40,12 @@ MSIDJWECryptoKeyResponseEncryptionAlgorithm const MSID_RESPONSE_ENCRYPTION_ALGOR
 
 @implementation MSIDJweResponse (EcdhAesGcm)
 
+/*  JWE response decryption relies on CryptoKit which is a swift dependency.
+    Certain macOS partners do not support swift in their build system.
+    Hence excluding the decryption logic for macOS platform until they upgrade their build system.
+*/
+
+#if !TARGET_OS_OSX
 - (nullable NSDictionary *)decryptJweResponseWithPrivateStk:(nonnull SecKeyRef)privateStkRef
                                                   jweCrypto:(nonnull MSIDJWECrypto *)jweCrypto
                                                       error:(NSError * _Nullable __autoreleasing * _Nullable)error
@@ -263,4 +269,5 @@ MSIDJWECryptoKeyResponseEncryptionAlgorithm const MSID_RESPONSE_ENCRYPTION_ALGOR
     
     return YES;
 }
+#endif
 @end

--- a/IdentityCore/src/MSIDSwiftBridgingHeader.h
+++ b/IdentityCore/src/MSIDSwiftBridgingHeader.h
@@ -40,7 +40,7 @@
 
 /*  Concat KDF key derivation & AESGCM decryption relies on CryptoKit which is a swift dependency.
     Certain macOS partners do not support swift in their build system.
-    Hence excluding swift bridging headder generation for macOS platform until they upgrade their build system.
+    Hence excluding swift bridging header generation for macOS platform until they upgrade their build system.
 */
 #if !TARGET_OS_OSX
 #if defined(MSAL_COCOAPOD)

--- a/IdentityCore/src/MSIDSwiftBridgingHeader.h
+++ b/IdentityCore/src/MSIDSwiftBridgingHeader.h
@@ -38,6 +38,11 @@
  MSAL podspec defines MSAL_COCOAPOD macro during pod creation and oneAuth defines ONEAUTH_COCOAPOD macro in its podspec.
  */
 
+/*  Concat KDF key derivation & AESGCM decryption relies on CryptoKit which is a swift dependency.
+    Certain macOS partners do not support swift in their build system.
+    Hence excluding swift bridging headder generation for macOS platform until they upgrade their build system.
+*/
+#if !TARGET_OS_OSX
 #if defined(MSAL_COCOAPOD)
 #if __has_include(<MSAL/MSAL-Swift.h>)
 #import <MSAL/MSAL-Swift.h>
@@ -52,4 +57,5 @@
 #endif
 #else
 #import "IdentityCore-Swift.h"
+#endif
 #endif

--- a/IdentityCore/src/network/response_serializer/preprocessor/MSIDJweResponseDecryptPreProcessor.m
+++ b/IdentityCore/src/network/response_serializer/preprocessor/MSIDJweResponseDecryptPreProcessor.m
@@ -69,7 +69,7 @@
         return nil;
     }
 
-    NSDictionary *decryptedResponse;
+    NSDictionary *decryptedResponse = nil;
     /*  JWE response decryption relies on CryptoKit which is a swift dependency.
         Certain macOS partners do not support swift in their build system.
         Hence excluding the decryption logic for macOS platform until they upgrade their build system.
@@ -89,6 +89,15 @@
         }
 
         decryptedResponse = [mutableDecryptedResponse copy];
+    }
+#else
+    __auto_type localError = MSIDCreateError(MSIDErrorDomain,
+                                             MSIDErrorInternal,
+                                             @"JWE decryption is unsupported on macOS.",
+                                             nil, nil, nil, context.correlationId, nil, YES);
+    if (error)
+    {
+        *error = localError;
     }
 #endif
     return decryptedResponse;

--- a/IdentityCore/src/network/response_serializer/preprocessor/MSIDJweResponseDecryptPreProcessor.m
+++ b/IdentityCore/src/network/response_serializer/preprocessor/MSIDJweResponseDecryptPreProcessor.m
@@ -69,8 +69,14 @@
         return nil;
     }
 
+    NSDictionary *decryptedResponse;
+    /*  JWE response decryption relies on CryptoKit which is a swift dependency.
+        Certain macOS partners do not support swift in their build system.
+        Hence excluding the decryption logic for macOS platform until they upgrade their build system.
+    */
+#if !TARGET_OS_OSX
     MSIDJweResponse *jweResponse = [[MSIDJweResponse alloc] initWithRawJWE:rawResponse];
-    NSDictionary *decryptedResponse = [jweResponse decryptJweResponseWithPrivateStk:self.decryptionKey jweCrypto:jweCrypto error:error];
+    decryptedResponse = [jweResponse decryptJweResponseWithPrivateStk:self.decryptionKey jweCrypto:jweCrypto error:error];
 
     if (self.additionalResponseClaims && decryptedResponse)
     {
@@ -84,6 +90,7 @@
 
         decryptedResponse = [mutableDecryptedResponse copy];
     }
+#endif
     return decryptedResponse;
 }
 - (nullable id)responseObjectForResponse:(nullable NSHTTPURLResponse *)httpResponse

--- a/IdentityCore/src/util/MSIDConcatKdfProvider.swift
+++ b/IdentityCore/src/util/MSIDConcatKdfProvider.swift
@@ -22,7 +22,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-
+/*  Concat KDF key derivation relies on CryptoKit which is a swift dependency.
+    Certain macOS partners do not support swift in their build system.
+    Hence excluding the key derivation logic for macOS platform until they upgrade their build system.
+*/
+#if !os(macOS)
 import Foundation
 import CommonCrypto
 import CryptoKit
@@ -103,3 +107,4 @@ public class MSIDConcatKdfProvider: NSObject {
         return derivedKeyingMaterial
     }
 }
+#endif

--- a/IdentityCore/tests/MSIDJweResponseDecryptionTests.m
+++ b/IdentityCore/tests/MSIDJweResponseDecryptionTests.m
@@ -35,7 +35,26 @@
 @end
 
 @implementation MSIDJweResponseDecryptionTests
+#if TARGET_OS_OSX
+- (void)testJweResponseEcdhAesGcmSelectors_whenRunningOnMacOS_shouldNotBeExposed
+{
+    MSIDJweResponse *jweResponse = [[MSIDJweResponse alloc] initWithRawJWE:@"a.b.c.d.e"];
 
+    SEL decryptSelector = NSSelectorFromString(@"decryptJweResponseWithPrivateStk:jweCrypto:error:");
+    SEL supportedAlgorithmSelector = NSSelectorFromString(@"IsJweResponseAlgorithmSupported:");
+
+    XCTAssertFalse([jweResponse respondsToSelector:decryptSelector]);
+    XCTAssertFalse([jweResponse respondsToSelector:supportedAlgorithmSelector]);
+}
+
+- (void)testSwiftCryptoClasses_whenRunningOnMacOS_shouldNotBeLinked
+{
+    XCTAssertNil(NSClassFromString(@"MSIDConcatKdfProvider"));
+    XCTAssertNil(NSClassFromString(@"MSIDAesGcmDecryptor"));
+}
+#endif
+
+#if !TARGET_OS_OSX
 - (void)testJWEDecryption_withCorrectJWE_andValidKeys_shouldReturnDecryptedContent
 {
     SecKeyRef privateKeyRef = [self testPrivateKey];
@@ -163,5 +182,5 @@
                                          &cfError);
     return key;
 }
-
+#endif
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ TBD
 * Add device token grant request/response handlers. (#1801)
 * Improve UI tests performance #1805
 * Close cookies popup in automation tests #1814
+* Exclude swift files from macOS targets #1827
 
 Version 1.23.1
 * Support saving and removing requestedClaims for ATs in mac legacy (ACL) cache (#1783)


### PR DESCRIPTION
…rom macOS

## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [ ] PR size is <= 500 LOC per PR Size Check policy
- [ ] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

Certain external teams have not updated their build systems to support swift files. Until they do, we need to exclude swift files from macOS IdentityCode targets.

MSIDAesGcmDecryptor.swift & MSIDConcatKdfProvider.swift that has dependency on CryptoKit(swift only) are being used only in iOS for the bound app refresh token feature, hence excluding them for macOS targets.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

