### PR TITLE
Centralize onboarding telemetry processing in MSIDOnboardingBlobBuilder

### DIFF
--- a/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
+++ b/IdentityCore/src/controllers/MSIDLocalInteractiveController.m
@@ -358,11 +358,11 @@
                                           completion:completion];
 }
 
-- (BOOL)processResponseHeadersAndCheckForASWebAuthHandoff:(NSDictionary *)headers
-                                              responseURL:(NSURL *)responseURL
+- (BOOL)processNavigationResponseAndCheckForASWebAuthHandoff:(NSHTTPURLResponse *)response
+                                   embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController
 {
-    return [self.navigationHandler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:responseURL];
+    return [self.navigationHandler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                                              embeddedWebviewController:embeddedWebviewController];
 }
 
 #if !MSID_EXCLUDE_SYSTEMWV

--- a/IdentityCore/src/telemetry/MSIDOnboardingBlobBuilder.h
+++ b/IdentityCore/src/telemetry/MSIDOnboardingBlobBuilder.h
@@ -71,6 +71,19 @@ typedef NS_ENUM(NSInteger, MSIDOnboardingSeedClassification)
 /// itself, sufficient evidence that this session is brokered.
 - (void)ensureBrokeredOnboardingMode;
 
+/// Processes navigation response data for onboarding telemetry signals.
+/// Extracts last-loaded domain from the URL host, reads blocking errors
+/// from the x-ms-clitelem header, and records remediation steps for known error codes.
+/// This consolidates the logic previously in processOnboardingTelemetryForResponse:
+/// so it can be called from both the base webview controller and the navigation handler.
+- (void)processResponseHeaders:(NSDictionary *)headers responseURL:(NSURL *)responseURL;
+
+/// Flags indicating which remediation steps have been recorded. Used by the base
+/// webview controller's finalizeOnboardingTelemetry:error: to decide which completion
+/// steps (StrongAuthSetupCompleted, MdmEnrollmentFinished) to add at flow end.
+@property (nonatomic, readonly) BOOL strongAuthSetupStarted;
+@property (nonatomic, readonly) BOOL mdmEnrollmentStarted;
+
 /// Returns the accumulated blob serialized as JSON. Always populated when the builder
 /// was constructed (carries the seed fields plus any recorded steps, blocking errors,
 /// ux flow, and last loaded domain). Returns @"" only if JSON serialization fails.

--- a/IdentityCore/src/telemetry/MSIDOnboardingBlobBuilder.m
+++ b/IdentityCore/src/telemetry/MSIDOnboardingBlobBuilder.m
@@ -25,6 +25,8 @@
 #import "MSIDOnboardingBlobBuilder.h"
 #import "MSIDOnboardingBlobFieldKeys.h"
 #import "MSIDSessionCachePersistence.h"
+#import "NSString+MSIDExtensions.h"
+#import "MSIDOAuth2Constants.h"
 
 // Seed field keys — must match xplat core (Djinni-generated constants).
 static NSString *const MSID_ONBOARDING_FIELD_SCHEMA_VERSION = @"schema_version";
@@ -81,6 +83,9 @@ static NSDictionary * _Nullable MSIDOnboardingParseSeedDictionary(NSString * _Nu
 @property (nonatomic, copy, nullable) NSString *lastLoadedDomain;
 
 @property (nonatomic) MSIDSessionCachePersistence *sessionCachePersistence;
+
+@property (nonatomic, readwrite) BOOL strongAuthSetupStarted;
+@property (nonatomic, readwrite) BOOL mdmEnrollmentStarted;
 
 @end
 
@@ -245,6 +250,97 @@ static NSDictionary * _Nullable MSIDOnboardingParseSeedDictionary(NSString * _Nu
     if (![self.onboardingMode isEqualToString:MSIDOnboardingModeBrokered])
     {
         self.onboardingMode = MSIDOnboardingModeBrokered;
+    }
+}
+
+#pragma mark - HTTP Response Telemetry Processing
+
+// Error codes that are returned during normal sign-in flow and should not be
+// treated as blocking onboarding errors.
+//   50058  UserInformationNotProvided      - User not signed in / no valid SSO session found
+//   50097  DeviceAuthenticationRequired    - Device auth interrupt triggered by CA policy
+//   50126  InvalidUserNameOrPassword       - Wrong username or password
++ (NSSet<NSString *> *)nonBlockingOnboardingErrorCodes
+{
+    static NSSet<NSString *> *codes = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        codes = [NSSet setWithObjects:@"50058", @"50097", @"50126", nil];
+    });
+    return codes;
+}
+
+- (void)processResponseHeaders:(NSDictionary *)headers responseURL:(NSURL *)responseURL
+{
+    NSString *host = responseURL.host;
+    if (host.length > 0)
+    {
+        [self setLastLoadedDomain:host];
+    }
+
+    NSString *cliTelem = headers[MSID_OAUTH2_CLIENT_TELEMETRY];
+    if ([NSString msidIsStringNilOrBlank:cliTelem])
+    {
+        return;
+    }
+
+    // Format: <version>,<error_code>,<suberror_code>,<rt_age>,<spe_info>
+    NSArray *components = [cliTelem componentsSeparatedByString:@","];
+    if (components.count < 2)
+    {
+        return;
+    }
+
+    NSString *errorCode = [components[1] msidTrimmedString];
+    if (errorCode.length == 0 || [errorCode isEqualToString:@"0"])
+    {
+        return;
+    }
+
+    if ([[self.class nonBlockingOnboardingErrorCodes] containsObject:errorCode])
+    {
+        return;
+    }
+
+    [self addBlockingError:errorCode];
+    [self recordRemediationStepForErrorCode:errorCode];
+}
+
+- (void)recordRemediationStepForErrorCode:(NSString *)errorCode
+{
+    NSDate *now = [NSDate date];
+
+    // 50079: Strong auth enrollment needed (MFA setup)
+    if ([errorCode isEqualToString:@"50079"] && !self.strongAuthSetupStarted)
+    {
+        [self addStep:MSIDOnboardingBlobStepStrongAuthSetupStarted timestamp:now];
+        self.strongAuthSetupStarted = YES;
+    }
+    // 50129 (DeviceIsNotWorkplaceJoined), 501291 (DeviceIsNotWorkplaceJoinedForMamApp)
+    else if ([errorCode isEqualToString:@"50129"] || [errorCode isEqualToString:@"501291"])
+    {
+        [self addStep:MSIDOnboardingBlobStepDeviceRegistrationRequired timestamp:now];
+    }
+    // 530001, 530002: Device not compliant
+    else if ([errorCode isEqualToString:@"530001"] || [errorCode isEqualToString:@"530002"])
+    {
+        [self addStep:MSIDOnboardingBlobStepDeviceNotCompliant timestamp:now];
+    }
+    // 53000, 530003: MDM enrollment required
+    else if ([errorCode isEqualToString:@"53000"] || [errorCode isEqualToString:@"530003"])
+    {
+        [self addStep:MSIDOnboardingBlobStepMdmEnrollmentRequired timestamp:now];
+        self.mdmEnrollmentStarted = YES;
+    }
+    // 50127: MAM app, device not registered
+    else if ([errorCode isEqualToString:@"50127"])
+    {
+        [self addStep:MSIDOnboardingBlobStepBrokerInstallPromptedForMAM timestamp:now];
+    }
+    // 501271: Broker app needs to be installed
+    else if ([errorCode isEqualToString:@"501271"])
+    {
+        [self addStep:MSIDOnboardingBlobStepBrokerInstallPrompted timestamp:now];
     }
 }
 

--- a/IdentityCore/src/telemetry/MSIDOnboardingBlobFieldKeys.h
+++ b/IdentityCore/src/telemetry/MSIDOnboardingBlobFieldKeys.h
@@ -72,3 +72,8 @@ extern NSString * const MSIDOnboardingBlobStepMdmEnrollmentStarted;
 extern NSString * const MSIDOnboardingBlobStepMdmEnrollmentFinished;
 extern NSString * const MSIDOnboardingBlobStepRemediationStarted;
 extern NSString * const MSIDOnboardingBlobStepRemediationFinished;
+extern NSString * const MSIDOnboardingBlobStepComplianceRemediationStarted;
+extern NSString * const MSIDOnboardingBlobStepProfileDownloadCompleted;
+
+// UX flow tag values (ux_flow_used array entries)
+extern NSString * const MSIDOnboardingUxFlowMobileOnboardingPhase1;

--- a/IdentityCore/src/telemetry/MSIDOnboardingBlobFieldKeys.m
+++ b/IdentityCore/src/telemetry/MSIDOnboardingBlobFieldKeys.m
@@ -65,3 +65,8 @@ NSString * const MSIDOnboardingBlobStepMdmEnrollmentStarted = @"MDMEnrollmentSta
 NSString * const MSIDOnboardingBlobStepMdmEnrollmentFinished = @"MDMEnrollmentFinished";
 NSString * const MSIDOnboardingBlobStepRemediationStarted = @"RemediationStarted";
 NSString * const MSIDOnboardingBlobStepRemediationFinished = @"RemediationFinished";
+NSString * const MSIDOnboardingBlobStepComplianceRemediationStarted = @"ComplianceRemediationStarted";
+NSString * const MSIDOnboardingBlobStepProfileDownloadCompleted = @"ProfileDownloadCompleted";
+
+// UX flow tag values
+NSString * const MSIDOnboardingUxFlowMobileOnboardingPhase1 = @"MobileOnboardingPhase1";

--- a/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDAADOAuthEmbeddedWebviewController.m
@@ -38,6 +38,8 @@
 #import "MSIDWebviewConstants.h"
 #import "NSURL+MSIDExtensions.h"
 #import "NSString+MSIDExtensions.h"
+#import "MSIDOnboardingBlobBuilder.h"
+#import "MSIDOnboardingBlobFieldKeys.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -118,6 +120,13 @@
             MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context,
                 @"Server issued msauth://enroll - enabling mobile onboarding for this session.");
             self.isMobileOnboardingEnabled = YES;
+
+            // Record onboarding telemetry: tag UX flow for the new mobile onboarding path.
+            MSIDOnboardingBlobBuilder *builder = self.onboardingBlobBuilder;
+            if (builder)
+            {
+                [builder addUxFlowUsed:MSIDOnboardingUxFlowMobileOnboardingPhase1];
+            }
         }
         else
         {

--- a/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDOAuth2EmbeddedWebviewController.m
@@ -375,50 +375,52 @@ NSString *const SDM_CAMERA_CONSENT_PROMPT_SUPPRESS_KEY = @"Microsoft.Broker.Feat
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler
 {
+    WKNavigationResponsePolicy responsePolicy = WKNavigationResponsePolicyAllow;
+
+    NSHTTPURLResponse *response = nil;
     if (navigationResponse && [navigationResponse.response isKindOfClass:[NSHTTPURLResponse class]])
     {
-        NSHTTPURLResponse *response = (NSHTTPURLResponse *)navigationResponse.response;
+        response = (NSHTTPURLResponse *)navigationResponse.response;
+    }
 
-        [self processOnboardingTelemetryForResponse:response];
+    if (response)
+    {
+        if (self.isMobileOnboardingEnabled)
+        {
+            // In the new onboarding flow, the navigation delegate processes telemetry
+            // and checks for ASWebAuthenticationSession hand-off in a single call.
+            id<MSIDWebviewNavigationDelegate> strongNavigationDelegate = self.navigationDelegate;
+            if ((strongNavigationDelegate)
+                && [strongNavigationDelegate respondsToSelector:@selector(processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController:)])
+            {
+                BOOL didHandoff = [strongNavigationDelegate processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                                            embeddedWebviewController:self];
+
+#if !MSID_EXCLUDE_SYSTEMWV
+                if (didHandoff
+                    && [strongNavigationDelegate respondsToSelector:@selector(performASWebAuthenticationHandoffWithCompletion:)])
+                {
+                    NSURL *responseURL = response.URL;
+                    responsePolicy = WKNavigationResponsePolicyCancel;
+                    [strongNavigationDelegate performASWebAuthenticationHandoffWithCompletion:^(MSIDWebviewNavigationDecision *decision, NSError *error)
+                    {
+                        [self performNavigationDecision:decision
+                                             requestURL:responseURL
+                                                  error:error];
+                    }];
+                }
+#endif // !MSID_EXCLUDE_SYSTEMWV
+            }
+        }
+        else
+        {
+            // Legacy flow: process onboarding telemetry locally.
+            [self processOnboardingTelemetryForResponse:response];
+        }
 
         if (self.navigationResponseBlock)
         {
             self.navigationResponseBlock(response);
-        }
-    }
-    
-    WKNavigationResponsePolicy responsePolicy = WKNavigationResponsePolicyAllow;
-
-    if (self.isMobileOnboardingEnabled)
-    {
-        id<MSIDWebviewNavigationDelegate> strongNavigationDelegate = self.navigationDelegate;
-        if ((strongNavigationDelegate)
-            && [strongNavigationDelegate respondsToSelector:@selector(processResponseHeadersAndCheckForASWebAuthHandoff:responseURL:)]
-            && [navigationResponse.response isKindOfClass:[NSHTTPURLResponse class]])
-        {
-            NSHTTPURLResponse *response = (NSHTTPURLResponse *)navigationResponse.response;
-
-            // Process the response headers and determine if a hand-off to ASWebAuthenticationSession is signaled.
-            // The response URL is passed so the delegate can verify the issuing origin is allowed (HTTPS + allowlisted host)
-            // before honoring an ASWebAuth header.
-            BOOL didHandoff = [strongNavigationDelegate processResponseHeadersAndCheckForASWebAuthHandoff:response.allHeaderFields
-                                                                                             responseURL:response.URL];
-
-#if !MSID_EXCLUDE_SYSTEMWV
-            // If a hand-off is signaled, and the navigation delegate implements the hand-off method, perform the hand-off to ASWebAuthenticationSession and cancel the current navigation.
-            if (didHandoff
-                && [strongNavigationDelegate respondsToSelector:@selector(performASWebAuthenticationHandoffWithCompletion:)])
-            {
-                NSURL *responseURL = response.URL;
-                responsePolicy = WKNavigationResponsePolicyCancel;
-                [strongNavigationDelegate performASWebAuthenticationHandoffWithCompletion:^(MSIDWebviewNavigationDecision *decision, NSError *error)
-                {
-                    [self performNavigationDecision:decision
-                                         requestURL:responseURL
-                                              error:error];
-                }];
-            }
-#endif // !MSID_EXCLUDE_SYSTEMWV
         }
     }
 
@@ -791,11 +793,11 @@ initiatedByFrame:(WKFrameInfo *)frame
         if (flowSucceeded)
         {
             NSDate *now = [NSDate date];
-            if (_onboardingStrongAuthSetupStarted)
+            if (_onboardingStrongAuthSetupStarted || onboardingBlobBuilder.strongAuthSetupStarted)
             {
                 [onboardingBlobBuilder addStep:MSIDOnboardingBlobStepStrongAuthSetupCompleted timestamp:now];
             }
-            if (_onboardingMdmEnrollmentStarted)
+            if (_onboardingMdmEnrollmentStarted || onboardingBlobBuilder.mdmEnrollmentStarted)
             {
                 [onboardingBlobBuilder addStep:MSIDOnboardingBlobStepMdmEnrollmentFinished timestamp:now];
             }
@@ -887,98 +889,11 @@ initiatedByFrame:(WKFrameInfo *)frame
         return;
     }
 
-    NSString *host = response.URL.host;
-    if (host.length > 0)
-    {
-        [builder setLastLoadedDomain:host];
-    }
+    [builder processResponseHeaders:response.allHeaderFields responseURL:response.URL];
 
-    NSString *cliTelem = response.allHeaderFields[MSID_OAUTH2_CLIENT_TELEMETRY];
-    if ([NSString msidIsStringNilOrBlank:cliTelem])
-    {
-        return;
-    }
-
-    // Format: <version>,<error_code>,<suberror_code>,<rt_age>,<spe_info>
-    NSArray *components = [cliTelem componentsSeparatedByString:@","];
-    if (components.count < 2)
-    {
-        return;
-    }
-
-    NSString *errorCode = [components[1] msidTrimmedString];
-    if (errorCode.length == 0 || [errorCode isEqualToString:@"0"])
-    {
-        return;
-    }
-
-    // Check list of expected errors to ignore as part of normal sign-in flow.
-    if ([[self.class nonBlockingOnboardingErrorCodes] containsObject:errorCode])
-    {
-        return;
-    }
-
-    [builder addBlockingError:errorCode];
-    [self recordOnboardingRemediationStepForErrorCode:errorCode builder:builder];
-}
-
-// Error codes that are returned during normal sign-in flow and should not be
-// treated as blocking onboarding errors (e.g. user not signed in, wrong password,
-// device auth interrupt). This list will be extended over time.
-//   50058  UserInformationNotProvided      - User not signed in / no valid SSO session found
-//   50097  DeviceAuthenticationRequired    - Device auth interrupt triggered by CA policy
-//   50126  InvalidUserNameOrPassword       - Wrong username or password
-+ (NSSet<NSString *> *)nonBlockingOnboardingErrorCodes
-{
-    static NSSet<NSString *> *codes = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        codes = [NSSet setWithObjects:@"50058", @"50097", @"50126", nil];
-    });
-    return codes;
-}
-
-- (void)recordOnboardingRemediationStepForErrorCode:(NSString *)errorCode
-                                            builder:(MSIDOnboardingBlobBuilder *)builder
-{
-    NSDate *now = [NSDate date];
-
-    // 50079: Strong auth enrollment needed (MFA setup, not MFA fulfillment like 50076/50078)
-    if ([errorCode isEqualToString:@"50079"] && !_onboardingStrongAuthSetupStarted)
-    {
-        [builder addStep:MSIDOnboardingBlobStepStrongAuthSetupStarted timestamp:now];
-        _onboardingStrongAuthSetupStarted = YES;
-    }
-    // 50129 (DeviceIsNotWorkplaceJoined): Device registration needed,
-    // 501291 (DeviceIsNotWorkplaceJoinedForMamApp): Device registration needed for MAM app
-    else if ([errorCode isEqualToString:@"50129"] || [errorCode isEqualToString:@"501291"])
-    {
-        [builder addStep:MSIDOnboardingBlobStepDeviceRegistrationRequired timestamp:now];
-    }
-    // 530001 (DeviceNotCompliantBrowserNotSupported): Browser not supported,
-    // 530002: (DeviceNotCompliantDeviceCompliantRequired): The device is required to be compliant to access this resource
-    else if ([errorCode isEqualToString:@"530001"] || [errorCode isEqualToString:@"530002"])
-    {
-        [builder addStep:MSIDOnboardingBlobStepDeviceNotCompliant timestamp:now];
-    }
-    // 53000 (DeviceNotCompliant): The user must enroll their device with an approved MDM provider like Intune,
-    // 530003 (DeviceNotCompliantDeviceManagementRequired): MDM enrollment required
-    else if ([errorCode isEqualToString:@"53000"] || [errorCode isEqualToString:@"530003"])
-    {
-        [builder addStep:MSIDOnboardingBlobStepMdmEnrollmentRequired timestamp:now];
-    }
-    // 50127: Client app is a MAM app and device is not registered
-    else if ([errorCode isEqualToString:@"50127"])
-    {
-        [builder addStep:MSIDOnboardingBlobStepBrokerInstallPromptedForMAM timestamp:now];
-    }
-    // 501271: Broker app needs to be installed for device authentication to succeed.
-    else if ([errorCode isEqualToString:@"501271"])
-    {
-        [builder addStep:MSIDOnboardingBlobStepBrokerInstallPrompted timestamp:now];
-    }
-    
-    // All other error codes (50076, 50078, 53005, 53003, etc.): blocking error only, no step
+    // Sync local flags from builder for use in finalizeOnboardingTelemetry:error:
+    _onboardingStrongAuthSetupStarted = builder.strongAuthSetupStarted;
+    _onboardingMdmEnrollmentStarted = builder.mdmEnrollmentStarted;
 }
 
 @end

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
@@ -28,6 +28,8 @@
 #import "MSIDSSOExtensionInteractiveTokenRequestController.h"
 #import "MSIDConstants.h"
 #import "MSIDIntuneDeviceIdCache.h"
+#import "MSIDOnboardingBlobBuilder.h"
+#import "MSIDOnboardingBlobFieldKeys.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -128,11 +130,13 @@
     {
         return [self decisionForEnrollURL:params
                                   appName:appName
-                               appVersion:appVersion];
+                               appVersion:appVersion
+                embeddedWebviewController:embeddedWebviewController];
     }
     else if ([host isEqualToString:MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST])
     {
-        return [self decisionForProfileDownloadComplete:params];
+        return [self decisionForProfileDownloadComplete:params
+                             embeddedWebviewController:embeddedWebviewController];
     }
     else if ([host isEqualToString:MSID_COMPLIANCE_HOST])
     {
@@ -157,8 +161,16 @@
 - (MSIDWebviewNavigationDecision *)decisionForEnrollURL:(NSDictionary *)params
                                                 appName:(NSString *)appName
                                              appVersion:(NSString *)appVersion
+                              embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[Enroll] Building enrollment request from msauth redirect.");
+
+    // Record onboarding telemetry step for MDM enrollment start.
+    MSIDOnboardingBlobBuilder *builder = embeddedWebviewController.onboardingBlobBuilder;
+    if (builder)
+    {
+        [builder addStep:MSIDOnboardingBlobStepMdmEnrollmentStarted timestamp:[NSDate date]];
+    }
 
     NSCharacterSet *whitespace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
 
@@ -256,8 +268,16 @@
 }
 
 - (MSIDWebviewNavigationDecision *)decisionForProfileDownloadComplete:(NSDictionary *)params
+                                           embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[ProfileDownload] Processing MDM profile download completion redirect.");
+
+    // Record onboarding telemetry step for profile download completion.
+    MSIDOnboardingBlobBuilder *builder = embeddedWebviewController.onboardingBlobBuilder;
+    if (builder)
+    {
+        [builder addStep:MSIDOnboardingBlobStepProfileDownloadCompleted timestamp:[NSDate date]];
+    }
 
     NSCharacterSet *whitespace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
 
@@ -381,6 +401,13 @@
                                   embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[Compliance] Building compliance request from msauth redirect.");
+
+    // Record onboarding telemetry step for compliance/remediation start.
+    MSIDOnboardingBlobBuilder *builder = embeddedWebviewController.onboardingBlobBuilder;
+    if (builder)
+    {
+        [builder addStep:MSIDOnboardingBlobStepComplianceRemediationStarted timestamp:[NSDate date]];
+    }
 
     NSCharacterSet *whitespace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
 

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDelegate.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDelegate.h
@@ -51,23 +51,25 @@ NS_ASSUME_NONNULL_BEGIN
                       completion:(void (^)(MSIDWebviewNavigationDecision * _Nullable navigationDecision, NSError * _Nullable error))completion;
 
 /**
- * Caches response headers and detects an ASWebAuthenticationSession hand-off signal.
+ * Caches response headers, processes onboarding telemetry, and detects an
+ * ASWebAuthenticationSession hand-off signal.
  * On YES, caller should cancel the WKWebView navigation and invoke the hand-off method below.
  *
- * Security: hand-off is honored only when @c responseURL is HTTPS and its host is on the allowlist.
+ * Security: hand-off is honored only when the response URL is HTTPS and its host is on the allowlist.
  *
- * @param headers     HTTP response headers (raw `allHeaderFields`)
- * @param responseURL URL of the response that delivered @c headers (@c NSHTTPURLResponse.URL).
- * @return YES if @c headers signal a hand-off AND @c responseURL is from allowed origin; NO otherwise.
+ * @param response    The HTTP navigation response containing headers and URL.
+ * @param embeddedWebviewController The controller that drove the navigation, passed explicitly
+ *        so the delegate does not have to reach back through shared state.
+ * @return YES if headers signal a hand-off AND the response URL is from allowed origin; NO otherwise.
  */
-- (BOOL)processResponseHeadersAndCheckForASWebAuthHandoff:(NSDictionary *)headers
-                                              responseURL:(nullable NSURL *)responseURL;
+- (BOOL)processNavigationResponseAndCheckForASWebAuthHandoff:(NSHTTPURLResponse *)response
+         embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController;
 
 #if !MSID_EXCLUDE_SYSTEMWV
 
 /**
  * Performs the hand-off using the headers cached by the last
- * @c processResponseHeadersAndCheckForASWebAuthHandoff:responseURL: call.
+ * @c processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController: call.
  *
  * @param completion Completion block - MUST be called exactly once; failures surface as a @c failWithError decision
  */

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDelegate.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDelegate.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return YES if headers signal a hand-off AND the response URL is from allowed origin; NO otherwise.
  */
 - (BOOL)processNavigationResponseAndCheckForASWebAuthHandoff:(NSHTTPURLResponse *)response
-         embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController;
+                                   embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController;
 
 #if !MSID_EXCLUDE_SYSTEMWV
 

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.h
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return YES if headers signal a hand-off AND the response URL is from allowed origin; NO otherwise.
  */
 - (BOOL)processNavigationResponseAndCheckForASWebAuthHandoff:(NSHTTPURLResponse *)response
-         embeddedWebviewController:(nullable MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController;
+                                   embeddedWebviewController:(nullable MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController;
 
 #if !MSID_EXCLUDE_SYSTEMWV
 /**

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.h
@@ -94,22 +94,25 @@ NS_ASSUME_NONNULL_BEGIN
                       completion:(void (^)(MSIDWebviewNavigationDecision * _Nullable navigationDecision, NSError * _Nullable error))completion;
 
 /**
- * Caches response headers and detects an ASWebAuthenticationSession hand-off signal.
+ * Caches response headers, processes onboarding telemetry, and detects an
+ * ASWebAuthenticationSession hand-off signal.
  * On YES, caller should cancel the WKWebView navigation and invoke the hand-off method below.
  *
- * Security: hand-off is honored only when @c responseURL is HTTPS and its host is on the allowlist.
+ * Security: hand-off is honored only when the response URL is HTTPS and its host is on the allowlist.
  *
- * @param headers     HTTP response headers (raw `allHeaderFields`)
- * @param responseURL URL of the response that delivered @c headers (@c NSHTTPURLResponse.URL).
- * @return YES if @c headers signal a hand-off AND @c responseURL is from allowed origin; NO otherwise.
+ * @param response    The HTTP navigation response containing headers and URL.
+ * @param embeddedWebviewController The controller that drove the navigation, passed explicitly
+ *        so the handler can access onboarding telemetry and other per-session state without
+ *        reaching back through shared state (which can race with session-completion cleanup).
+ * @return YES if headers signal a hand-off AND the response URL is from allowed origin; NO otherwise.
  */
-- (BOOL)processResponseHeadersAndCheckForASWebAuthHandoff:(NSDictionary *)headers
-                                              responseURL:(nullable NSURL *)responseURL;
+- (BOOL)processNavigationResponseAndCheckForASWebAuthHandoff:(NSHTTPURLResponse *)response
+         embeddedWebviewController:(nullable MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController;
 
 #if !MSID_EXCLUDE_SYSTEMWV
 /**
  * Performs the hand-off using the headers cached by the last
- * @c processResponseHeadersAndCheckForASWebAuthHandoff:responseURL: call.
+ * @c processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController: call.
  *
  * @param parentController The view controller that presents the webview
  * @param completion Completion block - MUST be called exactly once; failures surface as a @c failWithError decision

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.m
@@ -30,6 +30,8 @@
 #import "MSIDRequestContext.h"
 #import "MSIDWebviewNavigationDelegate.h"
 #import "MSIDWebviewConstants.h"
+#import "MSIDOnboardingBlobBuilder.h"
+#import "MSIDOnboardingBlobFieldKeys.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -89,13 +91,22 @@
     completion(navigationDecision, nil);
 }
 
-- (BOOL)processResponseHeadersAndCheckForASWebAuthHandoff:(NSDictionary *)headers
-                                              responseURL:(NSURL *)responseURL
+- (BOOL)processNavigationResponseAndCheckForASWebAuthHandoff:(NSHTTPURLResponse *)response
+         embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController
 {
+    NSDictionary *headers = response.allHeaderFields;
+    NSURL *responseURL = response.URL;
+
     // Normalize and capture headers for later use. This also allows for case-insensitive lookup of header values.
     self.lastResponseHeaders = [self normalizeHeaders:headers];
 
-    // TODO: Add telemetry for response headers
+    // Process onboarding telemetry from the response if the builder is available.
+    // This records blocking errors (x-ms-clitelem) and last-loaded domain.
+    MSIDOnboardingBlobBuilder *builder = embeddedWebviewController.onboardingBlobBuilder;
+    if (builder && responseURL)
+    {
+        [builder processResponseHeaders:headers responseURL:responseURL];
+    }
 
     NSString *handoffURLString = self.lastResponseHeaders[MSID_ASWEBAUTH_HANDOFF_URL_KEY];
     BOOL hasHandoffHeader = [handoffURLString isKindOfClass:NSString.class] && ((NSString *)handoffURLString).length > 0;
@@ -132,7 +143,7 @@
     }
 
     // Retrieve the hand-off URL captured by the most recent
-    // processResponseHeadersAndCheckForASWebAuthHandoff:responseURL: call.
+    // processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController: call.
     id rawHandoffURL = self.lastResponseHeaders[MSID_ASWEBAUTH_HANDOFF_URL_KEY];
     NSString *handoffURLString = [rawHandoffURL isKindOfClass:NSString.class] ? (NSString *)rawHandoffURL : nil;
     NSURL *handoffURL = handoffURLString.length > 0 ? [NSURL URLWithString:handoffURLString] : nil;

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.m
@@ -88,7 +88,7 @@
 }
 
 - (BOOL)processNavigationResponseAndCheckForASWebAuthHandoff:(NSHTTPURLResponse *)response
-         embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController
+                                   embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController *)embeddedWebviewController
 {
     NSDictionary *headers = response.allHeaderFields;
     NSURL *responseURL = response.URL;

--- a/IdentityCore/tests/MSIDWebviewNavigationHandlerTests.m
+++ b/IdentityCore/tests/MSIDWebviewNavigationHandlerTests.m
@@ -373,7 +373,7 @@
     NSString *upperCaseHeader = [[NSString stringWithFormat:@"%@token", MSID_ASWEBAUTH_HANDOFF_HEADER_PREFIX] uppercaseString];
     NSString *lowerCaseHeader = [upperCaseHeader lowercaseString];
     
-    // Simulate what processResponseHeadersAndCheckForASWebAuthHandoff:responseURL: does: normalize the raw server headers first
+    // Simulate what processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController: does: normalize the raw server headers first
     NSDictionary *rawHeaders = @{upperCaseHeader: @"tok123"};
     NSDictionary *normalised = [self.handler normalizeHeaders:rawHeaders];
     self.handler.lastResponseHeaders = normalised;
@@ -522,7 +522,7 @@
     [self waitForExpectations:@[expectation] timeout:1.0];
 }
 
-#pragma mark - processResponseHeadersAndCheckForASWebAuthHandoff:responseURL: (synchronous)
+#pragma mark - processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController: (synchronous)
 
 // An allowed response URL used by happy-path tests below. Matches an entry in
 // MSIDASWebAuthenticationConstants.asWebAuthAllowedDomains so the origin check passes.
@@ -531,12 +531,22 @@ static NSURL *MSIDTestAllowedResponseURL(void)
     return [NSURL URLWithString:@"https://portal.manage.microsoft.com/some/path"];
 }
 
+// Helper to create an NSHTTPURLResponse with given headers and URL.
+static NSHTTPURLResponse *MSIDTestHTTPResponse(NSDictionary *headers, NSURL *url)
+{
+    return [[NSHTTPURLResponse alloc] initWithURL:url
+                                      statusCode:200
+                                     HTTPVersion:@"HTTP/1.1"
+                                    headerFields:headers];
+}
+
 - (void)testProcessResponseHeaders_whenNoHandoffHeader_shouldReturnNO
 {
     NSDictionary *headers = @{@"Content-Type": @"application/json"};
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, MSIDTestAllowedResponseURL());
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:MSIDTestAllowedResponseURL()];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertFalse(hasHandoff);
     // Side effect: headers are still normalized into lastResponseHeaders for later use.
@@ -546,9 +556,10 @@ static NSURL *MSIDTestAllowedResponseURL(void)
 - (void)testProcessResponseHeaders_whenHandoffHeaderIsEmptyString_shouldReturnNO
 {
     NSDictionary *headers = @{MSID_ASWEBAUTH_HANDOFF_URL_KEY: @""};
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, MSIDTestAllowedResponseURL());
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:MSIDTestAllowedResponseURL()];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertFalse(hasHandoff);
 }
@@ -556,9 +567,10 @@ static NSURL *MSIDTestAllowedResponseURL(void)
 - (void)testProcessResponseHeaders_whenHandoffHeaderIsNonString_shouldReturnNO
 {
     NSDictionary *headers = @{MSID_ASWEBAUTH_HANDOFF_URL_KEY: @42};
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, MSIDTestAllowedResponseURL());
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:MSIDTestAllowedResponseURL()];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertFalse(hasHandoff);
 }
@@ -568,9 +580,10 @@ static NSURL *MSIDTestAllowedResponseURL(void)
     // Server may send the header in any casing; normalization must catch it.
     NSString *uppercaseKey = MSID_ASWEBAUTH_HANDOFF_URL_KEY.uppercaseString;
     NSDictionary *headers = @{uppercaseKey: @"https://www.example.com/handoff"};
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, MSIDTestAllowedResponseURL());
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:MSIDTestAllowedResponseURL()];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertTrue(hasHandoff);
     // The normalized headers should expose the lowercased key for later use.
@@ -583,24 +596,32 @@ static NSURL *MSIDTestAllowedResponseURL(void)
     self.handler.lastResponseHeaders = @{@"stale": @"value"};
 
     NSDictionary *headers = @{@"X-Custom": @"v1", @"Other-Header": @"v2"};
-    (void)[self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                             responseURL:MSIDTestAllowedResponseURL()];
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, MSIDTestAllowedResponseURL());
+
+    (void)[self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                         embeddedWebviewController:nil];
 
     XCTAssertEqualObjects(self.handler.lastResponseHeaders[@"x-custom"], @"v1");
     XCTAssertEqualObjects(self.handler.lastResponseHeaders[@"other-header"], @"v2");
     XCTAssertNil(self.handler.lastResponseHeaders[@"stale"], @"Previous headers must be replaced, not merged.");
 }
 
-#pragma mark - processResponseHeadersAndCheckForASWebAuthHandoff:responseURL: (response-URL origin gate)
+#pragma mark - processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController: (response-URL origin gate)
 
 - (void)testProcessResponseHeaders_whenHandoffHeaderPresentButResponseURLIsNil_shouldReturnNOAndStillCacheHeaders
 {
     // Security gate: an attacker-controlled page (or a non-HTTP response somehow reaching here)
     // must not be able to force a hand-off by injecting only the header.
+    // NSHTTPURLResponse with nil URL — we pass a response with an explicit URL of nil origin.
     NSDictionary *headers = @{MSID_ASWEBAUTH_HANDOFF_URL_KEY: @"https://portal.manage.microsoft.com/handoff"};
+    // Create response with a nil-equivalent URL (empty string results in nil .URL)
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@""]
+                                                             statusCode:200
+                                                            HTTPVersion:@"HTTP/1.1"
+                                                           headerFields:headers];
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:nil];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertFalse(hasHandoff);
     // Headers are still cached so downstream consumers see consistent state.
@@ -612,10 +633,11 @@ static NSURL *MSIDTestAllowedResponseURL(void)
 {
     // HTTP origin must never be allowed as a hand-off issuer, even if the host itself is on the allowlist.
     NSDictionary *headers = @{MSID_ASWEBAUTH_HANDOFF_URL_KEY: @"https://portal.manage.microsoft.com/handoff"};
-    NSURL *httpResponseURL = [NSURL URLWithString:@"http://portal.manage.microsoft.com/some/path"];
+    NSURL *httpOrigin = [NSURL URLWithString:@"http://portal.manage.microsoft.com/some/path"];
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, httpOrigin);
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:httpResponseURL];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertFalse(hasHandoff);
 }
@@ -626,9 +648,10 @@ static NSURL *MSIDTestAllowedResponseURL(void)
     // Because the page itself is not served from an allowlisted host, the hand-off must be refused.
     NSDictionary *headers = @{MSID_ASWEBAUTH_HANDOFF_URL_KEY: @"https://portal.manage.microsoft.com/handoff"};
     NSURL *attackerOrigin = [NSURL URLWithString:@"https://evil.example.com/landing"];
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, attackerOrigin);
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:attackerOrigin];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertFalse(hasHandoff);
 }
@@ -638,9 +661,10 @@ static NSURL *MSIDTestAllowedResponseURL(void)
     // Defense against suffix-style spoofing — `portal.manage.microsoft.com.attacker.com` must NOT be allowed.
     NSDictionary *headers = @{MSID_ASWEBAUTH_HANDOFF_URL_KEY: @"https://portal.manage.microsoft.com/handoff"};
     NSURL *spoofedOrigin = [NSURL URLWithString:@"https://portal.manage.microsoft.com.attacker.com/path"];
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, spoofedOrigin);
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:spoofedOrigin];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertFalse(hasHandoff);
 }
@@ -648,9 +672,10 @@ static NSURL *MSIDTestAllowedResponseURL(void)
 - (void)testProcessResponseHeaders_whenHandoffHeaderPresentAndResponseURLIsAllowed_shouldReturnYES
 {
     NSDictionary *headers = @{MSID_ASWEBAUTH_HANDOFF_URL_KEY: @"https://portal.manage.microsoft.com/handoff"};
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, MSIDTestAllowedResponseURL());
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:MSIDTestAllowedResponseURL()];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertTrue(hasHandoff);
 }
@@ -660,9 +685,10 @@ static NSURL *MSIDTestAllowedResponseURL(void)
     // Hosts are case-insensitive in DNS; the allowlist check must lowercase the host before matching.
     NSDictionary *headers = @{MSID_ASWEBAUTH_HANDOFF_URL_KEY: @"https://portal.manage.microsoft.com/handoff"};
     NSURL *mixedCaseOrigin = [NSURL URLWithString:@"https://PORTAL.MANAGE.microsoft.com/path"];
+    NSHTTPURLResponse *response = MSIDTestHTTPResponse(headers, mixedCaseOrigin);
 
-    BOOL hasHandoff = [self.handler processResponseHeadersAndCheckForASWebAuthHandoff:headers
-                                                                         responseURL:mixedCaseOrigin];
+    BOOL hasHandoff = [self.handler processNavigationResponseAndCheckForASWebAuthHandoff:response
+                                    embeddedWebviewController:nil];
 
     XCTAssertTrue(hasHandoff);
 }
@@ -683,7 +709,7 @@ static NSURL *MSIDTestAllowedResponseURL(void)
 
 - (void)testPerformASWebAuthHandoff_whenNoHandoffURLCaptured_shouldCompleteWithFailWithError
 {
-    // No prior processResponseHeadersAndCheckForASWebAuthHandoff:responseURL: call captured a hand-off URL.
+    // No prior processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController: call captured a hand-off URL.
     XCTestExpectation *expectation = [self expectationWithDescription:@"completion invoked"];
     MSIDViewController *parent = [MSIDViewController new];
 
@@ -705,7 +731,7 @@ static NSURL *MSIDTestAllowedResponseURL(void)
 {
     // Capture a hand-off URL whose domain is not in the allowlist so validation
     // short-circuits before reaching the system webview transition manager.
-    // Bypass the processResponseHeadersAndCheckForASWebAuthHandoff:responseURL: origin gate by
+    // Bypass the processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController: origin gate by
     // populating lastResponseHeaders directly — this test isolates the perform-side validation.
     self.handler.lastResponseHeaders = @{MSID_ASWEBAUTH_HANDOFF_URL_KEY: @"https://www.example.com/handoff"};
 


### PR DESCRIPTION
## Summary

Moves HTTP response telemetry logic from the base webview controller into `MSIDOnboardingBlobBuilder` so it can be shared between the legacy flow and the new mobile onboarding navigation handler (non-broker path).

## Changes

### Builder (`MSIDOnboardingBlobBuilder`)
- Added `processResponseHeaders:responseURL:` — extracts last-loaded domain, blocking errors from `x-ms-clitelem`, and records remediation steps
- Exposed `strongAuthSetupStarted` / `mdmEnrollmentStarted` readonly flags for the base controller's finalize logic
- Moved `nonBlockingOnboardingErrorCodes` and `recordRemediationStepForErrorCode:` from base controller

### Field Keys
- `MSIDOnboardingBlobStepComplianceRemediationStarted` — recorded at `msauth://compliance`
- `MSIDOnboardingBlobStepProfileDownloadCompleted` — recorded at `msauth://profiledownloadcomplete`
- `MSIDOnboardingUxFlowMobileOnboardingPhase1` — UX flow tag for non-broker onboarding

### Navigation Handler / Delegate
- Renamed to `processNavigationResponseAndCheckForASWebAuthHandoff:embeddedWebviewController:`
- Takes `NSHTTPURLResponse *` (typed object from WKWebView) + explicit controller reference
- Handler calls `builder.processResponseHeaders:` for telemetry in the new flow

### Base Webview Controller
- Refactored `decidePolicyForNavigationResponse:` — single HTTP response cast, clean if/else for new vs legacy
- `processOnboardingTelemetryForResponse:` now delegates to builder (legacy flow only)
- `finalizeOnboardingTelemetry:error:` checks both ivar OR builder flags directly — fixes new flow gap where ivar was never synced

### Decision Resolver
- Records telemetry steps at `msauth://` redirect points: enroll (MdmEnrollmentStarted), compliance (ComplianceRemediationStarted), profiledownloadcomplete (ProfileDownloadCompleted)

### Tests
- Updated all 12 handler test call sites to new method signature with `MSIDTestHTTPResponse()` helper

## Related
- Depends on: #2461 (non-broker controller in common-core)
- OneAuth integration: separate PR needed for `finalizeAndPersist` to update MSID params