### PR TITLE
[minor][feature]: Allow including onboardingBlob as part of the error metadata response from broker

### DIFF
--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultBrokerResponseHandler.m
@@ -37,6 +37,7 @@
 #import "MSIDAuthenticationScheme.h"
 #import "MSIDAuthenticationSchemePop.h"
 #import "MSIDAuthScheme.h"
+#import "MSIDOnboardingBlobFieldKeys.h"
 #import "NSOrderedSet+MSIDExtensions.h"
 
 @implementation MSIDDefaultBrokerResponseHandler
@@ -60,6 +61,7 @@
                                 @"declined_scopes" : MSIDDeclinedScopesKey,
                                 @"granted_scopes" : MSIDGrantedScopesKey,
                                 @"client_data" : MSID_CLIENT_DATA_RESPONSE,
+                                MSIDOnboardingBlobIPCKey : MSIDOnboardingBlobIPCKey,
                                 };
     }
     

--- a/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
@@ -47,6 +47,7 @@
 #import "MSIDIdToken.h"
 #import "MSIDDefaultTokenCacheAccessor.h"
 #import "MSIDAccountMetadataCacheAccessor.h"
+#import "MSIDOnboardingBlobFieldKeys.h"
 
 @interface MSIDDefaultBrokerResponseHandlerTests : XCTestCase
 
@@ -1704,6 +1705,91 @@
     XCTAssertNil(result);
     XCTAssertNotNil(error);
     XCTAssertNil(error.userInfo[MSID_CLIENT_DATA_RESPONSE]);
+}
+
+- (void)testHandleBrokerResponse_whenErrorMetadataContainsOnboardingBlob_shouldSurfaceOnboardingBlobInErrorUserInfo
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+
+    NSString *correlationId = [[NSUUID UUID] UUIDString];
+    NSString *onboardingBlobValue = @"{\"last_completed_step\":\"broker_install_prompted\"}";
+
+    NSDictionary *errorMetadata =
+    @{
+      @"http_response_code" : @200,
+      @"username" : @"user@contoso.com",
+      MSIDOnboardingBlobIPCKey : onboardingBlobValue,
+      };
+    NSString *errorMetaDataString = [errorMetadata msidJSONSerializeWithContext:nil];
+
+    NSDictionary *brokerResponseParams =
+    @{
+      @"broker_error_code" : @"-42004",
+      @"broker_error_domain" : @"MSALErrorDomain",
+      @"correlation_id" : correlationId,
+      @"x-broker-app-ver" : @"1.0.0",
+      @"error_metadata" : errorMetaDataString,
+      @"error": @"invalid_grant",
+      @"suberror": @"consent_required",
+      @"error_description": @"Error occured",
+      @"success": @NO,
+      @"broker_nonce" : @"nonce"
+      };
+
+    NSURL *brokerResponseURL = [MSIDTestBrokerResponseHelper createDefaultBrokerResponse:brokerResponseParams
+                                                                             redirectUri:@"x-msauth-test://com.microsoft.testapp"
+                                                                           encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];
+
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, -42004);
+    XCTAssertEqualObjects(error.domain, @"MSALErrorDomain");
+    XCTAssertEqualObjects(error.userInfo[MSIDOnboardingBlobIPCKey], onboardingBlobValue);
+}
+
+- (void)testHandleBrokerResponse_whenErrorMetadataHasNoOnboardingBlob_shouldNotContainOnboardingBlobInErrorUserInfo
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+
+    NSString *correlationId = [[NSUUID UUID] UUIDString];
+
+    NSDictionary *errorMetadata =
+    @{
+      @"http_response_code" : @200,
+      @"username" : @"user@contoso.com",
+      };
+    NSString *errorMetaDataString = [errorMetadata msidJSONSerializeWithContext:nil];
+
+    NSDictionary *brokerResponseParams =
+    @{
+      @"broker_error_code" : @"-42004",
+      @"broker_error_domain" : @"MSALErrorDomain",
+      @"correlation_id" : correlationId,
+      @"x-broker-app-ver" : @"1.0.0",
+      @"error_metadata" : errorMetaDataString,
+      @"error": @"invalid_grant",
+      @"error_description": @"Error occured",
+      @"success": @NO,
+      @"broker_nonce" : @"nonce"
+      };
+
+    NSURL *brokerResponseURL = [MSIDTestBrokerResponseHelper createDefaultBrokerResponse:brokerResponseParams
+                                                                             redirectUri:@"x-msauth-test://com.microsoft.testapp"
+                                                                           encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];
+
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertNil(error.userInfo[MSIDOnboardingBlobIPCKey]);
 }
 
 @end


### PR DESCRIPTION
Allow including onboardingBlob as part of the error metadata response from broker.

## PR Checklist (must be completed before review)

- [ ] All tests pass locally
- [ ] PR size is <= 500 LOC per PR Size Check policy
- [ ] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## Proposed changes

This pull request introduces a small update to the `MSIDDefaultBrokerResponseHandler` class, primarily focused on onboarding blob support. The changes ensure that the onboarding blob field key is properly imported and mapped in the response handler.

- Onboarding blob support:
  * Added import for `MSIDOnboardingBlobFieldKeys.h` to ensure access to onboarding blob field definitions.
  * Mapped `MSIDOnboardingBlobIPCKey` in the response handler's dictionary, enabling the handler to process onboarding blob data in broker responses.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

