### PR TITLE
[patch] [bugfix]: Fix MSIDFlightManager reader data race on flightProvider

### DIFF
--- a/IdentityCore/src/MSIDFlightManager.m
+++ b/IdentityCore/src/MSIDFlightManager.m
@@ -120,7 +120,7 @@
 
 #pragma mark - MSIDFlightManagerInterface
 
-- (BOOL)boolForKey:(nonnull NSString *)flightKey 
+- (BOOL)boolForKey:(nonnull NSString *)flightKey
 {
     __block BOOL result = NO;
     // Read the provider only from within the synchronization queue. Testing it via the

--- a/IdentityCore/src/MSIDFlightManager.m
+++ b/IdentityCore/src/MSIDFlightManager.m
@@ -34,6 +34,8 @@
 
 @implementation MSIDFlightManager
 
+@synthesize flightProvider = _flightProvider;
+
 + (instancetype)sharedInstance
 {
     static MSIDFlightManager *sharedInstance = nil;
@@ -116,6 +118,19 @@
     dispatch_barrier_sync(self.synchronizationQueue, ^{
         self->_flightProvider = flightProvider;
     });
+}
+
+- (id<MSIDFlightManagerInterface>)flightProvider
+{
+    __block id<MSIDFlightManagerInterface> flightProvider = nil;
+    // Read on the synchronization queue so external callers are serialized against the
+    // barrier write in setFlightProvider:, matching the internal readers below. Capturing
+    // into a strong local keeps the provider alive for the duration of the call.
+    dispatch_sync(self.synchronizationQueue, ^{
+        flightProvider = self->_flightProvider;
+    });
+    
+    return flightProvider;
 }
 
 #pragma mark - MSIDFlightManagerInterface

--- a/IdentityCore/src/MSIDFlightManager.m
+++ b/IdentityCore/src/MSIDFlightManager.m
@@ -123,25 +123,33 @@
 - (BOOL)boolForKey:(nonnull NSString *)flightKey 
 {
     __block BOOL result = NO;
-    if (self.flightProvider)
-    {
-        dispatch_sync(self.synchronizationQueue, ^{
-            result = [self.flightProvider boolForKey:flightKey];
-        });
-    }
+    // Read the provider only from within the synchronization queue. Testing it via the
+    // unsynchronized property getter first would race the barrier write in setFlightProvider:,
+    // and capturing it into a strong local keeps it alive for the duration of the call.
+    dispatch_sync(self.synchronizationQueue, ^{
+        id<MSIDFlightManagerInterface> flightProvider = self->_flightProvider;
+        if (flightProvider)
+        {
+            result = [flightProvider boolForKey:flightKey];
+        }
+    });
     
     return result;
 }
 
 - (nullable NSString *)stringForKey:(nonnull NSString *)flightKey
 {
-    __block NSString* result = nil;
-    if (self.flightProvider)
-    {
-        dispatch_sync(self.synchronizationQueue, ^{
-            result = [self.flightProvider stringForKey:flightKey];
-        });
-    }
+    __block NSString *result = nil;
+    // Read the provider only from within the synchronization queue. Testing it via the
+    // unsynchronized property getter first would race the barrier write in setFlightProvider:,
+    // and capturing it into a strong local keeps it alive for the duration of the call.
+    dispatch_sync(self.synchronizationQueue, ^{
+        id<MSIDFlightManagerInterface> flightProvider = self->_flightProvider;
+        if (flightProvider)
+        {
+            result = [flightProvider stringForKey:flightKey];
+        }
+    });
     
     return result;
 }

--- a/IdentityCore/tests/MSIDFlightManagerTests.swift
+++ b/IdentityCore/tests/MSIDFlightManagerTests.swift
@@ -275,20 +275,47 @@ class MockFlightProvider: NSObject, MSIDFlightManagerInterface {
     var boolValues: [String: Bool] = [:]
     var stringValues: [String: String] = [:]
     
-    var boolForKeyCalled = false
-    var stringForKeyCalled = false
-    var lastBoolKey: String?
-    var lastStringKey: String?
+    // Call-tracking state is guarded by `lock` so concurrent reads through
+    // bool(forKey:)/string(forKey:) don't race on it (which would trip Thread Sanitizer).
+    private let lock = NSLock()
+    private var _boolForKeyCalled = false
+    private var _stringForKeyCalled = false
+    private var _lastBoolKey: String?
+    private var _lastStringKey: String?
+    
+    var boolForKeyCalled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _boolForKeyCalled
+    }
+    
+    var stringForKeyCalled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _stringForKeyCalled
+    }
+    
+    var lastBoolKey: String? {
+        lock.lock(); defer { lock.unlock() }
+        return _lastBoolKey
+    }
+    
+    var lastStringKey: String? {
+        lock.lock(); defer { lock.unlock() }
+        return _lastStringKey
+    }
     
     func bool(forKey flightKey: String) -> Bool {
-        boolForKeyCalled = true
-        lastBoolKey = flightKey
+        lock.lock()
+        _boolForKeyCalled = true
+        _lastBoolKey = flightKey
+        lock.unlock()
         return boolValues[flightKey] ?? false
     }
     
     func string(forKey key: String) -> String? {
-        stringForKeyCalled = true
-        lastStringKey = key
+        lock.lock()
+        _stringForKeyCalled = true
+        _lastStringKey = key
+        lock.unlock()
         return stringValues[key]
     }
 }

--- a/IdentityCore/tests/MSIDFlightManagerTests.swift
+++ b/IdentityCore/tests/MSIDFlightManagerTests.swift
@@ -211,15 +211,17 @@ class MSIDFlightManagerTests: XCTestCase {
     func testConcurrentReads_whileProviderSwappedAndCleared_doNotCrash() {
         let flightManager = MSIDFlightManager.sharedInstance()
         
+        let iterations = 100
+        let operationsPerIteration = 3
         let expectation = XCTestExpectation(description: "All operations complete")
-        expectation.expectedFulfillmentCount = 300
+        expectation.expectedFulfillmentCount = iterations * operationsPerIteration
         
         // Interleave provider swaps (including nil) with concurrent reads. Before the reader
         // fix, boolForKey:/stringForKey: tested the provider through the unsynchronized getter
         // before dispatching onto the synchronization queue, so a swap-and-release racing a
         // read could leave the read messaging a freed provider. Reading the provider once from
         // inside the queue into a strong local removes that window.
-        for i in 0..<100 {
+        for i in 0..<iterations {
             DispatchQueue.global().async {
                 let provider = MockFlightProvider()
                 provider.identifier = "provider-\(i)"

--- a/IdentityCore/tests/MSIDFlightManagerTests.swift
+++ b/IdentityCore/tests/MSIDFlightManagerTests.swift
@@ -208,6 +208,44 @@ class MSIDFlightManagerTests: XCTestCase {
         XCTAssertTrue(mockFlightProvider.stringForKeyCalled)
     }
     
+    func testConcurrentReads_whileProviderSwappedAndCleared_doNotCrash() {
+        let flightManager = MSIDFlightManager.sharedInstance()
+        
+        let expectation = XCTestExpectation(description: "All operations complete")
+        expectation.expectedFulfillmentCount = 300
+        
+        // Interleave provider swaps (including nil) with concurrent reads. Before the reader
+        // fix, boolForKey:/stringForKey: tested the provider through the unsynchronized getter
+        // before dispatching onto the synchronization queue, so a swap-and-release racing a
+        // read could leave the read messaging a freed provider. Reading the provider once from
+        // inside the queue into a strong local removes that window.
+        for i in 0..<100 {
+            DispatchQueue.global().async {
+                let provider = MockFlightProvider()
+                provider.identifier = "provider-\(i)"
+                provider.boolValues["bool-key"] = true
+                provider.stringValues["string-key"] = "value-\(i)"
+                flightManager.flightProvider = (i % 2 == 0) ? provider : nil
+                expectation.fulfill()
+            }
+            
+            DispatchQueue.global().async {
+                _ = flightManager.bool(forKey: "bool-key")
+                expectation.fulfill()
+            }
+            
+            DispatchQueue.global().async {
+                _ = flightManager.string(forKey: "string-key")
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 10.0)
+        
+        // Reset shared singleton state mutated by this test.
+        flightManager.flightProvider = nil
+    }
+    
     // MARK: - Edge Cases
     
     func testQueryKeyInstance_WithWhitespaceOnlyKey_ReturnsSharedInstance() {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 TBD
-* Fix a data race in MSIDFlightManager: boolForKey:/stringForKey: read the flight provider once from inside the synchronization queue into a strong local instead of testing it through the unsynchronized property getter first, preventing a use-after-free when a concurrent setFlightProvider: swaps/releases the provider mid-read.
+* Fix a data race in MSIDFlightManager: boolForKey:/stringForKey: read the flight provider once from inside the synchronization queue into a strong local instead of testing it through the unsynchronized property getter first, preventing a use-after-free when a concurrent setFlightProvider: swaps/releases the provider mid-read. Also serialize the public flightProvider getter through the same queue so external callers no longer race the barrier setter.
 * Gate the reqCnf presence validation for Pop token requests in MSIDBrowserNativeMessageGetTokenRequest behind the browser_core_disable_reqcnf_validation flight (kill switch, validation enabled by default).
 * iOS: opt-in test injection hook for in-process CBA challenge handling #1889
 * Add MSIDUXCallbackProtocol and MSIDUXCallbackProvider to allow host apps to receive UX callbacks (e.g., schedule and cancel MDM profile installed notification) from CommonCore navigation layer. Add delay validation for flight-configured notification delay.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Fix a data race in MSIDFlightManager: boolForKey:/stringForKey: read the flight provider once from inside the synchronization queue into a strong local instead of testing it through the unsynchronized property getter first, preventing a use-after-free when a concurrent setFlightProvider: swaps/releases the provider mid-read.
 * Gate the reqCnf presence validation for Pop token requests in MSIDBrowserNativeMessageGetTokenRequest behind the browser_core_disable_reqcnf_validation flight (kill switch, validation enabled by default).
 * iOS: opt-in test injection hook for in-process CBA challenge handling #1889
 * Add MSIDUXCallbackProtocol and MSIDUXCallbackProvider to allow host apps to receive UX callbacks (e.g., schedule and cancel MDM profile installed notification) from CommonCore navigation layer. Add delay validation for flight-configured notification delay.


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [x] Appropriate reviewers are assigned
- [x] PR reviewed by code owner (required if Copilot-generated)
- [x] SME or Senior IC assigned where required

## Proposed changes

`MSIDFlightManager`'s `boolForKey:` and `stringForKey:` tested `self.flightProvider` through the (unsynchronized) property getter **before** dispatching onto the synchronization queue, then re-read it inside the queue:

```objc
if (self.flightProvider) {                      // unsynchronized read
    dispatch_sync(self.synchronizationQueue, ^{
        result = [self.flightProvider ...];     // second read
    });
}
```

That first read races the barrier write in `setFlightProvider:`. When another thread swaps/releases the provider concurrently with a read, the read can end up messaging a freed provider (use-after-free).

In the Microsoft Authenticator app this surfaced as an `objc_msgSend` crash inside `-[MSIDAccountCredentialCache checkFRTEnabled:error:]` at the flight-status read (`stringForKey:MSID_FLIGHT_CLIENT_SFRT_STATUS`), driven from a launch-time background thread that reads FRT/flight state while the main flow assigns a new `flightProvider` from a parsed broker device-info response.

This change reads `_flightProvider` **once from inside the synchronization queue** into a strong local and messages that local, removing the unsynchronized access and keeping the provider alive for the duration of the call. It complements #1876 (which made the setter synchronous via `dispatch_barrier_sync`); the setter and readers are now fully serialized through the queue.

Adds a concurrency regression test (`testConcurrentReads_whileProviderSwappedAndCleared_doNotCrash`) that interleaves provider swaps (including `nil`) with concurrent `boolForKey:`/`stringForKey:` reads.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

All 15 `MSIDFlightManagerTests` pass locally (iOS, Xcode 26.5, iPhone 17 simulator), including the new regression test. Changelog updated under `TBD`.
