### PR TITLE
iOS: opt-in test injection hook for in-process CBA challenge handling

### DIFF
--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/ios/MSIDCertAuthHandler.m
@@ -30,21 +30,75 @@
 #import "NSDictionary+MSIDQueryItems.h"
 #import "MSIDCertAuthManager.h"
 
-#if !MSID_EXCLUDE_SYSTEMWV
+#if MSID_ENABLE_TEST_HOOKS
+#import <Security/Security.h>
+#endif
 
-static BOOL s_disableCertBasedAuth = NO; 
+#if !MSID_EXCLUDE_SYSTEMWV && MSID_ENABLE_TEST_HOOKS
+
+// Test-only API surface. Declared in a file-private class extension so the
+// formal property contract lives only inside this .m and never reaches any
+// header consumer. The implementations are additionally compiled out of any
+// build where MSID_ENABLE_TEST_HOOKS is not defined, so no shipping binary
+// contains the test hooks even via Objective-C runtime reflection.
+// Consumers opt in by defining MSID_ENABLE_TEST_HOOKS=1 only for
+// test-bearing CMake/Xcode configurations.
+@interface MSIDCertAuthHandler ()
+
+// When YES, +handleChallenge: refuses the CBA challenge.
+@property (class, nonatomic) BOOL disableCertBasedAuth;
+
+// When non-NULL, the iOS challenge handler answers every subsequent
+// WKWebView client-cert challenge in-process with this identity (until
+// the slot is cleared) instead of routing to SFSafariViewController.
+// The host test installs the identity via SecPKCS12Import and assigns
+// it here; tear-down assigns NULL to clear it. This is the mechanism
+// that lets MSAL ObjC consumers run end-to-end CBA tests on hosted CI
+// without a UI agent (matching what other platforms already do via
+// silent client-cert credential responses).
+@property (class, nonatomic) SecIdentityRef testIdentityForCertBasedAuth;
+
+@end
+
+static BOOL s_disableCertBasedAuth = NO;
+static SecIdentityRef s_testIdentityForCertBasedAuth = NULL;
 
 #endif
 
 @implementation MSIDCertAuthHandler
 
-#if TARGET_OS_IPHONE && !MSID_EXCLUDE_SYSTEMWV
+#if TARGET_OS_IPHONE && !MSID_EXCLUDE_SYSTEMWV && MSID_ENABLE_TEST_HOOKS
 
-+ (void)disableCertBasedAuth
++ (BOOL)disableCertBasedAuth
 {
-    // This is a private API only to ensure nobody with access to internal headers takes dependency on it
-    // This should be executed in automation tests only
-    s_disableCertBasedAuth = YES;
+    return s_disableCertBasedAuth;
+}
+
++ (void)setDisableCertBasedAuth:(BOOL)disableCertBasedAuth
+{
+    s_disableCertBasedAuth = disableCertBasedAuth;
+}
+
++ (SecIdentityRef)testIdentityForCertBasedAuth
+{
+    return s_testIdentityForCertBasedAuth;
+}
+
++ (void)setTestIdentityForCertBasedAuth:(SecIdentityRef)testIdentityForCertBasedAuth
+{
+    // Retain the new identity BEFORE releasing the old one. If a caller passes
+    // the same SecIdentityRef that's already installed, releasing first could
+    // drop the last reference and leave us retaining a dangling pointer.
+    SecIdentityRef previous = s_testIdentityForCertBasedAuth;
+    if (testIdentityForCertBasedAuth)
+    {
+        CFRetain(testIdentityForCertBasedAuth);
+    }
+    s_testIdentityForCertBasedAuth = testIdentityForCertBasedAuth;
+    if (previous)
+    {
+        CFRelease(previous);
+    }
 }
 
 #endif
@@ -66,11 +120,27 @@ static BOOL s_disableCertBasedAuth = NO;
 {
 #if !MSID_EXCLUDE_SYSTEMWV
     
+#if MSID_ENABLE_TEST_HOOKS
     if (s_disableCertBasedAuth)
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"Cert based auth is explicitly disabled. Ignoring challenge.");
         return NO;
     }
+
+    // Test-only short-circuit: if a test has injected an identity via
+    // +setTestIdentityForCertBasedAuth:, answer the challenge in-process
+    // and skip the SFSafariViewController hand-off entirely. This is what
+    // lets end-to-end CBA tests run on hosted CI with no UI agent.
+    if (s_testIdentityForCertBasedAuth)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Answering CBA challenge with injected test identity.");
+        NSURLCredential *credential = [NSURLCredential credentialWithIdentity:s_testIdentityForCertBasedAuth
+                                                                 certificates:nil
+                                                                  persistence:NSURLCredentialPersistenceNone];
+        completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+        return YES;
+    }
+#endif
     
     MSIDWebviewSession *currentSession = [MSIDWebviewAuthorization currentSession];
     


### PR DESCRIPTION
## Summary

Adds an opt-in, compile-time-gated test injection slot to the iOS `MSIDCertAuthHandler` so end-to-end CBA tests can answer the `WKWebView` client-cert challenge in-process with a `SecIdentityRef`, bypassing the production `SFSafariViewController` hand-off (which cannot be driven silently on hosted CI).

Mirrors the in-process injection pattern other MSAL platforms already use for the same scenario, and aligns with the existing private `+disableCertBasedAuth` automation hook on this class.

## Changes
- New static slot `s_testIdentityForCertBasedAuth` (test-hook-only).
- New `+ setTestIdentityForCertBasedAuth:` that retains/releases the injected identity. Pass `NULL` to clear.
- `handleChallenge:` short-circuits with `NSURLCredential` + `NSURLSessionAuthChallengeUseCredential` when the slot is non-`NULL`.
- Existing `+ disableCertBasedAuth` and its backing static are moved under the same opt-in guard for symmetry (already private-by-header-omission and documented as test-only).

## Compile-time gating
1. `TARGET_OS_IPHONE && !MSID_EXCLUDE_SYSTEMWV` — only meaningful on iOS embedded webview, same as the existing hook.
2. `#if MSID_ENABLE_TEST_HOOKS` — opt-in macro, **undefined by default**, so symbols are literally absent from production binaries regardless of build configuration. Test builds opt in by defining it (e.g. via `target_compile_definitions(msalobjc PRIVATE MSID_ENABLE_TEST_HOOKS=1)` in CMake, gated on the same flag that enables other MSAL test-only utilities). Replaces the previously-used `#if DEBUG`, which incorrectly excluded the hook from Release CI test runs (MSAL nightly builds end-to-end tests in both Debug and Release).
3. No public header declaration — mirrors the prior `+disableCertBasedAuth` contract.

## Testing
End-to-end CBA test in the consuming app (OneAuth-MSAL iOS) passes against the labs CBA user in both Debug (~14s) and Release/MinSizeRel (~11s) on iOS Simulator (iPhone 15, iOS 17.x, Apple Silicon host), with `MSID_ENABLE_TEST_HOOKS=1` wired through the test build's CMake.

## Risk
Zero impact on shipping binaries: the macro is undefined by default, so the gated code does not exist in production builds (Debug or Release). Test-only.