### PR TITLE
[MINOR] [Feature]: Resolve token type from extra query parameters then request in browser-native GetToken request

### DIFF
--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
@@ -50,7 +50,6 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_PLATFORM_SEQUENCE_KEY = @"x-client-x
 NSString *const MSID_BROWSER_NATIVE_MESSAGE_CAN_SHOW_UI_KEY = @"canShowUI";
 NSString *const MSID_BROWSER_NATIVE_MESSAGE_REQUEST_CONFIRMATION_KEY = @"reqCnf";
 NSString *const MSID_BROWSER_NATIVE_MESSAGE_TOKEN_TYPE_KEY = @"tokenType";
-NSString *const MSID_BROWSER_NATIVE_MESSAGE_AUTHENTICATION_SCHEME_KEY = @"authenticationScheme";
 NSString *const MSID_BROWSER_NATIVE_MESSAGE_CLAIMS_KEY = @"claims";
 
 @implementation MSIDBrowserNativeMessageGetTokenRequest
@@ -218,12 +217,12 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_CLAIMS_KEY = @"claims";
     if (!disablePop)
     {
         NSString *reqCnf = [requestJson msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_REQUEST_CONFIRMATION_KEY] ?: [_extraParameters msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_REQUEST_CONFIRMATION_KEY];
-        // Read authenticationScheme (MSAL JS contract), fall back to tokenType for backward compatibility
-        NSString *authenticationScheme = [requestJson msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_AUTHENTICATION_SCHEME_KEY]
+        // Read tokenType from the extra query parameters, falling back to the top-level request.
+        NSString *tokenType = [_extraParameters msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_TOKEN_TYPE_KEY]
             ?: [requestJson msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_TOKEN_TYPE_KEY];
-        authenticationScheme = authenticationScheme.capitalizedString;
+        tokenType = tokenType.capitalizedString;
         
-        if (MSIDAuthSchemeTypeFromString(authenticationScheme) == MSIDAuthSchemePop)
+        if (MSIDAuthSchemeTypeFromString(tokenType) == MSIDAuthSchemePop)
         {
             
             if ([NSString msidIsStringNilOrBlank:reqCnf])
@@ -235,7 +234,7 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_CLAIMS_KEY = @"claims";
             }
             
             NSMutableDictionary *schemeParams = [NSMutableDictionary new];
-            schemeParams[MSID_OAUTH2_TOKEN_TYPE] = authenticationScheme;
+            schemeParams[MSID_OAUTH2_TOKEN_TYPE] = tokenType;
             schemeParams[MSID_OAUTH2_REQUEST_CONFIRMATION] = reqCnf;
             
             _authScheme = [[MSIDAuthenticationSchemePop alloc] initWithSchemeParameters:schemeParams];

--- a/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
@@ -755,7 +755,7 @@
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndPopAuthenticationScheme_shouldInit
+- (void)testInitWithJSONDictionary_whenAuthenticationSchemeProvided_shouldBeIgnoredAndDefaultToBearer
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -805,10 +805,11 @@
     XCTAssertTrue(request.instanceAware);
     XCTAssertEqualObjects(extraParameters, request.extraParameters);
     XCTAssertNotNil(request.authScheme);
-    XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
+    // authenticationScheme is not read; only tokenType is honored, so this defaults to Bearer.
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndPopTokenTypeFallback_shouldInit
+- (void)testInitWithJSONDictionary_whenJsonValidAndPopTokenType_shouldInit
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -845,7 +846,7 @@
     XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenBothAuthenticationSchemeAndTokenType_shouldPrioritizeAuthenticationScheme
+- (void)testInitWithJSONDictionary_whenBothAuthenticationSchemeAndTokenType_shouldUseTokenType
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -880,11 +881,11 @@
     XCTAssertNil(error);
     XCTAssertNotNil(request);
     XCTAssertNotNil(request.authScheme);
-    // authenticationScheme ("pop") should win over tokenType ("bearer")
-    XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
+    // authenticationScheme is ignored; tokenType ("bearer") is used.
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndPopTokenTypeInEQP_shouldDefaultToBearer
+- (void)testInitWithJSONDictionary_whenJsonValidAndPopTokenTypeInEQP_shouldInit
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -919,11 +920,50 @@
     XCTAssertNotNil(request);
     XCTAssertEqualObjects(extraParameters, request.extraParameters);
     XCTAssertNotNil(request.authScheme);
-    // tokenType in extraParameters should no longer be read for auth scheme detection
-    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+    // tokenType is read from extraParameters first.
+    XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndInvalidPopAuthenticationSchemeReqCnf_shouldInit
+- (void)testInitWithJSONDictionary_whenTokenTypeInBothEQPAndTopLevel_shouldPrioritizeEQP
+{
+    __auto_type extraParameters = @{
+        @"k1": @"v1",
+        @"k2": @"v2",
+        @"tokenType": @"pop",
+        @"reqCnf": @"eyJraWQiOiJYaU1hYWdoSXdCWXQwLWU2RUFydWxuaWtLbExVdVlrcXVHRk05YmE5RDF3In0"
+    };
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"accountId": @"uid.utid",
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"prompt": @"login",
+            @"isSts": @(YES),
+            @"canShowUI": @(NO),
+            @"nonce": @"e98aba90-bc47-4ff9-8809-b6e1c7e7cd47",
+            @"state": @"state1",
+            @"loginHint": @"user@microsoft.com",
+            @"instance_aware": @(YES),
+            @"extraParameters": extraParameters,
+            @"tokenType": @"bearer",
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(request);
+    XCTAssertNotNil(request.authScheme);
+    // tokenType in extraParameters ("pop") wins over the top-level tokenType ("bearer").
+    XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
+}
+
+- (void)testInitWithJSONDictionary_whenJsonValidAndInvalidPopTokenTypeReqCnf_shouldInit
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -946,7 +986,7 @@
             @"loginHint": @"user@microsoft.com",
             @"instance_aware": @(YES),
             @"extraParameters": extraParameters,
-            @"authenticationScheme": @"pop",
+            @"tokenType": @"pop",
             @"reqCnf": @"qwe"
         }
     };
@@ -999,7 +1039,7 @@
             @"loginHint": @"user@microsoft.com",
             @"instance_aware": @(YES),
             @"extraParameters": extraParameters,
-            @"authenticationScheme": @"pop",
+            @"tokenType": @"pop",
             @"reqCnf": @1
         }
     };
@@ -1012,7 +1052,7 @@
     XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndNumberAuthenticationScheme_shouldNotFail
+- (void)testInitWithJSONDictionary_whenJsonValidAndNumberTokenType_shouldNotFail
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -1035,7 +1075,7 @@
             @"loginHint": @"user@microsoft.com",
             @"instance_aware": @(YES),
             @"extraParameters": extraParameters,
-            @"authenticationScheme": @1,
+            @"tokenType": @1,
             @"reqCnf": @"eyJraWQiOiJYaU1hYWdoSXdCWXQwLWU2RUFydWxuaWtLbExVdVlrcXVHRk05YmE5RDF3In0"
         }
     };
@@ -1048,12 +1088,11 @@
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndAuthenticationSchemeInEQPOnlyAndReqCnfAsNumber_shouldDefaultToBearer
+- (void)testInitWithJSONDictionary_whenPopTokenTypeInEQPAndReqCnfAsNumber_shouldReturnNilWithError
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
         @"k2": @"v2",
-        @"authenticationScheme": @"pop",
         @"tokenType": @"pop",
         @"reqCnf": @1
     };
@@ -1080,10 +1119,10 @@
     NSError *error;
     __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
     
-    XCTAssertNotNil(request);
-    XCTAssertNil(error);
-    // authenticationScheme/tokenType in extraParameters should not be read — defaults to Bearer
-    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+    // tokenType in extraParameters is Pop but reqCnf is not a valid string, so the request is rejected.
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
 - (void)testInitWithJSONDictionary_whenJsonValidAndNumberTokenTypeAsEQP_shouldNotFail
@@ -1119,7 +1158,7 @@
     
     XCTAssertNotNil(request);
     XCTAssertNil(error);
-    // authenticationScheme in extraParameters should not be read for auth scheme detection
+    // tokenType in extraParameters is not a string, so it is ignored and defaults to Bearer.
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
@@ -1170,7 +1209,7 @@
     XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
-- (void)testInitWithJSONDictionary_whenPopTokenTypeInEQPAndNilReqCnf_shouldDefaultToBearer
+- (void)testInitWithJSONDictionary_whenPopTokenTypeInEQPAndNilReqCnf_shouldReturnNilWithError
 {
     __auto_type extraParameters = @{
         @"tokenType": @"pop",
@@ -1191,10 +1230,10 @@
     NSError *error;
     __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
     
-    XCTAssertNotNil(request);
-    XCTAssertNil(error);
-    // tokenType in extraParameters should not be read — defaults to Bearer
-    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+    // tokenType in extraParameters is Pop but reqCnf is missing, so the request is rejected.
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
 @end


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## Proposed changes

Simplifies how the Apple broker resolves the requested token type when parsing a browser-native `GetToken` request.

The request now resolves `tokenType` as follows:

1. `tokenType` in `extraParameters` (extra query parameters)
2. `tokenType` at the top level of the request (fallback)

`authenticationScheme` is no longer read at any point. The previously added `authenticationScheme` key constant has been removed. When `tokenType` resolves to `pop`, a valid `reqCnf` is still required (top-level or in `extraParameters`); otherwise the request is rejected. When no usable `tokenType` is present, the scheme defaults to Bearer, preserving existing behavior.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios.
- [ ] Medium – Errors could cause regression of 1 or more scenarios.
- [x] Small – No issues are expected.

## Additional information

- Related work item: Task 3596198 — Parse token_type from ESTS Response in Apple Brokers.
- Updated unit tests in `MSIDBrowserNativeMessageGetTokenRequestTests` to cover `tokenType` in extra query parameters and at the top level, extraParameters-first precedence, PoP `reqCnf` validation in both positions, non-string `tokenType` handling, and regression tests confirming `authenticationScheme` is ignored. Full `MSIDBrowserNativeMessageGetTokenRequestTests` suite passes (39 tests, 0 failures).
