### PR TITLE
[minor] [bugfix] Skip broker/SSO extension for prompt=create on iOS

### DIFF
--- a/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
+++ b/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
@@ -308,7 +308,15 @@
         return nil;
     }
     
-    if ([parameters shouldUseBroker])
+    // Account creation (prompt=create) must never be routed to the broker / Apple SSO
+    // extension. On iOS an installed Microsoft Authenticator registers an Enterprise SSO
+    // extension that intercepts brokered interactive requests and presents its stored-account
+    // experience instead of the sign-up page, which blocks users from creating a new account
+    // (e.g. a consumer/MSA account). Force such requests through the local interactive
+    // (webview) controller so the sign-up experience is shown.
+    BOOL isAccountCreation = parameters.promptType == MSIDPromptTypeCreate;
+    
+    if ([parameters shouldUseBroker] && !isAccountCreation)
     {
         MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDInteractiveControllerShouldUseBrokerTag),
                                        nil,
@@ -326,6 +334,10 @@
         MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDInteractiveControllerNoBrokerFallbackTag),
                                        nil,
                                        parameters.correlationId);
+    }
+    else if (isAccountCreation)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, parameters, @"prompt=create requested; skipping broker/SSO extension and using local interactive controller so the account creation experience is shown.", nil);
     }
 
     return localController;

--- a/IdentityCore/tests/MSIDRequestControllerFactoryTests.m
+++ b/IdentityCore/tests/MSIDRequestControllerFactoryTests.m
@@ -845,6 +845,71 @@
     XCTAssertEqualObjects(requestParameters.nestedAuthBrokerRedirectUri, @"my_redirect_uri");
 }
 
+#if TARGET_OS_IPHONE
+- (void)testInteractiveController_whenPromptCreate_andSsoExtensionEnabled_usesLocalInteractiveController
+{
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil
+                                                                                              testError:nil
+                                                                                  testWebMSAuthResponse:nil];
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+    parameters.promptType = MSIDPromptTypeCreate;
+
+    NSError *error;
+    SEL selectorForMSIDSSOExtensionInteractiveTokenRequestController = NSSelectorFromString(@"canPerformRequest");
+    [MSIDTestSwizzle classMethod:selectorForMSIDSSOExtensionInteractiveTokenRequestController
+                           class:[MSIDSSOExtensionInteractiveTokenRequestController class]
+                           block:(id)^(void)
+    {
+        return YES;
+    }];
+
+    SEL selectorForMSIDRequestParameters = NSSelectorFromString(@"shouldUseBroker");
+    [MSIDTestSwizzle instanceMethod:selectorForMSIDRequestParameters
+                              class:[MSIDRequestParameters class]
+                              block:(id)^(void)
+    {
+        return YES;
+    }];
+
+    id<MSIDRequestControlling> controller = [MSIDRequestControllerFactory interactiveControllerForParameters:parameters tokenRequestProvider:provider error:&error];
+
+    // prompt=create must bypass the broker / SSO extension so the account creation
+    // experience is shown instead of the Authenticator stored-account UI.
+    XCTAssertTrue([controller isMemberOfClass:MSIDLocalInteractiveController.class]);
+}
+
+- (void)testInteractiveController_whenPromptLogin_andSsoExtensionEnabled_usesSsoExtensionController
+{
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil
+                                                                                              testError:nil
+                                                                                  testWebMSAuthResponse:nil];
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+    parameters.promptType = MSIDPromptTypeLogin;
+
+    NSError *error;
+    SEL selectorForMSIDSSOExtensionInteractiveTokenRequestController = NSSelectorFromString(@"canPerformRequest");
+    [MSIDTestSwizzle classMethod:selectorForMSIDSSOExtensionInteractiveTokenRequestController
+                           class:[MSIDSSOExtensionInteractiveTokenRequestController class]
+                           block:(id)^(void)
+    {
+        return YES;
+    }];
+
+    SEL selectorForMSIDRequestParameters = NSSelectorFromString(@"shouldUseBroker");
+    [MSIDTestSwizzle instanceMethod:selectorForMSIDRequestParameters
+                              class:[MSIDRequestParameters class]
+                              block:(id)^(void)
+    {
+        return YES;
+    }];
+
+    id<MSIDRequestControlling> controller = [MSIDRequestControllerFactory interactiveControllerForParameters:parameters tokenRequestProvider:provider error:&error];
+
+    // Any non-create interactive request should still be routed to the SSO extension.
+    XCTAssertTrue([controller isMemberOfClass:MSIDSSOExtensionInteractiveTokenRequestController.class]);
+}
+#endif
+
 - (MSIDInteractiveTokenRequestParameters *)requestParameters
 {
     MSIDInteractiveTokenRequestParameters *parameters = [MSIDInteractiveTokenRequestParameters new];


### PR DESCRIPTION
On iOS, an installed Microsoft Authenticator registers an Apple Enterprise SSO extension that intercepts brokered interactive requests. For account creation (prompt=create) this surfaced Authenticator's stored-account experience instead of the sign-up page, blocking users from creating a new consumer/MSA account (Teams sign-up scenario).

Gate the broker/SSO-extension routing in
MSIDRequestControllerFactory.platformInteractiveController: on prompt type so that prompt=create falls through to the local interactive (webview) controller and the account creation experience is shown. Silent flows and all other interactive prompts are unchanged.

Adds iOS unit tests covering both the prompt=create bypass and that a normal login still routes to the SSO extension.

## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [x] Appropriate reviewers are assigned
- [x] PR reviewed by code owner (required if Copilot-generated)
- [x] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

