### PR TITLE
Hotfix 1.24.1

### DIFF
--- a/IdentityCore/src/telemetry/MSIDOnboardingBlobBuilder.m
+++ b/IdentityCore/src/telemetry/MSIDOnboardingBlobBuilder.m
@@ -39,19 +39,6 @@ static NSString *const MSID_ONBOARDING_FIELD_TS = @"ts";
 // as forward-compat passthrough by callers.
 static NSString *const MSID_ONBOARDING_SUPPORTED_SCHEMA_VERSION = @"1.0.0";
 
-// Process-wide serial queue that gates load/mutate/save against the shared
-// NSUserDefaults-backed session correlation cache. Multiple concurrent builders
-// would otherwise race in `persistSessionCorrelation` and lose entries.
-static dispatch_queue_t MSIDOnboardingPersistQueue(void)
-{
-    static dispatch_queue_t queue;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        queue = dispatch_queue_create("com.microsoft.identitycore.onboardingblob.persist", DISPATCH_QUEUE_SERIAL);
-    });
-    return queue;
-}
-
 // Parses `json` into an NSDictionary if and only if the input represents a JSON object.
 // Returns nil for nil/empty/non-JSON/non-dictionary inputs.
 static NSDictionary * _Nullable MSIDOnboardingParseSeedDictionary(NSString * _Nullable json)
@@ -241,7 +228,6 @@ static NSDictionary * _Nullable MSIDOnboardingParseSeedDictionary(NSString * _Nu
 - (void)addBlockingError:(NSString *)errorCode
 {
     [self.blockingErrors addObject:errorCode];
-    [self persistSessionCorrelation];
 }
 
 - (void)setLastLoadedDomain:(NSString *)domain
@@ -308,56 +294,6 @@ static NSDictionary * _Nullable MSIDOnboardingParseSeedDictionary(NSString * _Nu
     }
 
     return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding] ?: @"";
-}
-
-#pragma mark - Private
-
-- (void)persistSessionCorrelation
-{
-    // Snapshot mutable state on the calling thread, then apply load/mutate/save under
-    // a process-wide serial queue. Without this, two concurrent flows recording a
-    // blocking error on different (clientId|target) pairs can read the cache, each
-    // mutate their own copy, and the second write loses the first.
-    NSString *clientId = self.clientId ?: @"";
-    NSString *target = self.target ?: @"";
-    NSString *sessionCorrelationId = self.sessionCorrelationId ?: @"";
-    MSIDSessionCachePersistence *persistence = self.sessionCachePersistence;
-
-    dispatch_async(MSIDOnboardingPersistQueue(), ^{
-        NSString *existing = [persistence load];
-        NSMutableDictionary *cache = [NSMutableDictionary dictionary];
-
-        if (![NSString msidIsStringNilOrBlank:existing])
-        {
-            NSData *data = [existing dataUsingEncoding:NSUTF8StringEncoding];
-
-            if (data)
-            {
-                NSError *error = nil;
-                id parsed = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&error];
-
-                if (!error && [parsed isKindOfClass:[NSDictionary class]])
-                {
-                    [cache addEntriesFromDictionary:parsed];
-                }
-            }
-        }
-
-        NSString *key = [NSString stringWithFormat:@"%@|%@", clientId, target];
-        cache[key] = @{
-            @"id" : sessionCorrelationId,
-            @"ts" : @((long)([[NSDate date] timeIntervalSince1970]))
-        };
-
-        NSError *serializationError = nil;
-        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:cache options:0 error:&serializationError];
-
-        if (!serializationError && jsonData)
-        {
-            NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-            [persistence save:jsonString];
-        }
-    });
 }
 
 @end

--- a/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.h
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 startURL:(NSURL *)startURL
                           callbackScheme:(NSString *)callbackURLScheme
                      useEphemeralSession:(BOOL)useEphemeralSession
-                       additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders API_AVAILABLE(ios(18.0), macos(15.0));
+                       additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders API_AVAILABLE(ios(18.0), macos(15.0), visionos(2.0));
 
 @end
 

--- a/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.m
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDASWebAuthenticationSessionHandler.m
@@ -83,7 +83,7 @@
                                 startURL:(NSURL *)startURL
                           callbackScheme:(NSString *)callbackURLScheme
                      useEphemeralSession:(BOOL)useEphemeralSession
-                       additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders API_AVAILABLE(ios(18.0), macos(15.0))
+                       additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders API_AVAILABLE(ios(18.0), macos(15.0), visionos(2.0))
 {
     return [self initCommonWithParentController:parentController
                                        startURL:startURL
@@ -124,8 +124,8 @@
     self.webAuthSession.presentationContextProvider = self;
     self.webAuthSession.prefersEphemeralWebBrowserSession = self.useEmpheralSession;
     
-    // Set additional headers if available (iOS 18+)
-    if (@available(iOS 18.0, macOS 15.0, *))
+    // Set additional headers if available (iOS 18+, macOS 15+, visionOS 2+)
+    if (@available(iOS 18.0, macOS 15.0, visionOS 2.0, *))
     {
         if (self.additionalHeaders && self.additionalHeaders.count > 0)
         {

--- a/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebViewControllerFactory.m
+++ b/IdentityCore/src/webview/systemWebview/session/MSIDSystemWebViewControllerFactory.m
@@ -64,8 +64,10 @@
                                             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
                                                       context:(__unused id<MSIDRequestContext>)context
 {
-    // Only pass headers to ASWebAuthN on iOS 18+, but method itself is available on all versions
-    if (@available(iOS 18.0, macOS 15.0, *))
+    // Only pass headers to ASWebAuthN when the additionalHeaders initializer is available
+    // (iOS 18+, macOS 15+, visionOS 2+). This factory method remains available on older OS
+    // versions and falls back to the initializer without additionalHeaders.
+    if (@available(iOS 18.0, macOS 15.0, visionOS 2.0, *))
     {
         if (additionalHeaders && additionalHeaders.count > 0)
         {

--- a/IdentityCore/tests/MSIDOnboardingBlobBuilderTests.m
+++ b/IdentityCore/tests/MSIDOnboardingBlobBuilderTests.m
@@ -540,29 +540,6 @@ static NSString * const kCacheKey = @"com.microsoft.oneauth.session_correlation_
     XCTAssertEqualObjects(parsed[@"last_blocking_error"], @"MDM_FLOW");
 }
 
-- (void)testAddBlockingError_whenCalled_shouldPersistSessionCorrelation
-{
-    MSIDOnboardingBlobBuilder *builder = [self builderWithTestDefaults];
-
-    [builder addBlockingError:@"65001"];
-
-    // Persistence happens asynchronously on a serial queue; wait briefly for it to complete.
-    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(__unused id evaluatedObject, __unused NSDictionary<NSString *,id> *bindings) {
-        return [self.testDefaults stringForKey:kCacheKey] != nil;
-    }];
-    [self expectationForPredicate:predicate evaluatedWithObject:nil handler:nil];
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];
-
-    NSString *persisted = [self.testDefaults stringForKey:kCacheKey];
-    XCTAssertNotNil(persisted);
-
-    NSDictionary *cache = [self parsedJsonFromBlob:persisted];
-    NSDictionary *entry = cache[@"clientA|resource1"];
-    XCTAssertNotNil(entry);
-    XCTAssertEqualObjects(entry[@"id"], @"abc-123");
-    XCTAssertNotNil(entry[@"ts"]);
-}
-
 #pragma mark - setLastLoadedDomain
 
 - (void)testSetLastLoadedDomain_whenSet_shouldAppearInBlob

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.24.1
+* Fix visionOS build failure: add visionos(2.0) availability annotation
+* Remove sessionCorrelationId persistence code not required
+
 Version 1.24.0
 * Add MSIDDIContainer dependency-injection container for swizzle-free test seams. (#1807)
 * Add Delos and GovSG sovereign cloud authorities as trusted hosts. (#1813)


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [ ] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## Proposed changes

This pull request primarily removes the session correlation persistence feature from the onboarding telemetry blob builder and updates support for additional headers in authentication sessions to include visionOS. The most significant changes are the elimination of asynchronous persistence logic and related tests, as well as expanding OS support checks for new Apple platforms.

### Removal of session correlation persistence logic

* Deleted the process-wide serial queue and the `persistSessionCorrelation` method from `MSIDOnboardingBlobBuilder`, removing all logic that asynchronously persisted session correlation data to the cache. 
* Removed the call to `persistSessionCorrelation` from the `addBlockingError:` method, so adding a blocking error no longer triggers persistence. (`IdentityCore/src/telemetry/MSIDOnboardingBlobBuilder.m`)
* Deleted the corresponding unit test that checked persistence of session correlation when adding a blocking error. (`IdentityCore/tests/MSIDOnboardingBlobBuilderTests.m`)

### Expansion of platform support for additional headers

* Updated the API availability checks and method signatures for passing additional headers to authentication sessions to include `visionOS 2.0` support, in addition to iOS 18 and macOS 15. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

