### PR TITLE
[patch] [bugfix]: Fix flaky automation action-button taps on iOS 26 simulators

### DIFF
--- a/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/MSIDBaseUITest.m
@@ -246,9 +246,9 @@ static NSTimeInterval const MSIDPasswordEntryPollingInterval = 1;
     }
     
     sleep(1);
-    [application.buttons[action] msidTap];
+    [self tapActionButtonWhenHittable:application.buttons[action] application:application];
 #else
-    [application.buttons[action] msidTap];
+    [self tapActionButtonWhenHittable:application.buttons[action] application:application];
     
     if (jsonString)
     {
@@ -258,6 +258,58 @@ static NSTimeInterval const MSIDPasswordEntryPollingInterval = 1;
         [application.buttons[@"Go"] msidTap];
     }
 #endif
+}
+
+// The automation host app's action buttons are arranged subviews of a
+// UIStackView with no enclosing scroll container (see MainAutomation.storyboard).
+// Diagnostics ruled out a degenerate-frame issue: the button reports
+// exists=1, isHittable=1, and a perfectly valid, fully on-screen frame right
+// before tapping.
+//
+// The activity log revealed the real race: between us requesting the tap
+// and XCTest synthesizing it, XCTest runs its own "make frontmost" dance —
+// "Check for interrupting elements affecting <button>" (looking for a
+// system alert/permission prompt from another app, e.g.
+// com.microsoft.azureauthenticator) followed by re-"Open"/"Activate"-ing
+// our target app to bring it back to the front. That dance can happen
+// *during* the tap call itself, so the coordinate we resolved beforehand
+// can go stale by the time the touch is actually delivered (e.g. if the
+// re-activation triggers a layout pass), and the touch is silently dropped.
+// Confirmed via the simulator's unified log (not just the XCTest driver's
+// own log, which never surfaces output from the app under test) that the
+// button's real UIKit target-action only fires reliably once this race is
+// removed.
+//
+// Explicitly activating the application and waiting for it to settle in
+// the foreground *before* resolving the button's coordinate avoids that
+// race: any interruption dance happens here, before we snapshot the tap
+// point, rather than concurrently with the tap itself. Tapping via an
+// explicit coordinate (rather than XCUIElement's own tap) also sidesteps a
+// separate, unrelated bug where XCTest's "scroll element to visible"
+// step (run unconditionally as part of its tap synthesis) corrupts the
+// hit-point computation to {-1, -1} on iOS/iPadOS 26 simulators even when
+// the button never needed to scroll.
+- (void)tapActionButtonWhenHittable:(XCUIElement *)button application:(XCUIApplication *)application
+{
+    if (application.state != XCUIApplicationStateRunningForeground)
+    {
+        [application activate];
+    }
+
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:10.0];
+    while (application.state != XCUIApplicationStateRunningForeground && deadline.timeIntervalSinceNow > 0)
+    {
+        [NSThread sleepForTimeInterval:0.2];
+    }
+
+    deadline = [NSDate dateWithTimeIntervalSinceNow:10.0];
+    while (!button.isHittable && deadline.timeIntervalSinceNow > 0)
+    {
+        [NSThread sleepForTimeInterval:0.2];
+    }
+
+    XCUICoordinate *tapPoint = [button coordinateWithNormalizedOffset:CGVectorMake(0.5, 0.5)];
+    [tapPoint msidTap];
 }
 
 - (void)assertAccessTokenNotNil:(XCUIApplication *)application

--- a/IdentityCore/tests/automation/ui_tests_lib/XCUIElement+CrossPlat.h
+++ b/IdentityCore/tests/automation/ui_tests_lib/XCUIElement+CrossPlat.h
@@ -31,3 +31,9 @@
 - (void)activateTextField;
 
 @end
+
+@interface XCUICoordinate (CrossPlat)
+
+- (void)msidTap;
+
+@end

--- a/IdentityCore/tests/automation/ui_tests_lib/XCUIElement+CrossPlat.m
+++ b/IdentityCore/tests/automation/ui_tests_lib/XCUIElement+CrossPlat.m
@@ -78,3 +78,16 @@
 }
 
 @end
+
+@implementation XCUICoordinate (CrossPlat)
+
+- (void)msidTap
+{
+#if TARGET_OS_IPHONE
+    [self tap];
+#else
+    [self click];
+#endif
+}
+
+@end


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

## Proposed changes

`ADBTokenBindingUITests` failures downstream (e.g. `testADRSDeviceRegistration_havingCAWithTokenBinding_andHavingSSOExtSecStorageDisabled_validateDeviceJoinIsECC`) were traced to `performAction:config:application:` tapping the automation host app's action buttons (e.g. "Acquire Token") without the touch ever actually reaching the button's real UIKit target-action handler.

Confirmed via the simulator's unified log (`xcrun simctl ... log show`) — **not** just the XCTest driver's own captured log, which never surfaces output from the app under test:

Between requesting a tap and XCTest synthesizing it, XCTest runs its own "make frontmost" dance (`Check for interrupting elements affecting <button>`, looking for a system alert/permission prompt from another app, followed by re-`Open`/`Activate`-ing our target app). That dance can happen *during* the tap call itself, so a coordinate resolved beforehand can go stale by the time the touch is actually delivered, and the touch is silently dropped. The button's target-action never fires, and the test hangs until a later, unrelated step times out ("Timed out waiting for the password field..." or "Wait for result pipeline").

Separately, XCTest's "scroll element to visible" step (run unconditionally as part of its tap synthesis) was observed corrupting the hit-point computation to `{-1, -1}` on iOS/iPadOS 26 simulators, even when the button never needed to scroll and had a perfectly valid, on-screen frame.

**Fix:**
- `performAction:config:application:` now taps action buttons via a new `tapActionButtonWhenHittable:application:` helper that explicitly activates the application and waits for it to settle in the foreground *before* resolving the button's tap coordinate, so any interruption dance happens before we snapshot the tap point rather than concurrently with the tap.
- Taps via an explicit `XCUICoordinate` (bypassing `XCUIElement`'s own tap/scroll-to-visible synthesis path) to avoid the `{-1, -1}` hit-point bug.
- Extended the existing `msidTap` cross-platform convention (`XCUIElement+CrossPlat`) to `XCUICoordinate` so the new coordinate tap follows the same tap-on-iOS/click-on-macOS pattern as the rest of the file, instead of duplicating the platform check inline.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

Change is scoped entirely to the UI test automation library (`tests/automation`), not the shipped SDK — no runtime/customer-facing impact.

## Additional information

Verified locally end-to-end against a real iPhone 17 / iOS 26.3.1 simulator with live lab credentials: all 4 previously-failing `ADBTokenBindingUITests` tests now pass consistently (previously always failed with "Timed out waiting for the password field..." or "Wait for result pipeline" timeouts caused by the dropped Acquire Token tap upstream).
