### PR TITLE
[patch] [Feature]: Mobile onboarding phase 1 — cache + broker controller integration (2/2)

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -2011,6 +2011,9 @@
 		B4A93B512FA5A656008FE445 /* MSIDSystemWebviewTransitionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B4A93B502FA5A653008FE445 /* MSIDSystemWebviewTransitionManager.h */; };
 		B4A93B532FA5A65C008FE445 /* MSIDSystemWebviewTransitionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A93B522FA5A65A008FE445 /* MSIDSystemWebviewTransitionManager.m */; };
 		B4A93B542FA5A65C008FE445 /* MSIDSystemWebviewTransitionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A93B522FA5A65A008FE445 /* MSIDSystemWebviewTransitionManager.m */; };
+		B4B591B32F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B4B591B22F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m */; };
+		B4B591B42F3AC90600CBA6A9 /* MSIDOnboardingStatusCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B4B591B22F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m */; };
+		B4B591B52F3AC90C00CBA6A9 /* MSIDOnboardingStatusCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B4B591B12F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.h */; };
 		B4C8501629E79E220055B0D3 /* MSIDTestURLSessionUploadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B4C8501429E79E140055B0D3 /* MSIDTestURLSessionUploadTask.m */; };
 		B4C8501729E79E230055B0D3 /* MSIDTestURLSessionUploadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B4C8501429E79E140055B0D3 /* MSIDTestURLSessionUploadTask.m */; };
 		B4C8501829E79E250055B0D3 /* MSIDTestURLSessionUploadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = B4C8501329E79E050055B0D3 /* MSIDTestURLSessionUploadTask.h */; };
@@ -2051,6 +2054,8 @@
 		B4FBF0352EF33A7600EDE1E9 /* MSIDOnboardingStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF0322EF33A7600EDE1E9 /* MSIDOnboardingStatus.m */; };
 		B4FBF0372EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF0362EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m */; };
 		B4FBF0382EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF0362EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m */; };
+		B4FBF0402EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF03F2EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m */; };
+		B4FBF0412EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF03F2EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m */; };
 		B86FA7D42383757100E5195A /* MSIDMacACLKeychainAccessorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B86FA7C62383748000E5195A /* MSIDMacACLKeychainAccessorTests.m */; };
 		B86FA7D52383757600E5195A /* MSIDMacTokenCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B86FA7C72383748000E5195A /* MSIDMacTokenCacheTests.m */; };
 		B86FA7D62383757A00E5195A /* MSIDMacKeychainTokenCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B86FA7C82383748000E5195A /* MSIDMacKeychainTokenCacheTests.m */; };
@@ -3620,6 +3625,8 @@
 		B4A5ACCC21F7ED4500D2A780 /* MSIDAccountCacheItem+MSIDAccountMatchers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDAccountCacheItem+MSIDAccountMatchers.m"; sourceTree = "<group>"; };
 		B4A93B502FA5A653008FE445 /* MSIDSystemWebviewTransitionManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSystemWebviewTransitionManager.h; sourceTree = "<group>"; };
 		B4A93B522FA5A65A008FE445 /* MSIDSystemWebviewTransitionManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSystemWebviewTransitionManager.m; sourceTree = "<group>"; };
+		B4B591B12F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDOnboardingStatusCache.h; sourceTree = "<group>"; };
+		B4B591B22F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatusCache.m; sourceTree = "<group>"; };
 		B4C8501329E79E050055B0D3 /* MSIDTestURLSessionUploadTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDTestURLSessionUploadTask.h; sourceTree = "<group>"; };
 		B4C8501429E79E140055B0D3 /* MSIDTestURLSessionUploadTask.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDTestURLSessionUploadTask.m; sourceTree = "<group>"; };
 		B4CC965F2F982FEA007F281A /* MSIDSessionCachePersistence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSessionCachePersistence.h; sourceTree = "<group>"; };
@@ -3649,6 +3656,7 @@
 		B4FBF0312EF33A7600EDE1E9 /* MSIDOnboardingStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDOnboardingStatus.h; sourceTree = "<group>"; };
 		B4FBF0322EF33A7600EDE1E9 /* MSIDOnboardingStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatus.m; sourceTree = "<group>"; };
 		B4FBF0362EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatusTests.m; sourceTree = "<group>"; };
+		B4FBF03F2EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatusCacheTests.m; sourceTree = "<group>"; };
 		B86FA7C62383748000E5195A /* MSIDMacACLKeychainAccessorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDMacACLKeychainAccessorTests.m; sourceTree = "<group>"; };
 		B86FA7C72383748000E5195A /* MSIDMacTokenCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDMacTokenCacheTests.m; sourceTree = "<group>"; };
 		B86FA7C82383748000E5195A /* MSIDMacKeychainTokenCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDMacKeychainTokenCacheTests.m; sourceTree = "<group>"; };
@@ -5053,6 +5061,8 @@
 		B214C39B1FE854CE0070C4F2 /* accessor */ = {
 			isa = PBXGroup;
 			children = (
+				B4B591B12F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.h */,
+				B4B591B22F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m */,
 				B29CB6D01FEC993D00F880ED /* MSIDLegacyTokenCacheAccessor.h */,
 				B214C39D1FE854FE0070C4F2 /* MSIDLegacyTokenCacheAccessor.m */,
 				B214C3A11FE855290070C4F2 /* MSIDDefaultTokenCacheAccessor.h */,
@@ -6261,6 +6271,7 @@
 				B223B0A222ADEE4500FB8713 /* MSIDMaskedUsernameLogParameterTests.m */,
 				B434A1382F8E475700CCC890 /* MSIDMDMEnrollmentCompletionResponseTests.m */,
 				729357F22DDBD3F60001D03C /* MSIDNonceTokenRequestTest.m */,
+				B4FBF03F2EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m */,
 				B4FBF0362EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m */,
 				B47844F52FB7DF180059EFCD /* MSIDWebviewNavigationDecisionResolverTests.m */,
 				606B108D20D08C9500B34224 /* MSIDOAuth2EmbeddedWebviewControllerTests.m */,
@@ -6479,6 +6490,7 @@
 				58BC2392271E0D94008A77BE /* MSIDSSOExtensionGetSsoCookiesRequest.h in Headers */,
 				B4FDC6F72F3EFFD300091B6C /* MSIDWebviewNavigationDecisionResolver.h in Headers */,
 				2A24814E2CB06A1A006FCB34 /* MSIDSSORemoteSilentTokenRequest.h in Headers */,
+				B4B591B52F3AC90C00CBA6A9 /* MSIDOnboardingStatusCache.h in Headers */,
 				B217863823A5994300839CE8 /* MSIDSSOExtensionSignoutController.h in Headers */,
 				A0C7DE4425D4522300F5B5B6 /* MSIDThrottlingModelFactory.h in Headers */,
 				B286B9942389DC76007833AD /* MSIDDefaultTokenRequestProvider+Internal.h in Headers */,
@@ -7514,6 +7526,7 @@
 				23CA0C5F220A68D400768729 /* MSIDPkeyAuthHelperTests.m in Sources */,
 				B274DEC721FC002300DB7757 /* MSIDInteractiveTokenRequestParametersTests.m in Sources */,
 				B4FBF0382EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m in Sources */,
+				B4FBF0412EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m in Sources */,
 				2376D8DD2D88FDE900ADC271 /* MSIDBrowserNativeMessageGetSupportedContractsResponseTests.m in Sources */,
 				5828740724D49C4100466916 /* MSIDBrokerRedirectUriTest.m in Sources */,
 				583BFCB124D907410035B901 /* MSIDRedirectUriVerifierTests.m in Sources */,
@@ -7908,6 +7921,7 @@
 				B23ECEF11FF2F6270015FC1D /* MSIDAADV2IdTokenClaims.m in Sources */,
 				239EED6A242D8FAD00162F0F /* MSIDAADTokenRequestServerTelemetry.m in Sources */,
 				B2C0748D246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m in Sources */,
+				B4B591B42F3AC90600CBA6A9 /* MSIDOnboardingStatusCache.m in Sources */,
 				9641B5251FCF3EEF00AFA0EC /* MSIDMacTokenCache.m in Sources */,
 				728209D126FEA0F600B5F018 /* MSIDKeyOperationUtil.m in Sources */,
 				962EA03E2190D4930049C4C8 /* MSIDCertAuthHandler.m in Sources */,
@@ -8326,6 +8340,7 @@
 				23D00DA92ABD0805006D7F16 /* MSIDBrowserNativeMessageGetTokenRequestTests.m in Sources */,
 				B431B5452AF1E5050020CD3D /* MSIDSSOExtensionPasskeyCredentialRequestTests.m in Sources */,
 				B4FBF0372EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m in Sources */,
+				B4FBF0402EF44BBB00EDE1E9 /* MSIDOnboardingStatusCacheTests.m in Sources */,
 				2361DE8C2048B6F8005FD48A /* MSIDAccountTests.m in Sources */,
 				B2DD5BA5204761720084313F /* MSIDRefreshTokenTests.m in Sources */,
 				23AE9DBC2148574F00B285F3 /* MSIDErrorExtensionsTests.m in Sources */,
@@ -8570,6 +8585,7 @@
 				B2AF1D2F218BCEDE0080C1A0 /* MSIDInteractiveTokenRequest.m in Sources */,
 				2394F1FE2D4893DA00E44F6E /* MSIDWebWPJOperation.m in Sources */,
 				B227035A22A3678A00030ADC /* MSIDMaskedUsernameLogParameter.m in Sources */,
+				B4B591B32F3AC8ED00CBA6A9 /* MSIDOnboardingStatusCache.m in Sources */,
 				96A2D5A8209D102900F80E3A /* MSIDAuthorizeWebRequestConfiguration.m in Sources */,
 				B23ECEF01FF2F6270015FC1D /* MSIDAADV2IdTokenClaims.m in Sources */,
 				60B3855E20A96E0600D546D0 /* MSIDWebviewUIController.m in Sources */,

--- a/IdentityCore/src/MSIDBrokerConstants.h
+++ b/IdentityCore/src/MSIDBrokerConstants.h
@@ -95,6 +95,7 @@ extern NSString * _Nonnull const MSID_BROKER_ACCOUNT_HOME_TENANT_ID;
 extern NSString * _Nonnull const MSID_CLIENT_SKU_KEY;
 extern NSString * _Nonnull const MSID_SKIP_VALIDATE_RESULT_ACCOUNT_KEY;
 extern NSString * _Nonnull const MSID_JIT_TROUBLESHOOTING_HOST;
+extern NSString * _Nonnull const MSID_IGNORE_BROKER_REQUEST;
 extern NSString * _Nonnull const MSID_IS_CALLER_MANAGED_KEY;
 extern NSString * _Nonnull const MSID_BROKER_PREFERRED_AUTH_CONFIGURATION_KEY;
 extern NSString * _Nonnull const MSID_BROKER_CLIENT_FLIGHTS_KEY;

--- a/IdentityCore/src/MSIDBrokerConstants.m
+++ b/IdentityCore/src/MSIDBrokerConstants.m
@@ -95,6 +95,7 @@ NSString *const MSID_PRIMARY_REGISTRATION_CLOUD = @"primary_registration_metadat
 NSString *const MSID_PRIMARY_REGISTRATION_CERTIFICATE_THUMBPRINT = @"primary_registration_metadata_certificate_thumbprint";
 NSString *const MSID_PLATFORM_SSO_STATUS_KEY = @"platform_sso_status";
 NSString *const MSID_JIT_TROUBLESHOOTING_HOST = @"jit_troubleshooting";
+NSString *const MSID_IGNORE_BROKER_REQUEST = @"ignore_broker_request";
 NSString *const MSID_IS_CALLER_MANAGED_KEY = @"isCallerAppManaged";
 NSString *const MSID_BROKER_SDM_WPJ_ATTEMPTED = @"sdm_reg_attempted";
 NSString *const MSID_BART_DEVICE_ID_KEY = @"bart_device_id";

--- a/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.h
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@class MSIDOnboardingStatus;
+@protocol MSIDRequestContext;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Cache accessor for reading and writing MSIDOnboardingStatus items to the keychain.
+ This class uses MSIDKeychainTokenCache.defaultKeychainGroup as its data source.
+ */
+@interface MSIDOnboardingStatusCache : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ Shared instance of MSIDOnboardingStatusCache using the default keychain group.
+ */
+@property (class, readonly, nonnull) MSIDOnboardingStatusCache *sharedInstance;
+
+/**
+ Sets the onboarding status.
+ 
+ @param status The MSIDOnboardingStatus to set.
+ @return YES if the operation succeeds, NO otherwise.
+ */
+- (BOOL)setWithStatus:(MSIDOnboardingStatus *)status;
+
+/**
+ Gets the current onboarding status.
+ 
+ @return The MSIDOnboardingStatus representing the current status. If no status is stored, a default status object is returned.
+ */
+- (MSIDOnboardingStatus *)getOnboardingStatus;
+
+/**
+ Clears the onboarding status for a specific bundle identifier.
+ 
+ @param bundleId The bundle identifier to clear the status for.
+ @return YES if the operation succeeds, NO otherwise.
+ */
+- (BOOL)clear:(NSString *)bundleId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.m
@@ -1,0 +1,419 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDOnboardingStatusCache.h"
+#import "MSIDTokenCacheDataSource.h"
+#import "MSIDKeychainTokenCache.h"
+#import "MSIDOnboardingStatus.h"
+#import "MSIDCacheKey.h"
+#import "MSIDCacheItemJsonSerializer.h"
+#import "MSIDJsonObject.h"
+#import "MSIDError.h"
+#import "MSIDLogger+Internal.h"
+#import "NSString+MSIDExtensions.h"
+
+static NSString *const MSID_ONBOARDING_STATUS_CACHE_SERVICE = @"OnboardingStatus";
+static NSString *const MSID_ONBOARDING_STATUS_CACHE_ACCOUNT = @"com.microsoft.onboardingStatus";
+
+@interface MSIDOnboardingStatusCache ()
+{
+    dispatch_queue_t _accessQueue;
+}
+
+@property (nonatomic) id<MSIDExtendedTokenCacheDataSource> dataSource;
+@property (nonatomic) MSIDCacheItemJsonSerializer *serializer;
+
+- (MSIDOnboardingStatus *)readOnboardingStatusWithCorrelationIdLocked:(NSUUID *)correlationId
+                                                               error:(NSError *__autoreleasing *)error;
+- (BOOL)writeOnboardingStatusLocked:(MSIDOnboardingStatus *)status
+                              error:(NSError *__autoreleasing *)error;
+- (BOOL)removeOnboardingStatusWithContextLocked:(id<MSIDRequestContext>)context
+                                          error:(NSError *__autoreleasing *)error;
+- (BOOL)setWithStatusLocked:(MSIDOnboardingStatus *)status;
+- (MSIDOnboardingStatus *)getOnboardingStatusLocked;
+- (BOOL)clearLocked:(NSString *)bundleId;
+- (BOOL)isOwnerOverride:(MSIDOnboardingStatus *)status;
+- (BOOL)caseInsensitiveString:(NSString *)left matchesString:(NSString *)right;
+
+@end
+
+@implementation MSIDOnboardingStatusCache
+
+#pragma mark - Shared Instance
+
++ (MSIDOnboardingStatusCache *)sharedInstance
+{
+    static MSIDOnboardingStatusCache *singleton = nil;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        singleton = [[self alloc] init];
+    });
+
+    return singleton;
+}
+
+#pragma mark - Init
+
+- (instancetype)init
+{
+    self = [super init];
+
+    if (self)
+    {
+        _dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:MSIDKeychainTokenCache.defaultKeychainGroup error:nil];
+        _serializer = [[MSIDCacheItemJsonSerializer alloc] init];
+        _accessQueue = dispatch_queue_create("com.microsoft.identity.onboardingStatusCache", DISPATCH_QUEUE_SERIAL);
+    }
+
+    return self;
+}
+
+#pragma mark - Cache Key
+
+- (MSIDCacheKey *)cacheKey
+{
+    return [[MSIDCacheKey alloc] initWithAccount:MSID_ONBOARDING_STATUS_CACHE_ACCOUNT
+                                         service:MSID_ONBOARDING_STATUS_CACHE_SERVICE
+                                         generic:nil
+                                            type:nil];
+}
+
+#pragma mark - Read
+
+- (MSIDOnboardingStatus *)readOnboardingStatusWithCorrelationId:(NSUUID *)correlationId
+                                                          error:(NSError *__autoreleasing *)error
+{
+    __block MSIDOnboardingStatus *status = nil;
+    dispatch_sync(_accessQueue, ^{
+        status = [self readOnboardingStatusWithCorrelationIdLocked:correlationId error:error];
+    });
+
+    return status;
+}
+
+- (MSIDOnboardingStatus *)readOnboardingStatusWithCorrelationIdLocked:(NSUUID *)correlationId
+                                                               error:(NSError *__autoreleasing *)error
+{
+    MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) Reading onboarding status from cache");
+
+    MSIDCacheKey *key = [self cacheKey];
+
+    NSArray<MSIDJsonObject *> *jsonObjects = [self.dataSource jsonObjectsWithKey:key
+                                                                      serializer:self.serializer
+                                                                         context:nil
+                                                                           error:error];
+
+    if (!jsonObjects || jsonObjects.count == 0)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) No onboarding status found in cache");
+        return nil;
+    }
+
+    if (jsonObjects.count > 1)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelWarning, correlationId, @"(MSIDOnboardingStatusCache) Multiple onboarding status items found in cache, using the first one");
+    }
+
+    MSIDJsonObject *jsonObject = jsonObjects.firstObject;
+    NSDictionary *jsonDictionary = [jsonObject jsonDictionary];
+
+    if (!jsonDictionary)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to get JSON dictionary from cached item");
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Failed to deserialize onboarding status from cache.", nil, nil, nil, correlationId, nil, YES);
+        }
+        return nil;
+    }
+
+    NSError *deserializationError = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:jsonDictionary error:&deserializationError];
+
+    if (!status)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to deserialize onboarding status: %@", deserializationError);
+        if (error)
+        {
+            *error = deserializationError;
+        }
+        return nil;
+    }
+
+    MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) Successfully read onboarding status from cache");
+    return status;
+}
+
+#pragma mark - Write
+
+- (BOOL)writeOnboardingStatus:(MSIDOnboardingStatus *)status
+                        error:(NSError *__autoreleasing *)error
+{
+    __block BOOL success = NO;
+    dispatch_sync(_accessQueue, ^{
+        success = [self writeOnboardingStatusLocked:status error:error];
+    });
+
+    return success;
+}
+
+- (BOOL)writeOnboardingStatusLocked:(MSIDOnboardingStatus *)status
+                              error:(NSError *__autoreleasing *)error
+{
+    if (!status)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, nil, @"(MSIDOnboardingStatusCache) Cannot write nil onboarding status");
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"Onboarding status cannot be nil.", nil, nil, nil, nil, nil, YES);
+        }
+        return NO;
+    }
+
+    NSUUID *correlationId = status.correlationId;
+
+    MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) Writing onboarding status to cache");
+
+    NSDictionary *jsonDictionary = [status jsonDictionary];
+
+    if (!jsonDictionary)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to serialize onboarding status to JSON");
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Failed to serialize onboarding status.", nil, nil, nil, correlationId, nil, YES);
+        }
+        return NO;
+    }
+
+    NSError *initError = nil;
+    MSIDJsonObject *jsonObject = [[MSIDJsonObject alloc] initWithJSONDictionary:jsonDictionary error:&initError];
+
+    if (!jsonObject)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to create JSON object: %@", initError);
+        if (error)
+        {
+            *error = initError;
+        }
+        return NO;
+    }
+
+    MSIDCacheKey *key = [self cacheKey];
+
+    BOOL success = [self.dataSource saveJsonObject:jsonObject
+                                        serializer:self.serializer
+                                               key:key
+                                           context:nil
+                                             error:error];
+
+    if (success)
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelInfo, correlationId, @"(MSIDOnboardingStatusCache) Successfully wrote onboarding status to cache");
+    }
+    else
+    {
+        MSID_LOG_WITH_CORR(MSIDLogLevelError, correlationId, @"(MSIDOnboardingStatusCache) Failed to write onboarding status to cache");
+    }
+
+    return success;
+}
+
+#pragma mark - Remove
+
+- (BOOL)removeOnboardingStatusWithContext:(id<MSIDRequestContext>)context
+                                    error:(NSError *__autoreleasing *)error
+{
+    __block BOOL success = NO;
+    dispatch_sync(_accessQueue, ^{
+        success = [self removeOnboardingStatusWithContextLocked:context error:error];
+    });
+
+    return success;
+}
+
+- (BOOL)removeOnboardingStatusWithContextLocked:(id<MSIDRequestContext>)context
+                                          error:(NSError *__autoreleasing *)error
+{
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(MSIDOnboardingStatusCache) Removing onboarding status from cache");
+
+    MSIDCacheKey *key = [self cacheKey];
+
+    // Using removeAccountsWithKey as it internally delegates to removeItemsWithKey
+    BOOL success = [self.dataSource removeAccountsWithKey:key
+                                                  context:context
+                                                    error:error];
+
+    if (success)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"(MSIDOnboardingStatusCache) Successfully removed onboarding status from cache");
+    }
+    else
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"(MSIDOnboardingStatusCache) Failed to remove onboarding status from cache");
+    }
+
+    return success;
+}
+
+#pragma mark - Public Convenience Methods
+
+- (BOOL)isOwnerOverride:(MSIDOnboardingStatus *)status
+{
+    // This method checks if the onboarding status is owned by the current running app.
+    NSString *currentBundleId = [[NSBundle mainBundle] bundleIdentifier];
+    return [self caseInsensitiveString:currentBundleId matchesString:status.ownerBundleId];
+}
+
+- (BOOL)setWithStatus:(MSIDOnboardingStatus *)status
+{
+    __block BOOL success = NO;
+    dispatch_sync(_accessQueue, ^{
+        success = [self setWithStatusLocked:status];
+    });
+
+    return success;
+}
+
+- (BOOL)setWithStatusLocked:(MSIDOnboardingStatus *)status
+{
+    if (!status)
+    {
+        return NO;
+    }
+
+    MSIDOnboardingStatus *current = [self getOnboardingStatusLocked];
+
+    // If there's an existing status with a phase other than none, validate that the new status is either
+    // from the same originating bundle or is an owner override. This prevents different apps from overwriting
+    // each other's onboarding status.
+    if (current && current.phase != MSIDOnboardingPhaseNone)
+    {
+        BOOL originatingBundleMatches = [self caseInsensitiveString:current.originatingBundleId matchesString:status.originatingBundleId];
+
+        // Validate ownership or self-override
+        if (!originatingBundleMatches && ![self isOwnerOverride:status])
+        {
+            return NO;
+        }
+    }
+
+    // Write to Keychain using shared access group
+    return [self writeOnboardingStatusLocked:status error:nil];
+}
+
+- (MSIDOnboardingStatus *)getOnboardingStatus
+{
+    __block MSIDOnboardingStatus *status = nil;
+    dispatch_sync(_accessQueue, ^{
+        status = [self getOnboardingStatusLocked];
+    });
+
+    return status;
+}
+
+- (MSIDOnboardingStatus *)getOnboardingStatusLocked
+{
+    MSIDOnboardingStatus *status = [self readOnboardingStatusWithCorrelationIdLocked:nil error:nil];
+
+    if (!status)
+    {
+        // return new status with phase set to none
+        return [MSIDOnboardingStatus new];
+    }
+
+    if (!status.startedAt)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(MSIDOnboardingStatusCache) Onboarding status is missing startedAt, removing from cache");
+        [self removeOnboardingStatusWithContextLocked:nil error:nil];
+        // return new status with phase set to none
+        return [MSIDOnboardingStatus new];
+    }
+
+    // Check TTL and remove if expired (status.startedAt + status.ttlSeconds < now)
+    NSDate *expirationDate = [status.startedAt dateByAddingTimeInterval:status.ttlSeconds];
+    if ([expirationDate timeIntervalSinceNow] < 0)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(MSIDOnboardingStatusCache) Onboarding status is expired, removing from cache");
+        [self removeOnboardingStatusWithContextLocked:nil error:nil];
+        // return new status with phase set to none
+        return [MSIDOnboardingStatus new];
+    }
+
+    return status;
+}
+
+- (BOOL)clear:(NSString *)bundleId
+{
+    __block BOOL success = NO;
+    dispatch_sync(_accessQueue, ^{
+        success = [self clearLocked:bundleId];
+    });
+
+    return success;
+}
+
+- (BOOL)clearLocked:(NSString *)bundleId
+{
+    if ([NSString msidIsStringNilOrBlank:bundleId])
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"(MSIDOnboardingStatusCache) Cannot clear with nil bundleId");
+        return NO;
+    }
+
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(MSIDOnboardingStatusCache) Clearing onboarding status for bundleId: %@", bundleId);
+
+    MSIDOnboardingStatus *current = [self getOnboardingStatusLocked];
+
+    // If there's no existing status or the phase is none, there's nothing to clear
+    if (!current || current.phase == MSIDOnboardingPhaseNone)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(MSIDOnboardingStatusCache) No onboarding status found to clear");
+        return YES;
+    }
+
+    BOOL ownerBundleMatches = [self caseInsensitiveString:current.ownerBundleId matchesString:bundleId];
+    BOOL originatingBundleMatches = [self caseInsensitiveString:current.originatingBundleId matchesString:bundleId];
+
+    // If the current status matches the bundleId (checking ownerBundleId or originatingBundleId), remove it
+    if (!ownerBundleMatches && !originatingBundleMatches)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"(MSIDOnboardingStatusCache) BundleId does not match current status, nothing to clear");
+        return NO;
+    }
+
+    return [self removeOnboardingStatusWithContextLocked:nil error:nil];
+}
+
+- (BOOL)caseInsensitiveString:(NSString *)left matchesString:(NSString *)right
+{
+    if ([NSString msidIsStringNilOrBlank:left] || [NSString msidIsStringNilOrBlank:right])
+    {
+        return NO;
+    }
+
+    return [left caseInsensitiveCompare:right] == NSOrderedSame;
+}
+
+@end

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -49,8 +49,14 @@
 #import "MSIDDefaultTokenCacheAccessor.h"
 #import "MSIDExecutionFlowLogger.h"
 #import "MSIDExecutionFlowConstants.h"
+#import "MSIDLogger+Internal.h"
+#import "NSURL+MSIDExtensions.h"
+#import "MSIDOnboardingStatus.h"
+#import "MSIDOnboardingStatusCache.h"
+#import "MSIDBrokerConstants.h"
 
 static MSIDBrokerInteractiveController *s_currentExecutingController;
+static MSIDBrokerTokenRequest *s_currentBrokerRequest;
 
 @interface MSIDBrokerInteractiveController()
 
@@ -58,6 +64,7 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
 @property (nonatomic, readwrite) MSIDBrokerKeyProvider *brokerKeyProvider;
 @property (nonatomic, readonly) NSURL *brokerInstallLink;
 @property (atomic, copy) MSIDRequestCompletionBlock requestCompletionBlock;
+@property (nonatomic, readwrite) BOOL isReplayRequest;
 
 @end
 
@@ -235,6 +242,22 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
         return;
     }
     
+    self.isReplayRequest = NO;
+    [self.class setCurrentBrokerRequest:brokerRequest];
+    // Phase 1, do not show UI to users, just save the current onboarding status for the current MSAL client, and overwrite it.
+    // This is to return to Authenticator with the same request if it was initiated from the same app.
+    // We are letting broker handle authentication, so broker is the owner
+    MSIDOnboardingStatus *onboardingStatus = [[MSIDOnboardingStatus alloc] initWithPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                                                       onboardingContext:MSIDOnboardingContextBroker
+                                                                           ownerBundleId:MSID_BROKER_APP_BUNDLE_ID
+                                                                           correlationId:self.requestParameters.correlationId];
+    
+    BOOL didPersistOnboardingStatus = [[MSIDOnboardingStatusCache sharedInstance] setWithStatus:onboardingStatus];
+    if (!didPersistOnboardingStatus)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.requestParameters, @"Failed to persist onboarding status for broker interactive request replay.");
+    }
+    
     NSDictionary *brokerResumeDictionary = brokerRequest.resumeDictionary;
     [[NSUserDefaults standardUserDefaults] setObject:brokerResumeDictionary forKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
 
@@ -250,6 +273,13 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
     CONDITIONAL_START_EVENT(CONDITIONAL_SHARED_INSTANCE, self.requestParameters.telemetryRequestId, MSID_TELEMETRY_EVENT_LAUNCH_BROKER);
 
     NSURL *brokerRequestURL = brokerRequest.brokerRequestURL;
+    
+#if !TARGET_OS_OSX
+    if (self.isReplayRequest)
+    {
+        brokerRequestURL = [brokerRequestURL msidURLWithQueryParameters:@{MSID_IGNORE_BROKER_REQUEST: @"1"}];
+    }
+#endif
 
     NSURL *launchURL = _brokerInstallLink ? _brokerInstallLink : brokerRequestURL;
     BOOL firstTimeInstall = _brokerInstallLink != nil;
@@ -393,9 +423,41 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
 
     if ([self.class currentBrokerController])
     {
-        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorBrokerResponseNotReceived, @"application did not receive response from broker.", nil, nil, nil, nil, nil, YES);
-
         MSIDBrokerInteractiveController *brokerController = [self.class currentBrokerController];
+        
+        // Go back to broker
+        BOOL returnToBroker = NO;
+        // First read from Keychain to see if we have a request in progress from this app
+        MSIDOnboardingStatus *onboardingStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+        NSString *originatingBundleId = onboardingStatus.originatingBundleId;
+        NSString *currentBundleId = [NSBundle.mainBundle bundleIdentifier];
+        if (onboardingStatus.phase == MSIDOnboardingPhaseBrokerInteractiveInProgress &&
+            onboardingStatus.onboardingContext == MSIDOnboardingContextBroker &&
+            originatingBundleId.length > 0 && currentBundleId.length > 0 &&
+            [originatingBundleId caseInsensitiveCompare:currentBundleId] == NSOrderedSame)
+        {
+            returnToBroker = YES;
+        }
+        
+        if (returnToBroker)
+        {
+            if ([self canPerformRequest:brokerController.interactiveParameters])
+            {
+                MSIDBrokerTokenRequest *brokerRequest = [self currentBrokerRequest];
+                if (brokerRequest)
+                {
+                    brokerController.isReplayRequest = YES;
+                    
+                    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, brokerController.requestParameters, @"Returning request to broker app to continue authentication.");
+                    [brokerController callBrokerWithRequest:brokerRequest];
+                    
+                    return;
+                }
+            }
+        }
+        
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorBrokerResponseNotReceived, @"Application did not receive response from broker.", nil, nil, nil, nil, nil, YES);
+
         [brokerController completeAcquireTokenWithResult:nil error:error];
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
     }
@@ -448,15 +510,41 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
     CONDITIONAL_STOP_EVENT(CONDITIONAL_SHARED_INSTANCE, self.requestParameters.telemetryRequestId, brokerEvent);
 #endif
 
+    if (error)
+    {
+        MSIDOnboardingStatus *status = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+        if (status && status.phase != MSIDOnboardingPhaseNone)
+        {
+            status.phase = MSIDOnboardingPhaseFailed;
+            [[MSIDOnboardingStatusCache sharedInstance] setWithStatus:status];
+        }
+    }
+    else
+    {
+        NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
+        if (!bundleId)
+        {
+            MSIDOnboardingStatus *status = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+            bundleId = status.originatingBundleId ?: status.ownerBundleId;
+        }
+        
+        if (bundleId)
+        {
+            [MSIDOnboardingStatusCache.sharedInstance clear:bundleId];
+        }
+    }
+    
     if (self.requestCompletionBlock)
     {
         MSIDRequestCompletionBlock requestCompletion = [self copyAndClearCompletionBlock];
         requestCompletion(tokenResult, error);
         [self.class setCurrentBrokerController:nil];
+        [self.class setCurrentBrokerRequest:nil];
         return YES;
     }
 
     [self.class setCurrentBrokerController:nil];
+    [self.class setCurrentBrokerRequest:nil];
     return NO;
 }
 
@@ -502,6 +590,13 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
 #endif
     
     [self.class setCurrentBrokerController:nil];
+    [self.class setCurrentBrokerRequest:nil];
+
+    NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
+    if (![NSString msidIsStringNilOrBlank:bundleId])
+    {
+        [[MSIDOnboardingStatusCache sharedInstance] clear:bundleId];
+    }
     
     MSIDRequestCompletionBlock completionBlock = [self copyAndClearCompletionBlock];
     
@@ -548,6 +643,22 @@ static MSIDBrokerInteractiveController *s_currentExecutingController;
 {
     @synchronized ([self class]) {
         return s_currentExecutingController;
+    }
+}
+
+#pragma mark - Current request
+
++ (void)setCurrentBrokerRequest:(MSIDBrokerTokenRequest *)currentBrokerRequest
+{
+    @synchronized ([self class]) {
+        s_currentBrokerRequest = currentBrokerRequest;
+    }
+}
+
++ (MSIDBrokerTokenRequest *)currentBrokerRequest
+{
+    @synchronized ([self class]) {
+        return s_currentBrokerRequest;
     }
 }
 

--- a/IdentityCore/tests/MSIDOnboardingStatusCacheTests.m
+++ b/IdentityCore/tests/MSIDOnboardingStatusCacheTests.m
@@ -1,0 +1,636 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDOnboardingStatusCache.h"
+#import "MSIDOnboardingStatus.h"
+#import "MSIDTestCacheDataSource.h"
+#import "MSIDCacheItemJsonSerializer.h"
+#import "MSIDBrokerConstants.h"
+#import "MSIDCacheKey.h"
+#import "MSIDJsonObject.h"
+
+@interface MSIDOnboardingStatusCache ()
+
+@property (nonatomic) id<MSIDExtendedTokenCacheDataSource> dataSource;
+@property (nonatomic) MSIDCacheItemJsonSerializer *serializer;
+
+- (MSIDCacheKey *)cacheKey;
+- (BOOL)isOwnerOverride:(MSIDOnboardingStatus *)status;
+
+@end
+
+@interface MSIDOnboardingStatusCacheTests : XCTestCase
+
+@property (nonatomic) MSIDOnboardingStatusCache *cache;
+@property (nonatomic) MSIDTestCacheDataSource *testDataSource;
+@property (nonatomic) id<MSIDExtendedTokenCacheDataSource> originalDataSource;
+
+@end
+
+@implementation MSIDOnboardingStatusCacheTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.cache = MSIDOnboardingStatusCache.sharedInstance;
+    self.originalDataSource = MSIDOnboardingStatusCache.sharedInstance.dataSource;
+    self.testDataSource = [MSIDTestCacheDataSource new];
+    self.cache.dataSource = self.testDataSource;
+}
+
+- (void)tearDown
+{
+    // Reset to clean state
+    [self.testDataSource reset];
+    MSIDOnboardingStatusCache.sharedInstance.dataSource = self.originalDataSource;
+    [super tearDown];
+}
+
+#pragma mark - Helper
+
+- (MSIDOnboardingStatus *)statusWithOwner:(NSString *)ownerBundleId
+                                    phase:(MSIDOnboardingPhase)phase
+                               ttlSeconds:(NSInteger)ttl
+                                startedAt:(NSDate *)startedAt
+{
+    return [self statusWithOwner:ownerBundleId
+                     originating:@"com.microsoft.teams"
+                           phase:phase
+                      ttlSeconds:ttl
+                       startedAt:startedAt];
+}
+
+- (MSIDOnboardingStatus *)statusWithOwner:(NSString *)ownerBundleId
+                              originating:(NSString *)originatingBundleId
+                                    phase:(MSIDOnboardingPhase)phase
+                               ttlSeconds:(NSInteger)ttl
+                                startedAt:(NSDate *)startedAt
+{
+    NSMutableDictionary *json = [NSMutableDictionary dictionary];
+    json[@"version"] = @1;
+    json[@"phase"] = [MSIDOnboardingStatus stringFromPhase:phase];
+    json[@"context"] = [MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextBroker];
+    json[@"ownerBundleId"] = ownerBundleId;
+    json[@"originatingBundleId"] = originatingBundleId;
+    json[@"originatingDisplayName"] = @"Teams";
+    json[@"correlationId"] = @"00000000-0000-0000-0000-000000000000";
+    json[@"ttlSeconds"] = @(ttl);
+    
+    if (startedAt)
+    {
+        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+        formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+        formatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+        json[@"startedAt"] = [formatter stringFromDate:startedAt];
+    }
+    
+    json[@"reason"] = @{@"code": @"none", @"message": @""};
+    
+    NSError *error = nil;
+    MSIDOnboardingStatus *status = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+    XCTAssertNotNil(status, @"Failed to create status: %@", error);
+    return status;
+}
+
+- (NSString *)isoStringFromDate:(NSDate *)date
+{
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    formatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+    return [formatter stringFromDate:date];
+}
+
+- (NSMutableDictionary *)statusJSONWithPhase:(MSIDOnboardingPhase)phase
+                               correlationId:(NSString *)correlationId
+                                    startedAt:(NSDate *)startedAt
+{
+    NSMutableDictionary *json = [NSMutableDictionary dictionary];
+    json[@"version"] = @1;
+    json[@"phase"] = [MSIDOnboardingStatus stringFromPhase:phase];
+    json[@"context"] = [MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextBroker];
+    json[@"originatingDisplayName"] = @"Teams";
+    json[@"correlationId"] = correlationId;
+    json[@"ttlSeconds"] = @900;
+    json[@"reason"] = @{@"code": @"none", @"message": @""};
+
+    if (startedAt)
+    {
+        json[@"startedAt"] = [self isoStringFromDate:startedAt];
+    }
+
+    return json;
+}
+
+- (BOOL)writeStatusJSONDirectly:(NSDictionary *)json
+{
+    NSError *error = nil;
+    MSIDJsonObject *jsonObject = [[MSIDJsonObject alloc] initWithJSONDictionary:json error:&error];
+    XCTAssertNotNil(jsonObject, @"Failed to create JSON object: %@", error);
+
+    BOOL result = [self.testDataSource saveJsonObject:jsonObject
+                                           serializer:self.cache.serializer
+                                                  key:[self.cache cacheKey]
+                                              context:nil
+                                                error:&error];
+    XCTAssertTrue(result, @"Failed to write status JSON directly: %@", error);
+    return result;
+}
+
+- (NSArray<MSIDJsonObject *> *)readStatusJSONDirectly
+{
+    NSError *error = nil;
+    NSArray<MSIDJsonObject *> *jsonObjects = [self.testDataSource jsonObjectsWithKey:[self.cache cacheKey]
+                                                                          serializer:self.cache.serializer
+                                                                             context:nil
+                                                                               error:&error];
+    XCTAssertNotNil(jsonObjects, @"Failed to read status JSON directly: %@", error);
+    return jsonObjects;
+}
+
+#pragma mark - getOnboardingStatus
+
+- (void)testGetOnboardingStatus_whenNothingCached_shouldReturnDefaultStatus
+{
+    MSIDOnboardingStatus *status = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(status);
+    XCTAssertEqual(status.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testGetOnboardingStatus_whenStatusCached_shouldReturnCachedStatus
+{
+    MSIDOnboardingStatus *original = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                     phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                                ttlSeconds:900
+                                                 startedAt:[NSDate date]];
+
+    BOOL writeResult = [self.cache setWithStatus:original];
+    XCTAssertTrue(writeResult);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(retrieved);
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+    XCTAssertEqualObjects(retrieved.ownerBundleId, @"com.microsoft.azureauthenticator");
+}
+
+- (void)testGetOnboardingStatus_whenStatusExpired_shouldReturnDefaultStatus
+{
+    // Create a status that started 2000 seconds ago with a 900-second TTL
+    NSDate *pastDate = [NSDate dateWithTimeIntervalSinceNow:-2000];
+    MSIDOnboardingStatus *expired = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                    phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                               ttlSeconds:900
+                                                startedAt:pastDate];
+
+    [self.cache setWithStatus:expired];
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(retrieved);
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testGetOnboardingStatus_whenStatusNotExpired_shouldReturnCachedStatus
+{
+    NSDate *recentDate = [NSDate dateWithTimeIntervalSinceNow:-100];
+    MSIDOnboardingStatus *valid = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                  phase:MSIDOnboardingPhaseFailed
+                                             ttlSeconds:900
+                                              startedAt:recentDate];
+
+    [self.cache setWithStatus:valid];
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(retrieved);
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseFailed);
+}
+
+#pragma mark - setWithStatus
+
+- (void)testSetWithStatus_whenNilStatus_shouldReturnNO
+{
+    MSIDOnboardingStatus *nilStatus = nil;
+    BOOL result = [self.cache setWithStatus:nilStatus];
+
+    XCTAssertFalse(result);
+}
+
+- (void)testSetWithStatus_whenNothingCached_shouldSucceed
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:status];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testSetWithStatus_whenSameOriginatingBundleId_shouldSucceed
+{
+    MSIDOnboardingStatus *first = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                            originating:@"com.microsoft.teams"
+                                                  phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                             ttlSeconds:900
+                                              startedAt:[NSDate date]];
+    [self.cache setWithStatus:first];
+
+    MSIDOnboardingStatus *second = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:second];
+
+    XCTAssertTrue(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseMdmEnrollmentInProgress);
+}
+
+- (void)testSetWithStatus_whenDifferentOriginatingBundleId_shouldReturnNO
+{
+    MSIDOnboardingStatus *first = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                            originating:@"com.microsoft.teams"
+                                                  phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                             ttlSeconds:900
+                                              startedAt:[NSDate date]];
+    [self.cache setWithStatus:first];
+
+    MSIDOnboardingStatus *second = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.outlook"
+                                                   phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:second];
+
+    XCTAssertFalse(result);
+}
+
+- (void)testSetWithStatus_whenDifferentOriginatingBundleIdButOwnerOverride_shouldSucceed
+{
+    MSIDOnboardingStatus *first = [self statusWithOwner:@"com.microsoft.another.app"
+                                            originating:@"com.microsoft.teams"
+                                                  phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                             ttlSeconds:900
+                                              startedAt:[NSDate date]];
+    [self.cache setWithStatus:first];
+
+    // Owner override: new status owned by current app bundle ID (test host)
+    // Even with different originatingBundleId, the override should succeed
+    NSString *currentBundleId = [[NSBundle mainBundle] bundleIdentifier];
+    MSIDOnboardingStatus *overrideStatus = [self statusWithOwner:currentBundleId
+                                                     originating:@"com.microsoft.outlook"
+                                                           phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                                      ttlSeconds:900
+                                                       startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:overrideStatus];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testSetWithStatus_whenOriginatingBundleIdMatchIsCaseInsensitive_shouldSucceed
+{
+    MSIDOnboardingStatus *first = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                            originating:@"com.Microsoft.Teams"
+                                                  phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                             ttlSeconds:900
+                                              startedAt:[NSDate date]];
+    [self.cache setWithStatus:first];
+
+    MSIDOnboardingStatus *second = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseFailed
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:second];
+
+    XCTAssertTrue(result);
+}
+
+#pragma mark - clear
+
+- (void)testClear_whenNilBundleId_shouldReturnNO
+{
+    NSString *nilBundleId = nil;
+    BOOL result = [self.cache clear:nilBundleId];
+
+    XCTAssertFalse(result);
+}
+
+- (void)testClear_whenEmptyBundleId_shouldReturnNO
+{
+    BOOL result = [self.cache clear:@""];
+
+    XCTAssertFalse(result);
+}
+
+- (void)testClear_whenNothingCached_shouldReturnYES
+{
+    BOOL result = [self.cache clear:@"com.microsoft.azureauthenticator"];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testClear_whenMatchingBundleId_shouldRemoveAndReturnYES
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    BOOL result = [self.cache clear:@"com.microsoft.azureauthenticator"];
+
+    XCTAssertTrue(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testClear_whenNonMatchingBundleId_shouldReturnNO
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    BOOL result = [self.cache clear:@"com.microsoft.other.app"];
+
+    XCTAssertFalse(result);
+
+    // Verify status is still there
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+}
+
+- (void)testClear_whenBundleIdMatchIsCaseInsensitive_shouldRemoveAndReturnYES
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    BOOL result = [self.cache clear:@"com.Microsoft.AzureAuthenticator"];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testClear_whenOriginatingBundleIdMatches_shouldRemoveAndReturnYES
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    // Clear using the originating bundle ID instead of owner bundle ID
+    BOOL result = [self.cache clear:@"com.microsoft.teams"];
+
+    XCTAssertTrue(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testClear_whenOriginatingBundleIdMatchIsCaseInsensitive_shouldRemoveAndReturnYES
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    // Clear using the originating bundle ID with different case
+    BOOL result = [self.cache clear:@"com.Microsoft.Teams"];
+
+    XCTAssertTrue(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)testClear_whenNeitherOwnerNorOriginatingBundleIdMatches_shouldReturnNO
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    [self.cache setWithStatus:status];
+
+    // Clear using a bundle ID that matches neither owner nor originating
+    BOOL result = [self.cache clear:@"com.microsoft.outlook"];
+
+    XCTAssertFalse(result);
+
+    // Verify status is still there
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+}
+
+#pragma mark - isOwnerOverride
+
+- (void)testIsOwnerOverride_whenOwnerMatchesCurrentBundleId_shouldReturnYES
+{
+    // The current bundle ID in tests is the test host's bundle ID
+    NSString *currentBundleId = [[NSBundle mainBundle] bundleIdentifier];
+    MSIDOnboardingStatus *status = [self statusWithOwner:currentBundleId
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache isOwnerOverride:status];
+
+    XCTAssertTrue(result);
+}
+
+- (void)testIsOwnerOverride_whenOwnerDoesNotMatchCurrentBundleId_shouldReturnNO
+{
+    MSIDOnboardingStatus *status = [self statusWithOwner:@"com.microsoft.other.app"
+                                                   phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+
+    BOOL result = [self.cache isOwnerOverride:status];
+
+    XCTAssertFalse(result);
+}
+
+#pragma mark - setWithStatus then getOnboardingStatus roundtrip
+
+- (void)testSetAndGet_shouldPreserveAllFields
+{
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    formatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+    NSDate *startDate = [NSDate date];
+    
+    NSDictionary *json = @{
+        @"version": @1,
+        @"phase": @"failed",
+        @"context": @"inAppWebview",
+        @"ownerBundleId": @"com.microsoft.azureauthenticator",
+        @"originatingBundleId": @"com.microsoft.outlook",
+        @"originatingDisplayName": @"Outlook",
+        @"correlationId": @"12345678-1234-1234-1234-123456789abc",
+        @"startedAt": [formatter stringFromDate:startDate],
+        @"ttlSeconds": @1800,
+        @"reason": @{@"code": @"network", @"message": @"Network error"}
+    };
+    
+    NSError *error = nil;
+    MSIDOnboardingStatus *original = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:&error];
+    XCTAssertNotNil(original);
+    XCTAssertNil(error);
+
+    BOOL writeResult = [self.cache setWithStatus:original];
+    XCTAssertTrue(writeResult);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+
+    XCTAssertNotNil(retrieved);
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseFailed);
+    XCTAssertEqual(retrieved.onboardingContext, MSIDOnboardingContextInAppWebview);
+    XCTAssertEqualObjects(retrieved.ownerBundleId, @"com.microsoft.azureauthenticator");
+    XCTAssertEqualObjects(retrieved.originatingBundleId, @"com.microsoft.outlook");
+    XCTAssertEqualObjects(retrieved.originatingDisplayName, @"Outlook");
+    XCTAssertEqual(retrieved.ttlSeconds, 1800);
+    XCTAssertNotNil(retrieved.reason);
+    XCTAssertEqual(retrieved.reason.code, MSIDOnboardingReasonCodeNetwork);
+    XCTAssertEqualObjects(retrieved.reason.message, @"Network error");
+}
+
+- (void)test_setWithStatus_whenCurrentStatusHasNilOriginatingBundleId_rejectsOverwriteFromDifferentApp
+{
+    NSString *originalCorrelationId = @"11111111-1111-1111-1111-111111111111";
+    NSMutableDictionary *json = [self statusJSONWithPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                            correlationId:originalCorrelationId
+                                                startedAt:[NSDate date]];
+    XCTAssertTrue([self writeStatusJSONDirectly:json]);
+
+    MSIDOnboardingStatus *newStatus = [self statusWithOwner:@"com.different.owner"
+                                                originating:@"com.different.app"
+                                                      phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                                 ttlSeconds:900
+                                                  startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:newStatus];
+
+    XCTAssertFalse(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+    XCTAssertEqualObjects(retrieved.correlationId, [[NSUUID alloc] initWithUUIDString:originalCorrelationId]);
+}
+
+- (void)test_clear_whenCurrentStatusHasNilBundleIds_returnsNo
+{
+    NSMutableDictionary *json = [self statusJSONWithPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                            correlationId:@"22222222-2222-2222-2222-222222222222"
+                                                startedAt:[NSDate date]];
+    XCTAssertTrue([self writeStatusJSONDirectly:json]);
+
+    BOOL result = [self.cache clear:@"com.any.bundle"];
+
+    XCTAssertFalse(result);
+    XCTAssertEqual([self readStatusJSONDirectly].count, 1);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+}
+
+- (void)test_getOnboardingStatus_whenStartedAtMissing_treatsAsExpiredAndPurges
+{
+    NSMutableDictionary *json = [self statusJSONWithPhase:MSIDOnboardingPhaseFailed
+                                            correlationId:@"33333333-3333-3333-3333-333333333333"
+                                                startedAt:nil];
+    json[@"ownerBundleId"] = @"com.microsoft.azureauthenticator";
+    json[@"originatingBundleId"] = @"com.microsoft.teams";
+    XCTAssertTrue([self writeStatusJSONDirectly:json]);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseNone);
+    XCTAssertEqual([self readStatusJSONDirectly].count, 0);
+
+    MSIDOnboardingStatus *secondRetrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(secondRetrieved.phase, MSIDOnboardingPhaseNone);
+}
+
+- (void)test_setWithStatus_concurrent_serializesAndDoesNotCorrupt
+{
+    NSMutableDictionary *jsonA = [self statusJSONWithPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                             correlationId:@"44444444-4444-4444-4444-444444444444"
+                                                 startedAt:[NSDate date]];
+    jsonA[@"ownerBundleId"] = @"com.microsoft.azureauthenticator";
+    jsonA[@"originatingBundleId"] = @"com.microsoft.teams";
+
+    NSMutableDictionary *jsonB = [self statusJSONWithPhase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                             correlationId:@"55555555-5555-5555-5555-555555555555"
+                                                 startedAt:[NSDate date]];
+    jsonB[@"ownerBundleId"] = @"com.microsoft.azureauthenticator";
+    jsonB[@"originatingBundleId"] = @"com.microsoft.teams";
+
+    NSError *error = nil;
+    MSIDOnboardingStatus *statusA = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:jsonA error:&error];
+    XCTAssertNotNil(statusA, @"Failed to create status A: %@", error);
+
+    error = nil;
+    MSIDOnboardingStatus *statusB = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:jsonB error:&error];
+    XCTAssertNotNil(statusB, @"Failed to create status B: %@", error);
+
+    dispatch_queue_t concurrentQueue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    dispatch_group_t group = dispatch_group_create();
+    __block BOOL resultA = NO;
+    __block BOOL resultB = NO;
+
+    dispatch_group_async(group, concurrentQueue, ^{
+        resultA = [self.cache setWithStatus:statusA];
+    });
+    dispatch_group_async(group, concurrentQueue, ^{
+        resultB = [self.cache setWithStatus:statusB];
+    });
+
+    long waitResult = dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)));
+    XCTAssertEqual(waitResult, 0);
+    XCTAssertTrue(resultA);
+    XCTAssertTrue(resultB);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertTrue([retrieved.correlationId isEqual:statusA.correlationId] || [retrieved.correlationId isEqual:statusB.correlationId]);
+}
+
+@end

--- a/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
@@ -57,8 +57,30 @@
 #import "MSIDDefaultTokenRequestProvider.h"
 #import "MSIDAccountMetadataCacheAccessor.h"
 #import "MSIDDefaultTokenCacheAccessor.h"
+#import "MSIDOnboardingStatus.h"
+#import "MSIDOnboardingStatusCache.h"
+#import "MSIDTestCacheDataSource.h"
+#import "MSIDCacheItemJsonSerializer.h"
+#import "MSIDBrokerInvocationOptions.h"
+#import "MSIDBrokerConstants.h"
+#import "NSURL+MSIDExtensions.h"
+
+@interface MSIDBrokerInteractiveController ()
++ (void)setCurrentBrokerController:(MSIDBrokerInteractiveController *)currentBrokerController;
++ (MSIDBrokerInteractiveController *)currentBrokerController;
++ (void)setCurrentBrokerRequest:(MSIDBrokerTokenRequest *)currentBrokerRequest;
++ (MSIDBrokerTokenRequest *)currentBrokerRequest;
+@property (nonatomic, readwrite) BOOL isReplayRequest;
+@end
+
+@interface MSIDOnboardingStatusCache ()
+@property (nonatomic) id<MSIDExtendedTokenCacheDataSource> dataSource;
+@end
 
 @interface MSIDBrokerInteractiveControllerIntegrationTests : XCTestCase
+
+@property (nonatomic) MSIDTestCacheDataSource *testCacheDataSource;
+@property (nonatomic) id<MSIDExtendedTokenCacheDataSource> originalOnboardingDataSource;
 
 @end
 
@@ -70,6 +92,10 @@
     [MSIDAADNetworkConfiguration.defaultConfiguration setValue:@"v2.0" forKey:@"aadApiVersion"];
 
     [MSIDTestBrokerKeyProviderHelper addKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"] accessGroup:@"com.microsoft.adalcache" applicationTag:MSID_BROKER_SYMMETRIC_KEY_TAG];
+    
+    self.testCacheDataSource = [MSIDTestCacheDataSource new];
+    self.originalOnboardingDataSource = MSIDOnboardingStatusCache.sharedInstance.dataSource;
+    MSIDOnboardingStatusCache.sharedInstance.dataSource = self.testCacheDataSource;
 }
 
 - (void)tearDown
@@ -87,6 +113,10 @@
     [MSIDAADNetworkConfiguration.defaultConfiguration setValue:nil forKey:@"aadApiVersion"];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
     [MSIDApplicationTestUtil reset];
+    [self.testCacheDataSource reset];
+    MSIDOnboardingStatusCache.sharedInstance.dataSource = self.originalOnboardingDataSource;
+    [MSIDBrokerInteractiveController setCurrentBrokerController:nil];
+    [MSIDBrokerInteractiveController setCurrentBrokerRequest:nil];
     [super tearDown];
 }
 
@@ -1193,6 +1223,515 @@
         {
             [expectation fulfill];
         }
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+#endif
+
+#pragma mark - Onboarding Status Tests
+
+- (void)testAcquireToken_whenBrokerRequestSent_shouldSetOnboardingStatusInCache
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=onboarding1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    MSIDTokenResult *testResult = [self resultWithParameters:parameters];
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+        MSIDOnboardingStatus *inFlightStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+        XCTAssertNotNil(inFlightStatus);
+        XCTAssertEqual(inFlightStatus.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+        XCTAssertNotNil(inFlightStatus.correlationId);
+
+        MSIDTestBrokerResponseHandler *brokerResponseHandler = [[MSIDTestBrokerResponseHandler alloc] initWithTestResponse:testResult testError:nil];
+        [MSIDBrokerInteractiveController completeAcquireToken:[NSURL URLWithString:@"https://contoso.com"]
+                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                        brokerResponseHandler:brokerResponseHandler];
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNotNil(result);
+        XCTAssertNil(acquireTokenError);
+
+        MSIDOnboardingStatus *cachedStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+        XCTAssertNotNil(cachedStatus);
+        XCTAssertEqual(cachedStatus.phase, MSIDOnboardingPhaseNone);
+        XCTAssertNil(cachedStatus.correlationId);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenOpenURLFails_clearsOnboardingStatusFromCache
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=onboarding2"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+        return NO;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token open URL failure"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+
+        MSIDOnboardingStatus *cachedStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+        XCTAssertEqual(cachedStatus.phase, MSIDOnboardingPhaseNone);
+        XCTAssertNil(cachedStatus.correlationId);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenCompletedSuccessfully_shouldClearCurrentBrokerRequest
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=clearreq1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    MSIDTokenResult *testResult = [self resultWithParameters:parameters];
+
+    __block BOOL brokerRequestWasSetBeforeCompletion = NO;
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        // Before completion, currentBrokerRequest should be set
+        brokerRequestWasSetBeforeCompletion = ([MSIDBrokerInteractiveController currentBrokerRequest] != nil);
+
+        MSIDTestBrokerResponseHandler *brokerResponseHandler = [[MSIDTestBrokerResponseHandler alloc] initWithTestResponse:testResult testError:nil];
+        [MSIDBrokerInteractiveController completeAcquireToken:[NSURL URLWithString:@"https://contoso.com"]
+                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                        brokerResponseHandler:brokerResponseHandler];
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNotNil(result);
+        XCTAssertNil(acquireTokenError);
+        XCTAssertTrue(brokerRequestWasSetBeforeCompletion);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+
+    // After completion unwinds, currentBrokerRequest and controller should be cleared
+    XCTAssertNil([MSIDBrokerInteractiveController currentBrokerRequest]);
+    XCTAssertNil([MSIDBrokerInteractiveController currentBrokerController]);
+}
+
+- (void)testAcquireToken_whenFailedToLaunchBroker_shouldClearCurrentBrokerRequest
+{
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=clearreq2"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:nil];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:[self requestParameters]
+                                                                                                                  tokenRequestProvider:provider
+                                                                                                                    fallbackController:nil
+                                                                                                                                 error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+        return NO;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+
+        // currentBrokerRequest should be cleared on failure
+        XCTAssertNil([MSIDBrokerInteractiveController currentBrokerRequest]);
+        XCTAssertNil([MSIDBrokerInteractiveController currentBrokerController]);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+#if !AD_BROKER
+- (void)testAcquireToken_whenBrokerResponseNotReceived_andOnboardingStatusMatches_shouldReplayRequest
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+    // Enable broker invocation so canPerformRequest: returns YES
+    [MSIDApplicationTestUtil setCanOpenURLSchemes:@[@"msauthv2", @"msauthv3"]];
+    parameters.brokerInvocationOptions = [[MSIDBrokerInvocationOptions alloc] initWithRequiredBrokerType:MSIDRequiredBrokerTypeDefault
+                                                                                           protocolType:MSIDBrokerProtocolTypeUniversalLink
+                                                                                      aadRequestVersion:MSIDBrokerAADRequestVersionV2];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=replay1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    MSIDTokenResult *testResult = [self resultWithParameters:parameters];
+
+    __block int openURLCallCount = 0;
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+        openURLCallCount++;
+
+        if (openURLCallCount == 1)
+        {
+            // First call: original request to broker; verify no ignore_broker_request param
+            XCTAssertNil([url msidQueryParameters][MSID_IGNORE_BROKER_REQUEST]);
+
+            // Simulate broker not responding - app returns to foreground
+            [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
+            [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+        }
+        else if (openURLCallCount == 2)
+        {
+            // Second call: replayed request should contain ignore_broker_request=1
+            XCTAssertEqualObjects([url msidQueryParameters][MSID_IGNORE_BROKER_REQUEST], @"1");
+
+            // Now simulate broker responding successfully
+            MSIDTestBrokerResponseHandler *brokerResponseHandler = [[MSIDTestBrokerResponseHandler alloc] initWithTestResponse:testResult testError:nil];
+            [MSIDBrokerInteractiveController completeAcquireToken:[NSURL URLWithString:@"https://contoso.com"]
+                                                sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                            brokerResponseHandler:brokerResponseHandler];
+        }
+
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNotNil(result);
+        XCTAssertNil(acquireTokenError);
+        XCTAssertEqual(openURLCallCount, 2);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenBrokerResponseNotReceived_andOnboardingPhaseDoesNotMatch_shouldReturnError
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=noreplay1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        // Manually overwrite onboarding status to a non-matching phase before simulating return
+        MSIDOnboardingStatus *nonMatchingStatus = [MSIDOnboardingStatus new];
+        nonMatchingStatus.phase = MSIDOnboardingPhaseNone;
+        [[MSIDOnboardingStatusCache sharedInstance] setWithStatus:nonMatchingStatus];
+
+        // Simulate broker not responding
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+        XCTAssertEqual(acquireTokenError.code, MSIDErrorBrokerResponseNotReceived);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenBrokerResponseNotReceived_andOriginatingBundleIdDoesNotMatch_shouldReturnError
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=noreplay2"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        // Overwrite onboarding status with a different originatingBundleId to simulate
+        // a status saved by another application. Use JSON initializer since originatingBundleId is readonly.
+        NSDictionary *mismatchedStatusJson = @{
+            @"phase": [MSIDOnboardingStatus stringFromPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress],
+            @"context": [MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextBroker],
+            @"ownerBundleId": @"com.microsoft.azureauthenticator",
+            @"originatingBundleId": @"com.microsoft.otherapp",
+            @"correlationId": @"00000000-1234-abcd-0000-000000000000"
+        };
+        MSIDOnboardingStatus *mismatchedStatus = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:mismatchedStatusJson error:nil];
+        [[MSIDOnboardingStatusCache sharedInstance] setWithStatus:mismatchedStatus];
+
+        // Simulate broker not responding - app returns to foreground
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+        XCTAssertEqual(acquireTokenError.code, MSIDErrorBrokerResponseNotReceived);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenBrokerResponseError_shouldSetOnboardingPhaseToFailed
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=onboardingerror1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    NSError *testError = MSIDCreateError(MSIDErrorDomain, 123456789, @"Test broker error", nil, nil, nil, parameters.correlationId, nil, YES);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        MSIDTestBrokerResponseHandler *brokerResponseHandler = [[MSIDTestBrokerResponseHandler alloc] initWithTestResponse:nil testError:testError];
+        [MSIDBrokerInteractiveController completeAcquireToken:[NSURL URLWithString:@"https://contoso.com"]
+                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                        brokerResponseHandler:brokerResponseHandler];
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+
+        // Verify onboarding status phase is set to Failed on error
+        MSIDOnboardingStatus *cachedStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+        XCTAssertNotNil(cachedStatus);
+        XCTAssertEqual(cachedStatus.phase, MSIDOnboardingPhaseFailed);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenBrokerResponseSuccess_shouldClearOnboardingStatus
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=onboardingsuccess1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    MSIDTokenResult *testResult = [self resultWithParameters:parameters];
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+        MSIDTestBrokerResponseHandler *brokerResponseHandler = [[MSIDTestBrokerResponseHandler alloc] initWithTestResponse:testResult testError:nil];
+        [MSIDBrokerInteractiveController completeAcquireToken:[NSURL URLWithString:@"https://contoso.com"]
+                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                        brokerResponseHandler:brokerResponseHandler];
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNotNil(result);
+        XCTAssertNil(acquireTokenError);
+
+        // Verify onboarding status was cleared on success
+        MSIDOnboardingStatus *cachedStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+        XCTAssertNotNil(cachedStatus);
+        XCTAssertEqual(cachedStatus.phase, MSIDOnboardingPhaseNone);
+        XCTAssertNil(cachedStatus.correlationId);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenBrokerResponseNotReceived_andOnboardingContextNotBroker_shouldReturnError
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=noreplay3"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        // Overwrite onboarding status with a different context (not broker) to prevent replay
+        NSDictionary *mismatchedContextJson = @{
+            @"phase": [MSIDOnboardingStatus stringFromPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress],
+            @"context": [MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextInAppWebview],
+            @"ownerBundleId": @"com.microsoft.azureauthenticator",
+            @"originatingBundleId": [[NSBundle mainBundle] bundleIdentifier] ?: @"xctest",
+            @"correlationId": @"00000000-1234-abcd-0000-000000000000"
+        };
+        MSIDOnboardingStatus *mismatchedContextStatus = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:mismatchedContextJson error:nil];
+        [[MSIDOnboardingStatusCache sharedInstance] setWithStatus:mismatchedContextStatus];
+
+        // Simulate broker not responding - app returns to foreground
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+        XCTAssertEqual(acquireTokenError.code, MSIDErrorBrokerResponseNotReceived);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenBrokerResponseNotReceived_andCanPerformRequestReturnsFalse_shouldReturnError
+{
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+    // brokerInvocationOptions is not set, so canPerformRequest: will return NO
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=noreplay4"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        // Simulate broker not responding - app returns to foreground
+        // Onboarding status will match, but canPerformRequest should return NO
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+        XCTAssertEqual(acquireTokenError.code, MSIDErrorBrokerResponseNotReceived);
+
+        [expectation fulfill];
     }];
 
     [self waitForExpectationsWithTimeout:1.0 handler:nil];


### PR DESCRIPTION
This PR is **part 2 of 2** splitting #1841 into two PRs to satisfy the 500-LOC PR Size Check policy.

- **Part 1**: #1846 — `MSIDOnboardingStatus` model + tests (364 code lines)
- **Part 2 (this PR)**: cache accessor, broker controller integration, broker constant + tests (**413 code lines**)

This PR is currently stacked on top of `jarias/mobile-onboarding-phase1-model` (#1846). Once #1846 merges to `dev`, this PR will be retargeted to `dev` (or automatically rebased by GitHub).

## Proposed changes

**Cache accessor**

- `MSIDOnboardingStatusCache.h/.m`: keychain-backed accessor for the `MSIDOnboardingStatus` model. All public reads/writes/clear serialize through a private serial dispatch queue; bundle-id comparisons go through a fail-closed nil/blank-safe `-caseInsensitiveString:matchesString:` helper; `-getOnboardingStatus` treats a missing `startedAt` as expired, purges the entry, and returns a fresh empty status; TTL is enforced on read.

**Broker constant**

- `MSID_IGNORE_BROKER_REQUEST` query-param key used to break broker-replay loops.

**Broker interactive controller (iOS)**

- On entry to broker interactive, persist an in-progress `MSIDOnboardingStatus` (phase = `BrokerInteractiveInProgress`, context = `Broker`, owner = Authenticator bundle id) and log if persistence fails.
- On replay (`-callBrokerWithRequest:` with `isReplayRequest`), append `MSID_IGNORE_BROKER_REQUEST=1` to the broker URL so the broker app does not loop back.
- In `+checkTokenResponse:`, read the in-progress status and re-launch the broker only when phase + context + originating bundle id match the current app.
- On `openURL` failure, clear the cache entry for the current bundle id; on completion, set phase = `Failed` when an error came back from the broker (guarded against writing on top of a freshly-cleared `None` status) or clear the entry on success.

**Tests**

- `MSIDOnboardingStatusCacheTests`: full coverage of `set`/`get`/`clear`, TTL purge, nil-bundle-id guards, ownership rules, and concurrent `-setWithStatus:` serialization. `setUp`/`tearDown` save and restore the shared singleton's `dataSource` so test state does not leak across suites.
- `MSIDBrokerInteractiveControllerIntegrationTests`: extended with coverage of the replay flow, in-flight cache assertions inside the `onOpenURL` hook, and the `openURL`-failure cleanup path. `setUp`/`tearDown` save and restore the shared singleton's `dataSource`.

Supersedes #1841 alongside #1846 (which will be closed once both parts are open).

## PR Checklist (must be completed before review)

- [x] All tests pass locally (`./build.py --targets ios_library` — iOS Library Succeeded, 51.07s)
- [x] PR size is <= 500 LOC per PR Size Check policy (**413** code lines)
- [x] PR is independently mergeable (stacked on #1846)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## Type of change

- [x] Feature work

## Risk

- [x] Small — additive cache + controller hooks; one new query-param key on broker replay URLs.
