### PR TITLE
[minor][bugfix] Hotfix release/1.25.1 with 2 commits relating to token type pop

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -260,6 +260,10 @@ extern NSString * _Nonnull const MSID_FLIGHT_BROWSER_CORE_DISABLE_POP;
 /// Owner: sedemche
 extern NSString * _Nonnull const MSID_FLIGHT_BROWSER_CORE_DISABLE_CLAIMS;
 
+/// Kill switch for the reqCnf presence validation on Pop token requests. Validation is enabled by default; set this flight to disable it.
+/// Owner: maagubuzo
+extern NSString * _Nonnull const MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION;
+
 extern NSString * _Nonnull const MSID_DOMAIN_HINT_KEY;
 
 extern NSString * _Nonnull const MSID_FLIGHT_ENABLE_THREAD_STARVATION;

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -112,6 +112,8 @@ NSString *const MSID_FLIGHT_BROWSER_CORE_DISABLE_POP = @"browser_core_disable_po
 
 NSString *const MSID_FLIGHT_BROWSER_CORE_DISABLE_CLAIMS = @"browser_core_disable_claims";
 
+NSString *const MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION = @"browser_core_disable_reqcnf_validation";
+
 NSString *const MSID_DOMAIN_HINT_KEY  = @"domain_hint";
 
 // This is SsoExt flow only flight

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
@@ -50,7 +50,6 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_PLATFORM_SEQUENCE_KEY = @"x-client-x
 NSString *const MSID_BROWSER_NATIVE_MESSAGE_CAN_SHOW_UI_KEY = @"canShowUI";
 NSString *const MSID_BROWSER_NATIVE_MESSAGE_REQUEST_CONFIRMATION_KEY = @"reqCnf";
 NSString *const MSID_BROWSER_NATIVE_MESSAGE_TOKEN_TYPE_KEY = @"tokenType";
-NSString *const MSID_BROWSER_NATIVE_MESSAGE_AUTHENTICATION_SCHEME_KEY = @"authenticationScheme";
 NSString *const MSID_BROWSER_NATIVE_MESSAGE_CLAIMS_KEY = @"claims";
 
 @implementation MSIDBrowserNativeMessageGetTokenRequest
@@ -218,12 +217,12 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_CLAIMS_KEY = @"claims";
     if (!disablePop)
     {
         NSString *reqCnf = [requestJson msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_REQUEST_CONFIRMATION_KEY] ?: [_extraParameters msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_REQUEST_CONFIRMATION_KEY];
-        // Read authenticationScheme (MSAL JS contract), fall back to tokenType for backward compatibility
-        NSString *authenticationScheme = [requestJson msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_AUTHENTICATION_SCHEME_KEY]
+        // Read tokenType from the extra query parameters, falling back to the top-level request.
+        NSString *tokenType = [_extraParameters msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_TOKEN_TYPE_KEY]
             ?: [requestJson msidStringObjectForKey:MSID_BROWSER_NATIVE_MESSAGE_TOKEN_TYPE_KEY];
-        authenticationScheme = authenticationScheme.capitalizedString;
+        tokenType = tokenType.capitalizedString;
         
-        if (MSIDAuthSchemeTypeFromString(authenticationScheme) == MSIDAuthSchemePop)
+        if (MSIDAuthSchemeTypeFromString(tokenType) == MSIDAuthSchemePop)
         {
             
             if ([NSString msidIsStringNilOrBlank:reqCnf])
@@ -235,7 +234,7 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_CLAIMS_KEY = @"claims";
             }
             
             NSMutableDictionary *schemeParams = [NSMutableDictionary new];
-            schemeParams[MSID_OAUTH2_TOKEN_TYPE] = authenticationScheme;
+            schemeParams[MSID_OAUTH2_TOKEN_TYPE] = tokenType;
             schemeParams[MSID_OAUTH2_REQUEST_CONFIRMATION] = reqCnf;
             
             _authScheme = [[MSIDAuthenticationSchemePop alloc] initWithSchemeParameters:schemeParams];

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRequest.m
@@ -224,8 +224,9 @@ NSString *const MSID_BROWSER_NATIVE_MESSAGE_CLAIMS_KEY = @"claims";
         
         if (MSIDAuthSchemeTypeFromString(tokenType) == MSIDAuthSchemePop)
         {
-            
-            if ([NSString msidIsStringNilOrBlank:reqCnf])
+            BOOL disableReqCnfValidation = [MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION];
+
+            if (!disableReqCnfValidation && [NSString msidIsStringNilOrBlank:reqCnf])
             {
                 MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to init MSIDBrowserNativeMessageGetTokenRequest: 'reqCnf' is required when token_type is Pop but was missing or empty.");
                 

--- a/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
@@ -30,6 +30,9 @@
 #import "MSIDClaimsRequest.h"
 #import "MSIDAuthenticationScheme.h"
 #import "MSIDError.h"
+#import "MSIDConstants.h"
+#import "MSIDFlightManager.h"
+#import "MSIDFlightManagerMockProvider.h"
 
 @interface MSIDBrowserNativeMessageGetTokenRequestTests : XCTestCase
 
@@ -43,6 +46,8 @@
 
 - (void)tearDown 
 {
+    MSIDFlightManager.sharedInstance.flightProvider = nil;
+    [super tearDown];
 }
 
 - (void)testOperation_shouldBeCorrect
@@ -1231,6 +1236,123 @@
     __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
     
     // tokenType in extraParameters is Pop but reqCnf is missing, so the request is rejected.
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeAndNilReqCnfAndValidationDisabledByFlight_shouldInitWithDefaultScheme
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION: @YES };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"tokenType": @"pop",
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    // Kill switch is enabled, so the missing reqCnf validation is skipped. Initialization succeeds; the Pop scheme
+    // cannot be built without reqCnf, so the request falls back to the default (Bearer) scheme instead of failing.
+    XCTAssertNotNil(request);
+    XCTAssertNil(error);
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeInEQPAndNilReqCnfAndValidationDisabledByFlight_shouldInitWithDefaultScheme
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION: @YES };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    __auto_type extraParameters = @{
+        @"tokenType": @"pop",
+    };
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"extraParameters": extraParameters,
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNotNil(request);
+    XCTAssertNil(error);
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeAndEmptyReqCnfAndValidationDisabledByFlight_shouldInitWithDefaultScheme
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION: @YES };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"tokenType": @"pop",
+            @"reqCnf": @""
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    // Kill switch is enabled, so the empty reqCnf validation is skipped. Initialization succeeds; the Pop scheme
+    // cannot be built without reqCnf, so the request falls back to the default (Bearer) scheme instead of failing.
+    XCTAssertNotNil(request);
+    XCTAssertNil(error);
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+}
+
+- (void)testInitWithJSONDictionary_whenPopTokenTypeAndNilReqCnfAndValidationEnabledByDefaultFlight_shouldReturnNilWithError
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_BROWSER_CORE_DISABLE_REQ_CNF_VALIDATION: @NO };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"isSts": @(YES),
+            @"tokenType": @"pop",
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    // Kill switch is explicitly off, so validation remains active and the request is rejected.
     XCTAssertNil(request);
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);

--- a/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
+++ b/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRequestTests.m
@@ -755,7 +755,7 @@
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndPopAuthenticationScheme_shouldInit
+- (void)testInitWithJSONDictionary_whenAuthenticationSchemeProvided_shouldBeIgnoredAndDefaultToBearer
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -805,10 +805,11 @@
     XCTAssertTrue(request.instanceAware);
     XCTAssertEqualObjects(extraParameters, request.extraParameters);
     XCTAssertNotNil(request.authScheme);
-    XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
+    // authenticationScheme is not read; only tokenType is honored, so this defaults to Bearer.
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndPopTokenTypeFallback_shouldInit
+- (void)testInitWithJSONDictionary_whenJsonValidAndPopTokenType_shouldInit
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -845,7 +846,7 @@
     XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenBothAuthenticationSchemeAndTokenType_shouldPrioritizeAuthenticationScheme
+- (void)testInitWithJSONDictionary_whenBothAuthenticationSchemeAndTokenType_shouldUseTokenType
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -880,11 +881,11 @@
     XCTAssertNil(error);
     XCTAssertNotNil(request);
     XCTAssertNotNil(request.authScheme);
-    // authenticationScheme ("pop") should win over tokenType ("bearer")
-    XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
+    // authenticationScheme is ignored; tokenType ("bearer") is used.
+    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndPopTokenTypeInEQP_shouldDefaultToBearer
+- (void)testInitWithJSONDictionary_whenJsonValidAndPopTokenTypeInEQP_shouldInit
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -919,11 +920,50 @@
     XCTAssertNotNil(request);
     XCTAssertEqualObjects(extraParameters, request.extraParameters);
     XCTAssertNotNil(request.authScheme);
-    // tokenType in extraParameters should no longer be read for auth scheme detection
-    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+    // tokenType is read from extraParameters first.
+    XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndInvalidPopAuthenticationSchemeReqCnf_shouldInit
+- (void)testInitWithJSONDictionary_whenTokenTypeInBothEQPAndTopLevel_shouldPrioritizeEQP
+{
+    __auto_type extraParameters = @{
+        @"k1": @"v1",
+        @"k2": @"v2",
+        @"tokenType": @"pop",
+        @"reqCnf": @"eyJraWQiOiJYaU1hYWdoSXdCWXQwLWU2RUFydWxuaWtLbExVdVlrcXVHRk05YmE5RDF3In0"
+    };
+    __auto_type json = @{
+        @"sender": @"https://login.microsoft.com",
+        @"request": @{
+            @"accountId": @"uid.utid",
+            @"clientId": @"29a788ca-7bcf-4732-b23c-c8d294347e5b",
+            @"authority": @"https://login.microsoftonline.com/common",
+            @"scope": @"user.read openid profile offline_access",
+            @"redirectUri": @"https://login.microsoft.com",
+            @"correlationId": @"9BBCA391-33A9-4EC9-A00E-A0FBFA71013D",
+            @"prompt": @"login",
+            @"isSts": @(YES),
+            @"canShowUI": @(NO),
+            @"nonce": @"e98aba90-bc47-4ff9-8809-b6e1c7e7cd47",
+            @"state": @"state1",
+            @"loginHint": @"user@microsoft.com",
+            @"instance_aware": @(YES),
+            @"extraParameters": extraParameters,
+            @"tokenType": @"bearer",
+        }
+    };
+
+    NSError *error;
+    __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(request);
+    XCTAssertNotNil(request.authScheme);
+    // tokenType in extraParameters ("pop") wins over the top-level tokenType ("bearer").
+    XCTAssertEqual(MSIDAuthSchemePop, request.authScheme.authScheme);
+}
+
+- (void)testInitWithJSONDictionary_whenJsonValidAndInvalidPopTokenTypeReqCnf_shouldInit
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -946,7 +986,7 @@
             @"loginHint": @"user@microsoft.com",
             @"instance_aware": @(YES),
             @"extraParameters": extraParameters,
-            @"authenticationScheme": @"pop",
+            @"tokenType": @"pop",
             @"reqCnf": @"qwe"
         }
     };
@@ -999,7 +1039,7 @@
             @"loginHint": @"user@microsoft.com",
             @"instance_aware": @(YES),
             @"extraParameters": extraParameters,
-            @"authenticationScheme": @"pop",
+            @"tokenType": @"pop",
             @"reqCnf": @1
         }
     };
@@ -1012,7 +1052,7 @@
     XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndNumberAuthenticationScheme_shouldNotFail
+- (void)testInitWithJSONDictionary_whenJsonValidAndNumberTokenType_shouldNotFail
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
@@ -1035,7 +1075,7 @@
             @"loginHint": @"user@microsoft.com",
             @"instance_aware": @(YES),
             @"extraParameters": extraParameters,
-            @"authenticationScheme": @1,
+            @"tokenType": @1,
             @"reqCnf": @"eyJraWQiOiJYaU1hYWdoSXdCWXQwLWU2RUFydWxuaWtLbExVdVlrcXVHRk05YmE5RDF3In0"
         }
     };
@@ -1048,12 +1088,11 @@
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
-- (void)testInitWithJSONDictionary_whenJsonValidAndAuthenticationSchemeInEQPOnlyAndReqCnfAsNumber_shouldDefaultToBearer
+- (void)testInitWithJSONDictionary_whenPopTokenTypeInEQPAndReqCnfAsNumber_shouldReturnNilWithError
 {
     __auto_type extraParameters = @{
         @"k1": @"v1",
         @"k2": @"v2",
-        @"authenticationScheme": @"pop",
         @"tokenType": @"pop",
         @"reqCnf": @1
     };
@@ -1080,10 +1119,10 @@
     NSError *error;
     __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
     
-    XCTAssertNotNil(request);
-    XCTAssertNil(error);
-    // authenticationScheme/tokenType in extraParameters should not be read — defaults to Bearer
-    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+    // tokenType in extraParameters is Pop but reqCnf is not a valid string, so the request is rejected.
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
 - (void)testInitWithJSONDictionary_whenJsonValidAndNumberTokenTypeAsEQP_shouldNotFail
@@ -1119,7 +1158,7 @@
     
     XCTAssertNotNil(request);
     XCTAssertNil(error);
-    // authenticationScheme in extraParameters should not be read for auth scheme detection
+    // tokenType in extraParameters is not a string, so it is ignored and defaults to Bearer.
     XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
 }
 
@@ -1170,7 +1209,7 @@
     XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
-- (void)testInitWithJSONDictionary_whenPopTokenTypeInEQPAndNilReqCnf_shouldDefaultToBearer
+- (void)testInitWithJSONDictionary_whenPopTokenTypeInEQPAndNilReqCnf_shouldReturnNilWithError
 {
     __auto_type extraParameters = @{
         @"tokenType": @"pop",
@@ -1191,10 +1230,10 @@
     NSError *error;
     __auto_type request = [[MSIDBrowserNativeMessageGetTokenRequest alloc] initWithJSONDictionary:json error:&error];
     
-    XCTAssertNotNil(request);
-    XCTAssertNil(error);
-    // tokenType in extraParameters should not be read — defaults to Bearer
-    XCTAssertEqual(MSIDAuthSchemeBearer, request.authScheme.authScheme);
+    // tokenType in extraParameters is Pop but reqCnf is missing, so the request is rejected.
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
 }
 
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.25.1
+* Gate the reqCnf presence validation for Pop token requests in MSIDBrowserNativeMessageGetTokenRequest behind the browser_core_disable_reqcnf_validation flight (kill switch, validation enabled by default) (#1891).
+* fall back token authSchema in Browser Native Messaging request to token type as extra qp and top level as a default (#1879).
+
 Version 1.25.0
 * Harden MSIDDIContainer: validate protocol conformance in resolveImplClassForProtocol:orDefault:; NSAssert in debug, log + fall back to default in release. Self-heal cache eviction on conformance failure; release-mode fallback test via NSAssertionHandler swap.
 * Hand off openid-vc:// URLs to the registered wallet from the AAD embedded webview without dismissing the webview; append x_ms_caller_redirect_uri/x_ms_caller_bundle_id/x_ms_correlation_id so the wallet can foreground the calling app when the VID flow completes. Add the MSIDOpenIdVcHandling delegate protocol on MSIDAADOAuthEmbeddedWebviewController so hosts (e.g. an SSO extension hosting VID in-process) can intercept openid-vc navigations and present in-process UI instead of bouncing out via openURL. Replaces the prior MSIDWebOpenIdVcResponse / MSIDWebOpenIdVcResponseOperation pipeline that erroneously errored out the interactive request.


### PR DESCRIPTION
## [minor][bugfix] Hotfix release/1.25.1 with 2 commits relating to token type pop

## Proposed changes
- fall back to support TokenType as top level and extra qp
DOM api reads from extra qp on ios
Extension flow reads from top level

this needs to be supported in both scenarios.

- added flight to fall back and drop req cnf validation for code safty as this change was not in common core prod 1.24.0

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

