### PR TITLE
[patch][engg]: Expose finalizeOnboardingTelemetry:error: in MSIDOAuth2EmbeddedWebviewController header

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.h
@@ -59,6 +59,9 @@ typedef NSURLRequest *(^MSIDExternalDecidePolicyForBrowserActionBlock)(MSIDOAuth
                                 webview:(WKWebView *)webView
                         decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler;
 
+- (void)finalizeOnboardingTelemetry:(NSURL *)endURL
+                              error:(NSError *)error;
+
 @property (atomic, readonly) NSURL *startURL;
 @property (nonatomic, readonly) NSDictionary<NSString *, NSString *> *customHeaders;
 @property (nonatomic, copy) MSIDNavigationResponseBlock navigationResponseBlock;


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

`[patch][engg]: Expose finalizeOnboardingTelemetry:error: in MSIDOAuth2EmbeddedWebviewController header`

## Proposed changes

Declare `finalizeOnboardingTelemetry:(NSURL *)endURL error:(NSError *)error` in
`MSIDOAuth2EmbeddedWebviewController.h`. The method is already implemented in
the corresponding `.m` file and invoked internally (see line 223 of
`MSIDOAuth2EmbeddedWebviewController.m`), but it was missing from the header,
preventing other components from calling it through a typed reference.

This is a header-only change — no implementation or behavior is modified.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios.
- [ ] Medium – Errors could cause regression of 1 or more scenarios.
- [x] Small – No issues are expected. (header-only declaration of an already-implemented method)

## Additional information

Follow-up to #1811 ("Enhance onboarding telemetry for 1st party apps"), which
introduced `finalizeOnboardingTelemetry:error:` but did not expose it in the
header.
