### PR TITLE
[minor][feature]: Support concurrent broker onboarding sessions across apps

### DIFF
--- a/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.h
@@ -24,7 +24,6 @@
 #import <Foundation/Foundation.h>
 #import "MSIDOnboardingStatus.h"
 
-@class MSIDOnboardingStatus;
 @protocol MSIDRequestContext;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.h
+++ b/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.h
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import "MSIDOnboardingStatus.h"
 
 @class MSIDOnboardingStatus;
 @protocol MSIDRequestContext;
@@ -64,6 +65,14 @@ NS_ASSUME_NONNULL_BEGIN
  @return YES if the operation succeeds, NO otherwise.
  */
 - (BOOL)clear:(NSString *)bundleId;
+
+/**
+ Checks whether the given onboarding phase is currently in progress.
+ 
+ @param phase The MSIDOnboardingPhase to check.
+ @return YES if the specified phase is in progress, NO otherwise.
+ */
+- (BOOL)isInProgressPhase:(MSIDOnboardingPhase)phase;
 
 @end
 

--- a/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.m
+++ b/IdentityCore/src/cache/accessor/MSIDOnboardingStatusCache.m
@@ -53,6 +53,7 @@ static NSString *const MSID_ONBOARDING_STATUS_CACHE_ACCOUNT = @"com.microsoft.on
 - (MSIDOnboardingStatus *)getOnboardingStatusLocked;
 - (BOOL)clearLocked:(NSString *)bundleId;
 - (BOOL)isOwnerOverride:(MSIDOnboardingStatus *)status;
+- (BOOL)isInProgressPhase:(MSIDOnboardingPhase)phase;
 - (BOOL)caseInsensitiveString:(NSString *)left matchesString:(NSString *)right;
 
 @end
@@ -286,6 +287,13 @@ static NSString *const MSID_ONBOARDING_STATUS_CACHE_ACCOUNT = @"com.microsoft.on
     return [self caseInsensitiveString:currentBundleId matchesString:status.ownerBundleId];
 }
 
+- (BOOL)isInProgressPhase:(MSIDOnboardingPhase)phase
+{
+    // Terminal phases (none/failed) are not in progress and may be overwritten by any app.
+    return phase == MSIDOnboardingPhaseBrokerInteractiveInProgress
+        || phase == MSIDOnboardingPhaseMdmEnrollmentInProgress;
+}
+
 - (BOOL)setWithStatus:(MSIDOnboardingStatus *)status
 {
     __block BOOL success = NO;
@@ -305,10 +313,11 @@ static NSString *const MSID_ONBOARDING_STATUS_CACHE_ACCOUNT = @"com.microsoft.on
 
     MSIDOnboardingStatus *current = [self getOnboardingStatusLocked];
 
-    // If there's an existing status with a phase other than none, validate that the new status is either
-    // from the same originating bundle or is an owner override. This prevents different apps from overwriting
-    // each other's onboarding status.
-    if (current && current.phase != MSIDOnboardingPhaseNone)
+    // If there's an existing status whose phase is still in progress, validate that the new status is
+    // either from the same originating bundle or is an owner override. This prevents different apps from
+    // overwriting each other's in-progress onboarding status. Terminal phases (none/failed) are not in
+    // progress, so a different app is free to overwrite them.
+    if (current && [self isInProgressPhase:current.phase])
     {
         BOOL originatingBundleMatches = [self caseInsensitiveString:current.originatingBundleId matchesString:status.originatingBundleId];
 

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -440,7 +440,7 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
         // Only evaluate ownership when both bundle ids are present. A malformed/legacy cache
         // entry with a missing originating or current bundle id falls through to the existing
         // non-response handling rather than cancelling the session.
-        if (onboardingStatus.phase == MSIDOnboardingPhaseBrokerInteractiveInProgress &&
+        if ([[MSIDOnboardingStatusCache sharedInstance] isInProgressPhase:onboardingStatus.phase] &&
             onboardingStatus.onboardingContext == MSIDOnboardingContextBroker &&
             originatingBundleId.length > 0 && currentBundleId.length > 0)
         {

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -64,7 +64,7 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
 @property (nonatomic, readwrite) MSIDBrokerKeyProvider *brokerKeyProvider;
 @property (nonatomic, readonly) NSURL *brokerInstallLink;
 @property (atomic, copy) MSIDRequestCompletionBlock requestCompletionBlock;
-@property (nonatomic, readwrite) BOOL isReplayRequest;
+@property (nonatomic, readwrite) BOOL shouldIgnoreBrokerRequest;
 
 @end
 
@@ -242,7 +242,13 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
         return;
     }
     
-    self.isReplayRequest = NO;
+    // Ignore this broker request when a broker interactive sign-in is already in progress
+    // (this or another app sharing the keychain group) so the in-progress session finishes.
+    // Read BEFORE the status is overwritten below.
+    MSIDOnboardingStatus *existingOnboardingStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+    self.shouldIgnoreBrokerRequest = [[MSIDOnboardingStatusCache sharedInstance] isInProgressPhase:existingOnboardingStatus.phase]
+        && existingOnboardingStatus.onboardingContext == MSIDOnboardingContextBroker;
+
     [self.class setCurrentBrokerRequest:brokerRequest];
     // Phase 1, do not show UI to users, just save the current onboarding status for the current MSAL client, and overwrite it.
     // This is to return to Authenticator with the same request if it was initiated from the same app.
@@ -275,7 +281,7 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
     NSURL *brokerRequestURL = brokerRequest.brokerRequestURL;
     
 #if !TARGET_OS_OSX
-    if (self.isReplayRequest)
+    if (self.shouldIgnoreBrokerRequest)
     {
         brokerRequestURL = [brokerRequestURL msidURLWithQueryParameters:@{MSID_IGNORE_BROKER_REQUEST: @"1"}];
     }
@@ -432,11 +438,21 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
         NSString *originatingBundleId = onboardingStatus.originatingBundleId;
         NSString *currentBundleId = [NSBundle.mainBundle bundleIdentifier];
         if (onboardingStatus.phase == MSIDOnboardingPhaseBrokerInteractiveInProgress &&
-            onboardingStatus.onboardingContext == MSIDOnboardingContextBroker &&
-            originatingBundleId.length > 0 && currentBundleId.length > 0 &&
-            [originatingBundleId caseInsensitiveCompare:currentBundleId] == NSOrderedSame)
+            onboardingStatus.onboardingContext == MSIDOnboardingContextBroker)
         {
-            returnToBroker = YES;
+            if (originatingBundleId.length > 0 && currentBundleId.length > 0 &&
+                [originatingBundleId caseInsensitiveCompare:currentBundleId] == NSOrderedSame)
+            {
+                returnToBroker = YES;
+            }
+            else
+            {
+                NSError *cancelError = MSIDCreateError(MSAIMSIDErrorDomain, MSIDErrorSessionCanceledProgrammatically, @"Authentication still in progress in broker, cancel current session.", nil, nil, nil, nil, nil, YES);
+
+                [brokerController completeAcquireTokenWithResult:nil error:cancelError];
+                [[NSUserDefaults standardUserDefaults] removeObjectForKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
+                return;
+            }
         }
         
         if (returnToBroker)
@@ -446,7 +462,7 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
                 MSIDBrokerTokenRequest *brokerRequest = [self currentBrokerRequest];
                 if (brokerRequest)
                 {
-                    brokerController.isReplayRequest = YES;
+                    brokerController.shouldIgnoreBrokerRequest = YES;
                     
                     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, brokerController.requestParameters, @"Returning request to broker app to continue authentication.");
                     [brokerController callBrokerWithRequest:brokerRequest];
@@ -510,10 +526,13 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
     CONDITIONAL_STOP_EVENT(CONDITIONAL_SHARED_INSTANCE, self.requestParameters.telemetryRequestId, brokerEvent);
 #endif
 
+    NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
     if (error)
     {
+        // Update onboarding status as failed only for the originating app
         MSIDOnboardingStatus *status = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
-        if (status && status.phase != MSIDOnboardingPhaseNone)
+        if (status && status.phase != MSIDOnboardingPhaseNone && bundleId
+            && [status.originatingBundleId caseInsensitiveCompare:bundleId] == NSOrderedSame)
         {
             status.phase = MSIDOnboardingPhaseFailed;
             [[MSIDOnboardingStatusCache sharedInstance] setWithStatus:status];
@@ -521,7 +540,6 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
     }
     else
     {
-        NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
         if (!bundleId)
         {
             MSIDOnboardingStatus *status = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -437,16 +437,21 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
         MSIDOnboardingStatus *onboardingStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
         NSString *originatingBundleId = onboardingStatus.originatingBundleId;
         NSString *currentBundleId = [NSBundle.mainBundle bundleIdentifier];
+        // Only evaluate ownership when both bundle ids are present. A malformed/legacy cache
+        // entry with a missing originating or current bundle id falls through to the existing
+        // non-response handling rather than cancelling the session.
         if (onboardingStatus.phase == MSIDOnboardingPhaseBrokerInteractiveInProgress &&
-            onboardingStatus.onboardingContext == MSIDOnboardingContextBroker)
+            onboardingStatus.onboardingContext == MSIDOnboardingContextBroker &&
+            originatingBundleId.length > 0 && currentBundleId.length > 0)
         {
-            if (originatingBundleId.length > 0 && currentBundleId.length > 0 &&
-                [originatingBundleId caseInsensitiveCompare:currentBundleId] == NSOrderedSame)
+            if ([originatingBundleId caseInsensitiveCompare:currentBundleId] == NSOrderedSame)
             {
                 returnToBroker = YES;
             }
             else
             {
+                // Both bundle ids are present and differ: another app's broker session is in
+                // progress, so cancel this duplicate session and clear the stale resume state.
                 NSError *cancelError = MSIDCreateError(MSIDErrorDomain, MSIDErrorSessionCanceledProgrammatically, @"Authentication still in progress in broker, cancel current session.", nil, nil, nil, nil, nil, YES);
 
                 [brokerController completeAcquireTokenWithResult:nil error:cancelError];

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -447,7 +447,7 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
             }
             else
             {
-                NSError *cancelError = MSIDCreateError(MSAIMSIDErrorDomain, MSIDErrorSessionCanceledProgrammatically, @"Authentication still in progress in broker, cancel current session.", nil, nil, nil, nil, nil, YES);
+                NSError *cancelError = MSIDCreateError(MSIDErrorDomain, MSIDErrorSessionCanceledProgrammatically, @"Authentication still in progress in broker, cancel current session.", nil, nil, nil, nil, nil, YES);
 
                 [brokerController completeAcquireTokenWithResult:nil error:cancelError];
                 [[NSUserDefaults standardUserDefaults] removeObjectForKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
@@ -531,7 +531,8 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
     {
         // Update onboarding status as failed only for the originating app
         MSIDOnboardingStatus *status = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
-        if (status && status.phase != MSIDOnboardingPhaseNone && bundleId
+        if (status && status.phase != MSIDOnboardingPhaseNone && bundleId.length > 0
+            && status.originatingBundleId.length > 0
             && [status.originatingBundleId caseInsensitiveCompare:bundleId] == NSOrderedSame)
         {
             status.phase = MSIDOnboardingPhaseFailed;

--- a/IdentityCore/tests/MSIDOnboardingStatusCacheTests.m
+++ b/IdentityCore/tests/MSIDOnboardingStatusCacheTests.m
@@ -633,4 +633,80 @@
     XCTAssertTrue([retrieved.correlationId isEqual:statusA.correlationId] || [retrieved.correlationId isEqual:statusB.correlationId]);
 }
 
+#pragma mark - isInProgressPhase
+
+- (void)testIsInProgressPhase_whenBrokerInteractiveInProgress_shouldReturnYES
+{
+    XCTAssertTrue([self.cache isInProgressPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress]);
+}
+
+- (void)testIsInProgressPhase_whenMdmEnrollmentInProgress_shouldReturnYES
+{
+    XCTAssertTrue([self.cache isInProgressPhase:MSIDOnboardingPhaseMdmEnrollmentInProgress]);
+}
+
+- (void)testIsInProgressPhase_whenNone_shouldReturnNO
+{
+    XCTAssertFalse([self.cache isInProgressPhase:MSIDOnboardingPhaseNone]);
+}
+
+- (void)testIsInProgressPhase_whenFailed_shouldReturnNO
+{
+    XCTAssertFalse([self.cache isInProgressPhase:MSIDOnboardingPhaseFailed]);
+}
+
+#pragma mark - setWithStatus terminal phase overwrite
+
+- (void)testSetWithStatus_whenCurrentPhaseFailedFromDifferentApp_shouldOverwrite
+{
+    // App A leaves a terminal (failed) status behind.
+    MSIDOnboardingStatus *failed = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                             originating:@"com.microsoft.teams"
+                                                   phase:MSIDOnboardingPhaseFailed
+                                              ttlSeconds:900
+                                               startedAt:[NSDate date]];
+    XCTAssertTrue([self.cache setWithStatus:failed]);
+
+    // A different app (B) must be allowed to overwrite a terminal status.
+    MSIDOnboardingStatus *fromOtherApp = [self statusWithOwner:@"com.microsoft.outlook"
+                                                   originating:@"com.microsoft.outlook"
+                                                         phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                                    ttlSeconds:900
+                                                     startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:fromOtherApp];
+
+    XCTAssertTrue(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+    XCTAssertEqualObjects(retrieved.originatingBundleId, @"com.microsoft.outlook");
+}
+
+- (void)testSetWithStatus_whenCurrentPhaseMdmEnrollmentInProgressFromDifferentApp_shouldReturnNO
+{
+    // App A has an in-progress (MDM enrollment) status.
+    MSIDOnboardingStatus *inProgress = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                 originating:@"com.microsoft.teams"
+                                                       phase:MSIDOnboardingPhaseMdmEnrollmentInProgress
+                                                  ttlSeconds:900
+                                                   startedAt:[NSDate date]];
+    XCTAssertTrue([self.cache setWithStatus:inProgress]);
+
+    // A different app (B) must NOT be allowed to overwrite an in-progress status.
+    MSIDOnboardingStatus *fromOtherApp = [self statusWithOwner:@"com.microsoft.azureauthenticator"
+                                                   originating:@"com.microsoft.outlook"
+                                                         phase:MSIDOnboardingPhaseBrokerInteractiveInProgress
+                                                    ttlSeconds:900
+                                                     startedAt:[NSDate date]];
+
+    BOOL result = [self.cache setWithStatus:fromOtherApp];
+
+    XCTAssertFalse(result);
+
+    MSIDOnboardingStatus *retrieved = [self.cache getOnboardingStatus];
+    XCTAssertEqual(retrieved.phase, MSIDOnboardingPhaseMdmEnrollmentInProgress);
+    XCTAssertEqualObjects(retrieved.originatingBundleId, @"com.microsoft.teams");
+}
+
 @end

--- a/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
@@ -1761,6 +1761,236 @@ static NSInteger gFakeThrottlingCallCount = 0;
 
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
+
+#pragma mark - app A in progress, app B opens
+
+- (MSIDOnboardingStatus *)inProgressBrokerStatusFromApp:(NSString *)originatingBundleId
+{
+    NSISO8601DateFormatter *formatter = [NSISO8601DateFormatter new];
+    NSDictionary *json = @{
+        @"phase": [MSIDOnboardingStatus stringFromPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress],
+        @"context": [MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextBroker],
+        @"ownerBundleId": @"com.microsoft.azureauthenticator",
+        @"originatingBundleId": originatingBundleId,
+        @"correlationId": @"00000000-1234-abcd-0000-000000000000",
+        @"startedAt": [formatter stringFromDate:[NSDate date]],
+        @"ttlSeconds": @900
+    };
+    return [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:nil];
+}
+
+- (void)testAcquireToken_whenAnotherAppHasInProgressBrokerStatus_shouldIgnoreBrokerRequestOnFirstCall
+{
+    // App A already has an in-progress broker session recorded in the shared cache.
+    MSIDOnboardingStatus *appAStatus = [self inProgressBrokerStatusFromApp:@"com.microsoft.appA"];
+    XCTAssertNotNil(appAStatus);
+    XCTAssertTrue([[MSIDOnboardingStatusCache sharedInstance] setWithStatus:appAStatus]);
+
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+    [MSIDApplicationTestUtil setCanOpenURLSchemes:@[@"msauthv2", @"msauthv3"]];
+    parameters.brokerInvocationOptions = [[MSIDBrokerInvocationOptions alloc] initWithRequiredBrokerType:MSIDRequiredBrokerTypeDefault
+                                                                                           protocolType:MSIDBrokerProtocolTypeUniversalLink
+                                                                                      aadRequestVersion:MSIDBrokerAADRequestVersionV2];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=ignore1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    MSIDTokenResult *testResult = [self resultWithParameters:parameters];
+
+    __block int openURLCallCount = 0;
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+        openURLCallCount++;
+
+        // Because another app's broker session is already in progress, the very first broker
+        // request must carry ignore_broker_request=1 so broker lets that session finish.
+        XCTAssertEqualObjects([url msidQueryParameters][MSID_IGNORE_BROKER_REQUEST], @"1");
+
+        MSIDTestBrokerResponseHandler *brokerResponseHandler = [[MSIDTestBrokerResponseHandler alloc] initWithTestResponse:testResult testError:nil];
+        [MSIDBrokerInteractiveController completeAcquireToken:[NSURL URLWithString:@"https://contoso.com"]
+                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                        brokerResponseHandler:brokerResponseHandler];
+
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNotNil(result);
+        XCTAssertNil(acquireTokenError);
+        XCTAssertEqual(openURLCallCount, 1);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenAnotherAppHasInProgressBrokerStatus_andReturnsToForeground_shouldCancelSession
+{
+    // App A already has an in-progress broker session recorded in the shared cache.
+    MSIDOnboardingStatus *appAStatus = [self inProgressBrokerStatusFromApp:@"com.microsoft.appA"];
+    XCTAssertNotNil(appAStatus);
+    XCTAssertTrue([[MSIDOnboardingStatusCache sharedInstance] setWithStatus:appAStatus]);
+
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=cancel1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        // The user returns to app B without a broker response while app A's session is still in progress.
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+        XCTAssertEqual(acquireTokenError.code, MSIDErrorSessionCanceledProgrammatically);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+
+    // The resume dictionary must be removed so the cancelled session is not resumed later.
+    // It is cleared after the completion block runs, so assert once the flow has finished.
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:MSID_BROKER_RESUME_DICTIONARY_KEY]);
+}
+
+- (void)testAcquireToken_whenBrokerResponseError_andStatusBelongsToAnotherApp_shouldNotSetOnboardingPhaseToFailed
+{
+    // App A already has an in-progress broker session recorded in the shared cache.
+    MSIDOnboardingStatus *appAStatus = [self inProgressBrokerStatusFromApp:@"com.microsoft.appA"];
+    XCTAssertNotNil(appAStatus);
+    XCTAssertTrue([[MSIDOnboardingStatusCache sharedInstance] setWithStatus:appAStatus]);
+
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=notfailed1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    NSError *testError = MSIDCreateError(MSIDErrorDomain, 123456789, @"Test broker error", nil, nil, nil, parameters.correlationId, nil, YES);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        MSIDTestBrokerResponseHandler *brokerResponseHandler = [[MSIDTestBrokerResponseHandler alloc] initWithTestResponse:nil testError:testError];
+        [MSIDBrokerInteractiveController completeAcquireToken:[NSURL URLWithString:@"https://contoso.com"]
+                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                        brokerResponseHandler:brokerResponseHandler];
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+
+        // The cached status belongs to another app, so it must NOT be flipped to failed.
+        MSIDOnboardingStatus *cachedStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+        XCTAssertNotNil(cachedStatus);
+        XCTAssertEqual(cachedStatus.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+        XCTAssertEqualObjects(cachedStatus.originatingBundleId, @"com.microsoft.appA");
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testAcquireToken_whenBrokerResponseError_andCachedStatusHasNilOriginatingBundleId_shouldNotSetOnboardingPhaseToFailed
+{
+    // An in-progress broker status with no originating bundle id is present in the cache.
+    NSISO8601DateFormatter *formatter = [NSISO8601DateFormatter new];
+    NSDictionary *json = @{
+        @"phase": [MSIDOnboardingStatus stringFromPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress],
+        @"context": [MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextBroker],
+        @"ownerBundleId": @"com.microsoft.azureauthenticator",
+        @"correlationId": @"00000000-1234-abcd-0000-000000000000",
+        @"startedAt": [formatter stringFromDate:[NSDate date]],
+        @"ttlSeconds": @900
+    };
+    MSIDOnboardingStatus *noOriginatingStatus = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:nil];
+    XCTAssertNotNil(noOriginatingStatus);
+    XCTAssertNil(noOriginatingStatus.originatingBundleId);
+    XCTAssertTrue([[MSIDOnboardingStatusCache sharedInstance] setWithStatus:noOriginatingStatus]);
+
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=nilorigin1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    NSError *testError = MSIDCreateError(MSIDErrorDomain, 123456789, @"Test broker error", nil, nil, nil, parameters.correlationId, nil, YES);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        MSIDTestBrokerResponseHandler *brokerResponseHandler = [[MSIDTestBrokerResponseHandler alloc] initWithTestResponse:nil testError:testError];
+        [MSIDBrokerInteractiveController completeAcquireToken:[NSURL URLWithString:@"https://contoso.com"]
+                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                        brokerResponseHandler:brokerResponseHandler];
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+
+        // A status with no originating bundle id must NOT be flipped to failed by a non-originating app.
+        MSIDOnboardingStatus *cachedStatus = [[MSIDOnboardingStatusCache sharedInstance] getOnboardingStatus];
+        XCTAssertNotNil(cachedStatus);
+        XCTAssertEqual(cachedStatus.phase, MSIDOnboardingPhaseBrokerInteractiveInProgress);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
 #endif
 
 @end

--- a/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
@@ -1883,6 +1883,61 @@ static NSInteger gFakeThrottlingCallCount = 0;
     XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:MSID_BROKER_RESUME_DICTIONARY_KEY]);
 }
 
+- (void)testAcquireToken_whenInProgressBrokerStatusHasMissingOriginatingBundleId_andReturnsToForeground_shouldReturnBrokerResponseNotReceived
+{
+    // A malformed/legacy in-progress broker status without an originating bundle id is cached.
+    NSISO8601DateFormatter *formatter = [NSISO8601DateFormatter new];
+    NSDictionary *json = @{
+        @"phase": [MSIDOnboardingStatus stringFromPhase:MSIDOnboardingPhaseBrokerInteractiveInProgress],
+        @"context": [MSIDOnboardingStatus stringFromContext:MSIDOnboardingContextBroker],
+        @"ownerBundleId": @"com.microsoft.azureauthenticator",
+        @"correlationId": @"00000000-1234-abcd-0000-000000000000",
+        @"startedAt": [formatter stringFromDate:[NSDate date]],
+        @"ttlSeconds": @900
+    };
+    MSIDOnboardingStatus *noOriginatingStatus = [[MSIDOnboardingStatus alloc] initWithJSONDictionary:json error:nil];
+    XCTAssertNotNil(noOriginatingStatus);
+    XCTAssertNil(noOriginatingStatus.originatingBundleId);
+    XCTAssertTrue([[MSIDOnboardingStatusCache sharedInstance] setWithStatus:noOriginatingStatus]);
+
+    MSIDInteractiveTokenRequestParameters *parameters = [self requestParameters];
+
+    NSURL *brokerRequestURL = [NSURL URLWithString:@"https://contoso.com?broker=request_url&broker_key=nilcancel1"];
+
+    MSIDTestTokenRequestProvider *provider = [[MSIDTestTokenRequestProvider alloc] initWithTestResponse:nil testError:nil testWebMSAuthResponse:nil brokerRequestURL:brokerRequestURL resumeDictionary:@{}];
+
+    NSError *error = nil;
+    MSIDBrokerInteractiveController *brokerController = [[MSIDBrokerInteractiveController alloc] initWithInteractiveRequestParameters:parameters tokenRequestProvider:provider fallbackController:nil error:&error];
+
+    XCTAssertNotNil(brokerController);
+
+    [MSIDApplicationTestUtil onOpenURL:^BOOL(__unused NSURL *url, __unused NSDictionary<NSString *,id> *options) {
+
+        // The user returns to the foreground without a broker response. Because the cached
+        // status has no originating bundle id, the session must NOT be cancelled; it falls
+        // through to the standard "broker response not received" handling.
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+
+        return YES;
+    }];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token"];
+
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:@"https://login.microsoftonline.com/common"];
+    [MSIDTestURLSession addResponse:discoveryResponse];
+
+    [brokerController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable acquireTokenError) {
+        XCTAssertNil(result);
+        XCTAssertNotNil(acquireTokenError);
+        XCTAssertEqual(acquireTokenError.code, MSIDErrorBrokerResponseNotReceived);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
 - (void)testAcquireToken_whenBrokerResponseError_andStatusBelongsToAnotherApp_shouldNotSetOnboardingPhaseToFailed
 {
     // App A already has an in-progress broker session recorded in the shared cache.

--- a/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDBrokerInteractiveControllerIntegrationTests.m
@@ -72,7 +72,7 @@
 + (MSIDBrokerInteractiveController *)currentBrokerController;
 + (void)setCurrentBrokerRequest:(MSIDBrokerTokenRequest *)currentBrokerRequest;
 + (MSIDBrokerTokenRequest *)currentBrokerRequest;
-@property (nonatomic, readwrite) BOOL isReplayRequest;
+@property (nonatomic, readwrite) BOOL shouldIgnoreBrokerRequest;
 @end
 
 @interface MSIDOnboardingStatusCache ()

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 TBD
 * Only attach the PRT (refresh token credential) header to the PkeyAuth challenge response for known/trusted AAD hosts, preventing PRT leakage to untrusted hosts. Record an execution-flow tag for the added/skipped decision when a correlation id is available.
+* Support concurrent broker onboarding & authentication sessions across apps (#1878)
 
 Version 1.25.0
 * Harden MSIDDIContainer: validate protocol conformance in resolveImplClassForProtocol:orDefault:; NSAssert in debug, log + fall back to default in release. Self-heal cache eviction on conformance failure; release-mode fallback test via NSAssertionHandler swap.


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

`[minor][feature]: Support concurrent broker onboarding sessions across apps`

## Proposed changes

Handles the scenario where **app A** has a broker (Authenticator) interactive sign-in in progress and the user then opens **app B** that shares the same keychain access group:

- Adds `isInProgressPhase:` to `MSIDOnboardingStatusCache` and only protects *in-progress* onboarding statuses from cross-app overwrite. Terminal phases (`none` / `failed`) may now be overwritten by another app.
- When a broker interactive session is already in progress, app B's broker request is tagged with `ignore_broker_request=1` so the in-progress session can finish instead of being clobbered.
- On returning to the foreground with a mismatched originating bundle id, the duplicate session is cancelled with `MSIDErrorSessionCanceledProgrammatically` and the stale resume dictionary is cleared.
- **Bug fix:** an app could not update its onboarding status when it was in the `failed` state; the status guard now allows this.
- Only the *originating* app marks its onboarding status as `failed` on error, using a nil-safe bundle-id comparison.
- **Build fix:** undefined `MSAIMSIDErrorDomain` → `MSIDErrorDomain`.
- Adds unit tests (`MSIDOnboardingStatusCacheTests`) and iOS integration tests (`MSIDBrokerInteractiveControllerIntegrationTests`) covering the new behavior.

## Type of change

- [x] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

- iOS-only broker controller changes are guarded by `#if !TARGET_OS_OSX`.
- **Local validation:** full `IdentityCoreTests iOS` bundle — 2916 tests, 0 failures (3 pre-existing skips) on iPhone 17 Pro / iOS 26.2.
- **PR size:** 358 added / 15 deleted vs `dev` (within the 500 LOC policy).
- Reviewer / code-owner / SME assignment boxes are intentionally left unchecked for the team to assign during review.
