### PR TITLE
[minor][bugfix] Fail When token type == Pop & RecCnf is nil or empty string

### DIFF
--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
@@ -222,6 +222,15 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_CLAIMS_KEY = @"claims";
         
         if (MSIDAuthSchemeTypeFromString(tokenType) == MSIDAuthSchemePop)
         {
+            
+            if ([NSString msidIsStringNilOrBlank:reqCnf])
+            {
+                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to init MSIDBrowserNativeMessageGetTokenRequest: 'reqCnf' is required when token_type is Pop but was missing or empty.");
+                
+                if (error) *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"'reqCnf' is required when token_type is Pop.", nil, nil, nil, nil, nil, YES);
+                return nil;
+            }
+            
             NSMutableDictionary *schemeParams = [NSMutableDictionary new];
             schemeParams[MSID_OAUTH2_TOKEN_TYPE] = tokenType;
             schemeParams[MSID_OAUTH2_REQUEST_CONFIRMATION] = reqCnf;

--- a/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
@@ -29,6 +29,7 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDClaimsRequest.h"
 #import "MSIDAuthenticationScheme.h"
+#import "MSIDError.h"
 
 @interface MSIDBrowserNativeMessageGetTokenRequestTests : XCTestCase
 
@@ -913,7 +914,7 @@
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndNumberReqCnf_shouldNotFail
+- (void)testInitWithJSONDictionary_whenJsonValidAndNumberReqCnf_shouldReturnNilWithError
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -944,9 +945,9 @@
     NSError *error;
     __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
     
-    XCTAssertNotNil(request);
-    XCTAssertNil(error);
-    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
 - (void)testInitWithJSONDictionary_whenJsonValidAndNumberTokenType_shouldNotFail
@@ -985,7 +986,7 @@
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndNumberReqCnfAsEQP_shouldNotFail
+- (void)testInitWithJSONDictionary_whenJsonValidAndNumberReqCnfAsEQP_shouldReturnNilWithError
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -1016,9 +1017,9 @@
     NSError *error;
     __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
     
-    XCTAssertNotNil(request);
-    XCTAssertNil(error);
-    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
 - (void)testInitWithJSONDictionary_whenJsonValidAndNumberTokenTypeAsEQP_shouldNotFail
@@ -1055,6 +1056,79 @@
     XCTAssertNotNil(request);
     XCTAssertNil(error);
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeAndNilReqCnf_shouldReturnNilWithError
+{
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"tokenType": @"pop",
+        }
+    };
+    
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+    
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeAndEmptyReqCnf_shouldReturnNilWithError
+{
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"tokenType": @"pop",
+            @"reqCnf": @""
+        }
+    };
+    
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+    
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeInEQPAndNilReqCnf_shouldReturnNilWithError
+{
+    __auto_type extraParameters = @{
+        @"tokenType": @"pop",
+    };
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"extraParameters": extraParameters,
+        }
+    };
+    
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+    
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
 @end


### PR DESCRIPTION
PR Title: [patch] [bugfix]: Fail initialization when token_type is Pop and reqCnf is nil or empty

## Proposed changes

When MSIDBrowserNativeMessageGetTokenRequest receives a tokenType of Pop but reqCnf is nil or empty, the initialization previously fell through silently — MSIDAuthenticationSchemePop returned nil, and the code fell back to a Bearer auth scheme without surfacing an error. This caused callers to unknowingly receive a Bearer token when they explicitly requested PoP, which could lead to auth failures downstream.

## This PR:

 - Adds an explicit nil/blank check for reqCnf when tokenType is MSIDAuthSchemePop, returning nil with an MSIDErrorInvalidInternalParameter error instead of silently downgrading to Bearer.
 - Updates existing tests that expected the silent Bearer fallback to now expect failure with an error.
 - Adds new test cases covering nil reqCnf, empty string reqCnf, and nil reqCnf via extraParameters when token type is Pop.

## Type of change:

 - [X]  Bug fix (non-breaking change which fixes an issue)


## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

