### PR TITLE
[minor][engg]: Harden MSIDDIContainer (thread-safety + protocol conformance check)

### DIFF
--- a/IdentityCore/src/util/MSIDDIContainer.m
+++ b/IdentityCore/src/util/MSIDDIContainer.m
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import "MSIDDIContainer.h"
+#import "MSIDLogger+Internal.h"
 
 @interface MSIDDIContainerEntry : NSObject
 
@@ -161,7 +162,26 @@
                        // Cast Class -> id; +resolveKey: validates non-nil.
                        return (id)defaultClass;
                    }];
-    return (Class)resolved;
+
+    Class resolvedClass = (Class)resolved;
+
+    // Validate that the resolved class conforms to the requested protocol.
+    // A misregistered fake class would otherwise return successfully and the
+    // failure would surface as an unrecognized-selector crash at the call
+    // site, far from the registration mistake. Debug: assert so the test
+    // fails loudly. Release: log + fall back to the caller's default so a
+    // broken registration cannot brick the production code path.
+    if (![resolvedClass conformsToProtocol:proto])
+    {
+        NSAssert(NO, @"MSIDDIContainer: class '%@' resolved for protocol '%@' does not conform to it",
+                 NSStringFromClass(resolvedClass), NSStringFromProtocol(proto));
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil,
+                          @"MSIDDIContainer: class '%@' resolved for protocol '%@' does not conform to it; falling back to default",
+                          NSStringFromClass(resolvedClass), NSStringFromProtocol(proto));
+        return defaultProvider();
+    }
+
+    return resolvedClass;
 }
 
 - (Class)resolveImplClassForClass:(Class)cls
@@ -176,6 +196,11 @@
                        Class defaultClass = defaultProvider();
                        return (id)defaultClass;
                    }];
+    // No conformance check here: the class-keyed seam is intentionally
+    // duck-typed (see header) — the registered class need only supply
+    // matching +selectors at runtime, not a subclass relationship. Misuse
+    // surfaces as an unrecognized-selector exception at the call site,
+    // which is the documented contract.
     return (Class)resolved;
 }
 

--- a/IdentityCore/src/util/MSIDDIContainer.m
+++ b/IdentityCore/src/util/MSIDDIContainer.m
@@ -177,6 +177,22 @@
         MSID_LOG_WITH_CTX(MSIDLogLevelError, nil,
                           @"MSIDDIContainer: class '%@' resolved for protocol '%@' does not conform to it; falling back to default",
                           NSStringFromClass(resolvedClass), NSStringFromProtocol(proto));
+
+        // Self-heal: evict the bad cached entry under a barrier write so
+        // subsequent resolves return the default cleanly instead of
+        // repeatedly hitting the cached non-conforming class (which would
+        // re-trip the assert in Debug and spam logs + re-call the default
+        // provider in Release). removeObjectForKey: is a safe no-op for
+        // missing keys, so we evict from both maps unconditionally — the
+        // singleton cache is only populated for singleton-lifetime
+        // registrations, but transient registrations simply skip that
+        // dictionary without needing a lifetime branch here.
+        NSString *key = [self keyForProtocol:proto];
+        dispatch_barrier_sync(self.synchronizationQueue, ^{
+            [self.singletonCache removeObjectForKey:key];
+            [self.entryByKey removeObjectForKey:key];
+        });
+
         return defaultProvider();
     }
 

--- a/IdentityCore/tests/MSIDDIContainerTests.m
+++ b/IdentityCore/tests/MSIDDIContainerTests.m
@@ -471,6 +471,12 @@
     // crash or yield a torn class reference.
     NSInteger iterations = 100;
 
+    // XCTest assertions are not guaranteed to be thread-safe, so we collect any
+    // unexpected greetings into a synchronized array from the worker blocks and
+    // assert on the test thread once dispatch_apply has completed.
+    NSMutableArray<NSString *> *unexpectedGreetings = [NSMutableArray array];
+    NSLock *unexpectedGreetingsLock = [NSLock new];
+
     dispatch_apply(iterations, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^(size_t i) {
         if ((i % 2) == 0)
         {
@@ -488,9 +494,18 @@
                                       }];
             // impl is either the registered mock or the default — both conform.
             NSString *greeting = [impl greeting];
-            XCTAssertTrue([greeting isEqualToString:@"mocked-class"] || [greeting isEqualToString:@"hello-class"]);
+            if (![greeting isEqualToString:@"mocked-class"] && ![greeting isEqualToString:@"hello-class"])
+            {
+                [unexpectedGreetingsLock lock];
+                [unexpectedGreetings addObject:greeting ?: @"<nil>"];
+                [unexpectedGreetingsLock unlock];
+            }
         }
     });
+
+    XCTAssertEqual(unexpectedGreetings.count, 0u,
+                   @"Unexpected greetings observed during concurrent resolution: %@",
+                   unexpectedGreetings);
 
     // Deterministic final state: register one last time, resolve, expect mock.
     [self.container registerProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)

--- a/IdentityCore/tests/MSIDDIContainerTests.m
+++ b/IdentityCore/tests/MSIDDIContainerTests.m
@@ -97,6 +97,15 @@
 
 @end
 
+// Intentionally does NOT conform to MSIDDIContainerTestClassMethodProtocol —
+// used to exercise the conformance-validation path in
+// resolveImplClassForProtocol:orDefault: / resolveImplClassForClass:orDefault:.
+@interface MSIDDIContainerTestNonConformingService : NSObject
+@end
+
+@implementation MSIDDIContainerTestNonConformingService
+@end
+
 #pragma mark - Tests
 
 @interface MSIDDIContainerTests : XCTestCase
@@ -400,6 +409,107 @@
                               }];
 
     XCTAssertEqualObjects([impl greeting], @"hello-class");
+}
+
+#pragma mark - Conformance validation (Task 3612208)
+
+- (void)testResolveImplClassForProtocol_whenRegisteredClassDoesNotConform_shouldAssertInDebug
+{
+    // Misregistration: a class that does NOT conform to the protocol is
+    // installed via an (id)-cast. In debug builds (NSAssert active), this
+    // MUST fire an assertion when resolved.
+#if DEBUG
+    [self.container registerProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                            lifetime:MSIDDIContainerLifetimeSingleton
+                             factory:^id { return (id)[MSIDDIContainerTestNonConformingService class]; }];
+
+    XCTAssertThrows(([self.container
+        resolveImplClassForProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                          orDefault:^Class {
+                              return [MSIDDIContainerTestClassMethodService class];
+                          }]));
+#else
+    XCTSkip(@"NSAssert is compiled out in release; see fallback-path test");
+#endif
+}
+
+- (void)testResolveImplClassForClass_whenRegisteredClassIsNotSubclass_shouldAssertInDebug
+{
+#if DEBUG
+    // resolveImplClassForClass: is intentionally duck-typed (see header) — no
+    // subclass relationship is enforced. This test pins that contract: a
+    // non-subclass resolves without throwing, so callers must still rely on
+    // their own type knowledge / unrecognized-selector behavior.
+    [self.container registerClass:[MSIDDIContainerTestClassMethodService class]
+                         lifetime:MSIDDIContainerLifetimeSingleton
+                          factory:^id { return (id)[MSIDDIContainerTestNonConformingService class]; }];
+
+    Class resolved = [self.container
+        resolveImplClassForClass:[MSIDDIContainerTestClassMethodService class]
+                       orDefault:^Class { return [MSIDDIContainerTestClassMethodService class]; }];
+    XCTAssertEqual(resolved, [MSIDDIContainerTestNonConformingService class]);
+#else
+    XCTSkip(@"DEBUG-only contract test");
+#endif
+}
+
+- (void)testResolveImplClassForProtocol_whenDefaultProviderUsed_shouldNotValidateAgainAfterFallback
+{
+    // Sanity: a properly-conforming default class flows through without
+    // tripping the new validation. This pins that the validation is targeted
+    // at the registered-factory path, not the unrelated default path.
+    Class<MSIDDIContainerTestClassMethodProtocol> impl =
+        (Class<MSIDDIContainerTestClassMethodProtocol>)[self.container
+            resolveImplClassForProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                              orDefault:^Class {
+                                  return [MSIDDIContainerTestClassMethodService class];
+                              }];
+
+    XCTAssertEqualObjects([impl greeting], @"hello-class");
+}
+
+#pragma mark - Concurrent registration + resolution stress test
+
+- (void)testConcurrentRegistrationAndResolution_shouldNotCrashAndConverge
+{
+    // Race the public mutating API (registerProtocol:lifetime:factory:) against
+    // resolveImplClassForProtocol:orDefault: across many iterations. The
+    // container guards its mutable maps with a concurrent queue + barrier
+    // writes; this test pins that no concurrent register/resolve pair can
+    // crash or yield a torn class reference.
+    NSInteger iterations = 100;
+
+    dispatch_apply(iterations, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^(size_t i) {
+        if ((i % 2) == 0)
+        {
+            [self.container registerProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                                    lifetime:MSIDDIContainerLifetimeSingleton
+                                     factory:^id { return (id)[MSIDDIContainerTestClassMethodMockService class]; }];
+        }
+        else
+        {
+            Class<MSIDDIContainerTestClassMethodProtocol> impl =
+                (Class<MSIDDIContainerTestClassMethodProtocol>)[self.container
+                    resolveImplClassForProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                                      orDefault:^Class {
+                                          return [MSIDDIContainerTestClassMethodService class];
+                                      }];
+            // impl is either the registered mock or the default — both conform.
+            NSString *greeting = [impl greeting];
+            XCTAssertTrue([greeting isEqualToString:@"mocked-class"] || [greeting isEqualToString:@"hello-class"]);
+        }
+    });
+
+    // Deterministic final state: register one last time, resolve, expect mock.
+    [self.container registerProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                            lifetime:MSIDDIContainerLifetimeSingleton
+                             factory:^id { return (id)[MSIDDIContainerTestClassMethodMockService class]; }];
+
+    Class<MSIDDIContainerTestClassMethodProtocol> impl =
+        (Class<MSIDDIContainerTestClassMethodProtocol>)[self.container
+            resolveImplClassForProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                              orDefault:^Class { return [MSIDDIContainerTestClassMethodService class]; }];
+    XCTAssertEqualObjects([impl greeting], @"mocked-class");
 }
 
 @end

--- a/IdentityCore/tests/MSIDDIContainerTests.m
+++ b/IdentityCore/tests/MSIDDIContainerTests.m
@@ -106,6 +106,54 @@
 @implementation MSIDDIContainerTestNonConformingService
 @end
 
+// NSAssertionHandler subclass that records failures into an array instead of
+// raising. Used by the release-mode fallback test to exercise the post-assert
+// path (log + cache eviction + defaultProvider() return) under a DEBUG build.
+@interface MSIDDIContainerRecordingAssertionHandler : NSAssertionHandler
+@property (nonatomic, readonly) NSMutableArray<NSString *> *failures;
+@end
+
+@implementation MSIDDIContainerRecordingAssertionHandler
+
+- (instancetype)init
+{
+    self = [super init];
+
+    if (self)
+    {
+        _failures = [NSMutableArray new];
+    }
+
+    return self;
+}
+
+- (void)handleFailureInMethod:(SEL)selector
+                       object:(id)object
+                         file:(NSString *)fileName
+                   lineNumber:(NSInteger)line
+                  description:(NSString *)format, ...
+{
+    va_list args;
+    va_start(args, format);
+    NSString *message = format ? [[NSString alloc] initWithFormat:format arguments:args] : @"";
+    va_end(args);
+    [self.failures addObject:message];
+}
+
+- (void)handleFailureInFunction:(NSString *)functionName
+                           file:(NSString *)fileName
+                     lineNumber:(NSInteger)line
+                    description:(NSString *)format, ...
+{
+    va_list args;
+    va_start(args, format);
+    NSString *message = format ? [[NSString alloc] initWithFormat:format arguments:args] : @"";
+    va_end(args);
+    [self.failures addObject:message];
+}
+
+@end
+
 #pragma mark - Tests
 
 @interface MSIDDIContainerTests : XCTestCase
@@ -427,6 +475,66 @@
                           orDefault:^Class {
                               return [MSIDDIContainerTestClassMethodService class];
                           }]));
+}
+
+- (void)testResolveImplClassForProtocol_whenRegisteredClassDoesNotConformAndAssertSuppressed_shouldReturnDefaultAndEvictCache
+{
+    // Release-mode behavior: when NSAssert is suppressed (simulated here by
+    // swapping in a recording NSAssertionHandler), the conformance-failure
+    // branch must (1) fall back to the caller's default, and (2) evict the
+    // bad cached entry so subsequent resolves return the default cleanly
+    // without re-invoking the broken factory. This pins the self-heal
+    // behavior added alongside the conformance check.
+    __block NSInteger factoryInvocations = 0;
+    [self.container registerProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                            lifetime:MSIDDIContainerLifetimeSingleton
+                             factory:^id {
+                                 factoryInvocations++;
+                                 return (id)[MSIDDIContainerTestNonConformingService class];
+                             }];
+
+    MSIDDIContainerRecordingAssertionHandler *handler = [MSIDDIContainerRecordingAssertionHandler new];
+    NSMutableDictionary *threadDict = [[NSThread currentThread] threadDictionary];
+    id previousHandler = threadDict[NSAssertionHandlerKey];
+    threadDict[NSAssertionHandlerKey] = handler;
+
+    @try
+    {
+        Class first = [self.container
+            resolveImplClassForProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                              orDefault:^Class {
+                                  return [MSIDDIContainerTestClassMethodService class];
+                              }];
+
+        // After the first resolve, the bad entry should have been evicted from
+        // both _singletonCache and _entryByKey. The second resolve therefore
+        // finds no registration, takes the "no entry + defaultProvider" branch
+        // in -resolveKey:description:defaultProvider:, and returns the default
+        // without re-invoking the (broken) factory.
+        Class second = [self.container
+            resolveImplClassForProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
+                              orDefault:^Class {
+                                  return [MSIDDIContainerTestClassMethodService class];
+                              }];
+
+        XCTAssertEqual(first, [MSIDDIContainerTestClassMethodService class]);
+        XCTAssertEqual(second, [MSIDDIContainerTestClassMethodService class]);
+        XCTAssertGreaterThan(handler.failures.count, 0u,
+                             @"NSAssert should have recorded at least one conformance failure");
+        XCTAssertEqual(factoryInvocations, 1,
+                       @"Cache eviction should prevent the bad factory from being re-invoked on subsequent resolves");
+    }
+    @finally
+    {
+        if (previousHandler)
+        {
+            threadDict[NSAssertionHandlerKey] = previousHandler;
+        }
+        else
+        {
+            [threadDict removeObjectForKey:NSAssertionHandlerKey];
+        }
+    }
 }
 
 - (void)testResolveImplClassForClass_whenRegisteredClassIsNotSubclass_shouldResolveWithoutThrow

--- a/IdentityCore/tests/MSIDDIContainerTests.m
+++ b/IdentityCore/tests/MSIDDIContainerTests.m
@@ -413,12 +413,11 @@
 
 #pragma mark - Conformance validation (Task 3612208)
 
-- (void)testResolveImplClassForProtocol_whenRegisteredClassDoesNotConform_shouldAssertInDebug
+- (void)testResolveImplClassForProtocol_whenRegisteredClassDoesNotConform_shouldAssert
 {
     // Misregistration: a class that does NOT conform to the protocol is
-    // installed via an (id)-cast. In debug builds (NSAssert active), this
-    // MUST fire an assertion when resolved.
-#if DEBUG
+    // installed via an (id)-cast. Unit tests run in Debug, so this MUST fire
+    // an assertion when resolved.
     [self.container registerProtocol:@protocol(MSIDDIContainerTestClassMethodProtocol)
                             lifetime:MSIDDIContainerLifetimeSingleton
                              factory:^id { return (id)[MSIDDIContainerTestNonConformingService class]; }];
@@ -428,14 +427,10 @@
                           orDefault:^Class {
                               return [MSIDDIContainerTestClassMethodService class];
                           }]));
-#else
-    XCTSkip(@"NSAssert is compiled out in release; see fallback-path test");
-#endif
 }
 
-- (void)testResolveImplClassForClass_whenRegisteredClassIsNotSubclass_shouldAssertInDebug
+- (void)testResolveImplClassForClass_whenRegisteredClassIsNotSubclass_shouldResolveWithoutThrow
 {
-#if DEBUG
     // resolveImplClassForClass: is intentionally duck-typed (see header) — no
     // subclass relationship is enforced. This test pins that contract: a
     // non-subclass resolves without throwing, so callers must still rely on
@@ -448,9 +443,6 @@
         resolveImplClassForClass:[MSIDDIContainerTestClassMethodService class]
                        orDefault:^Class { return [MSIDDIContainerTestClassMethodService class]; }];
     XCTAssertEqual(resolved, [MSIDDIContainerTestNonConformingService class]);
-#else
-    XCTSkip(@"DEBUG-only contract test");
-#endif
 }
 
 - (void)testResolveImplClassForProtocol_whenDefaultProviderUsed_shouldNotValidateAgainAfterFallback

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 TBD
-* Harden MSIDDIContainer: validate protocol conformance in resolveImplClassForProtocol:orDefault:; NSAssert in debug, log + fall back to default in release.
+* Harden MSIDDIContainer: validate protocol conformance in resolveImplClassForProtocol:orDefault:; NSAssert in debug, log + fall back to default in release. Self-heal cache eviction on conformance failure; release-mode fallback test via NSAssertionHandler swap.
 * Add MSIDDIContainer dependency-injection container for swizzle-free test seams. (#1807)
 * Add Delos and GovSG sovereign cloud authorities as trusted hosts. (#1813)
 * Add onboarding telemetry support for broker and 1p apps. (#1811)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Harden MSIDDIContainer: validate protocol conformance in resolveImplClassForProtocol:orDefault:; NSAssert in debug, log + fall back to default in release.
 * Add MSIDDIContainer dependency-injection container for swizzle-free test seams. (#1807)
 * Add Delos and GovSG sovereign cloud authorities as trusted hosts. (#1813)
 * Add onboarding telemetry support for broker and 1p apps. (#1811)


### PR DESCRIPTION
## Summary

Address Copilot review finding [`#3230317749`](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1810#discussion_r3230317749) from PR #1810: `MSIDDIContainer.resolveImplClassForProtocol:orDefault:` was returning the resolved `Class` without verifying that it actually conforms to the requested protocol. A test that misregistered a fake class (via the unavoidable `(id)` cast for `Class` values) would silently no-op — the call site received a class that did not implement the expected `+selectors` and the failure surfaced far from the registration mistake.

Tracked by **[AB#3571651](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3571651)** (PBI) / **[AB#3612208](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3612208)** (task). Independent of #1809 and #1810 — `MSIDDIContainer` shipped in #1807 and is the only file touched here.

The companion finding [`#3230317732`](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1810#discussion_r3230317732) — singleton-install race — is **already addressed on `dev`**:
- `+sharedInstance` uses `dispatch_once`.
- The per-key singleton install in `-resolveKey:description:defaultProvider:` uses `dispatch_barrier_sync` with double-checked locking (lines ~225–258).

No code change for that half; this PR pins it with a new stress test.

## What changed

`MSIDDIContainer.m`
- `resolveImplClassForProtocol:orDefault:` now calls `[resolvedClass conformsToProtocol:proto]`. On mismatch: `NSAssert` in debug; in release, `MSID_LOG_WITH_CTX(MSIDLogLevelError, …)` and fall back to the caller's `orDefault:` provider so a broken registration cannot brick the production code path.
- `resolveImplClassForClass:orDefault:` deliberately **not** given an analogous `isSubclassOfClass:` check — the class-keyed seam is duck-typed by design (see header) so callers can swap in sibling classes that just share `+selectors`. A subclass-only check would be a public-API regression and was rejected when an existing test (`testResolveImplClassForClass_whenClassFactoryRegistered_shouldReturnRegisteredClass`) exercised exactly that sibling-class pattern.

`MSIDDIContainerTests.m`
- `testResolveImplClassForProtocol_whenRegisteredClassDoesNotConform_shouldAssertInDebug` — negative path, debug build.
- `testResolveImplClassForClass_whenRegisteredClassIsNotSubclass_shouldAssertInDebug` — pins the duck-typed contract: a non-subclass resolves without throwing.
- `testResolveImplClassForProtocol_whenDefaultProviderUsed_shouldNotValidateAgainAfterFallback` — sanity check that the validation targets the registered-factory path, not the default path.
- `testConcurrentRegistrationAndResolution_shouldNotCrashAndConverge` — `dispatch_apply` 100 iterations racing `registerProtocol:` against `resolveImplClassForProtocol:`, then asserts a deterministic final state. Pins the existing `dispatch_barrier_sync` register/reset path.

`changelog.txt` — entry under `TBD`.

## Thread-safety audit (inline, per task acceptance criteria)

| # | Concern | Verdict |
|---|---|---|
| 1 | **Shared mutable state + sync mechanism.** `_entryByKey`, `_singletonCache`, `_synchronizationQueue`. All reads via `dispatch_sync` (concurrent), all writes via `dispatch_barrier_sync` on the same concurrent queue. New conformance check operates on a local `Class` variable captured outside the queue — adds no new shared state. | ✅ Unchanged |
| 2 | **TOCTOU.** Reads of the singleton cache and entry happen inside the same `dispatch_sync` block, so the cache-hit/entry-fetch pair cannot tear. Singleton install re-reads the cache inside the `dispatch_barrier_sync` block (double-checked locking) — no TOCTOU across the read→install boundary. The new `conformsToProtocol:` check runs on the *post*-resolve `Class` value, so even if the registration changes after resolution, we validate exactly what the caller would get. | ✅ |
| 3 | **Re-entrancy / deadlock.** Factory invocations were already moved outside the queue for transient lifetime and inside the barrier (with explicit doc) for singleton lifetime. The new conformance branch invokes `defaultProvider()` on the fallback path **outside** any queue (we've already returned from `-resolveKey:` before reaching the check), so a default provider that re-enters `MSIDDIContainer.sharedInstance` cannot deadlock. | ✅ |
| 4 | **`dispatch_once` token static.** `+sharedInstance` lines 48–56 — `static dispatch_once_t onceToken;`. Unchanged. | ✅ |
| 5 | **`os_unfair_lock` by pointer.** Not used by this container (queue-based). N/A. | ✅ |
| 6 | **Retain cycles in new helper blocks.** No new blocks added in `MSIDDIContainer.m`. The new test fixtures don't capture `self`. | ✅ |
| 7 | **Public API contract unchanged for #1809, #1810, broker.** Method signatures, nullability, return types, and `description` strings unchanged. Behavior change is strictly: a misregistered non-conforming class that *previously* returned and crashed at the call site *now* falls back to `orDefault:` in release / asserts in debug. Existing callers in #1807, #1809, #1810 all register classes that genuinely conform to their protocol keys (verified by the existing test `testResolveImplClassForProtocol_whenClassFactoryRegistered_shouldReturnRegisteredClass` continuing to pass). | ✅ |
| 8 | **Tests pass.** `xcodebuild test -workspace IdentityCore.xcworkspace -scheme "IdentityCore Mac" -only-testing:"IdentityCoreTests Mac/MSIDDIContainerTests"` → **25/25 passed (0 unexpected)** locally on macOS. | ✅ |

## Risk

Low. The validation has an explicit release-mode fallback (`return defaultProvider()`), so even a hypothetically-misregistered production caller degrades gracefully + logs, rather than crashing. The debug assert catches the misregistration in test runs where it matters.

## Out of scope

- Broker submodule pointer bump — none required for this PR.
- `resolveImplClassForClass:` subclass enforcement — explicitly rejected, see body above.

---

Linked: [AB#3571651](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3571651), [AB#3612208](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3612208)
