### PR TITLE
Fix visionOS build failure: add visionos(2.0) availability annotation

### DIFF
--- a/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.h
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 startURL:(NSURL *)startURL
                           callbackScheme:(NSString *)callbackURLScheme
                      useEphemeralSession:(BOOL)useEphemeralSession
-                       additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders API_AVAILABLE(ios(18.0), macos(15.0));
+                       additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders API_AVAILABLE(ios(18.0), macos(15.0), visionos(2.0));
 
 @end
 

--- a/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.m
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.m
@@ -83,7 +83,7 @@
                                 startURL:(NSURL *)startURL
                           callbackScheme:(NSString *)callbackURLScheme
                      useEphemeralSession:(BOOL)useEphemeralSession
-                       additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders API_AVAILABLE(ios(18.0), macos(15.0))
+                       additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders API_AVAILABLE(ios(18.0), macos(15.0), visionos(2.0))
 {
     return [self initCommonWithParentController:parentController
                                        startURL:startURL
@@ -125,7 +125,7 @@
     self.webAuthSession.prefersEphemeralWebBrowserSession = self.useEmpheralSession;
     
     // Set additional headers if available (iOS 18+)
-    if (@available(iOS 18.0, macOS 15.0, *))
+    if (@available(iOS 18.0, macOS 15.0, visionOS 2.0, *))
     {
         if (self.additionalHeaders && self.additionalHeaders.count > 0)
         {

--- a/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.m
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.m
@@ -124,7 +124,7 @@
     self.webAuthSession.presentationContextProvider = self;
     self.webAuthSession.prefersEphemeralWebBrowserSession = self.useEmpheralSession;
     
-    // Set additional headers if available (iOS 18+)
+    // Set additional headers if available (iOS 18+, macOS 15+, visionOS 2+)
     if (@available(iOS 18.0, macOS 15.0, visionOS 2.0, *))
     {
         if (self.additionalHeaders && self.additionalHeaders.count > 0)

--- a/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebViewControllerFactory.m
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebViewControllerFactory.m
@@ -64,7 +64,9 @@
                                             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
                                                       context:(__unused id<MSIDRequestContext>)context
 {
-    // Only pass headers to ASWebAuthN on iOS 18+, but method itself is available on all versions
+    // Only pass headers to ASWebAuthN when the additionalHeaders initializer is available
+    // (iOS 18+, macOS 15+, visionOS 2+). This factory method remains available on older OS
+    // versions and falls back to the initializer without additionalHeaders.
     if (@available(iOS 18.0, macOS 15.0, visionOS 2.0, *))
     {
         if (additionalHeaders && additionalHeaders.count > 0)

--- a/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebViewControllerFactory.m
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebViewControllerFactory.m
@@ -65,7 +65,7 @@
                                                       context:(__unused id<MSIDRequestContext>)context
 {
     // Only pass headers to ASWebAuthN on iOS 18+, but method itself is available on all versions
-    if (@available(iOS 18.0, macOS 15.0, *))
+    if (@available(iOS 18.0, macOS 15.0, visionOS 2.0, *))
     {
         if (additionalHeaders && additionalHeaders.count > 0)
         {


### PR DESCRIPTION
## Problem

After PR #1785, the Broker visionOS pipeline fails to compile `MSIDSystemWebViewControllerFactory.m` for the `xrsimulator` target.

**Root cause:** `API_AVAILABLE(ios(18.0), macos(15.0))` on the new `initWithParentController:...additionalHeaders:` method does NOT include `visionos`. In Xcode 16.2, visionOS (`xros`) is a distinct platform — omitting it from `API_AVAILABLE` makes the compiler treat the API as **unavailable** on visionOS. Combined with:
- `CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE`  
- `GCC_TREAT_WARNINGS_AS_ERRORS = YES`

...this produces a hard build error.

## Fix

Add `visionos(2.0)` to:
1. `API_AVAILABLE` annotation on the `additionalHeaders` init method (header + implementation)
2. `@available` runtime checks in both `MSIDASWebAuthenticationSessionHandler.m` and `MSIDSystemWebViewControllerFactory.m`

This matches the actual visionOS SDK availability of `ASWebAuthenticationSession.additionalHeaderFields` (available from visionOS 2.0).

## Files Changed
- `MSIDASWebAuthenticationSessionHandler.h` — declaration annotation
- `MSIDASWebAuthenticationSessionHandler.m` — implementation annotation + `@available` check
- `MSIDSystemWebViewControllerFactory.m` — `@available` check

## Risk
Minimal — this is a purely additive annotation change that makes the existing code visionOS-safe without changing behavior.