### PR TITLE
[patch] [bugfix]: Fix automation password-selection link lookup for iOS 26

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -1937,6 +1937,9 @@
 		B4134C1B2FEA3E410037FE68 /* MSIDMobileOnboardingState.m in Sources */ = {isa = PBXBuildFile; fileRef = B4134C192FEA3E410037FE68 /* MSIDMobileOnboardingState.m */; };
 		B4134C1C2FEA3E410037FE68 /* MSIDMobileOnboardingState.h in Headers */ = {isa = PBXBuildFile; fileRef = B4134C182FEA3E410037FE68 /* MSIDMobileOnboardingState.h */; };
 		B4134C1D2FEA3E410037FE68 /* MSIDMobileOnboardingState.m in Sources */ = {isa = PBXBuildFile; fileRef = B4134C192FEA3E410037FE68 /* MSIDMobileOnboardingState.m */; };
+		B4134C442FEC495C0037FE68 /* MSIDMockUXCallbackProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B4134C422FEC495C0037FE68 /* MSIDMockUXCallbackProvider.h */; };
+		B4134C452FEC495C0037FE68 /* MSIDMockUXCallbackProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B4134C432FEC495C0037FE68 /* MSIDMockUXCallbackProvider.m */; };
+		B4134C462FEC495C0037FE68 /* MSIDMockUXCallbackProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B4134C432FEC495C0037FE68 /* MSIDMockUXCallbackProvider.m */; };
 		B41DD0A22FB4187500F81A9A /* MSIDIntuneDeviceIdCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B41DD0A12FB4187200F81A9A /* MSIDIntuneDeviceIdCache.h */; };
 		B41DD0A42FB4187B00F81A9A /* MSIDIntuneDeviceIdCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B41DD0A32FB4187900F81A9A /* MSIDIntuneDeviceIdCache.m */; };
 		B41DD0A52FB4187B00F81A9A /* MSIDIntuneDeviceIdCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B41DD0A32FB4187900F81A9A /* MSIDIntuneDeviceIdCache.m */; };
@@ -3597,6 +3600,8 @@
 		B41163BB29BAC9DE00E64619 /* MSIDWKNavigationActionMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDWKNavigationActionMock.h; sourceTree = "<group>"; };
 		B4134C182FEA3E410037FE68 /* MSIDMobileOnboardingState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDMobileOnboardingState.h; sourceTree = "<group>"; };
 		B4134C192FEA3E410037FE68 /* MSIDMobileOnboardingState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMobileOnboardingState.m; sourceTree = "<group>"; };
+		B4134C422FEC495C0037FE68 /* MSIDMockUXCallbackProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDMockUXCallbackProvider.h; sourceTree = "<group>"; };
+		B4134C432FEC495C0037FE68 /* MSIDMockUXCallbackProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDMockUXCallbackProvider.m; sourceTree = "<group>"; };
 		B41DD0A12FB4187200F81A9A /* MSIDIntuneDeviceIdCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDIntuneDeviceIdCache.h; sourceTree = "<group>"; };
 		B41DD0A32FB4187900F81A9A /* MSIDIntuneDeviceIdCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIntuneDeviceIdCache.m; sourceTree = "<group>"; };
 		B41DD0A62FB41A0000F81A9A /* MSIDIntuneDeviceIdCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDIntuneDeviceIdCacheTests.m; sourceTree = "<group>"; };
@@ -4108,6 +4113,8 @@
 		23642AB32187D88C00F97009 /* mocks */ = {
 			isa = PBXGroup;
 			children = (
+				B4134C422FEC495C0037FE68 /* MSIDMockUXCallbackProvider.h */,
+				B4134C432FEC495C0037FE68 /* MSIDMockUXCallbackProvider.m */,
 				722AC5182F0EF275005BE6A5 /* MSIDTestBoundAppRefreshTokenRequest.m */,
 				722AC5162F0EF1AC005BE6A5 /* MSIDTestBoundAppRefreshTokenRequest.h */,
 				729357EE2DDBCBAB0001D03C /* MSIDNonceTokenRequestMock.m */,
@@ -6995,6 +7002,7 @@
 				B217861823A57ED800839CE8 /* MSIDAuthorizationControllerMock.h in Headers */,
 				B2E4A07B24DDE5D7007CE642 /* NSUUID+MSIDTestUtil.h in Headers */,
 				B217862923A5839300839CE8 /* MSIDSSOExtensionSignoutRequestMock.h in Headers */,
+				B4134C442FEC495C0037FE68 /* MSIDMockUXCallbackProvider.h in Headers */,
 				2A0278A32D6E3787005655B4 /* MSIDLastRequestTelemetry+Tests.h in Headers */,
 				969CCB5622A9EB0300A55515 /* MSIDTestCacheDataSource.h in Headers */,
 				B28AC66421A0BB9D00A1FC4A /* MSIDTestBrokerResponseHelper.h in Headers */,
@@ -8504,6 +8512,7 @@
 				D626FFF71FBD200A00EE4487 /* MSIDTestURLSessionDataTask.m in Sources */,
 				6078EB50226DA97100235498 /* MSIDTestCacheUtil.m in Sources */,
 				B2E2A94D239320B100BA2EA3 /* MSIDTestParametersProvider.m in Sources */,
+				B4134C462FEC495C0037FE68 /* MSIDMockUXCallbackProvider.m in Sources */,
 				961ACE0522A1FA8200B9266C /* MSIDApplicationTestUtil.m in Sources */,
 				D626FFF41FBD200A00EE4487 /* MSIDTestURLSession.m in Sources */,
 				D6D9A44D1FBD3EEA00EFA430 /* NSDictionary+MSIDTestUtil.m in Sources */,
@@ -8539,6 +8548,7 @@
 				B216826223AB09C300F4897A /* MSIDSSOExtensionGetAccountsRequestMock.m in Sources */,
 				B2E4A07424DDE576007CE642 /* MSIDTestTelemetryEventsObserver.m in Sources */,
 				5898429F252544900075DFED /* MSIDAccountMetadataCacheMockGetAuthorityParameters.m in Sources */,
+				B4134C452FEC495C0037FE68 /* MSIDMockUXCallbackProvider.m in Sources */,
 				B2E2A94E239320B100BA2EA3 /* MSIDTestParametersProvider.m in Sources */,
 				969CCB5822A9EB7D00A55515 /* MSIDTestCacheDataSource.m in Sources */,
 				96290E5721489BB800FDD5C8 /* NSString+MSIDTestUtil.m in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -2045,6 +2045,12 @@
 		B4EC850F2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m in Sources */ = {isa = PBXBuildFile; fileRef = B4EC850C2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m */; };
 		B4EC85102EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.h in Headers */ = {isa = PBXBuildFile; fileRef = B4EC850B2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.h */; };
 		B4EC85122EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m in Sources */ = {isa = PBXBuildFile; fileRef = B4EC850C2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m */; };
+		B4F104BF2FE3A16500EBEB5F /* MSIDUXCallbackProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B4F104BE2FE3A16500EBEB5F /* MSIDUXCallbackProvider.m */; };
+		B4F104C02FE3A16500EBEB5F /* MSIDUXCallbackProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B4F104BC2FE3A16500EBEB5F /* MSIDUXCallbackProtocol.h */; };
+		B4F104C12FE3A16500EBEB5F /* MSIDUXCallbackProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B4F104BD2FE3A16500EBEB5F /* MSIDUXCallbackProvider.h */; };
+		B4F104C22FE3A16500EBEB5F /* MSIDUXCallbackProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B4F104BE2FE3A16500EBEB5F /* MSIDUXCallbackProvider.m */; };
+		B4F104C32FE3A16500EBEB5F /* MSIDUXCallbackProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B4F104BC2FE3A16500EBEB5F /* MSIDUXCallbackProtocol.h */; };
+		B4F104C42FE3A16500EBEB5F /* MSIDUXCallbackProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B4F104BD2FE3A16500EBEB5F /* MSIDUXCallbackProvider.h */; };
 		B4FBF0332EF33A7600EDE1E9 /* MSIDOnboardingStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF0322EF33A7600EDE1E9 /* MSIDOnboardingStatus.m */; };
 		B4FBF0342EF33A7600EDE1E9 /* MSIDOnboardingStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = B4FBF0312EF33A7600EDE1E9 /* MSIDOnboardingStatus.h */; };
 		B4FBF0352EF33A7600EDE1E9 /* MSIDOnboardingStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FBF0322EF33A7600EDE1E9 /* MSIDOnboardingStatus.m */; };
@@ -3661,6 +3667,9 @@
 		B4EC850A2EF65C58005567DA /* MSIDAesGcmDecryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSIDAesGcmDecryptor.swift; sourceTree = "<group>"; };
 		B4EC850B2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDJweResponse+EcdhAesGcm.h"; sourceTree = "<group>"; };
 		B4EC850C2EF65C58005567DA /* MSIDJweResponse+EcdhAesGcm.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDJweResponse+EcdhAesGcm.m"; sourceTree = "<group>"; };
+		B4F104BC2FE3A16500EBEB5F /* MSIDUXCallbackProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDUXCallbackProtocol.h; sourceTree = "<group>"; };
+		B4F104BD2FE3A16500EBEB5F /* MSIDUXCallbackProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDUXCallbackProvider.h; sourceTree = "<group>"; };
+		B4F104BE2FE3A16500EBEB5F /* MSIDUXCallbackProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDUXCallbackProvider.m; sourceTree = "<group>"; };
 		B4FBF0312EF33A7600EDE1E9 /* MSIDOnboardingStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDOnboardingStatus.h; sourceTree = "<group>"; };
 		B4FBF0322EF33A7600EDE1E9 /* MSIDOnboardingStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatus.m; sourceTree = "<group>"; };
 		B4FBF0362EF33AAA00EDE1E9 /* MSIDOnboardingStatusTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDOnboardingStatusTests.m; sourceTree = "<group>"; };
@@ -6064,6 +6073,9 @@
 		D6DA89721FBA6A4E004C56C7 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				B4F104BC2FE3A16500EBEB5F /* MSIDUXCallbackProtocol.h */,
+				B4F104BD2FE3A16500EBEB5F /* MSIDUXCallbackProvider.h */,
+				B4F104BE2FE3A16500EBEB5F /* MSIDUXCallbackProvider.m */,
 				7252BB772F2AE53700B2287F /* MSIDSwiftBridgingHeader.h */,
 				7209A3D42EB581BB0050CB13 /* MSIDJweResponse.m */,
 				7209A3D22EB581A90050CB13 /* MSIDJweResponse.h */,
@@ -6407,6 +6419,8 @@
 				AE6838E26F5648EFAB74A481 /* MSIDThrottlingRefreshing.h in Headers */,
 				B4134C1C2FEA3E410037FE68 /* MSIDMobileOnboardingState.h in Headers */,
 				B5E8A92C146D4F38B5C92E17 /* MSIDThrottlingMetaDataReading.h in Headers */,
+				B4F104C02FE3A16500EBEB5F /* MSIDUXCallbackProtocol.h in Headers */,
+				B4F104C12FE3A16500EBEB5F /* MSIDUXCallbackProvider.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6837,6 +6851,8 @@
 				B5AAE11B2F03D7AA0026B21B /* MSIDBrokerOperationGetDefaultAccountResponse.h in Headers */,
 				B26CEAE723653C62009E6E54 /* MSIDASWebAuthenticationSessionHandler.h in Headers */,
 				2338ECCE208A675D00809B9E /* MSIDAADRequestErrorHandler.h in Headers */,
+				B4F104C32FE3A16500EBEB5F /* MSIDUXCallbackProtocol.h in Headers */,
+				B4F104C42FE3A16500EBEB5F /* MSIDUXCallbackProvider.h in Headers */,
 				B26A0B8C2071B763006BD95A /* MSIDAADV1Oauth2Factory.h in Headers */,
 				B2C708B4219A620E00D917B8 /* MSIDBrokerCryptoProvider.h in Headers */,
 				B2CDB5791FE33A46003A4B5C /* MSIDAccount.h in Headers */,
@@ -7964,6 +7980,7 @@
 				D6D9A4521FBD3FB800EFA430 /* NSURL+MSIDExtensions.m in Sources */,
 				B23ECEF11FF2F6270015FC1D /* MSIDAADV2IdTokenClaims.m in Sources */,
 				239EED6A242D8FAD00162F0F /* MSIDAADTokenRequestServerTelemetry.m in Sources */,
+				B4F104C22FE3A16500EBEB5F /* MSIDUXCallbackProvider.m in Sources */,
 				B2C0748D246B71300008D701 /* MSIDAssymetricKeyPairWithCert.m in Sources */,
 				B4B591B42F3AC90600CBA6A9 /* MSIDOnboardingStatusCache.m in Sources */,
 				9641B5251FCF3EEF00AFA0EC /* MSIDMacTokenCache.m in Sources */,
@@ -8604,6 +8621,7 @@
 				72C1EBFE2DEA81A1004C40A4 /* MSIDBoundRefreshTokenCacheItem.m in Sources */,
 				A0C7DDA425D1EA0D00F5B5B6 /* NSError+MSIDThrottlingExtension.m in Sources */,
 				235480C720DDF81000246F72 /* MSIDAuthorityFactory.m in Sources */,
+				B4F104BF2FE3A16500EBEB5F /* MSIDUXCallbackProvider.m in Sources */,
 				239DF9C920E05847002D428B /* MSIDAADRequestConfigurator.m in Sources */,
 				E733EDFD25C0A4B100ACB79A /* MSIDThumbprintCalculator.m in Sources */,
 				23B39A8220993302000AA905 /* MSIDAadAuthorityResolver.m in Sources */,

--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -287,4 +287,11 @@ extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_OPEN_NEW_WINDOW_IN_BROWSER;
 /// Default: OFF
 extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_MOBILE_ONBOARDING;
 
+/// Flight key for MDM profile install notification delay (seconds).
+/// Owner: swagup
+extern NSString * _Nonnull const MSID_FLIGHT_MDM_PROFILE_INSTALLED_NOTIFICATION_DELAY;
+
+/// Default delay (in seconds) before the MDM profile install notification fires.
+extern NSTimeInterval const MSIDMDMProfileInstalledNotificationDefaultDelay;
+
 #define METHODANDLINE   [NSString stringWithFormat:@"%s [Line %d]", __PRETTY_FUNCTION__, __LINE__]

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -133,6 +133,6 @@ NSString *const MSID_FLIGHT_DISABLE_MOBILE_ONBOARDING = @"disable_mobile_onboard
 
 NSString *const MSID_FLIGHT_MDM_PROFILE_INSTALLED_NOTIFICATION_DELAY = @"mdm_profile_installed_notification_delay";
 
-NSTimeInterval const MSIDMDMProfileInstalledNotificationDefaultDelay = 80.0;
+NSTimeInterval const MSIDMDMProfileInstalledNotificationDefaultDelay = 60.0;
 
 #define METHODANDLINE   [NSString stringWithFormat:@"%s [Line %d]", __PRETTY_FUNCTION__, __LINE__]

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -131,4 +131,8 @@ NSString *const MSID_FLIGHT_DISABLE_OPEN_NEW_WINDOW_IN_BROWSER = @"disable_open_
 
 NSString *const MSID_FLIGHT_DISABLE_MOBILE_ONBOARDING = @"disable_mobile_onboarding";
 
+NSString *const MSID_FLIGHT_MDM_PROFILE_INSTALLED_NOTIFICATION_DELAY = @"mdm_profile_installed_notification_delay";
+
+NSTimeInterval const MSIDMDMProfileInstalledNotificationDefaultDelay = 80.0;
+
 #define METHODANDLINE   [NSString stringWithFormat:@"%s [Line %d]", __PRETTY_FUNCTION__, __LINE__]

--- a/IdentityCore/src/MSIDUXCallbackProtocol.h
+++ b/IdentityCore/src/MSIDUXCallbackProtocol.h
@@ -35,6 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// The host app should schedule a local notification after the given delay.
 - (void)scheduleMDMProfileInstalledNotificationWithDelay:(NSTimeInterval)delay;
 
+/// Called when enrollment completes successfully. The host app should cancel
+/// any previously scheduled MDM profile installed notification.
+- (void)cancelMDMProfileInstalledNotification;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/MSIDUXCallbackProtocol.h
+++ b/IdentityCore/src/MSIDUXCallbackProtocol.h
@@ -1,0 +1,40 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MSIDUXCallbackProtocol <NSObject>
+
+/// Called when the webview loads a profile install URL during MDM onboarding.
+/// The host app should schedule a local notification after the given delay.
+- (void)scheduleMDMProfileInstalledNotificationWithDelay:(NSTimeInterval)delay;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/MSIDUXCallbackProvider.h
+++ b/IdentityCore/src/MSIDUXCallbackProvider.h
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import "MSIDUXCallbackProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDUXCallbackProvider : NSObject
+
+@property (nonatomic, class) id<MSIDUXCallbackProtocol> uxCallbackProvider;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/MSIDUXCallbackProvider.h
+++ b/IdentityCore/src/MSIDUXCallbackProvider.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDUXCallbackProvider : NSObject
 
-@property (nonatomic, class) id<MSIDUXCallbackProtocol> uxCallbackProvider;
+@property (nonatomic, class, nullable) id<MSIDUXCallbackProtocol> uxCallbackProvider;
 
 @end
 

--- a/IdentityCore/src/MSIDUXCallbackProvider.m
+++ b/IdentityCore/src/MSIDUXCallbackProvider.m
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSIDUXCallbackProvider.h"
+
+static id<MSIDUXCallbackProtocol> s_uxCallbackProvider;
+
+@implementation MSIDUXCallbackProvider
+
++ (id<MSIDUXCallbackProtocol>)uxCallbackProvider
+{
+    return s_uxCallbackProvider;
+}
+
++ (void)setUxCallbackProvider:(id<MSIDUXCallbackProtocol>)uxCallbackProvider
+{
+    s_uxCallbackProvider = uxCallbackProvider;
+}
+
+@end

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
@@ -29,6 +29,8 @@
 #import "MSIDConstants.h"
 #import "MSIDIntuneDeviceIdCache.h"
 #import "MSIDVersion.h"
+#import "MSIDUXCallbackProvider.h"
+#import "MSIDFlightManager.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -316,6 +318,13 @@
     }
 
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[ProfileDownload] Built profile install request for host '%@'.", profileURL.host);
+
+    NSString *delayString = [[MSIDFlightManager sharedInstance] stringForKey:MSID_FLIGHT_MDM_PROFILE_INSTALLED_NOTIFICATION_DELAY];
+    NSTimeInterval delay = delayString.length > 0 ? delayString.doubleValue : MSIDMDMProfileInstalledNotificationDefaultDelay;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [MSIDUXCallbackProvider.uxCallbackProvider scheduleMDMProfileInstalledNotificationWithDelay:delay];
+    });
+
     return [MSIDWebviewNavigationDecision loadRequest:[NSURLRequest requestWithURL:profileURL]];
 }
 

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
@@ -321,9 +321,16 @@
 
     NSString *delayString = [[MSIDFlightManager sharedInstance] stringForKey:MSID_FLIGHT_MDM_PROFILE_INSTALLED_NOTIFICATION_DELAY];
     NSTimeInterval delay = delayString.length > 0 ? delayString.doubleValue : MSIDMDMProfileInstalledNotificationDefaultDelay;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [MSIDUXCallbackProvider.uxCallbackProvider scheduleMDMProfileInstalledNotificationWithDelay:delay];
-    });
+    if (delay <= 0)
+    {
+        delay = MSIDMDMProfileInstalledNotificationDefaultDelay;
+    }
+
+    id<MSIDUXCallbackProtocol> provider = MSIDUXCallbackProvider.uxCallbackProvider;
+    if (provider)
+    {
+        [provider scheduleMDMProfileInstalledNotificationWithDelay:delay];
+    }
 
     return [MSIDWebviewNavigationDecision loadRequest:[NSURLRequest requestWithURL:profileURL]];
 }

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
@@ -341,6 +341,13 @@
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[EnrollmentCompletion] Processing enrollment completion redirect.");
 
+    // Cancel any previously scheduled MDM profile installed notification
+    id<MSIDUXCallbackProtocol> provider = MSIDUXCallbackProvider.uxCallbackProvider;
+    if (provider)
+    {
+        [provider cancelMDMProfileInstalledNotification];
+    }
+
     // Check if SSO extension can perform request
     if ([MSIDSSOExtensionInteractiveTokenRequestController canPerformRequest])
     {

--- a/IdentityCore/tests/MSIDWebviewNavigationDecisionResolverTests.m
+++ b/IdentityCore/tests/MSIDWebviewNavigationDecisionResolverTests.m
@@ -34,6 +34,12 @@
 #import "MSIDTestCacheDataSource.h"
 #import "MSIDTestSwizzle.h"
 #import "MSIDVersion.h"
+#import "MSIDUXCallbackProvider.h"
+#import "MSIDUXCallbackProtocol.h"
+#import "MSIDFlightManager.h"
+#import "MSIDFlightManagerMockProvider.h"
+#import "MSIDConstants.h"
+#import "MSIDMockUXCallbackProvider.h"
 
 @interface MSIDWebviewNavigationDecisionResolverTests : XCTestCase
 
@@ -61,6 +67,8 @@
 {
     [MSIDTestSwizzle reset];
     [self.dataSource reset];
+    MSIDUXCallbackProvider.uxCallbackProvider = nil;
+    MSIDFlightManager.sharedInstance.flightProvider = nil;
     [super tearDown];
 }
 
@@ -597,6 +605,94 @@
                                                          embeddedWebviewController:nil];
     XCTAssertNotNil(decision);
     XCTAssertFalse(invoked, @"External block must not be invoked when no webview controller is provided.");
+    XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
+}
+
+#pragma mark - UX Callback Tests
+
+- (void)testProfileDownloadComplete_whenProviderSet_shouldInvokeCallbackWithDefaultDelay
+{
+    MSIDMockUXCallbackProvider *mockProvider = [MSIDMockUXCallbackProvider new];
+    MSIDUXCallbackProvider.uxCallbackProvider = mockProvider;
+
+    NSString *profileURL = @"https://manage.microsoft.com/profile.mobileconfig";
+    NSString *encodedURL = [profileURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSString *urlString = [NSString stringWithFormat:@"msauth://%@?%@=device123&%@=%@",
+                           MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST,
+                           MSID_INTUNE_DEVICE_ID_KEY,
+                           MSID_INTUNE_PROFILE_INSTALL_URL_KEY,
+                           encodedURL];
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+
+    XCTAssertTrue(mockProvider.scheduleCalled, @"UX callback should be invoked on profile download complete.");
+    XCTAssertEqualWithAccuracy(mockProvider.receivedDelay, MSIDMDMProfileInstalledNotificationDefaultDelay, 0.01);
+}
+
+- (void)testProfileDownloadComplete_whenFlightConfiguresDelay_shouldPassFlightDelay
+{
+    MSIDMockUXCallbackProvider *mockProvider = [MSIDMockUXCallbackProvider new];
+    MSIDUXCallbackProvider.uxCallbackProvider = mockProvider;
+
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.stringForKeyContainer = @{ MSID_FLIGHT_MDM_PROFILE_INSTALLED_NOTIFICATION_DELAY: @"300" };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    NSString *profileURL = @"https://manage.microsoft.com/profile.mobileconfig";
+    NSString *encodedURL = [profileURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSString *urlString = [NSString stringWithFormat:@"msauth://%@?%@=device123&%@=%@",
+                           MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST,
+                           MSID_INTUNE_DEVICE_ID_KEY,
+                           MSID_INTUNE_PROFILE_INSTALL_URL_KEY,
+                           encodedURL];
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+
+    XCTAssertTrue(mockProvider.scheduleCalled);
+    XCTAssertEqualWithAccuracy(mockProvider.receivedDelay, 300.0, 0.01);
+}
+
+- (void)testProfileDownloadComplete_whenFlightDelayIsNegative_shouldFallbackToDefault
+{
+    MSIDMockUXCallbackProvider *mockProvider = [MSIDMockUXCallbackProvider new];
+    MSIDUXCallbackProvider.uxCallbackProvider = mockProvider;
+
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.stringForKeyContainer = @{ MSID_FLIGHT_MDM_PROFILE_INSTALLED_NOTIFICATION_DELAY: @"-5" };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    NSString *profileURL = @"https://manage.microsoft.com/profile.mobileconfig";
+    NSString *encodedURL = [profileURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSString *urlString = [NSString stringWithFormat:@"msauth://%@?%@=device123&%@=%@",
+                           MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST,
+                           MSID_INTUNE_DEVICE_ID_KEY,
+                           MSID_INTUNE_PROFILE_INSTALL_URL_KEY,
+                           encodedURL];
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+
+    XCTAssertTrue(mockProvider.scheduleCalled);
+    XCTAssertEqualWithAccuracy(mockProvider.receivedDelay, MSIDMDMProfileInstalledNotificationDefaultDelay, 0.01);
+}
+
+- (void)testProfileDownloadComplete_whenProviderIsNil_shouldNotCrash
+{
+    MSIDUXCallbackProvider.uxCallbackProvider = nil;
+
+    NSString *profileURL = @"https://manage.microsoft.com/profile.mobileconfig";
+    NSString *encodedURL = [profileURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSString *urlString = [NSString stringWithFormat:@"msauth://%@?%@=device123&%@=%@",
+                           MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST,
+                           MSID_INTUNE_DEVICE_ID_KEY,
+                           MSID_INTUNE_PROFILE_INSTALL_URL_KEY,
+                           encodedURL];
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+    XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
 }
 

--- a/IdentityCore/tests/MSIDWebviewNavigationDecisionResolverTests.m
+++ b/IdentityCore/tests/MSIDWebviewNavigationDecisionResolverTests.m
@@ -696,6 +696,47 @@
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
 }
 
+#pragma mark - Cancel Notification on Enrollment Completion
+
+- (void)testEnrollmentCompletion_whenProviderSet_shouldCancelNotification
+{
+    MSIDMockUXCallbackProvider *mockProvider = [MSIDMockUXCallbackProvider new];
+    MSIDUXCallbackProvider.uxCallbackProvider = mockProvider;
+
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionInteractiveTokenRequestController class]
+                           block:(id)^(void)
+    {
+        return YES;
+    }];
+
+    NSString *urlString = [NSString stringWithFormat:@"msauth://%@", MSID_MDM_ENROLLMENT_COMPLETION_HOST];
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+
+    XCTAssertTrue(mockProvider.cancelCalled, @"Cancel should be invoked on enrollment completion.");
+}
+
+- (void)testEnrollmentCompletion_whenProviderIsNil_shouldNotCrash
+{
+    MSIDUXCallbackProvider.uxCallbackProvider = nil;
+
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionInteractiveTokenRequestController class]
+                           block:(id)^(void)
+    {
+        return YES;
+    }];
+
+    NSString *urlString = [NSString stringWithFormat:@"msauth://%@", MSID_MDM_ENROLLMENT_COMPLETION_HOST];
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+    XCTAssertNotNil(decision);
+    XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionCompleteWithURL);
+}
+
 @end
 
 #endif // !MSID_EXCLUDE_WEBKIT

--- a/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
@@ -429,16 +429,29 @@ static NSTimeInterval const MSIDPasswordEntryPollingInterval = 1;
     // picker on CI sims with no saved credentials and the test loops forever.
     // The polling loop in enterPassword: retries every second, so returning NO
     // here when the web button hasn't rendered yet is the desired behavior.
+    //
+    // On iOS/iPadOS 26 simulators, WebKit's accessibility tree sometimes
+    // exposes this link as a StaticText rather than a Button (the underlying
+    // markup is an anchor/span styled as a link, and the accessibility role
+    // mapping WebKit chooses for it changed across OS versions). Fall back to
+    // a staticTexts lookup so the tap still lands when that happens; without
+    // this, enterPassword: never finds a match and times out with "Timed out
+    // waiting for the password field or a password selection button to appear."
     for (NSString *buttonTitle in passwordButtonTitles)
     {
         XCUIElement *button = application.webViews.buttons[buttonTitle];
-        if (!button.exists || !button.isHittable)
+        if (button.exists && button.isHittable)
         {
-            continue;
+            [button msidTap];
+            return YES;
         }
 
-        [button msidTap];
-        return YES;
+        XCUIElement *staticTextButton = application.webViews.staticTexts[buttonTitle];
+        if (staticTextButton.exists && staticTextButton.isHittable)
+        {
+            [staticTextButton msidTap];
+            return YES;
+        }
     }
 
     return NO;

--- a/IdentityCore/tests/mocks/MSIDMockUXCallbackProvider.h
+++ b/IdentityCore/tests/mocks/MSIDMockUXCallbackProvider.h
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDUXCallbackProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDMockUXCallbackProvider : NSObject <MSIDUXCallbackProtocol>
+
+@property (nonatomic) BOOL scheduleCalled;
+@property (nonatomic) NSTimeInterval receivedDelay;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/tests/mocks/MSIDMockUXCallbackProvider.h
+++ b/IdentityCore/tests/mocks/MSIDMockUXCallbackProvider.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL scheduleCalled;
 @property (nonatomic) NSTimeInterval receivedDelay;
+@property (nonatomic) BOOL cancelCalled;
 
 @end
 

--- a/IdentityCore/tests/mocks/MSIDMockUXCallbackProvider.m
+++ b/IdentityCore/tests/mocks/MSIDMockUXCallbackProvider.m
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDMockUXCallbackProvider.h"
+
+@implementation MSIDMockUXCallbackProvider
+
+- (void)scheduleMDMProfileInstalledNotificationWithDelay:(NSTimeInterval)delay
+{
+    self.scheduleCalled = YES;
+    self.receivedDelay = delay;
+}
+
+@end

--- a/IdentityCore/tests/mocks/MSIDMockUXCallbackProvider.m
+++ b/IdentityCore/tests/mocks/MSIDMockUXCallbackProvider.m
@@ -32,4 +32,9 @@
     self.receivedDelay = delay;
 }
 
+- (void)cancelMDMProfileInstalledNotification
+{
+    self.cancelCalled = YES;
+}
+
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 TBD
-* Add MSIDUXCallbackProtocol and MSIDUXCallbackProvider to allow host apps to receive UX callbacks (e.g., schedule MDM profile installed notification) from CommonCore navigation layer. Add delay validation for flight-configured notification delay.
+* Add MSIDUXCallbackProtocol and MSIDUXCallbackProvider to allow host apps to receive UX callbacks (e.g., schedule and cancel MDM profile installed notification) from CommonCore navigation layer. Add delay validation for flight-configured notification delay.
 * Only attach the PRT (refresh token credential) header to the PkeyAuth challenge response for known/trusted AAD hosts, preventing PRT leakage to untrusted hosts. Record an execution-flow tag for the added/skipped decision when a correlation id is available.
 
 Version 1.25.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Add MSIDUXCallbackProtocol and MSIDUXCallbackProvider to allow host apps to receive UX callbacks (e.g., schedule MDM profile installed notification) from CommonCore navigation layer. Add delay validation for flight-configured notification delay.
 * Only attach the PRT (refresh token credential) header to the PkeyAuth challenge response for known/trusted AAD hosts, preventing PRT leakage to untrusted hosts. Record an execution-flow tag for the added/skipped decision when a correlation id is available.
 
 Version 1.25.0


### PR DESCRIPTION
## Summary
On iOS/iPadOS 26 simulators, WebKit sometimes exposes the AAD/MSA "Use my password" / "Use your password" link as a `StaticText` instead of a `Button` in the accessibility tree.

`tapPasswordSelectionButtonIfPresentInApp:` only queried `webViews.buttons`, so on iOS 26 it never found a match and `enterPassword:` timed out with:
```
Timed out waiting for the password field or a password selection button to appear.
```

This was observed in CI failures of `ADBTokenBindingUITests` (e.g. `testADRSDeviceRegistration_havingCAWithTokenBinding_andHavingSSOExtSecStorageDisabled_validateDeviceJoinIsECC`) on iPhone 17 / iOS 26.3.1, and confirmed via the failure's xcresult debug-description attachments which show a `webViews > staticTexts` query for "Use your password" was captured at the time of the failure.

## Fix
Fall back to a `webViews.staticTexts` lookup for the same set of password-selection titles, tapping whichever element (button or static text) is present and hittable.

## Testing
Automation UI tests require live lab credentials (Key Vault / conf.json) that aren't available in this environment, so this could not be re-run end-to-end locally. The change is a minimal, additive fallback that preserves all existing button-matching behavior.