### PR TITLE
[MAJOR] [Feature]: Add BRT acquisition hook to MSIDLocalInteractiveController

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1921,6 +1921,9 @@
 		B2F671E32467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B2F671E12467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.h */; };
 		B2F671E42467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F671E22467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.m */; };
 		B2F671E52467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F671E22467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.m */; };
+		AC2EF4FE07FB4543B6223EED /* MSIDExternalRedirectContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 8750947BC8E046989E031365 /* MSIDExternalRedirectContext.h */; };
+		641EF65AA9114728AD7AFDAB /* MSIDExternalRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 30AE0CB6AC044DD1AB720DDF /* MSIDExternalRedirectContext.m */; };
+		59296E78E0C14816BC4C4568 /* MSIDExternalRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 30AE0CB6AC044DD1AB720DDF /* MSIDExternalRedirectContext.m */; };
 		B2F671E82467A34400649855 /* MSIDAuthorizationCodeResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B2F671E62467A34400649855 /* MSIDAuthorizationCodeResult.h */; };
 		B2F671E92467A34400649855 /* MSIDAuthorizationCodeResult.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F671E72467A34400649855 /* MSIDAuthorizationCodeResult.m */; };
 		B2F671EA2467A34400649855 /* MSIDAuthorizationCodeResult.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F671E72467A34400649855 /* MSIDAuthorizationCodeResult.m */; };
@@ -3568,6 +3571,8 @@
 		B2EF14391FF2F21E005DC1C0 /* MSIDAADV2TokenResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAADV2TokenResponse.h; sourceTree = "<group>"; };
 		B2F671E12467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDInteractiveAuthorizationCodeRequest.h; sourceTree = "<group>"; };
 		B2F671E22467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDInteractiveAuthorizationCodeRequest.m; sourceTree = "<group>"; };
+		8750947BC8E046989E031365 /* MSIDExternalRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDExternalRedirectContext.h; sourceTree = "<group>"; };
+		30AE0CB6AC044DD1AB720DDF /* MSIDExternalRedirectContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDExternalRedirectContext.m; sourceTree = "<group>"; };
 		B2F671E62467A34400649855 /* MSIDAuthorizationCodeResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDAuthorizationCodeResult.h; sourceTree = "<group>"; };
 		B2F671E72467A34400649855 /* MSIDAuthorizationCodeResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDAuthorizationCodeResult.m; sourceTree = "<group>"; };
 		B2F671EB2467AB4500649855 /* MSIDInteractiveRequestControlling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDInteractiveRequestControlling.h; sourceTree = "<group>"; };
@@ -5485,6 +5490,8 @@
 				23985AB22391BA1100942308 /* MSIDTokenResponseHandler.m */,
 				B2F671E12467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.h */,
 				B2F671E22467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.m */,
+				8750947BC8E046989E031365 /* MSIDExternalRedirectContext.h */,
+				30AE0CB6AC044DD1AB720DDF /* MSIDExternalRedirectContext.m */,
 				B2F671E62467A34400649855 /* MSIDAuthorizationCodeResult.h */,
 				B2F671E72467A34400649855 /* MSIDAuthorizationCodeResult.m */,
 				7233F08D2F88967A009C9602 /* MSIDDeviceTokenGrantRequest.h */,
@@ -6912,6 +6919,7 @@
 				2AADDAC82DADB84D00CB7740 /* MSIDSSOXpcSilentTokenRequest.h in Headers */,
 				B286B9C52389DE78007833AD /* MSIDAccountMetadata.h in Headers */,
 				B2F671E32467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.h in Headers */,
+				AC2EF4FE07FB4543B6223EED /* MSIDExternalRedirectContext.h in Headers */,
 				1E707FE02407336300716148 /* MSIDBrokerBrowserOperationResponse.h in Headers */,
 				B427654F2F3EC29200F79587 /* MSIDWebviewNavigationHandler.h in Headers */,
 				2A1CBC892ECE5F6E00D2E6BB /* MSIDGCDStarvationDetector.h in Headers */,
@@ -7842,6 +7850,7 @@
 				60B3856020A96E2700D546D0 /* MSIDWebviewUIController.m in Sources */,
 				B251CC412041058D005E0179 /* MSIDRefreshToken.m in Sources */,
 				B2F671E52467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.m in Sources */,
+				59296E78E0C14816BC4C4568 /* MSIDExternalRedirectContext.m in Sources */,
 				B28BDA7C217E961F003E5670 /* MSIDB2COauth2Factory.m in Sources */,
 				9658103320C7E1180025F4A4 /* MSIDWebviewResponse.m in Sources */,
 				B214C3A51FE855290070C4F2 /* MSIDDefaultTokenCacheAccessor.m in Sources */,
@@ -8521,6 +8530,7 @@
 				1EC0AB482499764700EAF327 /* MSIDCacheConfig.m in Sources */,
 				B251CC392041058D005E0179 /* MSIDLegacySingleResourceToken.m in Sources */,
 				B2F671E42467A30400649855 /* MSIDInteractiveAuthorizationCodeRequest.m in Sources */,
+				641EF65AA9114728AD7AFDAB /* MSIDExternalRedirectContext.m in Sources */,
 				2308476C207D6D500024CE7C /* NSData+MSIDExtensions.m in Sources */,
 				A0C7DE8425D46D7000F5B5B6 /* MSIDThrottlingModelFactory.m in Sources */,
 				B229841829AA8C2F0005F83D /* MSIDWebViewPlatformParams.m in Sources */,

--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.h
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.h
@@ -25,6 +25,7 @@
 #import "MSIDBaseRequestController.h"
 #import "MSIDTokenRequestProviding.h"
 #import "MSIDRequestControlling.h"
+#import "MSIDWebviewNavigationDelegate.h"
 
 @class MSIDInteractiveTokenRequestParameters;
 @class MSIDWebWPJResponse;
@@ -39,7 +40,7 @@
  */
 typedef void (^MSIDBRTAcquisitionBlock)(MSIDExternalRedirectContext * _Nonnull context);
 
-@interface MSIDLocalInteractiveController : MSIDBaseRequestController <MSIDRequestControlling>
+@interface MSIDLocalInteractiveController : MSIDBaseRequestController <MSIDRequestControlling, MSIDWebviewNavigationDelegate>
 
 @property (nonatomic, readonly, nullable) MSIDInteractiveTokenRequestParameters *interactiveRequestParamaters;
 

--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.h
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.h
@@ -28,10 +28,28 @@
 
 @class MSIDInteractiveTokenRequestParameters;
 @class MSIDWebWPJResponse;
+@class MSIDExternalRedirectContext;
+
+/**
+ * Block invoked fire-and-forget when the webview encounters a special redirect
+ * (e.g. msauth://enroll) during an interactive sign-in.
+ *
+ * Higher-level SDKs (OneAuth) inject an implementation that performs silent
+ * BRT acquisition using the snapshot in @c context.
+ */
+typedef void (^MSIDBRTAcquisitionBlock)(MSIDExternalRedirectContext * _Nonnull context);
 
 @interface MSIDLocalInteractiveController : MSIDBaseRequestController <MSIDRequestControlling>
 
 @property (nonatomic, readonly, nullable) MSIDInteractiveTokenRequestParameters *interactiveRequestParamaters;
+
+/**
+ * Optional block that is called fire-and-forget when a special redirect URL
+ * is intercepted during the interactive flow.
+ *
+ * Set by the host SDK (e.g. OneAuth) before calling @c acquireToken:.
+ */
+@property (nonatomic, copy, nullable) MSIDBRTAcquisitionBlock brtAcquisitionBlock;
 
 - (nullable instancetype)initWithInteractiveRequestParameters:(nonnull MSIDInteractiveTokenRequestParameters *)parameters
                                          tokenRequestProvider:(nonnull id<MSIDTokenRequestProviding>)tokenRequestProvider

--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
@@ -37,20 +37,24 @@
 #import "MSIDWebWPJResponse.h"
 #import "MSIDWebUpgradeRegResponse.h"
 #import "MSIDThrottlingService.h"
-#import "MSIDWebviewNavigationDelegate.h"
+#import "MSIDWebMDMEnrollmentCompletionResponse.h"
+#import "MSIDRequestControllerFactory.h"
+#import "MSIDKeychainUtil.h"
+#import "MSIDExternalRedirectContext.h"
+#if !MSID_EXCLUDE_WEBKIT
+#import "MSIDWebviewNavigationHandler.h"
 #import "MSIDWebviewNavigationDecision.h"
 #import "MSIDOAuth2EmbeddedWebviewController.h"
-#import "MSIDExternalRedirectContext.h"
-#import "MSIDDefaultTokenCacheAccessor.h"
-#import "MSIDAccountMetadataCacheAccessor.h"
-#import "MSIDOauth2Factory.h"
-#import "MSIDWebviewInteracting.h"
-#import "MSIDKeychainUtil.h"
+#endif
 
-@interface MSIDLocalInteractiveController() <MSIDWebviewNavigationDelegate>
+@interface MSIDLocalInteractiveController()
 
 @property (nonatomic, readwrite) MSIDInteractiveTokenRequestParameters *interactiveRequestParamaters;
 @property (nonatomic) MSIDInteractiveTokenRequest *currentRequest;
+@property (nonatomic) BOOL brtAttempted;
+#if !MSID_EXCLUDE_WEBKIT
+@property (nonatomic, strong) MSIDWebviewNavigationHandler *navigationHandler;
+#endif
 
 @end
 
@@ -71,22 +75,20 @@
     {
         _interactiveRequestParamaters = parameters;
         
-        // Wire this controller as the webview's navigation delegate so we
-        // receive handleSpecialRedirectURL: callbacks from the embedded
-        // webview controller when mobile onboarding redirects are detected.
+#if !MSID_EXCLUDE_WEBKIT
+        // Wire self as navigation delegate for BRT acquisition (POC)
+        _navigationHandler = [[MSIDWebviewNavigationHandler alloc] initWithContext:parameters];
+
         __weak typeof(self) weakSelf = self;
-        MSIDWebviewConfigurationBlock existingBlock = parameters.webviewConfigurationBlock;
         parameters.webviewConfigurationBlock = ^(id<MSIDWebviewInteracting> webviewController) {
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            if (existingBlock)
+            __strong typeof(self) strongSelf = weakSelf;
+            if (strongSelf)
             {
-                existingBlock(webviewController);
-            }
-            if ([webviewController isKindOfClass:[MSIDOAuth2EmbeddedWebviewController class]])
-            {
-                ((MSIDOAuth2EmbeddedWebviewController *)webviewController).navigationDelegate = strongSelf;
+                [strongSelf.navigationHandler configureWebviewController:webviewController
+                                                               delegate:strongSelf];
             }
         };
+#endif
     }
 
     return self;
@@ -251,11 +253,20 @@
     
     [request executeRequestWithCompletion:^(MSIDTokenResult *result, NSError *error, MSIDWebviewResponse *msauthResponse)
     {
-        if (msauthResponse && [msauthResponse isKindOfClass:[MSIDWebWPJResponse class]])
+        if (msauthResponse)
         {
             self.currentRequest = nil;
-            [self handleWebMSAuthResponse:(MSIDWebWPJResponse *)msauthResponse completion:completionBlock];
-            return;
+            if ([msauthResponse isKindOfClass:MSIDWebMDMEnrollmentCompletionResponse.class])
+            {
+                [self handleWebMDMEnrollmentCompletionResponse:(MSIDWebMDMEnrollmentCompletionResponse *)msauthResponse
+                                                  completion:completionBlock];
+                return;
+            }
+            if ([msauthResponse isKindOfClass:[MSIDWebWPJResponse class]])
+            {
+                [self handleWebMSAuthResponse:(MSIDWebWPJResponse *)msauthResponse completion:completionBlock];
+                return;
+            }
         }
         
 #if !EXCLUDE_FROM_MSALCPP
@@ -269,64 +280,153 @@
     }];
 }
 
-#pragma mark - MSIDWebviewNavigationDelegate
+#pragma mark - MDM Response Handlers
 
-#if TARGET_OS_IPHONE
+- (void)handleWebMDMEnrollmentCompletionResponse:(MSIDWebMDMEnrollmentCompletionResponse *)mdmEnrollmentCompletionResponse
+                                      completion:(MSIDRequestCompletionBlock)completionBlock
+{
+    NSString *status = mdmEnrollmentCompletionResponse.status ?: @"<none>";
+    
+    if (mdmEnrollmentCompletionResponse.isSuccess)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Profile installation completed successfully. Resuming authentication flow in broker context.");
+        
+        // TODO: Perform any custom actions needed by localInteractiveController before continuing
+        NSError *brokerError = nil;
+        id<MSIDRequestControlling> brokerController = [MSIDRequestControllerFactory interactiveControllerForParameters:self.interactiveRequestParamaters tokenRequestProvider:self.tokenRequestProvider error:&brokerError];
+        
+        // if broker is installed and sso profile is active this should return sso controller
+        if (!brokerController)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, self.requestParameters,
+                              @"Failed to create broker controller after profile installation: %@", brokerError);
+            CONDITIONAL_STOP_TELEMETRY_EVENT([self telemetryAPIEvent], brokerError);
+            completionBlock(nil, brokerError);
+            return;
+        }
+        
+        // Broker will invoke SSO extension which handles the request in its own webview
+        // Response will be sent back to calling app through the broker completion handler
+        [brokerController acquireToken:completionBlock];
+    }
+    else
+    {
+        // Profile installation failed or status is not success
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, self.requestParameters,
+                          @"MDM Enrollment failed (status=%@).", status);
+        
+        NSError *profileError = MSIDCreateError(MSIDErrorDomain,
+                                                MSIDErrorInternal,
+                                                @"Profile installation failed",
+                                                nil, nil, nil,
+                                                self.requestParameters.correlationId,
+                                                nil, NO);
+        
+        CONDITIONAL_STOP_TELEMETRY_EVENT([self telemetryAPIEvent], profileError);
+        completionBlock(nil, profileError);
+    }
+}
+
+#if !MSID_EXCLUDE_WEBKIT
+#pragma mark - MSIDWebviewNavigationDelegate (BRT POC)
+
 - (void)handleSpecialRedirectURL:(NSURL *)URL
        embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController
-                      completion:(void (^)(MSIDWebviewNavigationDecision * _Nullable navigationDecision, NSError * _Nullable error))completion
+                      completion:(void (^)(MSIDWebviewNavigationDecision * _Nullable, NSError * _Nullable))completion
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters,
                       @"Received special redirect URL: %@", URL.scheme);
     
-    MSIDBRTAcquisitionBlock block = self.brtAcquisitionBlock;
-    
-    // Only fire BRT acquisition for the enroll redirect (msauth://enroll?url=…).
-    // Other special redirects (e.g. browser://) should not trigger BRT seeding.
-    BOOL isBRTEnrollRedirect = [URL.scheme caseInsensitiveCompare:@"msauth"] == NSOrderedSame
-                               && [URL.host caseInsensitiveCompare:@"enroll"] == NSOrderedSame;
-    
-    // Defense-in-depth: BRT seeding is only allowed for Microsoft 1P apps
-    // (Team ID UBF8T346G9). This prevents 3P apps from triggering BRT
-    // acquisition even if they somehow obtain a reference to this controller.
-    NSString *teamId = [MSIDKeychainUtil sharedInstance].teamId;
-    BOOL isMicrosoftApp = [teamId isEqualToString:@"UBF8T346G9"];
-    
-    if (block && isBRTEnrollRedirect && isMicrosoftApp)
+    // Fire-and-forget BRT seeding — does not block parent navigation
+    if (!self.brtAttempted)
     {
+        self.brtAttempted = YES;
+
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters,
-                          @"BRT acquisition block is set — building context and firing (fire-and-forget).");
+                          @"BRT POC: Firing opportunistic BRT seed (fire-and-forget).");
+
+        MSIDBRTAcquisitionBlock block = self.brtAcquisitionBlock;
         
-        MSIDExternalRedirectContext *context =
-            [[MSIDExternalRedirectContext alloc] initWithRedirectURL:URL
-                                                      parentWebView:embeddedWebviewController.webView
-                                                    parentAuthority:self.interactiveRequestParamaters.authority
-                                                      correlationId:self.interactiveRequestParamaters.correlationId
-                                                          loginHint:self.interactiveRequestParamaters.loginHint
-                                                         tokenCache:self.currentRequest.tokenCache
-                                               accountMetadataCache:self.currentRequest.accountMetadataCache
-                                                       oauthFactory:self.currentRequest.oauthFactory
-                                       parentExtraURLQueryParameters:self.interactiveRequestParamaters.extraURLQueryParameters];
+        // Only fire BRT acquisition for the enroll redirect (msauth://enroll?url=…).
+        // Other special redirects (e.g. browser://) should not trigger BRT seeding.
+        BOOL isBRTEnrollRedirect = [URL.scheme caseInsensitiveCompare:@"msauth"] == NSOrderedSame
+                                   && [URL.host caseInsensitiveCompare:@"enroll"] == NSOrderedSame;
         
-        // Fire-and-forget — do not block the parent interactive flow.
-        block(context);
+        if (block && isBRTEnrollRedirect && MSIDIsMicrosoft1PHostProcess())
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters,
+                              @"BRT acquisition block is set — building context and firing (fire-and-forget).");
+            
+            MSIDExternalRedirectContext *context =
+                [[MSIDExternalRedirectContext alloc] initWithRedirectURL:URL
+                                                          parentWebView:embeddedWebviewController.webView
+                                                        parentAuthority:self.interactiveRequestParamaters.authority
+                                                          correlationId:self.interactiveRequestParamaters.correlationId
+                                                              loginHint:self.interactiveRequestParamaters.loginHint
+                                                             tokenCache:self.currentRequest.tokenCache
+                                                   accountMetadataCache:self.currentRequest.accountMetadataCache
+                                                           oauthFactory:self.currentRequest.oauthFactory
+                                           parentExtraURLQueryParameters:self.interactiveRequestParamaters.extraURLQueryParameters];
+            
+            // Fire-and-forget — do not block the parent interactive flow.
+            block(context);
+        }
+        else if (!block)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters,
+                              @"No BRT acquisition block set — skipping.");
+        }
+        else if (MSIDIsMicrosoft1PHostProcess())
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelWarning, self.requestParameters,
+                              @"BRT acquisition skipped — app team ID is not Microsoft (UBF8T346G9).");
+        }
     }
-    else if (!block)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters,
-                          @"No BRT acquisition block set — skipping.");
-    }
-    else if (!isMicrosoftApp)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, self.requestParameters,
-                          @"BRT acquisition skipped — app team ID is not Microsoft (UBF8T346G9).");
-    }
-    
-    // Always let the parent webview continue with its default navigation.
-    MSIDWebviewNavigationDecision *decision = [MSIDWebviewNavigationDecision new];
-    decision.type = MSIDWebviewNavigationDecisionContinueDefault;
-    completion(decision, nil);
+
+    // Proceed immediately — seeder runs in background
+    [self.navigationHandler handleSpecialRedirectURL:URL
+                        embeddedWebviewController:embeddedWebviewController
+                                          appName:@"MSAL"
+                                       appVersion:@"1.0"
+                                       completion:completion];
 }
 #endif
 
+- (BOOL)processResponseHeadersAndCheckForASWebAuthHandoff:(NSDictionary *)headers
+                                              responseURL:(NSURL *)responseURL
+{
+    return [self.navigationHandler processResponseHeadersAndCheckForASWebAuthHandoff:headers
+                                                                              responseURL:responseURL];
+}
+
+#if !MSID_EXCLUDE_SYSTEMWV
+- (void)performASWebAuthenticationHandoffWithCompletion:(void (^)(MSIDWebviewNavigationDecision * _Nullable decision,
+                                                                  NSError * _Nullable error))completion
+{
+    [self.navigationHandler performASWebAuthenticationHandoffWithParentController:self.interactiveRequestParamaters.parentViewController
+                                                                       completion:completion];
+}
+#endif // !MSID_EXCLUDE_SYSTEMWV
+
+static NSString * const kMSIDMicrosoft1PTeamIdIosA   = @"SGGM6D27TK";
+static NSString * const kMSIDMicrosoft1PTeamIdIosB   = @"9KBH5RKYEW";
+
+// Returns YES iff the currently-running process is signed by Microsoft.
+// Result is cached (Team ID does not change during process lifetime).
+static BOOL MSIDIsMicrosoft1PHostProcess(void)
+{
+    static BOOL isMicrosoft1P = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSString *teamId = [MSIDKeychainUtil sharedInstance].teamId;
+        if (teamId.length == 0) return;
+
+        NSSet<NSString *> *allowedTeamIds = [NSSet setWithObjects:
+                                             kMSIDMicrosoft1PTeamIdIosA,
+                                             kMSIDMicrosoft1PTeamIdIosB,
+                                             nil];
+        isMicrosoft1P = [allowedTeamIds containsObject:teamId];
+    });
+    return isMicrosoft1P;
+}
 @end

--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
@@ -37,8 +37,17 @@
 #import "MSIDWebWPJResponse.h"
 #import "MSIDWebUpgradeRegResponse.h"
 #import "MSIDThrottlingService.h"
+#import "MSIDWebviewNavigationDelegate.h"
+#import "MSIDWebviewNavigationDecision.h"
+#import "MSIDOAuth2EmbeddedWebviewController.h"
+#import "MSIDExternalRedirectContext.h"
+#import "MSIDDefaultTokenCacheAccessor.h"
+#import "MSIDAccountMetadataCacheAccessor.h"
+#import "MSIDOauth2Factory.h"
+#import "MSIDWebviewInteracting.h"
+#import "MSIDKeychainUtil.h"
 
-@interface MSIDLocalInteractiveController()
+@interface MSIDLocalInteractiveController() <MSIDWebviewNavigationDelegate>
 
 @property (nonatomic, readwrite) MSIDInteractiveTokenRequestParameters *interactiveRequestParamaters;
 @property (nonatomic) MSIDInteractiveTokenRequest *currentRequest;
@@ -61,6 +70,23 @@
     if (self)
     {
         _interactiveRequestParamaters = parameters;
+        
+        // Wire this controller as the webview's navigation delegate so we
+        // receive handleSpecialRedirectURL: callbacks from the embedded
+        // webview controller when mobile onboarding redirects are detected.
+        __weak typeof(self) weakSelf = self;
+        MSIDWebviewConfigurationBlock existingBlock = parameters.webviewConfigurationBlock;
+        parameters.webviewConfigurationBlock = ^(id<MSIDWebviewInteracting> webviewController) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (existingBlock)
+            {
+                existingBlock(webviewController);
+            }
+            if ([webviewController isKindOfClass:[MSIDOAuth2EmbeddedWebviewController class]])
+            {
+                ((MSIDOAuth2EmbeddedWebviewController *)webviewController).navigationDelegate = strongSelf;
+            }
+        };
     }
 
     return self;
@@ -242,5 +268,65 @@
         completionBlock(result, error);
     }];
 }
+
+#pragma mark - MSIDWebviewNavigationDelegate
+
+#if TARGET_OS_IPHONE
+- (void)handleSpecialRedirectURL:(NSURL *)URL
+       embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController
+                      completion:(void (^)(MSIDWebviewNavigationDecision * _Nullable navigationDecision, NSError * _Nullable error))completion
+{
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters,
+                      @"Received special redirect URL: %@", URL.scheme);
+    
+    MSIDBRTAcquisitionBlock block = self.brtAcquisitionBlock;
+    
+    // Only fire BRT acquisition for the enroll redirect (msauth://enroll?url=…).
+    // Other special redirects (e.g. browser://) should not trigger BRT seeding.
+    BOOL isBRTEnrollRedirect = [URL.scheme caseInsensitiveCompare:@"msauth"] == NSOrderedSame
+                               && [URL.host caseInsensitiveCompare:@"enroll"] == NSOrderedSame;
+    
+    // Defense-in-depth: BRT seeding is only allowed for Microsoft 1P apps
+    // (Team ID UBF8T346G9). This prevents 3P apps from triggering BRT
+    // acquisition even if they somehow obtain a reference to this controller.
+    NSString *teamId = [MSIDKeychainUtil sharedInstance].teamId;
+    BOOL isMicrosoftApp = [teamId isEqualToString:@"UBF8T346G9"];
+    
+    if (block && isBRTEnrollRedirect && isMicrosoftApp)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters,
+                          @"BRT acquisition block is set — building context and firing (fire-and-forget).");
+        
+        MSIDExternalRedirectContext *context =
+            [[MSIDExternalRedirectContext alloc] initWithRedirectURL:URL
+                                                      parentWebView:embeddedWebviewController.webView
+                                                    parentAuthority:self.interactiveRequestParamaters.authority
+                                                      correlationId:self.interactiveRequestParamaters.correlationId
+                                                          loginHint:self.interactiveRequestParamaters.loginHint
+                                                         tokenCache:self.currentRequest.tokenCache
+                                               accountMetadataCache:self.currentRequest.accountMetadataCache
+                                                       oauthFactory:self.currentRequest.oauthFactory
+                                       parentExtraURLQueryParameters:self.interactiveRequestParamaters.extraURLQueryParameters];
+        
+        // Fire-and-forget — do not block the parent interactive flow.
+        block(context);
+    }
+    else if (!block)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters,
+                          @"No BRT acquisition block set — skipping.");
+    }
+    else if (!isMicrosoftApp)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, self.requestParameters,
+                          @"BRT acquisition skipped — app team ID is not Microsoft (UBF8T346G9).");
+    }
+    
+    // Always let the parent webview continue with its default navigation.
+    MSIDWebviewNavigationDecision *decision = [MSIDWebviewNavigationDecision new];
+    decision.type = MSIDWebviewNavigationDecisionContinueDefault;
+    completion(decision, nil);
+}
+#endif
 
 @end

--- a/IdentityCore/src/requests/MSIDExternalRedirectContext.h
+++ b/IdentityCore/src/requests/MSIDExternalRedirectContext.h
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IPHONE
+#import <WebKit/WebKit.h>
+#endif
+
+@class MSIDAuthority;
+@class MSIDAccountMetadataCacheAccessor;
+@class MSIDOauth2Factory;
+@protocol MSIDCacheAccessor;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Immutable snapshot of state captured when a special redirect URL (e.g.
+ * msauth://enroll) is intercepted during an interactive sign-in flow.
+ *
+ * CommonCore builds this DTO inside @c MSIDLocalInteractiveController and
+ * passes it to the @c brtAcquisitionBlock so that the higher-level SDK
+ * (e.g. OneAuth) can spin up a silent BRT acquisition without reaching back
+ * into the controller.
+ */
+@interface MSIDExternalRedirectContext : NSObject
+
+/// The special redirect URL that triggered this context (e.g. msauth://enroll?url=…)
+@property (nonatomic, readonly) NSURL *redirectURL;
+
+#if TARGET_OS_IPHONE
+/// The WKWebView that hosted the parent interactive sign-in.
+/// Consumers share its websiteDataStore (and optionally processPool) to
+/// reuse the authenticated session cookie.
+/// Strong reference — the consumer must extract configuration synchronously
+/// and release the context promptly after starting its async work.
+@property (nonatomic, readonly) WKWebView *parentWebView;
+#endif
+
+/// Authority of the parent sign-in request.
+@property (nonatomic, readonly) MSIDAuthority *parentAuthority;
+
+/// Correlation ID of the parent flow, carried through for telemetry.
+@property (nonatomic, readonly, nullable) NSUUID *correlationId;
+
+/// Login hint (UPN) from the parent request parameters.
+@property (nonatomic, readonly, nullable) NSString *loginHint;
+
+/// Token cache accessor — used by the consumer to persist the acquired BRT.
+@property (nonatomic, readonly) id<MSIDCacheAccessor> tokenCache;
+
+/// Account metadata cache accessor.
+@property (nonatomic, readonly) MSIDAccountMetadataCacheAccessor *accountMetadataCache;
+
+/// OAuth2 factory for creating token responses.
+@property (nonatomic, readonly) MSIDOauth2Factory *oauthFactory;
+
+/// Extra URL query parameters from the parent request (e.g. instance_aware).
+@property (nonatomic, readonly, nullable) NSDictionary<NSString *, NSString *> *parentExtraURLQueryParameters;
+
+#if TARGET_OS_IPHONE
+- (instancetype)initWithRedirectURL:(NSURL *)redirectURL
+                      parentWebView:(WKWebView *)parentWebView
+                    parentAuthority:(MSIDAuthority *)parentAuthority
+                      correlationId:(nullable NSUUID *)correlationId
+                          loginHint:(nullable NSString *)loginHint
+                         tokenCache:(id<MSIDCacheAccessor>)tokenCache
+               accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
+                       oauthFactory:(MSIDOauth2Factory *)oauthFactory
+       parentExtraURLQueryParameters:(nullable NSDictionary<NSString *, NSString *> *)parentExtraURLQueryParameters
+    NS_DESIGNATED_INITIALIZER;
+#endif
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/requests/MSIDExternalRedirectContext.m
+++ b/IdentityCore/src/requests/MSIDExternalRedirectContext.m
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDExternalRedirectContext.h"
+#import "MSIDAuthority.h"
+#import "MSIDCacheAccessor.h"
+#import "MSIDAccountMetadataCacheAccessor.h"
+#import "MSIDOauth2Factory.h"
+
+@implementation MSIDExternalRedirectContext
+
+#if TARGET_OS_IPHONE
+- (instancetype)initWithRedirectURL:(NSURL *)redirectURL
+                      parentWebView:(WKWebView *)parentWebView
+                    parentAuthority:(MSIDAuthority *)parentAuthority
+                      correlationId:(NSUUID *)correlationId
+                          loginHint:(NSString *)loginHint
+                         tokenCache:(id<MSIDCacheAccessor>)tokenCache
+               accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
+                       oauthFactory:(MSIDOauth2Factory *)oauthFactory
+       parentExtraURLQueryParameters:(NSDictionary<NSString *, NSString *> *)parentExtraURLQueryParameters
+{
+    if ((self = [super init]))
+    {
+        _redirectURL = redirectURL;
+        _parentWebView = parentWebView;
+        _parentAuthority = parentAuthority;
+        _correlationId = correlationId;
+        _loginHint = [loginHint copy];
+        _tokenCache = tokenCache;
+        _accountMetadataCache = accountMetadataCache;
+        _oauthFactory = oauthFactory;
+        _parentExtraURLQueryParameters = [parentExtraURLQueryParameters copy];
+    }
+    return self;
+}
+#endif
+
+@end

--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -98,7 +98,76 @@
     // Stop at broker or browser
     BOOL isBrokerUrl  = [@"msauth"  caseInsensitiveCompare:requestURL.scheme] == NSOrderedSame;
     BOOL isBrowserUrl = [@"browser" caseInsensitiveCompare:requestURL.scheme] == NSOrderedSame;
-
+    
+    // TODO: testing
+    NSString *host = requestURL.host;
+    NSString *path = requestURL.path;
+    if (isBrowserUrl)
+    {
+        NSDictionary *queryParams = [requestURL msidQueryParameters];
+        NSString *linkId = queryParams[@"LinkId"] ?: queryParams[@"linkid"];
+        linkId = linkId ? linkId : queryParams[@"linkid"] ?: queryParams[@"linkId"];
+        NSString *compliance = queryParams[@"portalAction"] ?: queryParams[@"PortalAction"];
+        BOOL isEnrollmentPath = [path isEqualToString:@"/fwlink"] || [path isEqualToString:@"/fwlink/"];
+        if ([host isEqualToString:@"go.microsoft.com"] &&
+            isEnrollmentPath
+            && ([linkId isEqualToString:@"396941"] || [linkId isEqual:@"399153"]))
+        {
+            // Construct proper https URL with all query parameters
+            NSString *cpurlValue;
+            if (requestURL.query && requestURL.query.length > 0)
+            {
+                cpurlValue = [NSString stringWithFormat:@"https://%@%@?%@", host, path, requestURL.query];
+            }
+            else
+            {
+                cpurlValue = [NSString stringWithFormat:@"https://%@%@", host, path];
+            }
+            // Properly encode the cpurl value for use as a query parameter
+            //            NSString *encodedCpurl = [cpurlValue stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+            //            NSRange range = [encodedCpurl rangeOfString:@"?"];
+            //            if (range.location != NSNotFound) {
+            //                encodedCpurl = [cpurlValue stringByReplacingCharactersInRange:range withString:@"&"];
+            //            }
+            
+            NSString *msauthURLString = [NSString stringWithFormat:@"msauth://enroll?%@=%@", MSID_INTUNE_URL_KEY, cpurlValue];
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.context, @"Converting browser enrollment URL to msauth URL. Original: %@, Converted: %@", MSID_PII_LOG_MASKABLE(requestURL.absoluteString), MSID_PII_LOG_MASKABLE(msauthURLString));
+            requestURL = [NSURL URLWithString:msauthURLString];
+            // Re-evaluate URL scheme flags after conversion
+            isBrokerUrl = [@"msauth" caseInsensitiveCompare:requestURL.scheme] == NSOrderedSame;
+            isBrowserUrl = [@"browser" caseInsensitiveCompare:requestURL.scheme] == NSOrderedSame;
+        }
+        
+        if ([host isEqualToString:@"portal.manage.microsoft.com"]
+            && ([compliance isEqualToString:@"Compliance"]))
+        {
+            // Construct proper https URL with all query parameters
+            NSString *cpurlValue;
+            if (requestURL.query && requestURL.query.length > 0)
+            {
+                cpurlValue = [NSString stringWithFormat:@"https://%@%@?%@", host, path, requestURL.query];
+            }
+            else
+            {
+                cpurlValue = [NSString stringWithFormat:@"https://%@%@", host, path];
+            }
+            // Properly encode the cpurl value for use as a query parameter
+            //            NSString *encodedCpurl = [cpurlValue stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+            //            NSRange range = [encodedCpurl rangeOfString:@"?"];
+            //            if (range.location != NSNotFound) {
+            //                encodedCpurl = [cpurlValue stringByReplacingCharactersInRange:range withString:@"&"];
+            //            }
+            
+            NSString *msauthURLString = [NSString stringWithFormat:@"msauth://compliance?%@=%@", MSID_INTUNE_URL_KEY, cpurlValue];
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, self.context, @"Converting browser enrollment URL to msauth URL. Original: %@, Converted: %@", MSID_PII_LOG_MASKABLE(requestURL.absoluteString), MSID_PII_LOG_MASKABLE(msauthURLString));
+            requestURL = [NSURL URLWithString:msauthURLString];
+            // Re-evaluate URL scheme flags after conversion
+            isBrokerUrl = [@"msauth" caseInsensitiveCompare:requestURL.scheme] == NSOrderedSame;
+            isBrowserUrl = [@"browser" caseInsensitiveCompare:requestURL.scheme] == NSOrderedSame;
+        }
+        
+    }
+    
     // Server-side trigger: msauth://enroll means the server opted this
     // session into the new mobile onboarding flow.
     BOOL isServerNewOnboardingRedirect =

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -113,6 +113,7 @@ NSString *const SDM_CAMERA_CONSENT_PROMPT_SUPPRESS_KEY = @"Microsoft.Broker.Feat
         
         _complete = NO;
         
+        _isMobileOnboardingEnabled = YES;
         // isMobileOnboardingEnabled starts as NO; it is dynamically set to YES
         // when the server issues msauth://enroll (server-driven enablement).
     }

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
@@ -119,6 +119,7 @@
     }
     
     // Parse query parameters
+    NSDictionary<NSString *, NSString *> *params1 = [self queryParamsFromURL:URL];
     NSDictionary<NSString *, NSString *> *params = [URL msidQueryParameters];
     
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[NavDecision] Resolving decision for msauth host '%@'.", host);
@@ -126,7 +127,7 @@
     // Route based on host
     if ([host isEqualToString:MSID_MDM_ENROLL_HOST])
     {
-        return [self decisionForEnrollURL:params
+        return [self decisionForEnrollURL:params1
                                   appName:appName
                                appVersion:appVersion];
     }
@@ -136,7 +137,7 @@
     }
     else if ([host isEqualToString:MSID_COMPLIANCE_HOST])
     {
-        return [self decisionForComplianceURL:params
+        return [self decisionForComplianceURL:params1
                     embeddedWebviewController:embeddedWebviewController];
     }
     else if ([host isEqualToString:MSID_MDM_ENROLLMENT_COMPLETION_HOST])
@@ -523,6 +524,46 @@
     }
 
     return request;
+}
+
+- (NSDictionary<NSString *, NSString *> *)queryParamsFromURL:(NSURL *)url
+{
+    if (!url)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Cannot extract query params: URL is nil");
+        return @{};
+    }
+    
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    if (!components)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Cannot extract query params: Failed to parse URL components for URL: %@", url);
+        return @{};
+    }
+    
+    NSMutableDictionary<NSString *, NSString *> *result = [NSMutableDictionary new];
+    
+    NSArray<NSURLQueryItem *> *queryItems = components.queryItems;
+    if (!queryItems || queryItems.count == 0)
+    {
+        return @{};
+    }
+    
+    for (NSURLQueryItem *item in queryItems)
+    {
+        // Only add items with both name and value present
+        if (item.name && item.value)
+        {
+            result[item.name] = item.value;
+        }
+        else if (item.name)
+        {
+            // Query parameter with no value - log as warning
+            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"Query parameter '%@' has no value", item.name);
+        }
+    }
+    
+    return [result copy];
 }
 
 @end


### PR DESCRIPTION
## Summary

Adds a generic **BRT (Broker Refresh Token) acquisition hook** to `MSIDLocalInteractiveController` so that higher-level SDKs (e.g. OneAuth) can perform silent BRT seeding during interactive sign-in flows.

## Architecture

### CommonCore (this PR)
- **`MSIDExternalRedirectContext`** — Immutable DTO snapshot capturing the redirect URL, parent WKWebView, authority, correlation ID, login hint, token/metadata caches, OAuth factory, and extra query parameters.
- **`MSIDBRTAcquisitionBlock`** — Block typedef: `void (^)(MSIDExternalRedirectContext *context)`
- **`brtAcquisitionBlock`** property on `MSIDLocalInteractiveController` — set by the host SDK before calling `acquireToken:`.
- **`handleSpecialRedirectURL:`** — Implements `MSIDWebviewNavigationDelegate` to intercept `msauth://enroll` redirects, build the context, and fire the block fire-and-forget.

### OneAuth (companion PR)
- Injects a `MSAISilentBRTRequest`-based block that spins up a hidden WKWebView, shares cookies from the parent session, performs `/authorize` + `/token` exchange for the broker client ID, and persists the BRT via `saveSSOStateWithConfiguration:`.

## Flow
1. User signs in → embedded webview navigates to AAD
2. AAD detects MDM-enrolled device → returns `msauth://enroll?url=...`
3. `MSIDAADOAuthEmbeddedWebviewController` calls `handleSpecialRedirectURL:` on the navigation delegate
4. Controller builds `MSIDExternalRedirectContext`, fires `brtAcquisitionBlock` (fire-and-forget)
5. Returns `ContinueDefault` immediately — parent interactive flow continues unblocked
6. OneAuth's block silently acquires and caches a BRT in the background

## Key Design Decisions
- **Fire-and-forget**: BRT acquisition is best-effort; parent flow is never blocked
- **Enroll-URL gating**: Only `msauth://enroll` triggers BRT acquisition (not other special redirects)
- **Strong `parentWebView` reference**: Consumer must synchronously extract webview configuration before starting async work
- **No session management conflicts**: Consumer uses its own WKNavigationDelegate, bypasses `MSIDWebviewAuthorization` singleton

## Files Changed
- `MSIDExternalRedirectContext.h/.m` (NEW) — DTO
- `MSIDLocalInteractiveController.h` — typedef + property
- `MSIDLocalInteractiveController.m` — delegate conformance + handler
- `project.pbxproj` — new file references

## Related
- Design doc: AuthLibrariesApiReview PR #24251
- OneAuth companion PR: TBD
- Broker consumer (Veena's branch): `veenasoman/poc-brt-seeded-silent-registration`