### PR TITLE
[minor][tests]: Refactor ACES pipelines to consume shared aces-macos-job template

### DIFF
--- a/azure_pipelines/broker_build_steps.yml
+++ b/azure_pipelines/broker_build_steps.yml
@@ -1,0 +1,196 @@
+# =============================================================================
+# Broker repo-specific build steps (checkouts, submodules, CocoaPods, build).
+#
+# These are the steps that are unique to the Broker submodule validation. The
+# generic macOS tool setup (pool, Xcode, Python, Ruby gems) is intentionally
+# NOT here so it can be provided by whichever environment runs these steps:
+#
+#   * ACES pipelines  -> Pipeline YAMLs/shared/aces-macos-job.yml provides the
+#                        pool + Xcode + tooling, then injects these steps.
+#   * visionOS (hosted) -> broker_submodule_steps.yml provides its own tool
+#                        setup (and selectLocalXcode below) and then includes
+#                        these steps.
+#
+# Parameters:
+#   target            build.py target (e.g. ios_library, mac_library, vision_library).
+#   selectLocalXcode  when true, run the Broker repo's select_xcode.sh (used by
+#                     consumers that do NOT get Xcode from the shared job template).
+#   localXcodeVersion Xcode version passed to select_xcode.sh when selectLocalXcode.
+# =============================================================================
+parameters:
+- name: target
+  type: string
+- name: selectLocalXcode
+  type: boolean
+  default: false
+- name: localXcodeVersion
+  type: string
+  default: '16.4'
+
+steps:
+- checkout: azure-activedirectory-tokenbroker-for-objc
+  displayName: 'Checkout Broker'
+  clean: false
+  submodules: false
+  fetchTags: true
+  persistCredentials: true
+
+- task: Bash@3
+  displayName: 'Checkout MSAL, ADAL, and submodules'
+  inputs:
+    workingDirectory: $(Pipeline.Workspace)/s
+    targetType: 'inline'
+    script: |
+      cd azure-activedirectory-tokenbroker-for-objc
+      git submodule update --init --recursive ADAuthenticationBroker/Frameworks/adal
+      git submodule update --init ADAuthenticationBroker/Frameworks/microsoft-authentication-library-for-objc
+
+- checkout: self
+  displayName: 'Checkout IdentityCore'
+  clean: false
+  submodules: false
+  fetchTags: true
+  path: 's/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/microsoft-authentication-library-for-objc/MSAL/IdentityCore'
+  persistCredentials: true
+
+- checkout: WorkplaceJoin-for-iOS
+  displayName: 'Checkout WPJ'
+  clean: false
+  submodules: false
+  fetchTags: true
+  path: 's/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/WorkplaceJoin-for-iOS'
+  persistCredentials: true
+
+- task: AzureCLI@2
+  inputs:
+    azureSubscription: 'AuthSdkResourceManager'
+    scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      # if this fails, check out this bash script that includes diagnostics:
+      # https://gist.github.com/johnterickson/19f80a3e969e39f1000d118739176e62
+      # uncomment these for more debugging spew
+      # GIT_TRACE=1
+      # GIT_CURL_VERBOSE=1
+
+      # Note that the resource is specified to limit the token to Azure DevOps
+      $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+      Write-Host "##vso[task.setvariable variable=aadToken;issecret=true]$token"
+- task: Bash@3
+  displayName: 'Checkout NGC Submodules'
+  env:
+    AccessToken: $(MSAzureToken_encoded)
+  inputs:
+    workingDirectory: $(Pipeline.Workspace)/s
+    targetType: 'inline'
+    script: |
+      cd azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks
+      git -c http.https://msazure.visualstudio.com/DefaultCollection/One/_git/AD-MFA-NGCAuthentication.extraheader="AUTHORIZATION: bearer $(aadToken)" submodule update --init AD-MFA-NGCAuthentication
+      cd AD-MFA-NGCAuthentication
+      git -c http.https://msazure.visualstudio.com/DefaultCollection/One/_git/AD-MFA-NGCKeyProvider-ios.extraheader="AUTHORIZATION: bearer $(aadToken)" submodule update --init NGCKeyProvider
+      git -c http.https://msazure.visualstudio.com/DefaultCollection/One/_git/AD-MFA-MSAuthNetworking.extraheader="AUTHORIZATION: bearer $(aadToken)" submodule update --init MSAuthNetworking
+
+- task: Bash@3
+  displayName: 'Checkout WPJ openssl-msft submodule'
+  inputs:
+    workingDirectory: $(Pipeline.Workspace)/s
+    targetType: 'inline'
+    script: |
+      cd azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/WorkplaceJoin-for-iOS
+      git -c http.https://msazure.visualstudio.com/DefaultCollection/PlatformCrypto/_git/openssl-msft.extraheader="AUTHORIZATION: bearer $(aadToken)" submodule update --init Frameworks/openssl-msft
+
+- task: Bash@3
+  displayName: 'Update WPJ submodules'
+  inputs:
+    workingDirectory: $(Pipeline.Workspace)/s
+    targetType: 'inline'
+    script: |
+      cd azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/WorkplaceJoin-for-iOS
+      git submodule update --init --recursive Frameworks/microsoft-authentication-library-for-objc
+
+- ${{ if eq(parameters.target, 'mac_library') }}:
+  - task: Cache@2
+    displayName: 'Cache CocoaPods'
+    inputs:
+      key: 'cocoapods | "$(Agent.OS)" | azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Podfile.lock'
+      path: '$(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Pods'
+
+  - task: Bash@3
+    displayName: 'Install CocoaPods (if needed)'
+    inputs:
+      targetType: 'inline'
+      script: |
+        if ! command -v pod >/dev/null 2>&1; then
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          if command -v brew >/dev/null 2>&1; then
+            brew install cocoapods
+          else
+            sudo gem install cocoapods -N
+          fi
+        fi
+
+  - task: Bash@3
+    displayName: 'Install CocoaPods dependencies'
+    env:
+      AAD_TOKEN: $(aadToken)
+    inputs:
+      workingDirectory: $(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker
+      targetType: 'inline'
+      script: |
+        # CocoaPods requires a UTF-8 locale; otherwise Ruby's unicode_normalize
+        # raises Encoding::CompatibilityError on ASCII-8BIT paths.
+        export LANG=en_US.UTF-8
+        export LC_ALL=en_US.UTF-8
+        GIT_CONFIG_COUNT=1 \
+        GIT_CONFIG_KEY_0=http.https://office.visualstudio.com/.extraheader \
+        GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer $AAD_TOKEN" \
+        pod install
+    retryCountOnTaskFailure: 1
+
+# Xcode selection for consumers that do not get Xcode from the shared ACES job
+# template (e.g. the hosted visionOS broker stage). Runs after checkout because
+# select_xcode.sh lives inside the Broker repo.
+- ${{ if eq(parameters.selectLocalXcode, true) }}:
+  - task: Bash@3
+    displayName: 'Select Xcode version'
+    inputs:
+      targetType: 'inline'
+      script: 'bash $(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/scripts/select_xcode.sh ${{ parameters.localXcodeVersion }}'
+
+- task: Bash@3
+  displayName: 'Run a python script for Broker'
+  inputs:
+    targetType: 'inline'
+    script: |
+      cd azure-activedirectory-tokenbroker-for-objc
+      echo "executing build:./build.py"
+      # Anchor the log path to the actual build cwd so the cleanup step
+      # cannot drift to a different location than what we tee'd to.
+      mkdir -p "$PWD/build"
+      LOG_FILE="$PWD/build/build_output.log"
+      echo "BROKER_BUILD_LOG=$LOG_FILE"
+      echo "##vso[task.setvariable variable=BROKER_BUILD_LOG]$LOG_FILE"
+      ./build.py --show-build-settings --target ${{ parameters.target }} 2>&1 | tee "$LOG_FILE"
+      final_status=$(<./build/status.txt)
+      echo "FINAL STATUS  = ${final_status}"
+
+      if [ $final_status != "0" ]; then
+        echo "Build & Testing Failed!" >&2
+      fi
+    failOnStderr: true
+
+- task: Bash@3
+  condition: always()
+  displayName: Cleanup
+  inputs:
+    targetType: 'inline'
+    script: |
+      LOG_FILE="${BROKER_BUILD_LOG:-$(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/build/build_output.log}"
+      echo "Looking for build log at: $LOG_FILE"
+      echo "Failed tests summary:"
+      if [ -f "$LOG_FILE" ]; then
+        grep -E "Test Case '-\\[.*\\]' failed|\\*\\* TEST FAILED \\*\\*" "$LOG_FILE" | sort -u || echo "No failed test lines found."
+      else
+        echo "No build log found at $LOG_FILE (build step likely did not run)."
+      fi
+      rm -rf ./build/status.txt

--- a/azure_pipelines/broker_build_steps.yml
+++ b/azure_pipelines/broker_build_steps.yml
@@ -193,4 +193,4 @@ steps:
       else
         echo "No build log found at $LOG_FILE (build step likely did not run)."
       fi
-      rm -rf ./build/status.txt
+      rm -rf $(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/build/status.txt

--- a/azure_pipelines/broker_submodule_check.yml
+++ b/azure_pipelines/broker_submodule_check.yml
@@ -42,7 +42,7 @@ resources:
    - repository: pipelinesShared
      type: git
      name: IDDP/MSAL-ObjC-Pipelines
-     ref: refs/heads/ameyapat/common-aces-config
+     ref: refs/heads/main
 
 stages:
 - stage: Stage_IOS

--- a/azure_pipelines/broker_submodule_check.yml
+++ b/azure_pipelines/broker_submodule_check.yml
@@ -16,11 +16,6 @@ pr:
     - '*'
   drafts: true
 
-pool:
-  name: 'AcesShared'
-  demands:
-    - ImageOverride -equals ACES_VM_SharedPool_Sequoia
-
 # Pipeline parameter: supply the branch of azure-activedirectory-tokenbroker-for-objc to validate against.
 # Defaults to 'dev'. Can be overridden when manually queuing the pipeline or via /azp run.
 parameters:
@@ -42,38 +37,41 @@ resources:
      endpoint: 'MSAL ObjC Service Connection'
      name: AzureAD/WorkplaceJoin-for-iOS
 
+   # Shared ACES macOS job template (pool + Xcode + tool setup) — source of truth.
+   # TODO: switch ref to 'main' once ameyapat/common-aces-config is merged.
+   - repository: pipelinesShared
+     type: git
+     name: IDDP/MSAL-ObjC-Pipelines
+     ref: refs/heads/ameyapat/common-aces-config
+
 stages:
 - stage: Stage_IOS
   displayName: "Validate iOS"
   dependsOn: []
   jobs:
-  - job: Validate_Pull_Request_IOS
-    displayName: Validate Pull Request (iOS)
-    # When 0 is specified, the maximum limit is used. On Microsoft-hosted agents, jobs can't run longer than this interval, regardless of any job level timeouts specified in the job.
-    timeoutInMinutes: 0
-    pool:
-      name: 'AcesShared'
-      demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Sequoia
-    variables:
-      target: "ios_library"
-    steps:
-    - template: broker_submodule_steps.yml
+  - template: Pipeline YAMLs/shared/aces-macos-job.yml@pipelinesShared
+    parameters:
+      jobName: Validate_Pull_Request_IOS
+      displayName: Validate Pull Request (iOS)
+      # 0 = use the maximum limit allowed by the pool.
+      timeoutInMinutes: 0
+      steps:
+        - template: /azure_pipelines/broker_build_steps.yml
+          parameters:
+            target: ios_library
 
 - stage: Stage_MAC
   displayName: "Validate Mac"
   dependsOn: []
   jobs:
-  - job: Validate_Pull_Request_MAC
-    displayName: Validate Pull Request (Mac)
-    # When 0 is specified, the maximum limit is used. On Microsoft-hosted agents, jobs can't run longer than this interval, regardless of any job level timeouts specified in the job.
-    timeoutInMinutes: 0
-    pool:
-      name: 'AcesShared'
-      demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Sequoia
-    variables:
-      target: "mac_library"
-    steps:
-    - template: broker_submodule_steps.yml
+  - template: Pipeline YAMLs/shared/aces-macos-job.yml@pipelinesShared
+    parameters:
+      jobName: Validate_Pull_Request_MAC
+      displayName: Validate Pull Request (Mac)
+      # 0 = use the maximum limit allowed by the pool.
+      timeoutInMinutes: 0
+      steps:
+        - template: /azure_pipelines/broker_build_steps.yml
+          parameters:
+            target: mac_library
         

--- a/azure_pipelines/broker_submodule_steps.yml
+++ b/azure_pipelines/broker_submodule_steps.yml
@@ -1,125 +1,15 @@
+# =============================================================================
+# Broker tool setup + build steps for consumers that do NOT use the shared ACES
+# macOS job template (currently only the hosted visionOS broker stage).
+#
+# The ACES Broker pipeline (broker_submodule_check.yml) instead gets its pool +
+# Xcode + Ruby/Python tooling from Pipeline YAMLs/shared/aces-macos-job.yml and
+# consumes broker_build_steps.yml directly, so the tool-install steps below are
+# only needed here for the hosted image.
+#
+# The consuming job must set a `target` variable (e.g. vision_library).
+# =============================================================================
 steps:
-- checkout: azure-activedirectory-tokenbroker-for-objc
-  displayName: 'Checkout Broker'
-  clean: false
-  submodules: false
-  fetchTags: true
-  persistCredentials: true
-
-- task: Bash@3
-  displayName: 'Checkout MSAL, ADAL, and submodules'
-  inputs:
-    workingDirectory: $(Pipeline.Workspace)/s
-    targetType: 'inline'
-    script: |
-      cd azure-activedirectory-tokenbroker-for-objc
-      git submodule update --init --recursive ADAuthenticationBroker/Frameworks/adal
-      git submodule update --init ADAuthenticationBroker/Frameworks/microsoft-authentication-library-for-objc
-
-- checkout: self
-  displayName: 'Checkout IdentityCore'
-  clean: false
-  submodules: false
-  fetchTags: true
-  path: 's/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/microsoft-authentication-library-for-objc/MSAL/IdentityCore'
-  persistCredentials: true
-
-- checkout: WorkplaceJoin-for-iOS
-  displayName: 'Checkout WPJ'
-  clean: false
-  submodules: false
-  fetchTags: true
-  path: 's/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/WorkplaceJoin-for-iOS'
-  persistCredentials: true
-
-- task: AzureCLI@2
-  inputs:
-    azureSubscription: 'AuthSdkResourceManager'
-    scriptType: 'pscore'
-    scriptLocation: 'inlineScript'
-    inlineScript: |
-      # if this fails, check out this bash script that includes diagnostics:
-      # https://gist.github.com/johnterickson/19f80a3e969e39f1000d118739176e62
-      # uncomment these for more debugging spew
-      # GIT_TRACE=1
-      # GIT_CURL_VERBOSE=1
-
-      # Note that the resource is specified to limit the token to Azure DevOps
-      $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
-      Write-Host "##vso[task.setvariable variable=aadToken;issecret=true]$token"
-- task: Bash@3
-  displayName: 'Checkout NGC Submodules'
-  env:
-    AccessToken: $(MSAzureToken_encoded)
-  inputs:
-    workingDirectory: $(Pipeline.Workspace)/s
-    targetType: 'inline'
-    script: |
-      cd azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks
-      git -c http.https://msazure.visualstudio.com/DefaultCollection/One/_git/AD-MFA-NGCAuthentication.extraheader="AUTHORIZATION: bearer $(aadToken)" submodule update --init AD-MFA-NGCAuthentication
-      cd AD-MFA-NGCAuthentication
-      git -c http.https://msazure.visualstudio.com/DefaultCollection/One/_git/AD-MFA-NGCKeyProvider-ios.extraheader="AUTHORIZATION: bearer $(aadToken)" submodule update --init NGCKeyProvider
-      git -c http.https://msazure.visualstudio.com/DefaultCollection/One/_git/AD-MFA-MSAuthNetworking.extraheader="AUTHORIZATION: bearer $(aadToken)" submodule update --init MSAuthNetworking
-
-- task: Bash@3
-  displayName: 'Checkout WPJ openssl-msft submodule'
-  inputs:
-    workingDirectory: $(Pipeline.Workspace)/s
-    targetType: 'inline'
-    script: |
-      cd azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/WorkplaceJoin-for-iOS
-      git -c http.https://msazure.visualstudio.com/DefaultCollection/PlatformCrypto/_git/openssl-msft.extraheader="AUTHORIZATION: bearer $(aadToken)" submodule update --init Frameworks/openssl-msft
-
-- task: Bash@3
-  displayName: 'Update WPJ submodules'
-  inputs:
-    workingDirectory: $(Pipeline.Workspace)/s
-    targetType: 'inline'
-    script: |
-      cd azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/WorkplaceJoin-for-iOS
-      git submodule update --init --recursive Frameworks/microsoft-authentication-library-for-objc
-
-- task: Cache@2
-  displayName: 'Cache CocoaPods'
-  condition: eq(variables['target'], 'mac_library')
-  inputs:
-    key: 'cocoapods | "$(Agent.OS)" | azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Podfile.lock'
-    path: '$(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Pods'
-
-- task: Bash@3
-  displayName: 'Install CocoaPods (if needed)'
-  condition: eq(variables['target'], 'mac_library')
-  inputs:
-    targetType: 'inline'
-    script: |
-      if ! command -v pod >/dev/null 2>&1; then
-        export HOMEBREW_NO_AUTO_UPDATE=1
-        if command -v brew >/dev/null 2>&1; then
-          brew install cocoapods
-        else
-          sudo gem install cocoapods -N
-        fi
-      fi
-
-- task: Bash@3
-  displayName: 'Install CocoaPods dependencies'
-  condition: eq(variables['target'], 'mac_library')
-  env:
-    AAD_TOKEN: $(aadToken)
-  inputs:
-    workingDirectory: $(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker
-    targetType: 'inline'
-    script: |
-      # CocoaPods requires a UTF-8 locale; otherwise Ruby's unicode_normalize
-      # raises Encoding::CompatibilityError on ASCII-8BIT paths.
-      export LANG=en_US.UTF-8
-      export LC_ALL=en_US.UTF-8
-      GIT_CONFIG_COUNT=1 \
-      GIT_CONFIG_KEY_0=http.https://office.visualstudio.com/.extraheader \
-      GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer $AAD_TOKEN" \
-      pod install
-  retryCountOnTaskFailure: 1
-
 - script: 'gem uninstall xcpretty -I --version 0.4.0'
   displayName: 'Uninstall xcpretty v0.4.0'
 
@@ -144,46 +34,9 @@ steps:
 - task: UsePythonVersion@0
   displayName: 'Use Python 3.x'
 
-- task: Bash@3
-  displayName: 'Select Xcode version'
-  inputs:
-    targetType: 'inline'
-    script: 'bash $(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/scripts/select_xcode.sh 16.4'
-
-- task: Bash@3
-  displayName: 'Run a python script for Broker'
-  inputs:
-    targetType: 'inline'
-    script: |
-      cd azure-activedirectory-tokenbroker-for-objc
-      echo "executing build:./build.py"
-      # Anchor the log path to the actual build cwd so the cleanup step
-      # cannot drift to a different location than what we tee'd to.
-      mkdir -p "$PWD/build"
-      LOG_FILE="$PWD/build/build_output.log"
-      echo "BROKER_BUILD_LOG=$LOG_FILE"
-      echo "##vso[task.setvariable variable=BROKER_BUILD_LOG]$LOG_FILE"
-      ./build.py --show-build-settings --target $(target) 2>&1 | tee "$LOG_FILE"
-      final_status=$(<./build/status.txt)
-      echo "FINAL STATUS  = ${final_status}"
-
-      if [ $final_status != "0" ]; then
-        echo "Build & Testing Failed!" >&2
-      fi
-    failOnStderr: true
-
-- task: Bash@3
-  condition: always()
-  displayName: Cleanup
-  inputs:
-    targetType: 'inline'
-    script: |
-      LOG_FILE="${BROKER_BUILD_LOG:-$(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/build/build_output.log}"
-      echo "Looking for build log at: $LOG_FILE"
-      echo "Failed tests summary:"
-      if [ -f "$LOG_FILE" ]; then
-        grep -E "Test Case '-\\[.*\\]' failed|\\*\\* TEST FAILED \\*\\*" "$LOG_FILE" | sort -u || echo "No failed test lines found."
-      else
-        echo "No build log found at $LOG_FILE (build step likely did not run)."
-      fi
-      rm -rf ./build/status.txt
+# Repo checkouts, CocoaPods, Xcode selection (16.4) and build.
+- template: broker_build_steps.yml
+  parameters:
+    target: $(target)
+    selectLocalXcode: true
+    localXcodeVersion: '16.4'

--- a/azure_pipelines/msal_submodule_check.yaml
+++ b/azure_pipelines/msal_submodule_check.yaml
@@ -139,6 +139,6 @@ jobs:
         displayName: Publish Test Report
         inputs:
           testResultsFormat: 'JUnit'
-          testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
+          testResultsFiles: '$(Agent.BuildDirectory)/s/microsoft-authentication-library-for-objc/build/reports/*'
           failTaskOnFailedTests: true
           testRunTitle: 'Test Run - macFramework'

--- a/azure_pipelines/msal_submodule_check.yaml
+++ b/azure_pipelines/msal_submodule_check.yaml
@@ -89,7 +89,7 @@ jobs:
         displayName: Publish Test Report
         inputs:
           testResultsFormat: 'JUnit'
-          testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
+          testResultsFiles: '$(Agent.BuildDirectory)/s/microsoft-authentication-library-for-objc/build/reports/*'
           failTaskOnFailedTests: true
           testRunTitle: 'Test Run - iosFramework'
 

--- a/azure_pipelines/msal_submodule_check.yaml
+++ b/azure_pipelines/msal_submodule_check.yaml
@@ -34,88 +34,111 @@ resources:
      name: AzureAD/microsoft-authentication-library-for-objc
      ref: refs/heads/${{ parameters.msalBranch }}
 
+   # Shared ACES macOS job template (pool + Xcode + tool setup) — source of truth.
+   # TODO: switch ref to 'main' once ameyapat/common-aces-config is merged.
+   - repository: pipelinesShared
+     type: git
+     name: IDDP/MSAL-ObjC-Pipelines
+     ref: refs/heads/ameyapat/common-aces-config
+
 # Define parallel jobs that run build script for specified targets
 jobs:
-- job: 'Validate_Pull_Request'
-  # When 0 is specified, the maximum limit is used. On Microsoft-hosted agents, jobs can't run longer than this interval, regardless of any job level timeouts specified in the job.
-  timeoutInMinutes: 0
-  strategy:
-    maxParallel: 2
-    matrix:
-      IOS_FRAMEWORK:
-        target: "iosFramework iosTestApp sampleIosApp sampleIosAppSwift"
-      MAC_FRAMEWORK:
-        target: "macFramework"
-  displayName: Validate Pull Request
-  pool:
-    name: 'AcesShared'
-    demands:
-      - ImageOverride -equals ACES_VM_SharedPool_Sequoia
+- template: Pipeline YAMLs/shared/aces-macos-job.yml@pipelinesShared
+  parameters:
+    jobName: Validate_Pull_Request_iOS
+    displayName: Validate Pull Request (iOS)
+    # 0 = use the maximum limit allowed by the pool.
+    timeoutInMinutes: 0
+    steps:
+      - checkout: microsoft-authentication-library-for-objc
+        displayName: 'Checkout MSAL'
+        clean: true
+        submodules: true
+        fetchTags: true
+        persistCredentials: true
+      - checkout: self
+        clean: true
+        submodules: false
+        fetchDepth: 1
+        path: 's/microsoft-authentication-library-for-objc/MSAL/IdentityCore'
+        persistCredentials: false
+      - task: Bash@3
+        displayName: Run Build script & check for Errors
+        inputs:
+          targetType: 'inline'
+          script: |
+            cd $(Agent.BuildDirectory)/s/microsoft-authentication-library-for-objc
+            { output=$(./build.py --target iosFramework iosTestApp sampleIosApp sampleIosAppSwift 2>&1 1>&3-) ;} 3>&1
+            final_status=$(<./build/status.txt)
+            echo "FINAL STATUS  = ${final_status}"
+            echo "POSSIBLE ERRORS: ${output}"
 
-  steps:
+            if [ $final_status != "0" ]; then
+              echo "Build & Testing Failed! \n ${output}" >&2
+            fi
+          failOnStderr: true
+      - task: Bash@3
+        condition: always()
+        displayName: Cleanup
+        inputs:
+          targetType: 'inline'
+          script: |
+            rm -rf $(Agent.BuildDirectory)/s/build/status.txt
+      - task: PublishTestResults@2
+        condition: always()
+        displayName: Publish Test Report
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
+          failTaskOnFailedTests: true
+          testRunTitle: 'Test Run - iosFramework'
 
-  - task: CmdLine@2
-    displayName: Uninstalling xcpretty v0.4.0
-    inputs:
-      script: |
-        sudo gem uninstall xcpretty -I --version 0.4.0
-      failOnStderr: false
+- template: Pipeline YAMLs/shared/aces-macos-job.yml@pipelinesShared
+  parameters:
+    jobName: Validate_Pull_Request_macOS
+    displayName: Validate Pull Request (macOS)
+    # 0 = use the maximum limit allowed by the pool.
+    timeoutInMinutes: 0
+    steps:
+      - checkout: microsoft-authentication-library-for-objc
+        displayName: 'Checkout MSAL'
+        clean: true
+        submodules: true
+        fetchTags: true
+        persistCredentials: true
+      - checkout: self
+        clean: true
+        submodules: false
+        fetchDepth: 1
+        path: 's/microsoft-authentication-library-for-objc/MSAL/IdentityCore'
+        persistCredentials: false
+      - task: Bash@3
+        displayName: Run Build script & check for Errors
+        inputs:
+          targetType: 'inline'
+          script: |
+            cd $(Agent.BuildDirectory)/s/microsoft-authentication-library-for-objc
+            { output=$(./build.py --target macFramework 2>&1 1>&3-) ;} 3>&1
+            final_status=$(<./build/status.txt)
+            echo "FINAL STATUS  = ${final_status}"
+            echo "POSSIBLE ERRORS: ${output}"
 
-  - task: CmdLine@2
-    displayName: Installing xcpretty v0.3.0
-    inputs:
-      script: |
-        sudo gem install xcpretty -N -v 0.3.0
-      failOnStderr: true
-
-  - checkout: microsoft-authentication-library-for-objc
-    displayName: 'Checkout MSAL'
-    clean: true
-    submodules: true
-    fetchTags: true
-    persistCredentials: true
-
-  - checkout: self
-    clean: true
-    submodules: false
-    fetchDepth: 1
-    path: 's/microsoft-authentication-library-for-objc/MSAL/IdentityCore'
-    persistCredentials: false
-
-  - task: UsePythonVersion@0
-    displayName: 'Use Python 3.x'
-    inputs:
-      versionSpec: '3.x'
-
-  - task: Bash@3
-    displayName: Run Build script & check for Errors
-    inputs:
-      targetType: 'inline'
-      script: |
-        cd $(Agent.BuildDirectory)/s/microsoft-authentication-library-for-objc
-        { output=$(./build.py --target $(target) 2>&1 1>&3-) ;} 3>&1
-        final_status=$(<./build/status.txt)
-        echo "FINAL STATUS  = ${final_status}"
-        echo "POSSIBLE ERRORS: ${output}"
-
-        if [ $final_status != "0" ]; then
-          echo "Build & Testing Failed! \n ${output}" >&2
-        fi
-      failOnStderr: true
-
-  - task: Bash@3
-    condition: always()
-    displayName: Cleanup
-    inputs:
-      targetType: 'inline'
-      script: |
-        rm -rf $(Agent.BuildDirectory)/s/build/status.txt
-
-  - task: PublishTestResults@2
-    condition: always()
-    displayName: Publish Test Report
-    inputs:
-      testResultsFormat: 'JUnit'
-      testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
-      failTaskOnFailedTests: true
-      testRunTitle: 'Test Run - $(target)'
+            if [ $final_status != "0" ]; then
+              echo "Build & Testing Failed! \n ${output}" >&2
+            fi
+          failOnStderr: true
+      - task: Bash@3
+        condition: always()
+        displayName: Cleanup
+        inputs:
+          targetType: 'inline'
+          script: |
+            rm -rf $(Agent.BuildDirectory)/s/build/status.txt
+      - task: PublishTestResults@2
+        condition: always()
+        displayName: Publish Test Report
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
+          failTaskOnFailedTests: true
+          testRunTitle: 'Test Run - macFramework'

--- a/azure_pipelines/msal_submodule_check.yaml
+++ b/azure_pipelines/msal_submodule_check.yaml
@@ -39,7 +39,7 @@ resources:
    - repository: pipelinesShared
      type: git
      name: IDDP/MSAL-ObjC-Pipelines
-     ref: refs/heads/ameyapat/common-aces-config
+     ref: refs/heads/main
 
 # Define parallel jobs that run build script for specified targets
 jobs:

--- a/azure_pipelines/msal_submodule_check.yaml
+++ b/azure_pipelines/msal_submodule_check.yaml
@@ -133,7 +133,7 @@ jobs:
         inputs:
           targetType: 'inline'
           script: |
-            rm -rf $(Agent.BuildDirectory)/s/build/status.txt
+            rm -rf $(Agent.BuildDirectory)/s/microsoft-authentication-library-for-objc/build/status.txt
       - task: PublishTestResults@2
         condition: always()
         displayName: Publish Test Report

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -16,6 +16,12 @@ resources:
       type: git
       name: IDDP/MSAL-ObjC-Pipelines
       ref: main
+    # Shared ACES macOS job template (pool + Xcode + tool setup) — source of truth.
+    # TODO: switch ref to 'main' once ameyapat/common-aces-config is merged.
+    - repository: pipelinesShared
+      type: git
+      name: IDDP/MSAL-ObjC-Pipelines
+      ref: refs/heads/ameyapat/common-aces-config
 
 # Define parallel jobs that run build script for specified targets
 jobs:
@@ -26,118 +32,112 @@ jobs:
     - template: Pipeline YAMLs/automation-health-tracker.yml@automationHealthTracker
       parameters:
         automationPipelineIds: [1956, 1284]
-- job: 'Validate_Pull_Request'
-  strategy:
-    maxParallel: 2
-    matrix:
-      IOS_LIB: 
-        target: "ios_library"
-      MAC_LIB: 
-        target: "mac_library"
-  displayName: Validate Pull Request
-  pool:
-    name: 'AcesShared'
-    demands:
-      - ImageOverride -equals ACES_VM_SharedPool_Sequoia
-    timeOutInMinutes: 30
 
-  steps:
-  - task: CmdLine@2
-    displayName: Uninstalling xcpretty v0.4.0
-    inputs:
-      script: |
-        sudo gem uninstall xcpretty -I --version 0.4.0
-      failOnStderr: false
-  - task: CmdLine@2
-    displayName: Installing xcpretty v0.3.0
-    inputs:
-      script: |
-        sudo gem install xcpretty -N -v 0.3.0
-      failOnStderr: true
-  - script: |
-      # System Ruby on macOS agents is 2.6, too old for current slather/bundler.
-      # Install a modern Ruby via Homebrew and prepend it to PATH for all subsequent steps.
-      export HOMEBREW_NO_AUTO_UPDATE=1
-      export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-      brew list ruby >/dev/null 2>&1 || brew install ruby
-      RUBY_BIN="$(brew --prefix ruby)/bin"
-      echo "##vso[task.prependpath]$GEM_HOME/bin"
-      echo "##vso[task.prependpath]$RUBY_BIN"
-      "$RUBY_BIN/ruby" --version
-    displayName: 'Install modern Ruby'
-  - task: CmdLine@2
-    displayName: Installing slather
-    inputs:
-      script: |
-        gem install slather bundler -N
-      failOnStderr: true
-  - checkout: self
-    clean: true
-    submodules: true
-    fetchDepth: 1
-    persistCredentials: false
-  - task: UsePythonVersion@0
-    displayName: 'Use Python 3.x'
-    inputs:
-      versionSpec: '3.x'
-  - task: Bash@3
-    displayName: 'Harden Python toolcache permissions (silence Ruby insecure PATH warning)'
-    inputs:
-      targetType: 'inline'
-      script: |
-        # /opt/hostedtoolcache/Python is created world-writable (mode 0777),
-        # which makes Ruby (used by xcpretty/slather) emit a warning to stderr
-        # whenever it loads rbconfig.rb. That warning trips `failOnStderr: true`
-        # on later steps. Strip the world-write bit from the toolcache tree.
-        if [ -d /opt/hostedtoolcache ]; then
-          sudo chmod -R o-w /opt/hostedtoolcache || true
-        fi
-      failOnStderr: false
-  - task: Bash@3
-    displayName: 'Select Xcode version'
-    inputs:
-      targetType: 'inline'
-      script: '/bin/bash -c "sudo xcode-select -s /Applications/Xcode_16.4.app"'
-  - task: Bash@3
-    displayName: Removing any lingering codecov files. These can cause issues when the xcode version changes
-    inputs:
-      targetType: 'inline'
-      script: |
-        find . -name "*.gcda" -print0 | xargs -0 rm
-  - task: Bash@3
-    displayName: Run CPP script
-    inputs:
-      targetType: 'inline'
-      script: |
-        python3 ./scripts/update_xcode_config_cpp_checks.py
-      failOnStderr: true
-  - task: Bash@3
-    displayName: Run Build script & check for Errors
-    inputs:
-      targetType: 'inline'
-      script: |
-        { output=$(./build.py --no-clean --show-build-settings --target $(target) 2>&1 1>&3-) ;} 3>&1
-        final_status=$(<./build/status.txt)
-        echo "FINAL STATUS  = ${final_status}"
-        echo "POSSIBLE ERRORS: ${output}"
-        
-        if [ $final_status != "0" ]; then
-          echo "Build & Testing Failed! \n ${output}" >&2
-        fi
-      failOnStderr: true
-  - task: Bash@3
-    condition: always()
-    displayName: Cleanup
-    inputs:
-      targetType: 'inline'
-      script: |
-        rm -rf ./build/status.txt
-  - task: PublishTestResults@2
-    condition: always()
-    displayName: Publish Test Report
-    inputs:
-      testResultsFormat: 'JUnit'
-      testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
-      failTaskOnFailedTests: true
-      testRunTitle: 'Test Run - $(target)'
+- template: Pipeline YAMLs/shared/aces-macos-job.yml@pipelinesShared
+  parameters:
+    jobName: Validate_Pull_Request_iOS
+    displayName: Validate Pull Request (iOS)
+    timeoutInMinutes: 30
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+        fetchDepth: 1
+        persistCredentials: false
+      - task: Bash@3
+        displayName: Removing any lingering codecov files. These can cause issues when the xcode version changes
+        inputs:
+          targetType: 'inline'
+          script: |
+            find . -name "*.gcda" -print0 | xargs -0 rm
+      - task: Bash@3
+        displayName: Run CPP script
+        inputs:
+          targetType: 'inline'
+          script: |
+            python3 ./scripts/update_xcode_config_cpp_checks.py
+          failOnStderr: true
+      - task: Bash@3
+        displayName: Run Build script & check for Errors
+        inputs:
+          targetType: 'inline'
+          script: |
+            { output=$(./build.py --no-clean --show-build-settings --target ios_library 2>&1 1>&3-) ;} 3>&1
+            final_status=$(<./build/status.txt)
+            echo "FINAL STATUS  = ${final_status}"
+            echo "POSSIBLE ERRORS: ${output}"
+
+            if [ $final_status != "0" ]; then
+              echo "Build & Testing Failed! \n ${output}" >&2
+            fi
+          failOnStderr: true
+      - task: Bash@3
+        condition: always()
+        displayName: Cleanup
+        inputs:
+          targetType: 'inline'
+          script: |
+            rm -rf ./build/status.txt
+      - task: PublishTestResults@2
+        condition: always()
+        displayName: Publish Test Report
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
+          failTaskOnFailedTests: true
+          testRunTitle: 'Test Run - ios_library'
+
+- template: Pipeline YAMLs/shared/aces-macos-job.yml@pipelinesShared
+  parameters:
+    jobName: Validate_Pull_Request_macOS
+    displayName: Validate Pull Request (macOS)
+    timeoutInMinutes: 30
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+        fetchDepth: 1
+        persistCredentials: false
+      - task: Bash@3
+        displayName: Removing any lingering codecov files. These can cause issues when the xcode version changes
+        inputs:
+          targetType: 'inline'
+          script: |
+            find . -name "*.gcda" -print0 | xargs -0 rm
+      - task: Bash@3
+        displayName: Run CPP script
+        inputs:
+          targetType: 'inline'
+          script: |
+            python3 ./scripts/update_xcode_config_cpp_checks.py
+          failOnStderr: true
+      - task: Bash@3
+        displayName: Run Build script & check for Errors
+        inputs:
+          targetType: 'inline'
+          script: |
+            { output=$(./build.py --no-clean --show-build-settings --target mac_library 2>&1 1>&3-) ;} 3>&1
+            final_status=$(<./build/status.txt)
+            echo "FINAL STATUS  = ${final_status}"
+            echo "POSSIBLE ERRORS: ${output}"
+
+            if [ $final_status != "0" ]; then
+              echo "Build & Testing Failed! \n ${output}" >&2
+            fi
+          failOnStderr: true
+      - task: Bash@3
+        condition: always()
+        displayName: Cleanup
+        inputs:
+          targetType: 'inline'
+          script: |
+            rm -rf ./build/status.txt
+      - task: PublishTestResults@2
+        condition: always()
+        displayName: Publish Test Report
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
+          failTaskOnFailedTests: true
+          testRunTitle: 'Test Run - mac_library'
   

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -21,7 +21,7 @@ resources:
     - repository: pipelinesShared
       type: git
       name: IDDP/MSAL-ObjC-Pipelines
-      ref: refs/heads/ameyapat/common-aces-config
+      ref: refs/heads/main
 
 # Define parallel jobs that run build script for specified targets
 jobs:


### PR DESCRIPTION
Convert pr-validation, msal_submodule_check and broker_submodule_check to use the central Pipeline YAMLs/shared/aces-macos-job.yml template for pool + Xcode + tool setup. Split broker steps into broker_build_steps.yml (repo-specific) so the hosted visionOS consumer keeps its own tool setup via broker_submodule_steps.yml.

## PR Checklist (must be completed before review)

- [ ] All tests pass locally
- [ ] PR size is <= 500 LOC per PR Size Check policy
- [ ] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

