### PR TITLE
[patch] [Feature]: Add MSIDOnboardingStatus model and keychain cache (phase 1a)

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -2011,6 +2011,9 @@
 		B4A93B512FA5A656008FE445 /* MSIDSystemWebviewTransitionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B4A93B502FA5A653008FE445 /* MSIDSystemWebviewTransitionManager.h */; };
 		B4A93B532FA5A65C008FE445 /* MSIDSystemWebviewTransitionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A93B522FA5A65A008FE445 /* MSIDSystemWebviewTransitionManager.m */; };
 		B4A93B542FA5A65C008FE445 /* MSIDSystemWebviewTransitionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A93B522FA5A65A008FE445 /* MSIDSystemWebviewTransitionManager.m */; };
+		B4B591B32F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B4B591B22F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m */; };
+		B4B591B42F3AC90600CBA6A9 /* MSIDOnboardingStatusCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B4B591B22F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m */; };
+		B4B591B52F3AC90C00CBA6A9 /* MSIDOnboardingStatusCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B4B591B12F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.h */; };
 		B4C8501629E79E220055B0D3 /* MSIDTestURLSessionUploadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B4C8501429E79E140055B0D3 /* MSIDTestURLSessionUploadTask.m */; };
 		B4C8501729E79E230055B0D3 /* MSIDTestURLSessionUploadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B4C8501429E79E140055B0D3 /* MSIDTestURLSessionUploadTask.m */; };
 		B4C8501829E79E250055B0D3 /* MSIDTestURLSessionUploadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = B4C8501329E79E050055B0D3 /* MSIDTestURLSessionUploadTask.h */; };
@@ -2046,6 +2049,13 @@
 		B5AAE11E2F03DADD0026B21B /* MSIDBrokerOperationGetDefaultAccountRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AAE11D2F03DADD0026B21B /* MSIDBrokerOperationGetDefaultAccountRequest.m */; };
 		B5AAE11F2F03DADD0026B21B /* MSIDBrokerOperationGetDefaultAccountRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B5AAE11C2F03DADD0026B21B /* MSIDBrokerOperationGetDefaultAccountRequest.h */; };
 		B5AAE1202F03DADD0026B21B /* MSIDBrokerOperationGetDefaultAccountRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AAE11D2F03DADD0026B21B /* MSIDBrokerOperationGetDefaultAccountRequest.m */; };
+		B4FBF0332EF33A7600EDE1E9 /* MSIDOnboardingStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF0322EF33A7600EDE1E9 /* MSIDOnboardingStatus.m */; };
+		B4FBF0342EF33A7600EDE1E9 /* MSIDOnboardingStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = B4FBF0312EF33A7600EDE1E9 /* MSIDOnboardingStatus.h */; };
+		B4FBF0352EF33A7600EDE1E9 /* MSIDOnboardingStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF0322EF33A7600EDE1E9 /* MSIDOnboardingStatus.m */; };
+		B4FBF0372EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF0362EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m */; };
+		B4FBF0382EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF0362EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m */; };
+		B4FBF0402EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF03F2EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m */; };
+		B4FBF0412EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF03F2EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m */; };
 		B86FA7D42383757100E5195A /* MSIDMacACLKeychainAccessorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B86FA7C62383748000E5195A /* MSIDMacACLKeychainAccessorTests.m */; };
 		B86FA7D52383757600E5195A /* MSIDMacTokenCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B86FA7C72383748000E5195A /* MSIDMacTokenCacheTests.m */; };
 		B86FA7D62383757A00E5195A /* MSIDMacKeychainTokenCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B86FA7C82383748000E5195A /* MSIDMacKeychainTokenCacheTests.m */; };
@@ -3615,6 +3625,8 @@
 		B4A5ACCC21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDAccountCacheItem+MSIDAccountMatchers.m"; sourceTree = "<group>"; };
 		B4A93B502FA5A653008FE445 /* MSIDSystemWebviewTransitionManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSystemWebviewTransitionManager.h; sourceTree = "<group>"; };
 		B4A93B522FA5A65A008FE445 /* MSIDSystemWebviewTransitionManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSystemWebviewTransitionManager.m; sourceTree = "<group>"; };
+		B4B591B12F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDOnboardingStatusCache.h; sourceTree = "<group>"; };
+		B4B591B22F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatusCache.m; sourceTree = "<group>"; };
 		B4C8501329E79E050055B0D3 /* MSIDTestURLSessionUploadTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTestURLSessionUploadTask.h; sourceTree = "<group>"; };
 		B4C8501429E79E140055B0D3 /* MSIDTestURLSessionUploadTask.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTestURLSessionUploadTask.m; sourceTree = "<group>"; };
 		B4CC965F2F982FEA007F281A /* MSIDSessionCachePersistence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSessionCachePersistence.h; sourceTree = "<group>"; };
@@ -3641,6 +3653,10 @@
 		B5AAE1182F03D7AA0026B21B /* MSIDBrokerOperationGetDefaultAccountResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBrokerOperationGetDefaultAccountResponse.m; sourceTree = "<group>"; };
 		B5AAE11C2F03DADD0026B21B /* MSIDBrokerOperationGetDefaultAccountRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBrokerOperationGetDefaultAccountRequest.h; sourceTree = "<group>"; };
 		B5AAE11D2F03DADD0026B21B /* MSIDBrokerOperationGetDefaultAccountRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBrokerOperationGetDefaultAccountRequest.m; sourceTree = "<group>"; };
+		B4FBF0312EF33A7600EDE1E9 /* MSIDOnboardingStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDOnboardingStatus.h; sourceTree = "<group>"; };
+		B4FBF0322EF33A7600EDE1E9 /* MSIDOnboardingStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatus.m; sourceTree = "<group>"; };
+		B4FBF0362EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatusTests.m; sourceTree = "<group>"; };
+		B4FBF03F2EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatusCacheTests.m; sourceTree = "<group>"; };
 		B86FA7C62383748000E5195A /* MSIDMacACLKeychainAccessorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDMacACLKeychainAccessorTests.m; sourceTree = "<group>"; };
 		B86FA7C72383748000E5195A /* MSIDMacTokenCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDMacTokenCacheTests.m; sourceTree = "<group>"; };
 		B86FA7C82383748000E5195A /* MSIDMacKeychainTokenCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDMacKeychainTokenCacheTests.m; sourceTree = "<group>"; };
@@ -4761,6 +4777,7 @@
 		9641B4FF1FCF3E1400AFA0EC /* cache */ = {
 			isa = PBXGroup;
 			children = (
+				B4FBF0302EF3384800EDE1E9 /* onboarding */,
 				72D961AF2DE12F2E005DED66 /* MSIDCachedNonce.m */,
 				72D961AD2DE12F19005DED66 /* MSIDCachedNonce.h */,
 				B2C0747E246B70DC0008D701 /* crypto */,
@@ -5044,6 +5061,8 @@
 		B214C39B1FE854CE0070C4F2 /* accessor */ = {
 			isa = PBXGroup;
 			children = (
+				B4B591B12F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.h */,
+				B4B591B22F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m */,
 				B29CB6D01FEC993D00F880ED /* MSIDLegacyTokenCacheAccessor.h */,
 				B214C39D1FE854FE0070C4F2 /* MSIDLegacyTokenCacheAccessor.m */,
 				B214C3A11FE855290070C4F2 /* MSIDDefaultTokenCacheAccessor.h */,
@@ -5735,6 +5754,15 @@
 			path = JWEResponse;
 			sourceTree = "<group>";
 		};
+		B4FBF0302EF3384800EDE1E9 /* onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				B4FBF0312EF33A7600EDE1E9 /* MSIDOnboardingStatus.h */,
+				B4FBF0322EF33A7600EDE1E9 /* MSIDOnboardingStatus.m */,
+			);
+			path = onboarding;
+			sourceTree = "<group>";
+		};
 		B86FA7C52383748000E5195A /* mac */ = {
 			isa = PBXGroup;
 			children = (
@@ -6243,6 +6271,8 @@
 				B223B0A222ADEE4500FB8713 /* MSIDMaskedUsernameLogParameterTests.m */,
 				B434A1382F8E475700CCC890 /* MSIDMDMEnrollmentCompletionResponseTests.m */,
 				729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */,
+				B4FBF03F2EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m */,
+				B4FBF0362EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m */,
 				B47844F52FB7DF180059EFCD /* MSIDWebviewNavigationDecisionResolverTests.m */,
 				606B108D20D08C9500B34224 /* MSIDOAuth2EmbeddedWebviewControllerTests.m */,
 				B26A0B8F2072B562006BD95A /* MSIDOauth2FactoryTests.m */,
@@ -6460,6 +6490,7 @@
 				58BC2392271E0D94008A77BE /* MSIDSSOExtensionGetSsoCookiesRequest.h in Headers */,
 				B4FDC6F72F3EFFD300091B6C /* MSIDWebviewNavigationDecisionResolver.h in Headers */,
 				2A24814E2CB06A1A006FCB34 /* MSIDSSORemoteSilentTokenRequest.h in Headers */,
+				B4B591B52F3AC90C00CBA6A9 /* MSIDOnboardingStatusCache.h in Headers */,
 				B217863823A5994300839CE8 /* MSIDSSOExtensionSignoutController.h in Headers */,
 				A0C7DE4425D4522300F5B5B6 /* MSIDThrottlingModelFactory.h in Headers */,
 				B286B9942389DC76007833AD /* MSIDDefaultTokenRequestProvider+Internal.h in Headers */,
@@ -6558,6 +6589,7 @@
 				0570FE80219B8C8C00958ECF /* MSIDCredentialCacheItem+MSIDBaseToken.h in Headers */,
 				B2DD4B2A20A7DCCE0047A66E /* MSIDCacheAccessor.h in Headers */,
 				B214C3A31FE855290070C4F2 /* MSIDDefaultTokenCacheAccessor.h in Headers */,
+				B4FBF0342EF33A7600EDE1E9 /* MSIDOnboardingStatus.h in Headers */,
 				B286B9952389DC7F007833AD /* MSIDDefaultBrokerResponseHandler.h in Headers */,
 				B286B9D12389DF09007833AD /* MSIDLogger.h in Headers */,
 				237777CA2853FF9400DDEAFC /* ASAuthorizationController+MSIDExtensions.h in Headers */,
@@ -7493,6 +7525,8 @@
 				A0410E5025E88B5E004D80FD /* MSIDThrottlingMetaDataTest.m in Sources */,
 				23CA0C5F220A68D400768729 /* MSIDPkeyAuthHelperTests.m in Sources */,
 				B274DEC721FC002300DB7757 /* MSIDInteractiveTokenRequestParametersTests.m in Sources */,
+				B4FBF0382EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m in Sources */,
+				B4FBF0412EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m in Sources */,
 				2376D8DD2D88FDE900ADC271 /* MSIDBrowserNativeMessageGetSupportedContractsResponseTests.m in Sources */,
 				5828740724D49C4100466916 /* MSIDBrokerRedirectUriTest.m in Sources */,
 				583BFCB124D907410035B901 /* MSIDRedirectUriVerifierTests.m in Sources */,
@@ -7716,6 +7750,7 @@
 				2A59B4402D7924E400304FB1 /* MSIDSSOXpcInteractiveTokenRequest.m in Sources */,
 				B2000C9C20EC65080092790A /* MSIDCredentialCacheItem.m in Sources */,
 				B2A3C27F2145D0020082525C /* MSIDAADIdTokenClaimsFactory.m in Sources */,
+				B4FBF0352EF33A7600EDE1E9 /* MSIDOnboardingStatus.m in Sources */,
 				23AE9DA5213A159C00B285F3 /* MSIDAADOpenIdConfigurationInfoResponseSerializer.m in Sources */,
 				232173ED2182B195009852C6 /* MSIDIntuneUserDefaultsCacheDataSource.m in Sources */,
 				B2AF1D4C218BD12E0080C1A0 /* MSIDInteractiveRequestParameters.m in Sources */,
@@ -7886,6 +7921,7 @@
 				B23ECEF11FF2F6270015FC1D /* MSIDAADV2IdTokenClaims.m in Sources */,
 				239EED6A242D8FAD00162F0F /* MSIDAADTokenRequestServerTelemetry.m in Sources */,
 				B2C0748D246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m in Sources */,
+				B4B591B42F3AC90600CBA6A9 /* MSIDOnboardingStatusCache.m in Sources */,
 				9641B5251FCF3EEF00AFA0EC /* MSIDMacTokenCache.m in Sources */,
 				728209D126FEA0F600B5F018 /* MSIDKeyOperationUtil.m in Sources */,
 				962EA03E2190D4930049C4C8 /* MSIDCertAuthHandler.m in Sources */,
@@ -8303,6 +8339,8 @@
 				B41DD0AA2FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m in Sources */,
 				23D00DA92ABD0805006D7F16 /* MSIDBrowserNativeMessageGetTokenRequestTests.m in Sources */,
 				B431B5452AF1E5050020CD3D /* MSIDSSOExtensionPasskeyCredentialRequestTests.m in Sources */,
+				B4FBF0372EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m in Sources */,
+				B4FBF0402EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m in Sources */,
 				2361DE8C2048B6F8005FD48A /* MSIDAccountTests.m in Sources */,
 				B2DD5BA5204761720084313F /* MSIDRefreshTokenTests.m in Sources */,
 				23AE9DBC2148574F00B285F3 /* MSIDErrorExtensionsTests.m in Sources */,
@@ -8547,6 +8585,7 @@
 				B2AF1D2F218BCEDE0080C1A0 /* MSIDInteractiveTokenRequest.m in Sources */,
 				2394F1FE2D4893DA00E44F6E /* MSIDWebWPJOperation.m in Sources */,
 				B227035A22A3678A00030ADC /* MSIDMaskedUsernameLogParameter.m in Sources */,
+				B4B591B32F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m in Sources */,
 				96A2D5A8209D102900F80E3A /* MSIDAuthorizeWebRequestConfiguration.m in Sources */,
 				B23ECEF01FF2F6270015FC1D /* MSIDAADV2IdTokenClaims.m in Sources */,
 				60B3855E20A96E0600D546D0 /* MSIDWebviewUIController.m in Sources */,
@@ -8726,6 +8765,7 @@
 				74F04D4A246C8AC000094017 /* MSIDLastRequestTelemetrySerializedItem.m in Sources */,
 				235480D020DDF81000246F72 /* MSIDADFSAuthority.m in Sources */,
 				B26A0B882071B752006BD95A /* MSIDAADV2Oauth2Factory.m in Sources */,
+				B4FBF0332EF33A7600EDE1E9 /* MSIDOnboardingStatus.m in Sources */,
 				230016412371126E00F7D19C /* MSIDProviderType.m in Sources */,
 				962EA0412190D4A50049C4C8 /* MSIDCertAuthHandler.m in Sources */,
 				B227F28D2056264F00F7B822 /* MSIDMacTokenCache.m in Sources */,

--- a/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.h
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@class MSIDOnboardingStatus;
+@protocol MSIDRequestContext;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Cache accessor for reading and writing MSIDOnboardingStatus items to the keychain.
+ This class uses MSIDKeychainTokenCache.defaultKeychainGroup as its data source.
+ */
+@interface MSIDOnboardingStatusCache : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ Shared instance of MSIDOnboardingStatusCache using the default keychain group.
+ */
+@property (class, readonly, nonnull) MSIDOnboardingStatusCache *sharedInstance;
+
+/**
+ Sets the onboarding status.
+ 
+ @param status The MSIDOnboardingStatus to set.
+ @return YES if the operation succeeds, NO otherwise.
+ */
+- (BOOL)setWithStatus:(MSIDOnboardingStatus *)status;
+
+/**
+ Gets the current onboarding status.
+ 
+ @return The MSIDOnboardingStatus representing the current status. If no status is stored, a default status object is returned.
+ */
+- (MSIDOnboardingStatus *)getOnboardingStatus;
+
+/**
+ Clears the onboarding status for a specific bundle identifier.
+ 
+ @param bundleId The bundle identifier to clear the status for.
+ @return YES if the operation succeeds, NO otherwise.
+ */
+- (BOOL)clear:(NSString *)bundleId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.m
@@ -1,0 +1,333 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDOnboardingStatusCache.h"
+#import "MSIDTokenCacheDataSource.h"
+#import "MSIDKeychainTokenCache.h"
+#import "MSIDOnboardingStatus.h"
+#import "MSIDCacheKey.h"
+#import "MSIDCacheItemJsonSerializer.h"
+#import "MSIDJsonObject.h"
+#import "MSIDError.h"
+#import "MSIDLogger+Internal.h"
+#import "MSIDBrokerConstants.h"
+#import "NSString+MSIDExtensions.h"
+
+static NSString *const MSID_ONBOARDING_STATUS_CACHE_SERVICE = @"OnboardingStatus";
+static NSString *const MSID_ONBOARDING_STATUS_CACHE_ACCOUNT = @"com.microsoft.onboardingStatus";
+
+@interface MSIDOnboardingStatusCache ()
+
+@property (nonatomic) id<MSIDExtendedTokenCacheDataSource> dataSource;
+@property (nonatomic) MSIDCacheItemJsonSerializer *serializer;
+
+- (BOOL)isOwnerOverride:(MSIDOnboardingStatus *)status;
+
+@end
+
+@implementation MSIDOnboardingStatusCache
+
+#pragma mark - Shared Instance
+
++ (MSIDOnboardingStatusCache *)sharedInstance
+{
+    static MSIDOnboardingStatusCache *singleton = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        singleton = [[self alloc] init];
+    });
+    
+    return singleton;
+}
+
+#pragma mark - Init
+
+- (instancetype)init
+{
+    self = [super init];
+    
+    if (self)
+    {
+        _dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:MSIDKeychainTokenCache.defaultKeychainGroup error:nil];
+        _serializer = [[MSIDCacheItemJsonSerializer alloc] init];
+    }
+    
+    return self;
+}
+
+#pragma mark - Cache Key
+
+- (MSIDCacheKey *)cacheKey
+{
+    return [[MSIDCacheKey alloc] initWithAccount:MSID_ONBOARDING_STATUS_CACHE_ACCOUNT
+                                         service:MSID_ONBOARDING_STATUS_CACHE_SERVICE
+                                         generic:nil
+                                            type:nil];
+}
+
+#pragma mark - Read
+
+- (MSIDOnboardingStatus *)readOnboardingStatusWithCorrelationId:(NSUUID *)correlationId
+                                                          error:(NSError *__autoreleasing *)error
+{
+    MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) Reading onboarding status from cache");
+    
+    MSIDCacheKey *key = [self cacheKey];
+    
+    NSArray<MSIDJsonObject *> *jsonObjects = [self.dataSource jsonObjectsWithKey:key
+                                                                      serializer:self.serializer
+                                                                         context:nil
+                                                                           error:error];
+    
+    if (!jsonObjects || jsonObjects.count == 0)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) No onboarding status found in cache");
+        return nil;
+    }
+    
+    if (jsonObjects.count > 1)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelWarning, correlationId, @"(MSIDOnboardingStatusCache) Multiple onboarding status items found in cache, using the first one");
+    }
+    
+    MSIDJsonObject *jsonObject = jsonObjects.firstObject;
+    NSDictionary *jsonDictionary = [jsonObject jsonDictionary];
+    
+    if (!jsonDictionary)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to get JSON dictionary from cached item");
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Failed to deserialize onboarding status from cache.", nil, nil, nil, correlationId, nil, YES);
+        }
+        return nil;
+    }
+    
+    NSError *deserializationError = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:jsonDictionary error:&deserializationError];
+    
+    if (!status)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to deserialize onboarding status: %@", deserializationError);
+        if (error)
+        {
+            *error = deserializationError;
+        }
+        return nil;
+    }
+    
+    MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) Successfully read onboarding status from cache");
+    return status;
+}
+
+#pragma mark - Write
+
+- (BOOL)writeOnboardingStatus:(MSIDOnboardingStatus *)status
+                        error:(NSError *__autoreleasing *)error
+{
+    if (!status)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, nil, @"(MSIDOnboardingStatusCache) Cannot write nil onboarding status");
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"Onboarding status cannot be nil.", nil, nil, nil, nil, nil, YES);
+        }
+        return NO;
+    }
+    
+    NSUUID *correlationId = status.correlationId;
+    
+    MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) Writing onboarding status to cache");
+    
+    NSDictionary *jsonDictionary = [status jsonDictionary];
+    
+    if (!jsonDictionary)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to serialize onboarding status to JSON");
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Failed to serialize onboarding status.", nil, nil, nil, correlationId, nil, YES);
+        }
+        return NO;
+    }
+    
+    NSError *initError = nil;
+    MSIDJsonObject *jsonObject = [[MSIDJsonObject alloc] initWithJSONDictionary:jsonDictionary error:&initError];
+    
+    if (!jsonObject)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to create JSON object: %@", initError);
+        if (error)
+        {
+            *error = initError;
+        }
+        return NO;
+    }
+    
+    MSIDCacheKey *key = [self cacheKey];
+    
+    BOOL success = [self.dataSource saveJsonObject:jsonObject
+                                        serializer:self.serializer
+                                               key:key
+                                           context:nil
+                                             error:error];
+    
+    if (success)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) Successfully wrote onboarding status to cache");
+    }
+    else
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to write onboarding status to cache");
+    }
+    
+    return success;
+}
+
+#pragma mark - Remove
+
+- (BOOL)removeOnboardingStatusWithContext:(id<MSIDRequestContext>)context
+                                    error:(NSError *__autoreleasing *)error
+{
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(MSIDOnboardingStatusCache) Removing onboarding status from cache");
+    
+    MSIDCacheKey *key = [self cacheKey];
+    
+    // Using removeAccountsWithKey as it internally delegates to removeItemsWithKey
+    BOOL success = [self.dataSource removeAccountsWithKey:key
+                                                  context:context
+                                                    error:error];
+    
+    if (success)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(MSIDOnboardingStatusCache) Successfully removed onboarding status from cache");
+    }
+    else
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"(MSIDOnboardingStatusCache) Failed to remove onboarding status from cache");
+    }
+    
+    return success;
+}
+
+#pragma mark - Public Convenience Methods
+
+- (BOOL)isOwnerOverride:(MSIDOnboardingStatus *)status
+{
+    // This method checks if the onboarding status is owned by the current running app.
+    NSString *currentBundleId = [[NSBundle mainBundle] bundleIdentifier];
+    if ([NSString msidIsStringNilOrBlank:currentBundleId])
+    {
+        currentBundleId = @"unknown";
+    }
+    
+    return [currentBundleId caseInsensitiveCompare:status.ownerBundleId] == NSOrderedSame;
+}
+
+- (BOOL)setWithStatus:(MSIDOnboardingStatus *)status
+{
+    if (!status)
+    {
+        return NO;
+    }
+    
+    MSIDOnboardingStatus *current = [self getOnboardingStatus];
+    
+    // If there's an existing status with a phase other than none, validate that the new status is either
+    // from the same originating bundle or is an owner override. This prevents different apps from overwriting
+    // each other's onboarding status.
+    if (current && current.phase != MSIDOnboardingPhaseNone)
+    {
+        NSString *currentBundleId = current.originatingBundleId;
+        if ([NSString msidIsStringNilOrBlank:currentBundleId])
+        {
+            currentBundleId = @"unknown";
+        }
+        
+        // Validate ownership or self-override
+        if ([currentBundleId caseInsensitiveCompare:status.originatingBundleId] != NSOrderedSame
+            && ![self isOwnerOverride:status])
+        {
+            return NO;
+        }
+    }
+    
+    // Write to Keychain using shared access group
+    return [self writeOnboardingStatus:status error:nil];
+}
+
+- (MSIDOnboardingStatus *)getOnboardingStatus
+{
+    MSIDOnboardingStatus *status = [self readOnboardingStatusWithCorrelationId:nil error:nil];
+    
+    if (!status)
+    {
+        // return new status with phase set to none
+        return [MSIDOnboardingStatus new];
+    }
+    
+    // Check TTL and remove if expired (status.startedAt + status.ttlSeconds < now)
+    NSDate *expirationDate = [status.startedAt dateByAddingTimeInterval:status.ttlSeconds];
+    if ([expirationDate timeIntervalSinceNow] < 0)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(MSIDOnboardingStatusCache) Onboarding status is expired, removing from cache");
+        [self removeOnboardingStatusWithContext:nil error:nil];
+        // return new status with phase set to none
+        return [MSIDOnboardingStatus new];
+    }
+    
+    return status;
+}
+
+- (BOOL)clear:(NSString *)bundleId
+{
+    if ([NSString msidIsStringNilOrBlank:bundleId])
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"(MSIDOnboardingStatusCache) Cannot clear with nil bundleId");
+        return NO;
+    }
+    
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(MSIDOnboardingStatusCache) Clearing onboarding status for bundleId: %@", bundleId);
+    
+    MSIDOnboardingStatus *current = [self getOnboardingStatus];
+    
+    // If there's no existing status or the phase is none, there's nothing to clear
+    if (!current || current.phase == MSIDOnboardingPhaseNone)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(MSIDOnboardingStatusCache) No onboarding status found to clear");
+        return YES;
+    }
+    
+    // If the current status matches the bundleId (checking ownerBundleId or originatingBundleId), remove it
+    if ([current.ownerBundleId caseInsensitiveCompare:bundleId] != NSOrderedSame &&
+        [current.originatingBundleId caseInsensitiveCompare:bundleId] != NSOrderedSame)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(MSIDOnboardingStatusCache) BundleId does not match current status, nothing to clear");
+        return NO;
+    }
+    
+    return [self removeOnboardingStatusWithContext:nil error:nil];
+}
+
+@end

--- a/IdentityCore/src/cache/onboarding/MSIDOnboardingStatus.h
+++ b/IdentityCore/src/cache/onboarding/MSIDOnboardingStatus.h
@@ -1,0 +1,98 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDJsonSerializable.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, MSIDOnboardingPhase)
+{
+    MSIDOnboardingPhaseNone = 0,
+    MSIDOnboardingPhaseBrokerInteractiveInProgress,
+    MSIDOnboardingPhaseMdmEnrollmentInProgress,
+    MSIDOnboardingPhaseFailed
+};
+
+typedef NS_ENUM(NSInteger, MSIDOnboardingContext)
+{
+    MSIDOnboardingContextUnknown = 0,
+    MSIDOnboardingContextBroker,
+    MSIDOnboardingContextInAppWebview
+};
+
+typedef NS_ENUM(NSInteger, MSIDOnboardingReasonCode)
+{
+    MSIDOnboardingReasonCodeNone = 0,
+    MSIDOnboardingReasonCodeUserCancel,
+    MSIDOnboardingReasonCodeNetwork,
+    MSIDOnboardingReasonCodePolicy,
+    MSIDOnboardingReasonCodeUnknown
+};
+
+@interface MSIDOnboardingReason : NSObject <MSIDJsonSerializable>
+
+@property (nonatomic, readonly) MSIDOnboardingReasonCode code;
+@property (nonatomic, readonly, nullable) NSString *message;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)initWithCode:(MSIDOnboardingReasonCode)code
+                     message:(nullable NSString *)message;
+
+@end
+
+@interface MSIDOnboardingStatus : NSObject <MSIDJsonSerializable>
+
+@property (nonatomic, readonly) NSInteger version;
+@property (nonatomic, readwrite) MSIDOnboardingPhase phase;
+@property (nonatomic, readonly) MSIDOnboardingContext onboardingContext;
+@property (nonatomic, readonly) NSString *ownerBundleId;
+@property (nonatomic, readonly) NSString *originatingBundleId;
+@property (nonatomic, readonly, nullable) NSString *originatingDisplayName;
+@property (nonatomic, readonly, nullable) NSUUID *correlationId;
+@property (nonatomic, readonly, nullable) NSDate *startedAt;
+@property (nonatomic, readonly) NSInteger ttlSeconds;
+@property (nonatomic, readwrite, nullable) MSIDOnboardingReason *reason;
+
+- (instancetype)initWithPhase:(MSIDOnboardingPhase)phase
+              onboardingContext:(MSIDOnboardingContext)onboardingContext
+                  ownerBundleId:(NSString *)ownerBundleId
+                  correlationId:(nullable NSUUID *)correlationId;
+
+#pragma mark - String/enum helpers
+
++ (MSIDOnboardingPhase)onboardingPhaseFromString:(NSString *)onboardingPhaseString;
++ (NSString *)stringFromPhase:(MSIDOnboardingPhase)phase;
+
++ (MSIDOnboardingContext)onboardingContextFromString:(NSString *)onboardingContextString;
++ (NSString *)stringFromContext:(MSIDOnboardingContext)context;
+
++ (MSIDOnboardingReasonCode)reasonCodeFromString:(NSString *)reasonCodeString;
++ (NSString *)stringFromReasonCode:(MSIDOnboardingReasonCode)code;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/onboarding/MSIDOnboardingStatus.m
+++ b/IdentityCore/src/cache/onboarding/MSIDOnboardingStatus.m
@@ -1,0 +1,393 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDOnboardingStatus.h"
+#import "NSString+MSIDExtensions.h"
+#import "NSDictionary+MSIDExtensions.h"
+#import "MSIDError.h"
+
+static NSString *const MSID_ONBOARDING_VERSION_JSON_KEY = @"version";
+static NSString *const MSID_ONBOARDING_PHASE_JSON_KEY = @"phase";
+static NSString *const MSID_ONBOARDING_CONTEXT_JSON_KEY = @"context";
+static NSString *const MSID_ONBOARDING_OWNER_BUNDLE_ID_JSON_KEY = @"ownerBundleId";
+static NSString *const MSID_ONBOARDING_ORIGINATING_BUNDLE_ID_JSON_KEY = @"originatingBundleId";
+static NSString *const MSID_ONBOARDING_ORIGINATING_DISPLAY_NAME_JSON_KEY = @"originatingDisplayName";
+static NSString *const MSID_ONBOARDING_CORRELATION_ID_JSON_KEY = @"correlationId";
+static NSString *const MSID_ONBOARDING_STARTED_AT_JSON_KEY = @"startedAt";
+static NSString *const MSID_ONBOARDING_TTL_SECONDS_JSON_KEY = @"ttlSeconds";
+static NSString *const MSID_ONBOARDING_REASON_JSON_KEY = @"reason";
+
+static NSString *const MSID_ONBOARDING_REASON_CODE_JSON_KEY = @"code";
+static NSString *const MSID_ONBOARDING_REASON_MESSAGE_JSON_KEY = @"message";
+
+static NSString *const MSID_ONBOARDING_STRING_NONE = @"none";
+static NSString *const MSID_ONBOARDING_STRING_UNKNOWN = @"unknown";
+
+static NSString *const MSID_ONBOARDING_PHASE_BROKER_INTERACTIVE_IN_PROGRESS_STRING = @"broker_interactive_in_progress";
+static NSString *const MSID_ONBOARDING_PHASE_MDM_ENROLLMENT_IN_PROGRESS_STRING = @"mdm_enrollment_in_progress";
+static NSString *const MSID_ONBOARDING_PHASE_FAILED_STRING = @"failed";
+
+static NSString *const MSID_ONBOARDING_CONTEXT_BROKER_STRING = @"broker";
+static NSString *const MSID_ONBOARDING_CONTEXT_IN_APP_WEBVIEW_STRING = @"inAppWebview";
+
+static NSString *const MSID_ONBOARDING_REASON_CODE_USER_CANCEL_STRING = @"user_cancel";
+static NSString *const MSID_ONBOARDING_REASON_CODE_NETWORK_STRING = @"network";
+static NSString *const MSID_ONBOARDING_REASON_CODE_POLICY_STRING = @"policy";
+
+static NSInteger const MSID_ONBOARDING_DEFAULT_TTL_SECONDS = 900;
+
+@implementation MSIDOnboardingReason
+
+- (instancetype)initWithCode:(MSIDOnboardingReasonCode)code
+                     message:(NSString *)message
+{
+    self = [super init];
+    if (self)
+    {
+        _code = code;
+        _message = message;
+    }
+    return self;
+}
+
+#pragma mark - MSIDJsonSerializable
+
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing *)error
+{
+    self = [super init];
+    if (!self) return nil;
+    
+    if (![json isKindOfClass:NSDictionary.class])
+    {
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"Invalid onboarding reason object.", nil, nil, nil, nil, nil, YES);
+        }
+        return nil;
+    }
+
+    NSString *codeString = nil;
+    if (![json msidAssertType:NSString.class ofKey:MSID_ONBOARDING_REASON_CODE_JSON_KEY required:YES error:error]) return nil;
+    codeString = json[MSID_ONBOARDING_REASON_CODE_JSON_KEY];
+
+    if (![json msidAssertType:NSString.class ofKey:MSID_ONBOARDING_REASON_MESSAGE_JSON_KEY required:NO error:error])
+    {
+        return nil;
+    }
+
+    _message = json[MSID_ONBOARDING_REASON_MESSAGE_JSON_KEY];
+    _code = [MSIDOnboardingStatus reasonCodeFromString:codeString];
+
+    return self;
+}
+
+- (NSDictionary *)jsonDictionary
+{
+    NSMutableDictionary *json = [NSMutableDictionary new];
+    json[MSID_ONBOARDING_REASON_CODE_JSON_KEY] = [MSIDOnboardingStatus stringFromReasonCode:self.code];
+
+    if (self.message) json[MSID_ONBOARDING_REASON_MESSAGE_JSON_KEY] = self.message;
+
+    return json;
+}
+
+@end
+
+@implementation MSIDOnboardingStatus
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        _version = 1;
+        _phase = MSIDOnboardingPhaseNone;
+        _onboardingContext = MSIDOnboardingContextUnknown;
+        _ownerBundleId = [[NSBundle mainBundle] bundleIdentifier];
+        _originatingBundleId = [[NSBundle mainBundle] bundleIdentifier];
+        NSString *displayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+        if (!displayName)
+        {
+            // Fallback to CFBundleName if CFBundleDisplayName is not set
+            displayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+        }
+        if (![NSString msidIsStringNilOrBlank:displayName])
+        {
+            _originatingDisplayName = displayName;
+        }
+        _correlationId = nil;
+        _startedAt = [NSDate date];
+        _ttlSeconds = MSID_ONBOARDING_DEFAULT_TTL_SECONDS;
+        _reason = nil;
+    }
+    return self;
+}
+
+- (instancetype)initWithPhase:(MSIDOnboardingPhase)phase
+              onboardingContext:(MSIDOnboardingContext)onboardingContext
+                  ownerBundleId:(NSString *)ownerBundleId
+                  correlationId:(NSUUID *)correlationId
+{
+    self = [super init];
+    if (self)
+    {
+        _version = 1;
+        _phase = phase;
+        _onboardingContext = onboardingContext;
+        _ownerBundleId = ownerBundleId;
+        _originatingBundleId = [[NSBundle mainBundle] bundleIdentifier];
+        NSString *displayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+        if (!displayName)
+        {
+            // Fallback to CFBundleName if CFBundleDisplayName is not set
+            displayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+        }
+        if (![NSString msidIsStringNilOrBlank:displayName])
+        {
+            _originatingDisplayName = displayName;
+        }
+        _correlationId = correlationId ?: [[NSUUID alloc] init];
+        _startedAt = [NSDate date];
+        _ttlSeconds = MSID_ONBOARDING_DEFAULT_TTL_SECONDS;
+    }
+    return self;
+}
+
+#pragma mark - MSIDJsonSerializable
+
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing *)error
+{
+    self = [super init];
+    if (!self) return nil;
+    
+    if (![json isKindOfClass:NSDictionary.class])
+    {
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"Invalid onboarding status object.", nil, nil, nil, nil, nil, YES);
+        }
+        return nil;
+    }
+
+    _version = 1;
+    if (json[MSID_ONBOARDING_VERSION_JSON_KEY])
+    {
+        if (![json msidAssertTypeIsOneOf:@[NSString.class, NSNumber.class] ofKey:MSID_ONBOARDING_VERSION_JSON_KEY required:NO error:error]) return nil;
+        _version = [json[MSID_ONBOARDING_VERSION_JSON_KEY] integerValue];
+    }
+
+    if (![json msidAssertType:NSString.class ofKey:MSID_ONBOARDING_PHASE_JSON_KEY required:YES error:error]) return nil;
+    NSString *phaseString = json[MSID_ONBOARDING_PHASE_JSON_KEY];
+    
+    if (![json msidAssertType:NSString.class ofKey:MSID_ONBOARDING_CONTEXT_JSON_KEY required:YES error:error]) return nil;
+    NSString *contextString = json[MSID_ONBOARDING_CONTEXT_JSON_KEY];
+
+    _phase = [MSIDOnboardingStatus onboardingPhaseFromString:phaseString];
+    _onboardingContext = [MSIDOnboardingStatus onboardingContextFromString:contextString];
+
+    if (![json msidAssertType:NSString.class ofKey:MSID_ONBOARDING_OWNER_BUNDLE_ID_JSON_KEY required:NO error:error]) return nil;
+    _ownerBundleId = json[MSID_ONBOARDING_OWNER_BUNDLE_ID_JSON_KEY];
+    
+    if (![json msidAssertType:NSString.class ofKey:MSID_ONBOARDING_ORIGINATING_BUNDLE_ID_JSON_KEY required:NO error:error]) return nil;
+    _originatingBundleId = json[MSID_ONBOARDING_ORIGINATING_BUNDLE_ID_JSON_KEY];
+    
+    if (![json msidAssertType:NSString.class ofKey:MSID_ONBOARDING_ORIGINATING_DISPLAY_NAME_JSON_KEY required:NO error:error]) return nil;
+    _originatingDisplayName = json[MSID_ONBOARDING_ORIGINATING_DISPLAY_NAME_JSON_KEY];
+
+    if (json[MSID_ONBOARDING_CORRELATION_ID_JSON_KEY])
+    {
+        if (![json msidAssertType:NSString.class ofKey:MSID_ONBOARDING_CORRELATION_ID_JSON_KEY required:NO error:error]) return nil;
+        _correlationId = [[NSUUID alloc] initWithUUIDString:json[MSID_ONBOARDING_CORRELATION_ID_JSON_KEY]];
+    }
+
+    if (json[MSID_ONBOARDING_STARTED_AT_JSON_KEY])
+    {
+        if (![json msidAssertType:NSString.class ofKey:MSID_ONBOARDING_STARTED_AT_JSON_KEY required:NO error:error]) return nil;
+        _startedAt = [MSIDOnboardingStatus dateFromISOString:json[MSID_ONBOARDING_STARTED_AT_JSON_KEY]];
+    }
+
+    _ttlSeconds = MSID_ONBOARDING_DEFAULT_TTL_SECONDS;
+    if (json[MSID_ONBOARDING_TTL_SECONDS_JSON_KEY])
+    {
+        if (![json msidAssertType:NSNumber.class ofKey:MSID_ONBOARDING_TTL_SECONDS_JSON_KEY required:NO error:error]) return nil;
+        _ttlSeconds = [json[MSID_ONBOARDING_TTL_SECONDS_JSON_KEY] integerValue];
+    }
+
+    if (json[MSID_ONBOARDING_REASON_JSON_KEY])
+    {
+        if (![json msidAssertType:NSDictionary.class ofKey:MSID_ONBOARDING_REASON_JSON_KEY required:NO error:error]) return nil;
+        _reason = [[MSIDOnboardingReason alloc] initWithJSONDictionary:json[MSID_ONBOARDING_REASON_JSON_KEY] error:error];
+        if (!_reason) return nil;
+    }
+    
+    return self;
+}
+
+- (NSDictionary *)jsonDictionary
+{
+    NSMutableDictionary *json = [NSMutableDictionary new];
+
+    json[MSID_ONBOARDING_VERSION_JSON_KEY] = @(self.version);
+    json[MSID_ONBOARDING_PHASE_JSON_KEY] = [[self class] stringFromPhase:self.phase];
+    json[MSID_ONBOARDING_CONTEXT_JSON_KEY] = [[self class] stringFromContext:self.onboardingContext];
+
+    if (self.ownerBundleId) json[MSID_ONBOARDING_OWNER_BUNDLE_ID_JSON_KEY] = self.ownerBundleId;
+    if (self.originatingBundleId) json[MSID_ONBOARDING_ORIGINATING_BUNDLE_ID_JSON_KEY] = self.originatingBundleId;
+    if (self.originatingDisplayName) json[MSID_ONBOARDING_ORIGINATING_DISPLAY_NAME_JSON_KEY] = self.originatingDisplayName;
+    if (self.correlationId) json[MSID_ONBOARDING_CORRELATION_ID_JSON_KEY] = [self.correlationId UUIDString];
+    if (self.startedAt) json[MSID_ONBOARDING_STARTED_AT_JSON_KEY] = [[self class] isoStringFromDate:self.startedAt];
+
+    json[MSID_ONBOARDING_TTL_SECONDS_JSON_KEY] = @(_ttlSeconds);
+
+    if (self.reason)
+    {
+        NSDictionary *reasonJson = [self.reason jsonDictionary];
+        if (!reasonJson) return nil;
+        json[MSID_ONBOARDING_REASON_JSON_KEY] = reasonJson;
+    }
+
+    return json;
+}
+
+#pragma mark - Helpers
+
++ (MSIDOnboardingPhase)onboardingPhaseFromString:(NSString *)onboardingPhaseString
+{
+    if ([NSString msidIsStringNilOrBlank:onboardingPhaseString])
+    {
+        return MSIDOnboardingPhaseNone;
+    }
+    
+    if ([onboardingPhaseString caseInsensitiveCompare:MSID_ONBOARDING_STRING_NONE] == NSOrderedSame) return MSIDOnboardingPhaseNone;
+    if ([onboardingPhaseString caseInsensitiveCompare:MSID_ONBOARDING_PHASE_BROKER_INTERACTIVE_IN_PROGRESS_STRING] == NSOrderedSame) return MSIDOnboardingPhaseBrokerInteractiveInProgress;
+    if ([onboardingPhaseString caseInsensitiveCompare:MSID_ONBOARDING_PHASE_MDM_ENROLLMENT_IN_PROGRESS_STRING] == NSOrderedSame) return MSIDOnboardingPhaseMdmEnrollmentInProgress;
+    if ([onboardingPhaseString caseInsensitiveCompare:MSID_ONBOARDING_PHASE_FAILED_STRING] == NSOrderedSame) return MSIDOnboardingPhaseFailed;
+
+    return MSIDOnboardingPhaseNone;
+}
+
++ (NSString *)stringFromPhase:(MSIDOnboardingPhase)phase
+{
+    switch (phase)
+    {
+        case MSIDOnboardingPhaseBrokerInteractiveInProgress: return MSID_ONBOARDING_PHASE_BROKER_INTERACTIVE_IN_PROGRESS_STRING;
+        case MSIDOnboardingPhaseMdmEnrollmentInProgress: return MSID_ONBOARDING_PHASE_MDM_ENROLLMENT_IN_PROGRESS_STRING;
+        case MSIDOnboardingPhaseFailed: return MSID_ONBOARDING_PHASE_FAILED_STRING;
+        case MSIDOnboardingPhaseNone:
+        default:
+            return MSID_ONBOARDING_STRING_NONE;
+    }
+}
+
++ (MSIDOnboardingContext)onboardingContextFromString:(NSString *)onboardingContextString
+{
+    if ([NSString msidIsStringNilOrBlank:onboardingContextString])
+    {
+        return MSIDOnboardingContextUnknown;
+    }
+    
+    if ([onboardingContextString caseInsensitiveCompare:MSID_ONBOARDING_CONTEXT_BROKER_STRING] == NSOrderedSame) return MSIDOnboardingContextBroker;
+    if ([onboardingContextString caseInsensitiveCompare:MSID_ONBOARDING_CONTEXT_IN_APP_WEBVIEW_STRING] == NSOrderedSame) return MSIDOnboardingContextInAppWebview;
+
+    return MSIDOnboardingContextUnknown;
+}
+
++ (NSString *)stringFromContext:(MSIDOnboardingContext)context
+{
+    switch (context)
+    {
+        case MSIDOnboardingContextBroker: return MSID_ONBOARDING_CONTEXT_BROKER_STRING;
+        case MSIDOnboardingContextInAppWebview: return MSID_ONBOARDING_CONTEXT_IN_APP_WEBVIEW_STRING;
+        case MSIDOnboardingContextUnknown:
+        default:
+            return MSID_ONBOARDING_STRING_UNKNOWN;
+    }
+}
+
++ (MSIDOnboardingReasonCode)reasonCodeFromString:(NSString *)reasonCodeString
+{
+    if ([NSString msidIsStringNilOrBlank:reasonCodeString])
+    {
+        return MSIDOnboardingReasonCodeUnknown;
+    }
+    
+    if ([reasonCodeString caseInsensitiveCompare:MSID_ONBOARDING_STRING_NONE] == NSOrderedSame) return MSIDOnboardingReasonCodeNone;
+    if ([reasonCodeString caseInsensitiveCompare:MSID_ONBOARDING_REASON_CODE_USER_CANCEL_STRING] == NSOrderedSame) return MSIDOnboardingReasonCodeUserCancel;
+    if ([reasonCodeString caseInsensitiveCompare:MSID_ONBOARDING_REASON_CODE_NETWORK_STRING] == NSOrderedSame) return MSIDOnboardingReasonCodeNetwork;
+    if ([reasonCodeString caseInsensitiveCompare:MSID_ONBOARDING_REASON_CODE_POLICY_STRING] == NSOrderedSame) return MSIDOnboardingReasonCodePolicy;
+    if ([reasonCodeString caseInsensitiveCompare:MSID_ONBOARDING_STRING_UNKNOWN] == NSOrderedSame) return MSIDOnboardingReasonCodeUnknown;
+
+    return MSIDOnboardingReasonCodeUnknown;
+}
+
++ (NSString *)stringFromReasonCode:(MSIDOnboardingReasonCode)reasonCode
+{
+    switch (reasonCode)
+    {
+        case MSIDOnboardingReasonCodeUserCancel: return MSID_ONBOARDING_REASON_CODE_USER_CANCEL_STRING;
+        case MSIDOnboardingReasonCodeNetwork: return MSID_ONBOARDING_REASON_CODE_NETWORK_STRING;
+        case MSIDOnboardingReasonCodePolicy: return MSID_ONBOARDING_REASON_CODE_POLICY_STRING;
+        case MSIDOnboardingReasonCodeUnknown: return MSID_ONBOARDING_STRING_UNKNOWN;
+        case MSIDOnboardingReasonCodeNone:
+        default:
+            return MSID_ONBOARDING_STRING_NONE;
+    }
+}
+
++ (NSDate *)dateFromISOString:(NSString *)string
+{
+    static NSISO8601DateFormatter *formatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [NSISO8601DateFormatter new];
+        formatter.formatOptions = NSISO8601DateFormatWithInternetDateTime | NSISO8601DateFormatWithFractionalSeconds;
+    });
+
+    NSDate *date = [formatter dateFromString:string];
+    if (date) return date;
+
+    // Retry without fractional seconds
+    static NSISO8601DateFormatter *formatter2;
+    static dispatch_once_t onceToken2;
+    dispatch_once(&onceToken2, ^{
+        formatter2 = [NSISO8601DateFormatter new];
+        formatter2.formatOptions = NSISO8601DateFormatWithInternetDateTime;
+    });
+
+    return [formatter2 dateFromString:string];
+}
+
++ (NSString *)isoStringFromDate:(NSDate *)date
+{
+    static NSISO8601DateFormatter *formatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [NSISO8601DateFormatter new];
+        formatter.formatOptions = NSISO8601DateFormatWithInternetDateTime;
+    });
+
+    return [formatter stringFromDate:date];
+}
+
+@end

--- a/IdentityCore/tests/MSIDOnboardingStatusCacheTests.m
+++ b/IdentityCore/tests/MSIDOnboardingStatusCacheTests.m
@@ -1,0 +1,475 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDOnboardingStatusCache.h"
+#import "MSIDOnboardingStatus.h"
+#import "MSIDTestCacheDataSource.h"
+#import "MSIDCacheItemJsonSerializer.h"
+#import "MSIDBrokerConstants.h"
+
+@interface MSIDOnboardingStatusCache ()
+
+@property (nonatomic) id<MSIDExtendedTokenCacheDataSource> dataSource;
+@property (nonatomic) MSIDCacheItemJsonSerializer *serializer;
+
+- (BOOL)isOwnerOverride:(MSIDOnboardingStatus *)status;
+
+@end
+
+@interface MSIDOnboardingStatusCacheTests : XCTestCase
+
+@property (nonatomic) MSIDOnboardingStatusCache *cache;
+@property (nonatomic) MSIDTestCacheDataSource *testDataSource;
+
+@end
+
+@implementation MSIDOnboardingStatusCacheTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.cache = MSIDOnboardingStatusCache.sharedInstance;
+    self.testDataSource = [MSIDTestCacheDataSource new];
+    self.cache.dataSource = self.testDataSource;
+}
+
+- (void)tearDown
+{
+    // Reset to clean state
+    [self.testDataSource reset];
+    [super tearDown];
+}
+
+#pragma mark - Helper
+
+- (MSIDOnboardingStatus *)statusWithOwner:(NSString *)ownerBundleId
+                                    phase:(MSIDOnboardingPhase)phase
+                               ttlSeconds:(NSInteger)ttl
+                                startedAt:(NSDate *)startedAt
+{
+    return [self statusWithOwner:ownerBundleId
+                     originating:@"com.microsoft.teams"
+                           phase:phase
+                      ttlSeconds:ttl
+                       startedAt:startedAt];
+}
+
+- (MSIDOnboardingStatus *)statusWithOwner:(NSString *)ownerBundleId
+                              originating:(NSString *)originatingBundleId
+                                    phase:(MSIDOnboardingPhase)phase
+                               ttlSeconds:(NSInteger)ttl
+                                startedAt:(NSDate *)startedAt
+{
+    NSMutableDictionary *json = [NSMutableDictionary dictionary];
+    json[@"version"] = @1;
+    json[@"phase"] = [MSIDOnboardingStatus stringFromPhase:phase];
+    json[@"context"] = [MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextBroker];
+    json[@"ownerBundleId"] = ownerBundleId;
+    json[@"originatingBundleId"] = originatingBundleId;
+    json[@"originatingDisplayName"] = @"Teams";
+    json[@"correlationId"] = @"00000000-0000-0000-0000-000000000000";
+    json[@"ttlSeconds"] = @(ttl);
+    
+    if (startedAt)
+    {
+        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+        formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+        formatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+        json[@"startedAt"] = [formatter stringFromDate:startedAt];
+    }
+    
+    json[@"reason"] = @{@"code": @"none", @"message": @""};
+    
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+    NSAssert(status != nil, @"Failed to create status: %@", error);
+    return status;
+}
+
+#pragma mark - getOnboardingStatus
+
+- (void)testGetOnboardingStatus_whenNothingCached_shouldReturnDefaultStatus
+{
+    MSIDOnboardingStatus *status = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(status);
+    XCTAssertEqual(status.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testGetOnboardingStatus_whenStatusCached_shouldReturnCachedStatus
+{
+    MSIDOnboardingStatus *original = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                     phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                                ttlSeconds:900
+                                                 startedAt:[NSDate date]];
+
+    BOOL writeResult = [self.cache setWithStatus:original];
+    XCTAssertTrue(writeResult);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(retrieved);
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+    XCTAssertEqualObjects(retrieved.ownerBundleId, @"com.microsoft.azureauthenticator");
+}
+
+- (void)testGetOnboardingStatus_whenStatusExpired_shouldReturnDefaultStatus
+{
+    // Create a status that started 2000 seconds ago with a 900-second TTL
+    NSDate *pastDate = [NSDate dateWithTimeIntervalSinceNow:-2000];
+    MSIDOnboardingStatus *expired = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                    phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                               ttlSeconds:900
+                                                startedAt:pastDate];
+
+    [self.cache setWithStatus:expired];
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(retrieved);
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testGetOnboardingStatus_whenStatusNotExpired_shouldReturnCachedStatus
+{
+    NSDate *recentDate = [NSDate dateWithTimeIntervalSinceNow:-100];
+    MSIDOnboardingStatus *valid = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                  phase:MSIDOnboardingPhaseFailed
+                                             ttlSeconds:900
+                                              startedAt:recentDate];
+
+    [self.cache setWithStatus:valid];
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(retrieved);
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseFailed);
+}
+
+#pragma mark - setWithStatus
+
+- (void)testSetWithStatus_whenNilStatus_shouldReturnNO
+{
+    MSIDOnboardingStatus *nilStatus = nil;
+    BOOL result = [self.cache setWithStatus:nilStatus];
+
+    XCTAssertFalse(result);
+}
+
+- (void)testSetWithStatus_whenNothingCached_shouldSucceed
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:status];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testSetWithStatus_whenSameOriginatingBundleId_shouldSucceed
+{
+    MSIDOnboardingStatus *first = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                            originating:@"com.microsoft.teams"
+                                                  phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                             ttlSeconds:900
+                                              startedAt:[NSDate date]];
+    [self.cache setWithStatus:first];
+
+    MSIDOnboardingStatus *second = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:second];
+
+    XCTAssertTrue(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseMdmEnrollmentInProgress);
+}
+
+- (void)testSetWithStatus_whenDifferentOriginatingBundleId_shouldReturnNO
+{
+    MSIDOnboardingStatus *first = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                            originating:@"com.microsoft.teams"
+                                                  phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                             ttlSeconds:900
+                                              startedAt:[NSDate date]];
+    [self.cache setWithStatus:first];
+
+    MSIDOnboardingStatus *second = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.outlook"
+                                                   phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:second];
+
+    XCTAssertFalse(result);
+}
+
+- (void)testSetWithStatus_whenDifferentOriginatingBundleIdButOwnerOverride_shouldSucceed
+{
+    MSIDOnboardingStatus *first = [self statusWithOwner:@"com.microsoft.another.app"
+                                            originating:@"com.microsoft.teams"
+                                                  phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                             ttlSeconds:900
+                                              startedAt:[NSDate date]];
+    [self.cache setWithStatus:first];
+
+    // Owner override: new status owned by current app bundle ID (test host)
+    // Even with different originatingBundleId, the override should succeed
+    NSString *currentBundleId = [[NSBundle mainBundle] bundleIdentifier];
+    MSIDOnboardingStatus *overrideStatus = [self statusWithOwner:currentBundleId
+                                                     originating:@"com.microsoft.outlook"
+                                                           phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                                      ttlSeconds:900
+                                                       startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:overrideStatus];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testSetWithStatus_whenOriginatingBundleIdMatchIsCaseInsensitive_shouldSucceed
+{
+    MSIDOnboardingStatus *first = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                            originating:@"com.Microsoft.Teams"
+                                                  phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                             ttlSeconds:900
+                                              startedAt:[NSDate date]];
+    [self.cache setWithStatus:first];
+
+    MSIDOnboardingStatus *second = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseFailed
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:second];
+
+    XCTAssertTrue(result);
+}
+
+#pragma mark - clear
+
+- (void)testClear_whenNilBundleId_shouldReturnNO
+{
+    NSString *nilBundleId = nil;
+    BOOL result = [self.cache clear:nilBundleId];
+
+    XCTAssertFalse(result);
+}
+
+- (void)testClear_whenEmptyBundleId_shouldReturnNO
+{
+    BOOL result = [self.cache clear:@""];
+
+    XCTAssertFalse(result);
+}
+
+- (void)testClear_whenNothingCached_shouldReturnYES
+{
+    BOOL result = [self.cache clear:@"com.microsoft.azureauthenticator"];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testClear_whenMatchingBundleId_shouldRemoveAndReturnYES
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    BOOL result = [self.cache clear:@"com.microsoft.azureauthenticator"];
+
+    XCTAssertTrue(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testClear_whenNonMatchingBundleId_shouldReturnNO
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    BOOL result = [self.cache clear:@"com.microsoft.other.app"];
+
+    XCTAssertFalse(result);
+
+    // Verify status is still there
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+}
+
+- (void)testClear_whenBundleIdMatchIsCaseInsensitive_shouldRemoveAndReturnYES
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    BOOL result = [self.cache clear:@"com.Microsoft.AzureAuthenticator"];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testClear_whenOriginatingBundleIdMatches_shouldRemoveAndReturnYES
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    // Clear using the originating bundle ID instead of owner bundle ID
+    BOOL result = [self.cache clear:@"com.microsoft.teams"];
+
+    XCTAssertTrue(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testClear_whenOriginatingBundleIdMatchIsCaseInsensitive_shouldRemoveAndReturnYES
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    // Clear using the originating bundle ID with different case
+    BOOL result = [self.cache clear:@"com.Microsoft.Teams"];
+
+    XCTAssertTrue(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testClear_whenNeitherOwnerNorOriginatingBundleIdMatches_shouldReturnNO
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    // Clear using a bundle ID that matches neither owner nor originating
+    BOOL result = [self.cache clear:@"com.microsoft.outlook"];
+
+    XCTAssertFalse(result);
+
+    // Verify status is still there
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+}
+
+#pragma mark - isOwnerOverride
+
+- (void)testIsOwnerOverride_whenOwnerMatchesCurrentBundleId_shouldReturnYES
+{
+    // The current bundle ID in tests is the test host's bundle ID
+    NSString *currentBundleId = [[NSBundle mainBundle] bundleIdentifier];
+    MSIDOnboardingStatus *status = [self statusWithOwner:currentBundleId
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache isOwnerOverride:status];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testIsOwnerOverride_whenOwnerDoesNotMatchCurrentBundleId_shouldReturnNO
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.other.app"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache isOwnerOverride:status];
+
+    XCTAssertFalse(result);
+}
+
+#pragma mark - setWithStatus then getOnboardingStatus roundtrip
+
+- (void)testSetAndGet_shouldPreserveAllFields
+{
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    formatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+    NSDate *startDate = [NSDate date];
+    
+    NSDictionary *json = @{
+        @"version": @1,
+        @"phase": @"failed",
+        @"context": @"inAppWebview",
+        @"ownerBundleId": @"com.microsoft.azureauthenticator",
+        @"originatingBundleId": @"com.microsoft.outlook",
+        @"originatingDisplayName": @"Outlook",
+        @"correlationId": @"12345678-1234-1234-1234-123456789abc",
+        @"startedAt": [formatter stringFromDate:startDate],
+        @"ttlSeconds": @1800,
+        @"reason": @{@"code": @"network", @"message": @"Network error"}
+    };
+    
+    NSError *error = nil;
+    MSIDOnboardingStatus *original = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+    XCTAssertNotNil(original);
+    XCTAssertNil(error);
+
+    BOOL writeResult = [self.cache setWithStatus:original];
+    XCTAssertTrue(writeResult);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(retrieved);
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseFailed);
+    XCTAssertEqual(retrieved.onboardingContext, MSIDOnboardingContextInAppWebview);
+    XCTAssertEqualObjects(retrieved.ownerBundleId, @"com.microsoft.azureauthenticator");
+    XCTAssertEqualObjects(retrieved.originatingBundleId, @"com.microsoft.outlook");
+    XCTAssertEqualObjects(retrieved.originatingDisplayName, @"Outlook");
+    XCTAssertEqual(retrieved.ttlSeconds, 1800);
+    XCTAssertNotNil(retrieved.reason);
+    XCTAssertEqual(retrieved.reason.code, MSIDOnboardingReasonCodeNetwork);
+    XCTAssertEqualObjects(retrieved.reason.message, @"Network error");
+}
+
+@end

--- a/IdentityCore/tests/MSIDOnboardingStatusTests.m
+++ b/IdentityCore/tests/MSIDOnboardingStatusTests.m
@@ -1,0 +1,527 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+
+#import "MSIDOnboardingStatus.h"
+
+@interface MSIDOnboardingStatusTests : XCTestCase
+@end
+
+@implementation MSIDOnboardingStatusTests
+
+- (void)testInitWithJSONDictionary_whenValidJSON_shouldParse
+{
+    NSDictionary *json = @{
+        @"version" : @1,
+        @"phase" : @"broker_interactive_in_progress",
+        @"context" : @"broker",
+        @"ownerBundleId" : @"com.microsoft.azureauthenticator",
+        @"originatingBundleId" : @"com.microsoft.teams",
+        @"originatingDisplayName" : @"Teams",
+        @"correlationId" : @"f2b9c6e7-1234-5678-90ab-abcdef123456",
+        @"startedAt" : @"2025-10-03T20:15:00Z",
+        @"ttlSeconds" : @900,
+        @"reason" : @{ @"code" : @"none" }
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(status);
+    XCTAssertNil(error);
+
+    XCTAssertEqual(status.version, 1);
+    XCTAssertEqual(status.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+    XCTAssertEqual(status.onboardingContext, MSIDOnboardingContextBroker);
+    XCTAssertEqualObjects(status.ownerBundleId, @"com.microsoft.azureauthenticator");
+    XCTAssertEqualObjects(status.originatingBundleId, @"com.microsoft.teams");
+    XCTAssertEqualObjects(status.originatingDisplayName, @"Teams");
+    XCTAssertEqualObjects(status.correlationId.UUIDString.lowercaseString, @"f2b9c6e7-1234-5678-90ab-abcdef123456");
+    XCTAssertNotNil(status.startedAt);
+    XCTAssertEqual(status.ttlSeconds, 900);
+    XCTAssertNotNil(status.reason);
+    XCTAssertEqual(status.reason.code, MSIDOnboardingReasonCodeNone);
+}
+
+- (void)testJsonDictionary_whenRoundtrip_shouldMatchExpectedKeys
+{
+    MSIDOnboardingReason *reason = [[MSIDOnboardingReason alloc] initWithCode:MSIDOnboardingReasonCodeUserCancel message:@"User canceled enrollment"];
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithPhase:MSIDOnboardingPhaseFailed
+                                                             onboardingContext:MSIDOnboardingContextInAppWebview
+                                                                 ownerBundleId:@"com.microsoft.azureauthenticator"
+                                                                 correlationId:[[NSUUID alloc] initWithUUIDString:@"f2b9c6e7-1234-5678-90ab-abcdef123456"]];
+    status.reason = reason;
+
+    NSDictionary *json = [status jsonDictionary];
+
+    XCTAssertEqualObjects(json[@"version"], @1);
+    XCTAssertEqualObjects(json[@"phase"], @"failed");
+    XCTAssertEqualObjects(json[@"context"], @"inAppWebview");
+    XCTAssertEqualObjects(json[@"ownerBundleId"], @"com.microsoft.azureauthenticator");
+    XCTAssertNotNil(json[@"originatingBundleId"]); // Set from main bundle
+    XCTAssertEqualObjects(json[@"correlationId"], @"F2B9C6E7-1234-5678-90AB-ABCDEF123456");
+    XCTAssertNotNil(json[@"startedAt"]); // Set automatically
+    XCTAssertEqualObjects(json[@"ttlSeconds"], @900);
+
+    NSDictionary *reasonJson = json[@"reason"];
+    XCTAssertEqualObjects(reasonJson[@"code"], @"user_cancel");
+    XCTAssertEqualObjects(reasonJson[@"message"], @"User canceled enrollment");
+}
+
+- (void)testInitWithJSONDictionary_whenTTLIsMissing_shouldDefault
+{
+    NSDictionary *json = @{
+        @"phase" : @"mdm_enrollment_in_progress",
+        @"context" : @"inAppWebview"
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(status);
+    XCTAssertNil(error);
+    XCTAssertEqual(status.ttlSeconds, 900);
+}
+
+- (void)testInitWithJSONDictionary_whenPhaseMissing_shouldFail
+{
+    NSDictionary *json = @{
+        @"context" : @"broker"
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNil(status);
+    XCTAssertNotNil(error);
+}
+
+- (void)testInitWithJSONDictionary_whenContextMissing_shouldFail
+{
+    NSDictionary *json = @{
+        @"phase" : @"none"
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNil(status);
+    XCTAssertNotNil(error);
+}
+
+- (void)testInitWithJSONDictionary_whenVersionMissing_shouldDefaultToOne
+{
+    NSDictionary *json = @{
+        @"phase" : @"none",
+        @"context" : @"broker"
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(status);
+    XCTAssertNil(error);
+    XCTAssertEqual(status.version, 1);
+}
+
+- (void)testInitWithJSONDictionary_whenVersionIsString_shouldParse
+{
+    NSDictionary *json = @{
+        @"version" : @"2",
+        @"phase" : @"none",
+        @"context" : @"broker"
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(status);
+    XCTAssertNil(error);
+    XCTAssertEqual(status.version, 2);
+}
+
+- (void)testInitWithJSONDictionary_whenOnlyRequiredFields_shouldParseWithDefaults
+{
+    NSDictionary *json = @{
+        @"phase" : @"failed",
+        @"context" : @"unknown"
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(status);
+    XCTAssertNil(error);
+    XCTAssertEqual(status.phase, MSIDOnboardingPhaseFailed);
+    XCTAssertEqual(status.onboardingContext, MSIDOnboardingContextUnknown);
+    XCTAssertEqual(status.version, 1);
+    XCTAssertEqual(status.ttlSeconds, 900);
+    XCTAssertNil(status.ownerBundleId);
+    XCTAssertNil(status.originatingBundleId);
+    XCTAssertNil(status.originatingDisplayName);
+    XCTAssertNil(status.correlationId);
+    XCTAssertNil(status.reason);
+}
+
+- (void)testInitWithJSONDictionary_whenNonDictionaryInput_shouldFail
+{
+    NSError *error = nil;
+    NSArray *notADict = @[@"not", @"a", @"dict"];
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:(NSDictionary *)notADict error:&error];
+
+    XCTAssertNil(status);
+    XCTAssertNotNil(error);
+}
+
+- (void)testInitWithJSONDictionary_whenStartedAtHasFractionalSeconds_shouldParse
+{
+    NSDictionary *json = @{
+        @"phase" : @"broker_interactive_in_progress",
+        @"context" : @"broker",
+        @"startedAt" : @"2025-10-03T20:15:00.123Z"
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(status);
+    XCTAssertNil(error);
+    XCTAssertNotNil(status.startedAt);
+}
+
+- (void)testInitWithJSONDictionary_whenReasonHasMessage_shouldParseMessage
+{
+    NSDictionary *json = @{
+        @"phase" : @"failed",
+        @"context" : @"broker",
+        @"reason" : @{
+            @"code" : @"network",
+            @"message" : @"Connection timed out"
+        }
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(status);
+    XCTAssertNil(error);
+    XCTAssertNotNil(status.reason);
+    XCTAssertEqual(status.reason.code, MSIDOnboardingReasonCodeNetwork);
+    XCTAssertEqualObjects(status.reason.message, @"Connection timed out");
+}
+
+- (void)testInitWithJSONDictionary_whenReasonMissingCode_shouldFail
+{
+    NSDictionary *json = @{
+        @"phase" : @"failed",
+        @"context" : @"broker",
+        @"reason" : @{
+            @"message" : @"some message"
+        }
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNil(status);
+    XCTAssertNotNil(error);
+}
+
+#pragma mark - init (default)
+
+- (void)testInit_shouldSetDefaultValues
+{
+    MSIDOnboardingStatus *status = [MSIDOnboardingStatus new];
+
+    XCTAssertEqual(status.version, 1);
+    XCTAssertEqual(status.phase, MSIDOnboardingPhaseNone);
+    XCTAssertEqual(status.onboardingContext, MSIDOnboardingContextUnknown);
+    XCTAssertNotNil(status.ownerBundleId);
+    XCTAssertNotNil(status.startedAt);
+    XCTAssertEqual(status.ttlSeconds, 900);
+    XCTAssertNil(status.correlationId);
+    XCTAssertNil(status.reason);
+}
+
+#pragma mark - initWithPhase tests
+
+- (void)testInitWithPhase_whenCalled_shouldSetProperties
+{
+    NSUUID *correlationId = [[NSUUID alloc] initWithUUIDString:@"00000000-0000-0000-0000-000000000000"];
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                                             onboardingContext:MSIDOnboardingContextBroker
+                                                                 ownerBundleId:@"com.test"
+                                                                 correlationId:correlationId];
+
+    XCTAssertEqual(status.version, 1);
+    XCTAssertEqual(status.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+    XCTAssertEqual(status.onboardingContext, MSIDOnboardingContextBroker);
+    XCTAssertEqualObjects(status.ownerBundleId, @"com.test");
+    XCTAssertEqualObjects(status.correlationId, correlationId);
+    XCTAssertNotNil(status.startedAt);
+    XCTAssertEqual(status.ttlSeconds, 900);
+}
+
+- (void)testInitWithPhase_whenCorrelationIdNil_shouldGenerateNew
+{
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithPhase:MSIDOnboardingPhaseNone
+                                                             onboardingContext:MSIDOnboardingContextUnknown
+                                                                 ownerBundleId:@"com.test"
+                                                                 correlationId:nil];
+
+    XCTAssertNotNil(status.correlationId);
+}
+
+#pragma mark - jsonDictionary
+
+- (void)testJsonDictionary_whenMinimalFields_shouldOmitOptionals
+{
+    MSIDOnboardingStatus *status = [MSIDOnboardingStatus new];
+
+    NSDictionary *json = [status jsonDictionary];
+
+    XCTAssertNotNil(json);
+    XCTAssertEqualObjects(json[@"version"], @1);
+    XCTAssertEqualObjects(json[@"phase"], @"none");
+    XCTAssertEqualObjects(json[@"context"], @"unknown");
+    XCTAssertEqualObjects(json[@"ttlSeconds"], @900);
+    XCTAssertNotNil(json[@"startedAt"]);
+    XCTAssertNotNil(json[@"ownerBundleId"]);
+    XCTAssertNil(json[@"correlationId"]);
+    XCTAssertNil(json[@"reason"]);
+}
+
+- (void)testJsonDictionary_thenInitFromJSON_shouldRoundtrip
+{
+    // Create the original status from JSON to set all the fields precisely
+    NSDictionary *originalJson = @{
+        @"version" : @1,
+        @"phase" : @"mdm_enrollment_in_progress",
+        @"context" : @"broker",
+        @"ownerBundleId" : @"com.microsoft.azureauthenticator",
+        @"originatingBundleId" : @"com.microsoft.outlook",
+        @"originatingDisplayName" : @"Outlook",
+        @"correlationId" : @"abcdef12-3456-7890-abcd-ef1234567890",
+        @"startedAt" : @"1970-01-12T13:46:40Z",
+        @"ttlSeconds" : @600,
+        @"reason" : @{
+            @"code" : @"policy",
+            @"message" : @"Policy violation"
+        }
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *original = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:originalJson error:&error];
+    XCTAssertNotNil(original);
+    XCTAssertNil(error);
+
+    NSDictionary *json = [original jsonDictionary];
+    MSIDOnboardingStatus *parsed = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(parsed);
+    XCTAssertNil(error);
+    XCTAssertEqual(parsed.version, original.version);
+    XCTAssertEqual(parsed.phase, original.phase);
+    XCTAssertEqual(parsed.onboardingContext, original.onboardingContext);
+    XCTAssertEqualObjects(parsed.ownerBundleId, original.ownerBundleId);
+    XCTAssertEqualObjects(parsed.originatingBundleId, original.originatingBundleId);
+    XCTAssertEqualObjects(parsed.originatingDisplayName, original.originatingDisplayName);
+    XCTAssertEqualObjects(parsed.correlationId, original.correlationId);
+    XCTAssertEqual(parsed.ttlSeconds, original.ttlSeconds);
+    XCTAssertEqual(parsed.reason.code, original.reason.code);
+    XCTAssertEqualObjects(parsed.reason.message, original.reason.message);
+}
+
+#pragma mark - onboardingPhaseFromString
+
+- (void)testOnboardingPhaseFromString_allValues
+{
+    XCTAssertEqual([MSIDOnboardingStatus onboardingPhaseFromString:@"none"], MSIDOnboardingPhaseNone);
+    XCTAssertEqual([MSIDOnboardingStatus onboardingPhaseFromString:@"broker_interactive_in_progress"], MSIDOnboardingPhaseBrokerInteractiveInProgress);
+    XCTAssertEqual([MSIDOnboardingStatus onboardingPhaseFromString:@"mdm_enrollment_in_progress"], MSIDOnboardingPhaseMdmEnrollmentInProgress);
+    XCTAssertEqual([MSIDOnboardingStatus onboardingPhaseFromString:@"failed"], MSIDOnboardingPhaseFailed);
+}
+
+- (void)testOnboardingPhaseFromString_whenCaseInsensitive_shouldParse
+{
+    XCTAssertEqual([MSIDOnboardingStatus onboardingPhaseFromString:@"FAILED"], MSIDOnboardingPhaseFailed);
+    XCTAssertEqual([MSIDOnboardingStatus onboardingPhaseFromString:@"Broker_Interactive_In_Progress"], MSIDOnboardingPhaseBrokerInteractiveInProgress);
+}
+
+- (void)testOnboardingPhaseFromString_whenUnknownValue_shouldReturnNone
+{
+    XCTAssertEqual([MSIDOnboardingStatus onboardingPhaseFromString:@"something_unexpected"], MSIDOnboardingPhaseNone);
+}
+
+- (void)testOnboardingPhaseFromString_whenEmptyString_shouldReturnNone
+{
+    XCTAssertEqual([MSIDOnboardingStatus onboardingPhaseFromString:@""], MSIDOnboardingPhaseNone);
+}
+
+#pragma mark - stringFromPhase
+
+- (void)testStringFromPhase_allValues
+{
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromPhase:MSIDOnboardingPhaseNone], @"none");
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress], @"broker_interactive_in_progress");
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromPhase:MSIDOnboardingPhaseMdmEnrollmentInProgress], @"mdm_enrollment_in_progress");
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromPhase:MSIDOnboardingPhaseFailed], @"failed");
+}
+
+#pragma mark - onboardingContextFromString
+
+- (void)testOnboardingContextFromString_allValues
+{
+    XCTAssertEqual([MSIDOnboardingStatus onboardingContextFromString:@"broker"], MSIDOnboardingContextBroker);
+    XCTAssertEqual([MSIDOnboardingStatus onboardingContextFromString:@"inAppWebview"], MSIDOnboardingContextInAppWebview);
+}
+
+- (void)testOnboardingContextFromString_whenCaseInsensitive_shouldParse
+{
+    XCTAssertEqual([MSIDOnboardingStatus onboardingContextFromString:@"BROKER"], MSIDOnboardingContextBroker);
+    XCTAssertEqual([MSIDOnboardingStatus onboardingContextFromString:@"InAppWebView"], MSIDOnboardingContextInAppWebview);
+}
+
+- (void)testOnboardingContextFromString_whenUnknownValue_shouldReturnUnknown
+{
+    XCTAssertEqual([MSIDOnboardingStatus onboardingContextFromString:@"something_else"], MSIDOnboardingContextUnknown);
+}
+
+- (void)testOnboardingContextFromString_whenEmptyString_shouldReturnUnknown
+{
+    XCTAssertEqual([MSIDOnboardingStatus onboardingContextFromString:@""], MSIDOnboardingContextUnknown);
+}
+
+#pragma mark - stringFromContext
+
+- (void)testStringFromContext_allValues
+{
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextUnknown], @"unknown");
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextBroker], @"broker");
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextInAppWebview], @"inAppWebview");
+}
+
+#pragma mark - reasonCodeFromString
+
+- (void)testReasonCodeFromString_allValues
+{
+    XCTAssertEqual([MSIDOnboardingStatus reasonCodeFromString:@"none"], MSIDOnboardingReasonCodeNone);
+    XCTAssertEqual([MSIDOnboardingStatus reasonCodeFromString:@"user_cancel"], MSIDOnboardingReasonCodeUserCancel);
+    XCTAssertEqual([MSIDOnboardingStatus reasonCodeFromString:@"network"], MSIDOnboardingReasonCodeNetwork);
+    XCTAssertEqual([MSIDOnboardingStatus reasonCodeFromString:@"policy"], MSIDOnboardingReasonCodePolicy);
+    XCTAssertEqual([MSIDOnboardingStatus reasonCodeFromString:@"unknown"], MSIDOnboardingReasonCodeUnknown);
+}
+
+- (void)testReasonCodeFromString_whenCaseInsensitive_shouldParse
+{
+    XCTAssertEqual([MSIDOnboardingStatus reasonCodeFromString:@"USER_CANCEL"], MSIDOnboardingReasonCodeUserCancel);
+    XCTAssertEqual([MSIDOnboardingStatus reasonCodeFromString:@"Network"], MSIDOnboardingReasonCodeNetwork);
+}
+
+- (void)testReasonCodeFromString_whenUnrecognized_shouldReturnUnknown
+{
+    XCTAssertEqual([MSIDOnboardingStatus reasonCodeFromString:@"something_random"], MSIDOnboardingReasonCodeUnknown);
+}
+
+- (void)testReasonCodeFromString_whenEmptyString_shouldReturnUnknown
+{
+    XCTAssertEqual([MSIDOnboardingStatus reasonCodeFromString:@""], MSIDOnboardingReasonCodeUnknown);
+}
+
+#pragma mark - stringFromReasonCode
+
+- (void)testStringFromReasonCode_allValues
+{
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromReasonCode:MSIDOnboardingReasonCodeNone], @"none");
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromReasonCode:MSIDOnboardingReasonCodeUserCancel], @"user_cancel");
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromReasonCode:MSIDOnboardingReasonCodeNetwork], @"network");
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromReasonCode:MSIDOnboardingReasonCodePolicy], @"policy");
+    XCTAssertEqualObjects([MSIDOnboardingStatus stringFromReasonCode:MSIDOnboardingReasonCodeUnknown], @"unknown");
+}
+
+#pragma mark - MSIDOnboardingReason JSON
+
+- (void)testReasonInitWithJSONDictionary_whenValidWithMessage_shouldParse
+{
+    NSDictionary *json = @{
+        @"code" : @"policy",
+        @"message" : @"MDM policy required"
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingReason *reason = [[MSIDOnboardingReason alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(reason);
+    XCTAssertNil(error);
+    XCTAssertEqual(reason.code, MSIDOnboardingReasonCodePolicy);
+    XCTAssertEqualObjects(reason.message, @"MDM policy required");
+}
+
+- (void)testReasonInitWithJSONDictionary_whenCodeOnlyNoMessage_shouldParse
+{
+    NSDictionary *json = @{
+        @"code" : @"user_cancel"
+    };
+
+    NSError *error = nil;
+    MSIDOnboardingReason *reason = [[MSIDOnboardingReason alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(reason);
+    XCTAssertNil(error);
+    XCTAssertEqual(reason.code, MSIDOnboardingReasonCodeUserCancel);
+    XCTAssertNil(reason.message);
+}
+
+- (void)testReasonInitWithJSONDictionary_whenNonDictionary_shouldFail
+{
+    NSError *error = nil;
+    NSArray *notADict = @[@"not", @"a", @"dict"];
+    MSIDOnboardingReason *reason = [[MSIDOnboardingReason alloc] initWithJSONDictionary:(NSDictionary *)notADict error:&error];
+
+    XCTAssertNil(reason);
+    XCTAssertNotNil(error);
+}
+
+- (void)testReasonJsonDictionary_whenMessagePresent_shouldIncludeMessage
+{
+    MSIDOnboardingReason *reason = [[MSIDOnboardingReason alloc] initWithCode:MSIDOnboardingReasonCodeNetwork message:@"Timeout"];
+
+    NSDictionary *json = [reason jsonDictionary];
+
+    XCTAssertEqualObjects(json[@"code"], @"network");
+    XCTAssertEqualObjects(json[@"message"], @"Timeout");
+}
+
+- (void)testReasonJsonDictionary_whenMessageNil_shouldOmitMessage
+{
+    MSIDOnboardingReason *reason = [[MSIDOnboardingReason alloc] initWithCode:MSIDOnboardingReasonCodePolicy message:nil];
+
+    NSDictionary *json = [reason jsonDictionary];
+
+    XCTAssertEqualObjects(json[@"code"], @"policy");
+    XCTAssertNil(json[@"message"]);
+}
+
+@end


### PR DESCRIPTION
This PR is part 1 of 2 splitting #1841 (which is too large to review as one unit). It introduces the onboarding-status data layer; the stacked follow-up PR wires the cache into the broker re-open flow.

## Proposed changes

- Introduce `MSIDOnboardingStatus` model (phase, context, correlationId, originating bundle id, JSON (de)serialization).
- Introduce `MSIDOnboardingStatusCache` — a keychain-backed cache accessor for `MSIDOnboardingStatus` (set/get/clear, owner-override semantics, expiry handling).
- Register the new files in `IdentityCore.xcodeproj/project.pbxproj` for both library and test targets.
- Unit tests: `MSIDOnboardingStatusTests` and `MSIDOnboardingStatusCacheTests`.

No pre-existing source files are modified by this PR (only the project file, and only to add new file references). The cache is not yet consumed by any production code in this PR — that consumer is in the stacked PR.

## PR Checklist (must be completed before review)

- [x] All tests pass locally (`./build.py --targets ios_library` — build + tests succeeded)
- [ ] PR size is <= 500 LOC per PR Size Check policy — exceeds (see Additional information)
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High
- [ ] Medium
- [x] Small — purely additive; no pre-existing source code modified; cache is not yet wired into any production call site.

## Additional information

Replaces #1841 in combination with the stacked follow-up PR. Production LOC is small (~894 across 4 new source files); the additional ~1000 LOC are unit tests written alongside the production code. Splitting tests away from the code they cover was rejected in favor of keeping each PR self-verifiable.
