### PR TITLE
[patch][bugfix]: Validate cloud_instance_host_name against known Microsoft identity host list

### DIFF
--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -34,6 +34,8 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDIntuneApplicationStateManager.h"
 #import "MSIDAuthenticationScheme.h"
+#import "MSIDAADNetworkConfiguration.h"
+#import "MSIDAadAuthorityCache.h"
 
 @implementation MSIDRequestParameters
 
@@ -172,13 +174,43 @@
 - (void)setCloudAuthorityWithCloudHostName:(NSString *)cloudHostName
 {
     if ([NSString msidIsStringNilOrBlank:cloudHostName]) return;
+
+    NSString *lowercaseHostName = cloudHostName.lowercaseString;
+
+    // Only rewrite the cloud authority when cloud_instance_host_name is a recognized
+    // Microsoft identity host: either a known AAD public/sovereign cloud host, or a
+    // network environment already discovered via instance metadata. Unrecognized
+    // values are ignored so the originally configured authority continues to be used.
+    BOOL isKnownHost = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:lowercaseHostName];
+
+    if (!isKnownHost)
+    {
+        // Host names are case-insensitive, but the cache may store preferred_network
+        // values without case normalization. Match case-insensitively so a valid host
+        // is not incorrectly ignored.
+        for (NSString *cloudEnvironment in [MSIDAadAuthorityCache sharedInstance].allCloudNetworkEnvironments)
+        {
+            if ([cloudEnvironment caseInsensitiveCompare:lowercaseHostName] == NSOrderedSame)
+            {
+                isKnownHost = YES;
+                break;
+            }
+        }
+    }
+
+    if (!isKnownHost)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Ignoring cloud_instance_host_name: host is not a recognized Microsoft identity host.");
+        return;
+    }
+
     NSError *cloudHostError = nil;
     
-    _cloudAuthority = [self.authority authorityWithUpdatedCloudHostInstanceName:cloudHostName error:&cloudHostError];
+    _cloudAuthority = [self.authority authorityWithUpdatedCloudHostInstanceName:lowercaseHostName error:&cloudHostError];
     
     if (!_cloudAuthority && cloudHostError)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create authority with cloud host name %@, and error %@, %ld", cloudHostName, cloudHostError.domain, (long)cloudHostError.code);
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create authority with cloud host name %@, and error %@, %ld", lowercaseHostName, cloudHostError.domain, (long)cloudHostError.code);
     }
     [self updateMSIDConfiguration];
 }

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -34,7 +34,6 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDIntuneApplicationStateManager.h"
 #import "MSIDAuthenticationScheme.h"
-#import "MSIDAADAuthority.h"
 
 @implementation MSIDRequestParameters
 
@@ -179,7 +178,7 @@
     // Only rewrite the cloud authority when cloud_instance_host_name is a recognized
     // Microsoft identity host; unrecognized values are ignored so the originally
     // configured authority continues to be used.
-    if (![MSIDAADAuthority isRecognizedMicrosoftIdentityHost:lowercaseHostName])
+    if (![self.authority isRecognizedMicrosoftIdentityHost:lowercaseHostName])
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Ignoring cloud_instance_host_name: host is not a recognized Microsoft identity host.");
         return;

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -34,8 +34,7 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDIntuneApplicationStateManager.h"
 #import "MSIDAuthenticationScheme.h"
-#import "MSIDAADNetworkConfiguration.h"
-#import "MSIDAadAuthorityCache.h"
+#import "MSIDAADAuthority.h"
 
 @implementation MSIDRequestParameters
 
@@ -178,27 +177,9 @@
     NSString *lowercaseHostName = cloudHostName.lowercaseString;
 
     // Only rewrite the cloud authority when cloud_instance_host_name is a recognized
-    // Microsoft identity host: either a known AAD public/sovereign cloud host, or a
-    // network environment already discovered via instance metadata. Unrecognized
-    // values are ignored so the originally configured authority continues to be used.
-    BOOL isKnownHost = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:lowercaseHostName];
-
-    if (!isKnownHost)
-    {
-        // Host names are case-insensitive, but the cache may store preferred_network
-        // values without case normalization. Match case-insensitively so a valid host
-        // is not incorrectly ignored.
-        for (NSString *cloudEnvironment in [MSIDAadAuthorityCache sharedInstance].allCloudNetworkEnvironments)
-        {
-            if ([cloudEnvironment caseInsensitiveCompare:lowercaseHostName] == NSOrderedSame)
-            {
-                isKnownHost = YES;
-                break;
-            }
-        }
-    }
-
-    if (!isKnownHost)
+    // Microsoft identity host; unrecognized values are ignored so the originally
+    // configured authority continues to be used.
+    if (![MSIDAADAuthority isRecognizedMicrosoftIdentityHost:lowercaseHostName])
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Ignoring cloud_instance_host_name: host is not a recognized Microsoft identity host.");
         return;

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -34,6 +34,8 @@
 #import "MSIDAccountIdentifier.h"
 #import "MSIDIntuneApplicationStateManager.h"
 #import "MSIDAuthenticationScheme.h"
+#import "MSIDExecutionFlowLogger.h"
+#import "MSIDExecutionFlowConstants.h"
 
 @implementation MSIDRequestParameters
 
@@ -180,7 +182,13 @@
     // configured authority continues to be used.
     if (![self.authority isRecognizedMicrosoftIdentityHost:lowercaseHostName])
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Ignoring cloud_instance_host_name: host is not a recognized Microsoft identity host.");
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, self, @"Ignoring cloud_instance_host_name: host is not a recognized Microsoft identity host.");
+
+        if (self.correlationId)
+        {
+            MSIDExecutionFlowInsertTag(MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameIgnoredTag), nil, self.correlationId);
+        }
+
         return;
     }
 
@@ -190,7 +198,7 @@
     
     if (!_cloudAuthority && cloudHostError)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create authority with cloud host name %@, and error %@, %ld", lowercaseHostName, cloudHostError.domain, (long)cloudHostError.code);
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, self, @"Failed to create authority with cloud host name %@, and error %@, %ld", lowercaseHostName, cloudHostError.domain, (long)cloudHostError.code);
     }
     [self updateMSIDConfiguration];
 }

--- a/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.h
+++ b/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.h
@@ -124,6 +124,14 @@ typedef NS_ENUM(NSInteger, MSIDSSORemoteSilentTokenRequestTag)
 /// Returns the string representation for each MSIDSSORemoteSilentTokenRequestTag value.
 FOUNDATION_EXPORT NSString * _Nonnull MSIDSSORemoteSilentTokenRequestTagToString(MSIDSSORemoteSilentTokenRequestTag state);
 
+/// An enum of MSIDCloudInstanceHostNameTag.
+typedef NS_ENUM(NSInteger, MSIDCloudInstanceHostNameTag)
+{
+    MSIDCloudInstanceHostNameIgnoredTag = 0
+};
+/// Returns the string representation for each MSIDCloudInstanceHostNameTag value.
+FOUNDATION_EXPORT NSString * _Nonnull MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameTag state);
+
 /// An enum of MSIDPkeyAuthTag.
 typedef NS_ENUM(NSInteger, MSIDPkeyAuthTag)
 {

--- a/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.m
+++ b/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.m
@@ -150,6 +150,17 @@ NSString *MSIDSSORemoteSilentTokenRequestTagToString(MSIDSSORemoteSilentTokenReq
     return [NSString stringWithFormat:@"MSIDSSORemoteSilentTokenRequestTag(%ld)", (long)state];
 }
 
+NSString *MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameTag state)
+{
+    switch (state)
+    {
+        case MSIDCloudInstanceHostNameIgnoredTag:
+            return @"UNTAGGED";
+    }
+    // Fallback for any future enum values
+    return [NSString stringWithFormat:@"MSIDCloudInstanceHostNameTag(%ld)", (long)state];
+}
+
 NSString *MSIDPkeyAuthTagToString(MSIDPkeyAuthTag state)
 {
     switch (state)
@@ -162,5 +173,3 @@ NSString *MSIDPkeyAuthTagToString(MSIDPkeyAuthTag state)
     // Fallback for any future enum values
     return [NSString stringWithFormat:@"MSIDPkeyAuthTag(%ld)", (long)state];
 }
-
-

--- a/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.m
+++ b/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.m
@@ -155,7 +155,7 @@ NSString *MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameTag stat
     switch (state)
     {
         case MSIDCloudInstanceHostNameIgnoredTag:
-            return @"UNTAGGED";
+            return @"lziv8";
     }
     // Fallback for any future enum values
     return [NSString stringWithFormat:@"MSIDCloudInstanceHostNameTag(%ld)", (long)state];

--- a/IdentityCore/src/validation/MSIDAADAuthority.h
+++ b/IdentityCore/src/validation/MSIDAADAuthority.h
@@ -44,11 +44,4 @@
                                         context:(nullable id<MSIDRequestContext>)context
                                           error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
-/*!
- Returns YES when @c host is a recognized Microsoft identity host: either a known
- AAD public/sovereign cloud host, or a network environment already discovered via
- instance metadata. Matching is case-insensitive. Returns NO for nil or blank input.
- */
-+ (BOOL)isRecognizedMicrosoftIdentityHost:(nullable NSString *)host;
-
 @end

--- a/IdentityCore/src/validation/MSIDAADAuthority.h
+++ b/IdentityCore/src/validation/MSIDAADAuthority.h
@@ -44,4 +44,11 @@
                                         context:(nullable id<MSIDRequestContext>)context
                                           error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
+/*!
+ Returns YES when @c host is a recognized Microsoft identity host: either a known
+ AAD public/sovereign cloud host, or a network environment already discovered via
+ instance metadata. Matching is case-insensitive. Returns NO for nil or blank input.
+ */
++ (BOOL)isRecognizedMicrosoftIdentityHost:(nullable NSString *)host;
+
 @end

--- a/IdentityCore/src/validation/MSIDAADAuthority.m
+++ b/IdentityCore/src/validation/MSIDAADAuthority.m
@@ -35,6 +35,7 @@
 #import "MSIDJsonSerializableFactory.h"
 #import "MSIDJsonSerializableTypes.h"
 #import "MSIDProviderType.h"
+#import "MSIDAADNetworkConfiguration.h"
 
 @interface MSIDAADAuthority()
 
@@ -359,8 +360,37 @@
 - (MSIDAuthority *)authorityWithUpdatedCloudHostInstanceName:(NSString *)cloudHostInstanceName error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:cloudHostInstanceName]) return nil;
-    
-    NSURL *cloudAuthorityURL = [self.url msidAADAuthorityWithCloudInstanceHostname:cloudHostInstanceName];
+
+    NSString *lowercaseHostName = cloudHostInstanceName.lowercaseString;
+
+    // Only build a cloud authority when the host is a recognized Microsoft identity
+    // host: a known AAD public/sovereign cloud host, or a network environment already
+    // discovered via instance metadata. This mirrors the check in
+    // setCloudAuthorityWithCloudHostName: so callers get consistent behavior.
+    BOOL isKnownHost = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:lowercaseHostName];
+
+    if (!isKnownHost)
+    {
+        // Host names are case-insensitive, but the cache may store preferred_network
+        // values without case normalization. Match case-insensitively so a valid host
+        // is not incorrectly ignored.
+        for (NSString *cloudEnvironment in [MSIDAadAuthorityCache sharedInstance].allCloudNetworkEnvironments)
+        {
+            if ([cloudEnvironment caseInsensitiveCompare:lowercaseHostName] == NSOrderedSame)
+            {
+                isKnownHost = YES;
+                break;
+            }
+        }
+    }
+
+    if (!isKnownHost)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Ignoring cloud_instance_host_name in authorityWithUpdatedCloudHostInstanceName: host is not a recognized Microsoft identity host.");
+        return nil;
+    }
+
+    NSURL *cloudAuthorityURL = [self.url msidAADAuthorityWithCloudInstanceHostname:lowercaseHostName];
     return [[MSIDAADAuthority alloc] initWithURL:cloudAuthorityURL context:nil error:error];
 }
 

--- a/IdentityCore/src/validation/MSIDAADAuthority.m
+++ b/IdentityCore/src/validation/MSIDAADAuthority.m
@@ -357,7 +357,7 @@
 
 #pragma mark - Sovereign
 
-+ (BOOL)isRecognizedMicrosoftIdentityHost:(NSString *)host
+- (BOOL)isRecognizedMicrosoftIdentityHost:(NSString *)host
 {
     if ([NSString msidIsStringNilOrBlank:host]) return NO;
 
@@ -386,7 +386,7 @@
     // Only build a cloud authority when the host is a recognized Microsoft identity
     // host. This mirrors the check in setCloudAuthorityWithCloudHostName: so callers
     // get consistent behavior.
-    if (![MSIDAADAuthority isRecognizedMicrosoftIdentityHost:lowercaseHostName])
+    if (![self isRecognizedMicrosoftIdentityHost:lowercaseHostName])
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Ignoring cloud_instance_host_name in authorityWithUpdatedCloudHostInstanceName: host is not a recognized Microsoft identity host.");
         return nil;

--- a/IdentityCore/src/validation/MSIDAADAuthority.m
+++ b/IdentityCore/src/validation/MSIDAADAuthority.m
@@ -357,6 +357,26 @@
 
 #pragma mark - Sovereign
 
++ (BOOL)isRecognizedMicrosoftIdentityHost:(NSString *)host
+{
+    if ([NSString msidIsStringNilOrBlank:host]) return NO;
+
+    NSString *lowercaseHost = host.lowercaseString;
+
+    // A known AAD public/sovereign cloud host.
+    if ([MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:lowercaseHost]) return YES;
+
+    // Otherwise, a network environment already discovered via instance metadata.
+    // Host names are case-insensitive, but the cache may store preferred_network
+    // values without case normalization, so match case-insensitively.
+    for (NSString *cloudEnvironment in [MSIDAadAuthorityCache sharedInstance].allCloudNetworkEnvironments)
+    {
+        if ([cloudEnvironment caseInsensitiveCompare:lowercaseHost] == NSOrderedSame) return YES;
+    }
+
+    return NO;
+}
+
 - (MSIDAuthority *)authorityWithUpdatedCloudHostInstanceName:(NSString *)cloudHostInstanceName error:(NSError *__autoreleasing*)error
 {
     if ([NSString msidIsStringNilOrBlank:cloudHostInstanceName]) return nil;
@@ -364,27 +384,9 @@
     NSString *lowercaseHostName = cloudHostInstanceName.lowercaseString;
 
     // Only build a cloud authority when the host is a recognized Microsoft identity
-    // host: a known AAD public/sovereign cloud host, or a network environment already
-    // discovered via instance metadata. This mirrors the check in
-    // setCloudAuthorityWithCloudHostName: so callers get consistent behavior.
-    BOOL isKnownHost = [MSIDAADNetworkConfiguration.defaultConfiguration isAADPublicCloud:lowercaseHostName];
-
-    if (!isKnownHost)
-    {
-        // Host names are case-insensitive, but the cache may store preferred_network
-        // values without case normalization. Match case-insensitively so a valid host
-        // is not incorrectly ignored.
-        for (NSString *cloudEnvironment in [MSIDAadAuthorityCache sharedInstance].allCloudNetworkEnvironments)
-        {
-            if ([cloudEnvironment caseInsensitiveCompare:lowercaseHostName] == NSOrderedSame)
-            {
-                isKnownHost = YES;
-                break;
-            }
-        }
-    }
-
-    if (!isKnownHost)
+    // host. This mirrors the check in setCloudAuthorityWithCloudHostName: so callers
+    // get consistent behavior.
+    if (![MSIDAADAuthority isRecognizedMicrosoftIdentityHost:lowercaseHostName])
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Ignoring cloud_instance_host_name in authorityWithUpdatedCloudHostInstanceName: host is not a recognized Microsoft identity host.");
         return nil;

--- a/IdentityCore/src/validation/MSIDAuthority+Internal.h
+++ b/IdentityCore/src/validation/MSIDAuthority+Internal.h
@@ -48,5 +48,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable MSIDAuthority *)authorityWithUpdatedCloudHostInstanceName:(NSString *)cloudHostInstanceName error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
+/*!
+ Returns YES when @c host is a recognized identity host for this authority type.
+ The base implementation returns NO; authority types that support cloud host
+ rewriting (e.g. AAD) override this to validate against their known host list.
+ Matching is expected to be case-insensitive. Returns NO for nil or blank input.
+ */
+- (BOOL)isRecognizedMicrosoftIdentityHost:(nullable NSString *)host;
+
 NS_ASSUME_NONNULL_END
 @end

--- a/IdentityCore/src/validation/MSIDAuthority.m
+++ b/IdentityCore/src/validation/MSIDAuthority.m
@@ -367,6 +367,11 @@ NSString *const MSID_AUTHORITY_TYPE_JSON_KEY = @"authority_type";
     return nil;
 }
 
+- (BOOL)isRecognizedMicrosoftIdentityHost:(__unused NSString *)host
+{
+    return NO;
+}
+
 #pragma mark - MSIDJsonSerializable
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error

--- a/IdentityCore/tests/MSIDAADAuthorityTests.m
+++ b/IdentityCore/tests/MSIDAADAuthorityTests.m
@@ -852,6 +852,56 @@
     XCTAssertNil(error);
 }
 
+#pragma mark - isRecognizedMicrosoftIdentityHost
+
+- (void)testIsRecognizedMicrosoftIdentityHost_whenKnownPublicCloudHost_shouldReturnYes
+{
+    XCTAssertTrue([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"login.microsoftonline.com"]);
+}
+
+- (void)testIsRecognizedMicrosoftIdentityHost_whenKnownSovereignCloudHost_shouldReturnYes
+{
+    XCTAssertTrue([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"login.microsoftonline.de"]);
+}
+
+- (void)testIsRecognizedMicrosoftIdentityHost_whenMixedCaseKnownHost_shouldReturnYes
+{
+    XCTAssertTrue([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"Login.MicrosoftOnline.COM"]);
+}
+
+- (void)testIsRecognizedMicrosoftIdentityHost_whenUnknownHost_shouldReturnNo
+{
+    XCTAssertFalse([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"unknown-host.example.com"]);
+}
+
+- (void)testIsRecognizedMicrosoftIdentityHost_whenNilHost_shouldReturnNo
+{
+    NSString *nilHost = nil;
+    XCTAssertFalse([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:nilHost]);
+}
+
+- (void)testIsRecognizedMicrosoftIdentityHost_whenBlankHost_shouldReturnNo
+{
+    XCTAssertFalse([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"   "]);
+}
+
+- (void)testIsRecognizedMicrosoftIdentityHost_whenHostInCacheWithDifferentCase_shouldReturnYes
+{
+    MSIDAadAuthorityCache *cache = [MSIDAadAuthorityCache sharedInstance];
+    NSSet *savedEnvironments = cache.allCloudNetworkEnvironments;
+    // Simulate a cache that stores the preferred_network host without case normalization.
+    cache.allCloudNetworkEnvironments = [NSSet setWithObject:@"Login.Contoso-Sovereign.COM"];
+
+    @try
+    {
+        XCTAssertTrue([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"login.contoso-sovereign.com"]);
+    }
+    @finally
+    {
+        cache.allCloudNetworkEnvironments = savedEnvironments;
+    }
+}
+
 
 #pragma mark - Private
 

--- a/IdentityCore/tests/MSIDAADAuthorityTests.m
+++ b/IdentityCore/tests/MSIDAADAuthorityTests.m
@@ -779,6 +779,74 @@
     XCTAssertTrue([authority needsUpdateToHomeAuthority:NO]);
 }
 
+#pragma mark - authorityWithUpdatedCloudHostInstanceName
+
+- (void)testAuthorityWithUpdatedCloudHostInstanceName_whenKnownPublicCloudHost_shouldReturnUpdatedAuthority
+{
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    NSError *error = nil;
+
+    MSIDAuthority *updatedAuthority = [authority authorityWithUpdatedCloudHostInstanceName:@"login.microsoftonline.com" error:&error];
+
+    XCTAssertNotNil(updatedAuthority);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(updatedAuthority.environment, @"login.microsoftonline.com");
+}
+
+- (void)testAuthorityWithUpdatedCloudHostInstanceName_whenKnownSovereignCloudHost_shouldReturnUpdatedAuthority
+{
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    NSError *error = nil;
+
+    MSIDAuthority *updatedAuthority = [authority authorityWithUpdatedCloudHostInstanceName:@"login.microsoftonline.de" error:&error];
+
+    XCTAssertNotNil(updatedAuthority);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(updatedAuthority.environment, @"login.microsoftonline.de");
+}
+
+- (void)testAuthorityWithUpdatedCloudHostInstanceName_whenUnknownHost_shouldReturnNil
+{
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    NSError *error = nil;
+
+    MSIDAuthority *updatedAuthority = [authority authorityWithUpdatedCloudHostInstanceName:@"unknown-host.example.com" error:&error];
+
+    XCTAssertNil(updatedAuthority);
+    XCTAssertNil(error);
+}
+
+- (void)testAuthorityWithUpdatedCloudHostInstanceName_whenHostInCacheWithDifferentCase_shouldReturnUpdatedAuthority
+{
+    MSIDAadAuthorityCache *cache = [MSIDAadAuthorityCache sharedInstance];
+    NSSet *savedEnvironments = cache.allCloudNetworkEnvironments;
+    // Simulate a cache that stores the preferred_network host without case normalization.
+    cache.allCloudNetworkEnvironments = [NSSet setWithObject:@"Login.Contoso-Sovereign.COM"];
+
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    NSError *error = nil;
+
+    MSIDAuthority *updatedAuthority = [authority authorityWithUpdatedCloudHostInstanceName:@"login.contoso-sovereign.com" error:&error];
+
+    XCTAssertNotNil(updatedAuthority);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(updatedAuthority.environment, @"login.contoso-sovereign.com");
+
+    cache.allCloudNetworkEnvironments = savedEnvironments;
+}
+
+- (void)testAuthorityWithUpdatedCloudHostInstanceName_whenNilHost_shouldReturnNil
+{
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    NSError *error = nil;
+    NSString *nilHost = nil;
+
+    MSIDAuthority *updatedAuthority = [authority authorityWithUpdatedCloudHostInstanceName:nilHost error:&error];
+
+    XCTAssertNil(updatedAuthority);
+    XCTAssertNil(error);
+}
+
 
 #pragma mark - Private
 

--- a/IdentityCore/tests/MSIDAADAuthorityTests.m
+++ b/IdentityCore/tests/MSIDAADAuthorityTests.m
@@ -823,16 +823,21 @@
     // Simulate a cache that stores the preferred_network host without case normalization.
     cache.allCloudNetworkEnvironments = [NSSet setWithObject:@"Login.Contoso-Sovereign.COM"];
 
-    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
-    NSError *error = nil;
+    @try
+    {
+        MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+        NSError *error = nil;
 
-    MSIDAuthority *updatedAuthority = [authority authorityWithUpdatedCloudHostInstanceName:@"login.contoso-sovereign.com" error:&error];
+        MSIDAuthority *updatedAuthority = [authority authorityWithUpdatedCloudHostInstanceName:@"login.contoso-sovereign.com" error:&error];
 
-    XCTAssertNotNil(updatedAuthority);
-    XCTAssertNil(error);
-    XCTAssertEqualObjects(updatedAuthority.environment, @"login.contoso-sovereign.com");
-
-    cache.allCloudNetworkEnvironments = savedEnvironments;
+        XCTAssertNotNil(updatedAuthority);
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(updatedAuthority.environment, @"login.contoso-sovereign.com");
+    }
+    @finally
+    {
+        cache.allCloudNetworkEnvironments = savedEnvironments;
+    }
 }
 
 - (void)testAuthorityWithUpdatedCloudHostInstanceName_whenNilHost_shouldReturnNil

--- a/IdentityCore/tests/MSIDAADAuthorityTests.m
+++ b/IdentityCore/tests/MSIDAADAuthorityTests.m
@@ -856,33 +856,39 @@
 
 - (void)testIsRecognizedMicrosoftIdentityHost_whenKnownPublicCloudHost_shouldReturnYes
 {
-    XCTAssertTrue([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"login.microsoftonline.com"]);
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    XCTAssertTrue([authority isRecognizedMicrosoftIdentityHost:@"login.microsoftonline.com"]);
 }
 
 - (void)testIsRecognizedMicrosoftIdentityHost_whenKnownSovereignCloudHost_shouldReturnYes
 {
-    XCTAssertTrue([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"login.microsoftonline.de"]);
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    XCTAssertTrue([authority isRecognizedMicrosoftIdentityHost:@"login.microsoftonline.de"]);
 }
 
 - (void)testIsRecognizedMicrosoftIdentityHost_whenMixedCaseKnownHost_shouldReturnYes
 {
-    XCTAssertTrue([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"Login.MicrosoftOnline.COM"]);
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    XCTAssertTrue([authority isRecognizedMicrosoftIdentityHost:@"Login.MicrosoftOnline.COM"]);
 }
 
 - (void)testIsRecognizedMicrosoftIdentityHost_whenUnknownHost_shouldReturnNo
 {
-    XCTAssertFalse([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"unknown-host.example.com"]);
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    XCTAssertFalse([authority isRecognizedMicrosoftIdentityHost:@"unknown-host.example.com"]);
 }
 
 - (void)testIsRecognizedMicrosoftIdentityHost_whenNilHost_shouldReturnNo
 {
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
     NSString *nilHost = nil;
-    XCTAssertFalse([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:nilHost]);
+    XCTAssertFalse([authority isRecognizedMicrosoftIdentityHost:nilHost]);
 }
 
 - (void)testIsRecognizedMicrosoftIdentityHost_whenBlankHost_shouldReturnNo
 {
-    XCTAssertFalse([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"   "]);
+    MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+    XCTAssertFalse([authority isRecognizedMicrosoftIdentityHost:@"   "]);
 }
 
 - (void)testIsRecognizedMicrosoftIdentityHost_whenHostInCacheWithDifferentCase_shouldReturnYes
@@ -894,12 +900,21 @@
 
     @try
     {
-        XCTAssertTrue([MSIDAADAuthority isRecognizedMicrosoftIdentityHost:@"login.contoso-sovereign.com"]);
+        MSIDAADAuthority *authority = (MSIDAADAuthority *)[@"https://login.microsoftonline.com/common" aadAuthority];
+        XCTAssertTrue([authority isRecognizedMicrosoftIdentityHost:@"login.contoso-sovereign.com"]);
     }
     @finally
     {
         cache.allCloudNetworkEnvironments = savedEnvironments;
     }
+}
+
+- (void)testIsRecognizedMicrosoftIdentityHost_whenNonAADAuthority_shouldReturnNo
+{
+    // Non-AAD authority types inherit the base implementation, which recognizes no
+    // cloud host, so even a known AAD host is not recognized for e.g. ADFS.
+    MSIDAuthority *adfsAuthority = [@"https://login.microsoftonline.com/adfs" adfsAuthority];
+    XCTAssertFalse([adfsAuthority isRecognizedMicrosoftIdentityHost:@"login.microsoftonline.com"]);
 }
 
 

--- a/IdentityCore/tests/MSIDRequestParametersTests.m
+++ b/IdentityCore/tests/MSIDRequestParametersTests.m
@@ -30,6 +30,8 @@
 #import "MSIDAuthenticationSchemePop.h"
 #import "MSIDAuthenticationSchemeSshCert.h"
 #import "MSIDAccountIdentifier.h"
+#import "MSIDExecutionFlowLogger.h"
+#import "MSIDExecutionFlowConstants.h"
 
 @interface MSIDRequestParametersTests : XCTestCase
 
@@ -625,6 +627,42 @@
     [parameters setCloudAuthorityWithCloudHostName:@"   "];
 
     XCTAssertNil(parameters.cloudAuthority);
+}
+
+- (void)testSetCloudAuthorityWithCloudHostName_whenUnknownHostAndCorrelationIdAvailable_shouldRecordExecutionFlowTag
+{
+    MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
+    NSOrderedSet *scopes = [NSOrderedSet orderedSetWithObjects:@"myscope1", nil];
+    NSOrderedSet *oidcScopes = [NSOrderedSet orderedSetWithObjects:@"openid", nil];
+    NSUUID *correlationId = [NSUUID new];
+    NSError *error = nil;
+    MSIDRequestParameters *parameters = [[MSIDRequestParameters alloc] initWithAuthority:authority
+                                                                          authScheme:[MSIDAuthenticationScheme new]
+                                                                         redirectUri:@"myredirect"
+                                                                            clientId:@"myclient_id"
+                                                                              scopes:scopes
+                                                                          oidcScopes:oidcScopes
+                                                                       correlationId:correlationId
+                                                                      telemetryApiId:nil
+                                                                 intuneAppIdentifier:@"com.microsoft.mytest"
+                                                                         requestType:MSIDRequestLocalType
+                                                                               error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(parameters);
+
+    MSIDExecutionFlowRegister(parameters.correlationId);
+
+    [parameters setCloudAuthorityWithCloudHostName:@"unknown-host.example.com"];
+
+    XCTAssertNil(parameters.cloudAuthority);
+
+    XCTestExpectation *flowExpectation = [self expectationWithDescription:@"execution flow should record the ignored cloud host tag"];
+    MSIDExecutionFlowRetrieve(parameters.correlationId, nil, YES, ^(NSString * _Nullable executionFlow) {
+        XCTAssertNotNil(executionFlow);
+        XCTAssertTrue([executionFlow containsString:MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameIgnoredTag)], @"Flow should record the ignored cloud host tag");
+        [flowExpectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end

--- a/IdentityCore/tests/MSIDRequestParametersTests.m
+++ b/IdentityCore/tests/MSIDRequestParametersTests.m
@@ -498,4 +498,133 @@
     XCTAssertEqualObjects(parameters.nestedAuthBrokerRedirectUri, @"myredirect");
 }
 
+#pragma mark - setCloudAuthorityWithCloudHostName
+
+- (void)testSetCloudAuthorityWithCloudHostName_whenKnownPublicCloudHost_shouldSetCloudAuthority
+{
+    MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
+    NSOrderedSet *scopes = [NSOrderedSet orderedSetWithObjects:@"myscope1", nil];
+    NSOrderedSet *oidcScopes = [NSOrderedSet orderedSetWithObjects:@"openid", nil];
+    NSError *error = nil;
+    MSIDRequestParameters *parameters = [[MSIDRequestParameters alloc] initWithAuthority:authority
+                                                                          authScheme:[MSIDAuthenticationScheme new]
+                                                                         redirectUri:@"myredirect"
+                                                                            clientId:@"myclient_id"
+                                                                              scopes:scopes
+                                                                          oidcScopes:oidcScopes
+                                                                       correlationId:nil
+                                                                      telemetryApiId:nil
+                                                                 intuneAppIdentifier:@"com.microsoft.mytest"
+                                                                         requestType:MSIDRequestLocalType
+                                                                               error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(parameters);
+
+    [parameters setCloudAuthorityWithCloudHostName:@"login.microsoftonline.com"];
+
+    XCTAssertNotNil(parameters.cloudAuthority);
+    XCTAssertEqualObjects(parameters.cloudAuthority.environment, @"login.microsoftonline.com");
+}
+
+- (void)testSetCloudAuthorityWithCloudHostName_whenKnownSovereignCloudHost_shouldSetCloudAuthority
+{
+    MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
+    NSOrderedSet *scopes = [NSOrderedSet orderedSetWithObjects:@"myscope1", nil];
+    NSOrderedSet *oidcScopes = [NSOrderedSet orderedSetWithObjects:@"openid", nil];
+    NSError *error = nil;
+    MSIDRequestParameters *parameters = [[MSIDRequestParameters alloc] initWithAuthority:authority
+                                                                          authScheme:[MSIDAuthenticationScheme new]
+                                                                         redirectUri:@"myredirect"
+                                                                            clientId:@"myclient_id"
+                                                                              scopes:scopes
+                                                                          oidcScopes:oidcScopes
+                                                                       correlationId:nil
+                                                                      telemetryApiId:nil
+                                                                 intuneAppIdentifier:@"com.microsoft.mytest"
+                                                                         requestType:MSIDRequestLocalType
+                                                                               error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(parameters);
+
+    [parameters setCloudAuthorityWithCloudHostName:@"login.microsoftonline.de"];
+
+    XCTAssertNotNil(parameters.cloudAuthority);
+    XCTAssertEqualObjects(parameters.cloudAuthority.environment, @"login.microsoftonline.de");
+}
+
+- (void)testSetCloudAuthorityWithCloudHostName_whenUnknownHost_shouldNotSetCloudAuthority
+{
+    MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
+    NSOrderedSet *scopes = [NSOrderedSet orderedSetWithObjects:@"myscope1", nil];
+    NSOrderedSet *oidcScopes = [NSOrderedSet orderedSetWithObjects:@"openid", nil];
+    NSError *error = nil;
+    MSIDRequestParameters *parameters = [[MSIDRequestParameters alloc] initWithAuthority:authority
+                                                                          authScheme:[MSIDAuthenticationScheme new]
+                                                                         redirectUri:@"myredirect"
+                                                                            clientId:@"myclient_id"
+                                                                              scopes:scopes
+                                                                          oidcScopes:oidcScopes
+                                                                       correlationId:nil
+                                                                      telemetryApiId:nil
+                                                                 intuneAppIdentifier:@"com.microsoft.mytest"
+                                                                         requestType:MSIDRequestLocalType
+                                                                               error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(parameters);
+
+    [parameters setCloudAuthorityWithCloudHostName:@"unknown-host.example.com"];
+
+    XCTAssertNil(parameters.cloudAuthority);
+}
+
+- (void)testSetCloudAuthorityWithCloudHostName_whenNilHost_shouldNotSetCloudAuthority
+{
+    MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
+    NSOrderedSet *scopes = [NSOrderedSet orderedSetWithObjects:@"myscope1", nil];
+    NSOrderedSet *oidcScopes = [NSOrderedSet orderedSetWithObjects:@"openid", nil];
+    NSError *error = nil;
+    MSIDRequestParameters *parameters = [[MSIDRequestParameters alloc] initWithAuthority:authority
+                                                                          authScheme:[MSIDAuthenticationScheme new]
+                                                                         redirectUri:@"myredirect"
+                                                                            clientId:@"myclient_id"
+                                                                              scopes:scopes
+                                                                          oidcScopes:oidcScopes
+                                                                       correlationId:nil
+                                                                      telemetryApiId:nil
+                                                                 intuneAppIdentifier:@"com.microsoft.mytest"
+                                                                         requestType:MSIDRequestLocalType
+                                                                               error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(parameters);
+
+    [parameters setCloudAuthorityWithCloudHostName:nil];
+
+    XCTAssertNil(parameters.cloudAuthority);
+}
+
+- (void)testSetCloudAuthorityWithCloudHostName_whenBlankHost_shouldNotSetCloudAuthority
+{
+    MSIDAuthority *authority = [@"https://login.microsoftonline.com/common" aadAuthority];
+    NSOrderedSet *scopes = [NSOrderedSet orderedSetWithObjects:@"myscope1", nil];
+    NSOrderedSet *oidcScopes = [NSOrderedSet orderedSetWithObjects:@"openid", nil];
+    NSError *error = nil;
+    MSIDRequestParameters *parameters = [[MSIDRequestParameters alloc] initWithAuthority:authority
+                                                                          authScheme:[MSIDAuthenticationScheme new]
+                                                                         redirectUri:@"myredirect"
+                                                                            clientId:@"myclient_id"
+                                                                              scopes:scopes
+                                                                          oidcScopes:oidcScopes
+                                                                       correlationId:nil
+                                                                      telemetryApiId:nil
+                                                                 intuneAppIdentifier:@"com.microsoft.mytest"
+                                                                         requestType:MSIDRequestLocalType
+                                                                               error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(parameters);
+
+    [parameters setCloudAuthorityWithCloudHostName:@"   "];
+
+    XCTAssertNil(parameters.cloudAuthority);
+}
+
 @end

--- a/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultInteractiveTokenRequestTests.m
@@ -237,7 +237,7 @@
                                 __unused id<MSIDRequestContext> context,
                                 MSIDWebviewAuthCompletionHandler completionHandler)
     {
-         NSString *responseString = [NSString stringWithFormat:@"x-msauth-test://com.microsoft.testapp?code=iamafakecode&cloud_instance_host_name=contoso.onmicrosoft.cn&client_info=%@", [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson]];
+         NSString *responseString = [NSString stringWithFormat:@"x-msauth-test://com.microsoft.testapp?code=iamafakecode&cloud_instance_host_name=login.partner.microsoftonline.cn&client_info=%@", [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson]];
 
          MSIDWebAADAuthCodeResponse *oauthResponse = [[MSIDWebAADAuthCodeResponse alloc] initWithURL:[NSURL URLWithString:responseString]
                                                                                              context:nil error:nil];
@@ -247,7 +247,7 @@
     NSMutableDictionary *reqHeaders = [[MSIDTestURLResponse msidDefaultRequestHeaders] mutableCopy];
     [reqHeaders setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
 
-    NSString *url = @"https://contoso.onmicrosoft.cn/common/oauth2/v2.0/token";
+    NSString *url = @"https://login.partner.microsoftonline.cn/common/oauth2/v2.0/token";
     
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
@@ -259,7 +259,7 @@
                                              @"grant_type" : @"authorization_code",
                                              @"code_verifier" : [MSIDTestRequireValueSentinel sentinel],
                                              @"client_info" : @"1"}
-                        responseURLString:@"https://contoso.onmicrosoft.cn/oauth2/v2.0/token"
+                        responseURLString:@"https://login.partner.microsoftonline.cn/oauth2/v2.0/token"
                              responseCode:200
                          httpHeaderFields:nil
                          dictionaryAsJSON:@{ @"access_token" : @"i am a access token!",
@@ -296,7 +296,7 @@
         XCTAssertEqualObjects(result.accessToken.accessToken, @"i am a access token!");
         XCTAssertEqualObjects(result.rawIdToken, [MSIDTestIdTokenUtil defaultV2IdToken]);
         XCTAssertFalse(result.extendedLifeTimeToken);
-        XCTAssertEqualObjects(result.authority.url.absoluteString, @"https://contoso.onmicrosoft.cn/"DEFAULT_TEST_UTID);
+        XCTAssertEqualObjects(result.authority.url.absoluteString, @"https://login.partner.microsoftonline.cn/"DEFAULT_TEST_UTID);
         XCTAssertNil(installBrokerResponse);
         XCTAssertNil(error);
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 TBD
 * Add MSIDUXCallbackProtocol and MSIDUXCallbackProvider to allow host apps to receive UX callbacks (e.g., schedule and cancel MDM profile installed notification) from CommonCore navigation layer. Add delay validation for flight-configured notification delay.
 * Only attach the PRT (refresh token credential) header to the PkeyAuth challenge response for known/trusted AAD hosts, preventing PRT leakage to untrusted hosts. Record an execution-flow tag for the added/skipped decision when a correlation id is available.
+* Validate cloud_instance_host_name from the auth redirect against the known Microsoft identity host list before using it to build the cloud authority in setCloudAuthorityWithCloudHostName: and authorityWithUpdatedCloudHostInstanceName:error:. Unrecognized values are ignored and logged; sovereign-cloud and instance-aware flows are unaffected.
 
 Version 1.25.0
 * Harden MSIDDIContainer: validate protocol conformance in resolveImplClassForProtocol:orDefault:; NSAssert in debug, log + fall back to default in release. Self-heal cache eviction on conformance failure; release-mode fallback test via NSAssertionHandler swap.


### PR DESCRIPTION
### Summary

`cloud_instance_host_name` from the auth webview redirect URL was previously used to build the cloud authority without checking whether it was a recognized Microsoft identity host. This PR makes that handling more accurate: the value is only used when it is a known AAD public/sovereign cloud host, or a network environment already discovered via instance metadata.

### Changes
- Add a recognized-host check in `setCloudAuthorityWithCloudHostName:` (`MSIDRequestParameters`) and `authorityWithUpdatedCloudHostInstanceName:error:` (`MSIDAADAuthority`). Unrecognized values are ignored and logged; the originally configured authority continues to be used.
- Host matching is case-insensitive to align with cached `preferred_network` values (which may not be case-normalized).
- Add unit tests for known public-cloud, known sovereign-cloud, unknown, nil, blank, and different-case host inputs.
- Update the instance-aware interactive token request integration test to use a valid sovereign-cloud host.

### Impact
- Sovereign-cloud and instance-aware flows are unaffected.
- No public API changes.