### PR TITLE
[patch] [bugfix]: Fix MSIDFlightManager provider assignment race

### DIFF
--- a/IdentityCore/src/MSIDFlightManager.m
+++ b/IdentityCore/src/MSIDFlightManager.m
@@ -113,7 +113,7 @@
 
 - (void)setFlightProvider:(id<MSIDFlightManagerInterface>)flightProvider
 {
-    dispatch_barrier_async(self.synchronizationQueue, ^{
+    dispatch_barrier_sync(self.synchronizationQueue, ^{
         self->_flightProvider = flightProvider;
     });
 }


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [X] All tests pass locally
- [X] PR size is <= 500 LOC per PR Size Check policy
- [ ] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required


## Proposed changes

The proposed change updates  MSIDFlightManager  so assigning  flightProvider  completes immediately before the setter returns.

 Before the change,  setFlightProvider:  used  dispatch_barrier_async . That means the assignment was placed onto the synchronization queue, but the caller did not wait for it to run. Code could set  flightProvider  and then immediately ask for a flight value, while the provider assignment was still waiting in the queue. In that case,  MSIDFlightManager  could still see  flightProvider  as  nil  and return the default value, usually  NO .

 After the change,  setFlightProvider:  uses  dispatch_barrier_sync . The assignment still goes through the same barrier queue, so the thread-safety model stays the same. The difference is that the caller now waits until the assignment is finished. Once  flightProvider = provider  returns, the provider is definitely stored and available to later reads.

 This fixes the CI flake because the failing tests inject a mock flight provider and immediately call code that reads from it. The old async setter allowed the read to happen too early.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
