### PR TITLE
[minor][bugfix]Only attach PRT header to PkeyAuth response for known AAD hosts

### DIFF
--- a/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.h
+++ b/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.h
@@ -123,3 +123,13 @@ typedef NS_ENUM(NSInteger, MSIDSSORemoteSilentTokenRequestTag)
 };
 /// Returns the string representation for each MSIDSSORemoteSilentTokenRequestTag value.
 FOUNDATION_EXPORT NSString * _Nonnull MSIDSSORemoteSilentTokenRequestTagToString(MSIDSSORemoteSilentTokenRequestTag state);
+
+/// An enum of MSIDPkeyAuthTag.
+typedef NS_ENUM(NSInteger, MSIDPkeyAuthTag)
+{
+    MSIDPkeyAuthAddedRefreshTokenCredentialTag = 0,
+    MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag
+};
+
+/// Returns the string representation for each MSIDPkeyAuthTag value.
+FOUNDATION_EXPORT NSString * _Nonnull MSIDPkeyAuthTagToString(MSIDPkeyAuthTag state);

--- a/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.m
+++ b/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.m
@@ -150,3 +150,17 @@ NSString *MSIDSSORemoteSilentTokenRequestTagToString(MSIDSSORemoteSilentTokenReq
     return [NSString stringWithFormat:@"MSIDSSORemoteSilentTokenRequestTag(%ld)", (long)state];
 }
 
+NSString *MSIDPkeyAuthTagToString(MSIDPkeyAuthTag state)
+{
+    switch (state)
+    {
+        case MSIDPkeyAuthAddedRefreshTokenCredentialTag:
+            return @"p5e7g";
+        case MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag:
+            return @"mi1dp";
+    }
+    // Fallback for any future enum values
+    return [NSString stringWithFormat:@"MSIDPkeyAuthTag(%ld)", (long)state];
+}
+
+

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -100,7 +100,7 @@
     if (credentialHeader)
     {
         NSString *submitHost = [NSURL URLWithString:submitUrl].host.lowercaseString;
-        if ([[MSIDAADNetworkConfiguration defaultConfiguration] isAADPublicCloud:submitHost])
+        if (submitHost && [[MSIDAADNetworkConfiguration defaultConfiguration] isAADPublicCloud:submitHost])
         {
             MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Added refresh token to the PkeyAuth response.");
             [responseReq setValue:credentialHeader forHTTPHeaderField:MSID_REFRESH_TOKEN_CREDENTIAL];

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -35,6 +35,7 @@
 #import "MSIDRequestTelemetryConstants.h"
 #endif
 #import "MSIDWorkPlaceJoinUtil.h"
+#import "MSIDAADNetworkConfiguration.h"
 
 @implementation MSIDPKeyAuthHandler
 
@@ -93,12 +94,21 @@
     [responseReq setValue:currentRequestTelemetryString forHTTPHeaderField:MSID_CURRENT_TELEMETRY_HEADER_NAME];
 #endif
     
-    // Adding refreshTokenCredential (PRT) header to the challenge response. Header is available in customheaders dictionary
+    // Adding refreshTokenCredential (PRT) header to the challenge response. Header is available in customheaders dictionary.
+    // Only attach the PRT header when the challenge is being submitted to a known AAD host, to avoid leaking it to untrusted hosts.
     NSString *credentialHeader = [customHeaders objectForKey:MSID_REFRESH_TOKEN_CREDENTIAL];
     if (credentialHeader)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Added refresh token to the PkeyAuth response.");
-        [responseReq setValue:credentialHeader forHTTPHeaderField:MSID_REFRESH_TOKEN_CREDENTIAL];
+        NSString *submitHost = [NSURL URLWithString:submitUrl].host.lowercaseString;
+        if ([[MSIDAADNetworkConfiguration defaultConfiguration] isAADPublicCloud:submitHost])
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Added refresh token to the PkeyAuth response.");
+            [responseReq setValue:credentialHeader forHTTPHeaderField:MSID_REFRESH_TOKEN_CREDENTIAL];
+        }
+        else
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Skipped adding refresh token to the PkeyAuth response because the submit URL host is not a known AAD host.");
+        }
     }
     else
     {

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -36,6 +36,8 @@
 #endif
 #import "MSIDWorkPlaceJoinUtil.h"
 #import "MSIDAADNetworkConfiguration.h"
+#import "MSIDExecutionFlowLogger.h"
+#import "MSIDExecutionFlowConstants.h"
 
 @implementation MSIDPKeyAuthHandler
 
@@ -104,10 +106,18 @@
         {
             MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Added refresh token to the PkeyAuth response.");
             [responseReq setValue:credentialHeader forHTTPHeaderField:MSID_REFRESH_TOKEN_CREDENTIAL];
+            if (context.correlationId)
+            {
+                MSIDExecutionFlowInsertTag(MSIDPkeyAuthTagToString(MSIDPkeyAuthAddedRefreshTokenCredentialTag), nil, context.correlationId);
+            }
         }
         else
         {
             MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Skipped adding refresh token to the PkeyAuth response because the submit URL host is not a known AAD host.");
+            if (context.correlationId)
+            {
+                MSIDExecutionFlowInsertTag(MSIDPkeyAuthTagToString(MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag), nil, context.correlationId);
+            }
         }
     }
     else

--- a/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
+++ b/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
@@ -143,6 +143,32 @@
     XCTAssertTrue(handleResult);
 }
 
+- (void)testHandleChallengeWithRefreshToken_whenSubmitUrlIsNotKnownAADHost_shouldNotAttachPRTHeader
+{
+    [self makeAppV2GroupEntitled:YES];
+
+    __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2fcontoso.untrusted.com%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+    NSString *value = @"FakeRefreshToken";
+    NSDictionary<NSString *, NSString *> *customHeaders = @{ MSID_REFRESH_TOKEN_CREDENTIAL : value};
+
+    __auto_type *context = [MSIDInteractiveTokenRequestParameters new];
+    context.appRequestMetadata = nil;
+    context.extraURLQueryParameters = @{@"eqp1": @"val1", @"eqp2": @"val2"};
+    __block BOOL callback = NO;
+    BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
+                                                     context:context
+                                               customHeaders:customHeaders
+                                          externalSSOContext:nil
+                                           completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
+        XCTAssertNotNil(challengeResponse);
+        XCTAssertNil([[challengeResponse allHTTPHeaderFields] objectForKey:MSID_REFRESH_TOKEN_CREDENTIAL], @"RefreshToken should not be attached for non-AAD hosts");
+        XCTAssertNil(error);
+        callback = YES;
+    }];
+    XCTAssertTrue(callback);
+    XCTAssertTrue(handleResult);
+}
+
 - (void)testHandleChallengeNilRefreshToken_shouldProceedWithSuccess
 {
     [self makeAppV2GroupEntitled:YES];

--- a/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
+++ b/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
@@ -31,6 +31,8 @@
 #import "MSIDBasicContext.h"
 #import "MSIDTestSwizzle.h"
 #import "MSIDInteractiveTokenRequestParameters.h"
+#import "MSIDExecutionFlowLogger.h"
+#import "MSIDExecutionFlowConstants.h"
 
 @interface MSIDPKeyAuthHandlerTests : XCTestCase
 
@@ -222,6 +224,80 @@
     }];
     XCTAssertTrue(callback);
     XCTAssertTrue(handleResult);
+}
+
+- (void)testHandleChallengeWithRefreshToken_whenKnownAADHost_shouldRecordAddedExecutionFlowTag
+{
+    [self makeAppV2GroupEntitled:YES];
+
+    __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2flogin.microsoftonline.com%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+    NSString *value = @"FakeRefreshToken";
+    NSDictionary<NSString *, NSString *> *customHeaders = @{ MSID_REFRESH_TOKEN_CREDENTIAL : value};
+
+    __auto_type *context = [MSIDInteractiveTokenRequestParameters new];
+    context.appRequestMetadata = nil;
+    context.correlationId = [NSUUID UUID];
+    MSIDExecutionFlowRegister(context.correlationId);
+
+    __block BOOL callback = NO;
+    BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
+                                                     context:context
+                                               customHeaders:customHeaders
+                                          externalSSOContext:nil
+                                           completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
+        XCTAssertNotNil(challengeResponse);
+        XCTAssertTrue([[[challengeResponse allHTTPHeaderFields] objectForKey:MSID_REFRESH_TOKEN_CREDENTIAL] isEqual:value]);
+        XCTAssertNil(error);
+        callback = YES;
+    }];
+    XCTAssertTrue(callback);
+    XCTAssertTrue(handleResult);
+
+    XCTestExpectation *flowExpectation = [self expectationWithDescription:@"execution flow should contain the added PRT tag"];
+    MSIDExecutionFlowRetrieve(context.correlationId, nil, YES, ^(NSString * _Nullable executionFlow) {
+        XCTAssertNotNil(executionFlow);
+        XCTAssertTrue([executionFlow containsString:MSIDPkeyAuthTagToString(MSIDPkeyAuthAddedRefreshTokenCredentialTag)], @"Flow should record the added PRT tag");
+        XCTAssertFalse([executionFlow containsString:MSIDPkeyAuthTagToString(MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag)], @"Flow should not record the skipped tag");
+        [flowExpectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testHandleChallengeWithRefreshToken_whenUntrustedHost_shouldRecordSkippedExecutionFlowTag
+{
+    [self makeAppV2GroupEntitled:YES];
+
+    __auto_type pkeyUrl = @"urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=SOMECONTEXT&nonce=_bQWemEag2Zze-FR1kw2r-XyrDYxmQB2PftHsshTEJc&SubmitUrl=https%3a%2f%2fcontoso.untrusted.com%2fcommon%2fDeviceAuthPKeyAuth&TenantId=f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+    NSString *value = @"FakeRefreshToken";
+    NSDictionary<NSString *, NSString *> *customHeaders = @{ MSID_REFRESH_TOKEN_CREDENTIAL : value};
+
+    __auto_type *context = [MSIDInteractiveTokenRequestParameters new];
+    context.appRequestMetadata = nil;
+    context.correlationId = [NSUUID UUID];
+    MSIDExecutionFlowRegister(context.correlationId);
+
+    __block BOOL callback = NO;
+    BOOL handleResult = [MSIDPKeyAuthHandler handleChallenge:pkeyUrl
+                                                     context:context
+                                               customHeaders:customHeaders
+                                          externalSSOContext:nil
+                                           completionHandler:^(NSURLRequest *challengeResponse, NSError *error) {
+        XCTAssertNotNil(challengeResponse);
+        XCTAssertNil([[challengeResponse allHTTPHeaderFields] objectForKey:MSID_REFRESH_TOKEN_CREDENTIAL]);
+        XCTAssertNil(error);
+        callback = YES;
+    }];
+    XCTAssertTrue(callback);
+    XCTAssertTrue(handleResult);
+
+    XCTestExpectation *flowExpectation = [self expectationWithDescription:@"execution flow should contain the skipped PRT tag"];
+    MSIDExecutionFlowRetrieve(context.correlationId, nil, YES, ^(NSString * _Nullable executionFlow) {
+        XCTAssertNotNil(executionFlow);
+        XCTAssertTrue([executionFlow containsString:MSIDPkeyAuthTagToString(MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag)], @"Flow should record the skipped PRT tag");
+        XCTAssertFalse([executionFlow containsString:MSIDPkeyAuthTagToString(MSIDPkeyAuthAddedRefreshTokenCredentialTag)], @"Flow should not record the added tag");
+        [flowExpectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)makeAppV2GroupEntitled:(BOOL)entitled

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Only attach the PRT (refresh token credential) header to the PkeyAuth challenge response for known/trusted AAD hosts, preventing PRT leakage to untrusted hosts.
 * Harden MSIDDIContainer: validate protocol conformance in resolveImplClassForProtocol:orDefault:; NSAssert in debug, log + fall back to default in release. Self-heal cache eviction on conformance failure; release-mode fallback test via NSAssertionHandler swap.
 
 Version 1.24.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 TBD
-* Only attach the PRT (refresh token credential) header to the PkeyAuth challenge response for known/trusted AAD hosts, preventing PRT leakage to untrusted hosts.
+* Only attach the PRT (refresh token credential) header to the PkeyAuth challenge response for known/trusted AAD hosts, preventing PRT leakage to untrusted hosts. Record an execution-flow tag for the added/skipped decision when a correlation id is available.
 
 Version 1.25.0
 * Harden MSIDDIContainer: validate protocol conformance in resolveImplClassForProtocol:orDefault:; NSAssert in debug, log + fall back to default in release. Self-heal cache eviction on conformance failure; release-mode fallback test via NSAssertionHandler swap.


### PR DESCRIPTION
Restrict the refresh token credential (PRT) header so it is only added to the PkeyAuth challenge response when the submit URL host is a known/trusted AAD host, preventing the PRT from being leaked to untrusted hosts.

## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x ] PR is independently mergeable (no hidden dependencies)
- [x ] Appropriate reviewers are assigned
- [x ] PR reviewed by code owner (required if Copilot-generated)
- [x ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

