### PR TITLE
[minor][feature]: add ECS enabled by default for reqCnf validation

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -260,6 +260,10 @@ extern NSString * _Nonnull const MSID_FLIGHT_BROWSER_CORE_DISABLE_POP;
 /// Owner: sedemche
 extern NSString * _Nonnull const MSID_FLIGHT_BROWSER_CORE_DISABLE_CLAIMS;
 
+/// Kill switch for the reqCnf presence validation on Pop token requests. Validation is enabled by default; set this flight to disable it.
+/// Owner: maagubuzo
+extern NSString * _Nonnull const MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION;
+
 extern NSString * _Nonnull const MSID_DOMAIN_HINT_KEY;
 
 extern NSString * _Nonnull const MSID_FLIGHT_ENABLE_THREAD_STARVATION;

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -112,6 +112,8 @@ NSString *const MSID_FLIGHT_BROWSER_CORE_DISABLE_POP = @"browser_core_disable_po
 
 NSString *const MSID_FLIGHT_BROWSER_CORE_DISABLE_CLAIMS = @"browser_core_disable_claims";
 
+NSString *const MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION = @"browser_core_disable_reqcnf_validation";
+
 NSString *const MSID_DOMAIN_HINT_KEY  = @"domain_hint";
 
 // This is SsoExt flow only flight

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
@@ -224,8 +224,9 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_CLAIMS_KEY = @"claims";
         
         if (MSIDAuthSchemeTypeFromString(tokenType) == MSIDAuthSchemePop)
         {
-            
-            if ([NSString msidIsStringNilOrBlank:reqCnf])
+            BOOL disableReqCnfValidation = [MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION];
+
+            if (!disableReqCnfValidation && [NSString msidIsStringNilOrBlank:reqCnf])
             {
                 MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to init MSIDBrowserNativeMessageGetTokenRequest: 'reqCnf' is required when token_type is Pop but was missing or empty.");
                 

--- a/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
@@ -30,6 +30,9 @@
 #import "MSIDClaimsRequest.h"
 #import "MSIDAuthenticationScheme.h"
 #import "MSIDError.h"
+#import "MSIDConstants.h"
+#import "MSIDFlightManager.h"
+#import "MSIDFlightManagerMockProvider.h"
 
 @interface MSIDBrowserNativeMessageGetTokenRequestTests : XCTestCase
 
@@ -43,6 +46,7 @@
 
 - (void)tearDown 
 {
+    MSIDFlightManager.sharedInstance.flightProvider = nil;
 }
 
 - (void)testOperation_shouldBeCorrect
@@ -1231,6 +1235,93 @@
     __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
     
     // tokenType in extraParameters is Pop but reqCnf is missing, so the request is rejected.
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeAndNilReqCnfAndValidationDisabledByFlight_shouldInitWithDefaultScheme
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION: @YES };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"tokenType": @"pop",
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    // Kill switch is enabled, so the missing reqCnf validation is skipped. Initialization succeeds; the Pop scheme
+    // cannot be built without reqCnf, so the request falls back to the default (Bearer) scheme instead of failing.
+    XCTAssertNotNil(request);
+    XCTAssertNil(error);
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeAndEmptyReqCnfAndValidationDisabledByFlight_shouldInitWithDefaultScheme
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION: @YES };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"tokenType": @"pop",
+            @"reqCnf": @""
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    // Kill switch is enabled, so the empty reqCnf validation is skipped. Initialization succeeds; the Pop scheme
+    // cannot be built without reqCnf, so the request falls back to the default (Bearer) scheme instead of failing.
+    XCTAssertNotNil(request);
+    XCTAssertNil(error);
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeAndNilReqCnfAndValidationEnabledByDefaultFlight_shouldReturnNilWithError
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION: @NO };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"tokenType": @"pop",
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    // Kill switch is explicitly off, so validation remains active and the request is rejected.
     XCTAssertNil(request);
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);

--- a/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
@@ -47,6 +47,7 @@
 - (void)tearDown 
 {
     MSIDFlightManager.sharedInstance.flightProvider = nil;
+    [super tearDown];
 }
 
 - (void)testOperation_shouldBeCorrect

--- a/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
@@ -1270,6 +1270,36 @@
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
+- (void)testInitWithJSONDictionary_whenPopTokenTypeInEQPAndNilReqCnfAndValidationDisabledByFlight_shouldInitWithDefaultScheme
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION: @YES };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    __auto_type extraParameters = @{
+        @"tokenType": @"pop",
+    };
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"extraParameters": extraParameters,
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(request);
+    XCTAssertNil(error);
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+}
+
 - (void)testInitWithJSONDictionary_whenPopTokenTypeAndEmptyReqCnfAndValidationDisabledByFlight_shouldInitWithDefaultScheme
 {
     MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Gate the reqCnf presence validation for Pop token requests in MSIDBrowserNativeMessageGetTokenRequest behind the browser_core_disable_reqcnf_validation flight (kill switch, validation enabled by default).
 * iOS: opt-in test injection hook for in-process CBA challenge handling #1889
 * Add MSIDUXCallbackProtocol and MSIDUXCallbackProvider to allow host apps to receive UX callbacks (e.g., schedule and cancel MDM profile installed notification) from CommonCore navigation layer. Add delay validation for flight-configured notification delay.
 * Only attach the PRT (refresh token credential) header to the PkeyAuth challenge response for known/trusted AAD hosts, preventing PRT leakage to untrusted hosts. Record an execution-flow tag for the added/skipped decision when a correlation id is available.


### PR DESCRIPTION
## Summary
Gate the reqCnf presence validation for Pop token requests in `MSIDBrowserNativeMessageGetTokenRequest` behind a new ECS flight, `browser_core_disable_reqcnf_validation`.

The flight is a **kill switch**: `MSIDFlightManager boolForKey:` returns `NO` when unset, so the validation is **enabled by default**. ECS can disable it to restore the prior fallback behavior (request initializes and falls back to the default Bearer scheme instead of failing when reqCnf is missing/blank on a Pop request).

This matches the existing `browser_core_disable_pop` / `browser_core_disable_claims` kill-switch convention in the same file. The tokenType lookup-order (extraParameters first, then request) is unchanged.

## Changes
- `MSIDConstants.h/.m`: add `MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION` (`browser_core_disable_reqcnf_validation`).
- `MSIDBrowserNativeMessageGetTokenRequest.m`: gate the reqCnf nil/blank guard behind the flight.
- `MSIDBrowserNativeMessageGetTokenRequestTests.m`: 3 new tests (flight on with nil/empty reqCnf -> init succeeds with default scheme; flight explicitly off -> still rejected) + `tearDown` resetting the flight provider.
- `changelog.txt`: entry under TBD.

## Testing
`IdentityCore Mac` scheme, `MSIDBrowserNativeMessageGetTokenRequestTests`: 42/42 passing.