### PR TITLE
[patch] [bugfix]: Harden msidIsStringNilOrBlank against non-string input

### DIFF
--- a/IdentityCore/src/util/NSString+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSString+MSIDExtensions.m
@@ -73,7 +73,10 @@ typedef unsigned char byte;
 
 + (BOOL)msidIsStringNilOrBlank:(NSString *)string
 {
-    if (!string || [string isKindOfClass:[NSNull class]] || !string.length)
+    // Treat any non-NSString (nil, NSNull, or a mis-typed value such as an NSNumber/__NSCFBoolean
+    // decoded from JSON or an MDM configuration plist) as blank, rather than sending -length to it
+    // and raising an unrecognized-selector exception.
+    if (!string || ![string isKindOfClass:[NSString class]] || !string.length)
     {
         return YES;
     }

--- a/IdentityCore/tests/MSIDStringExtensionsTests.m
+++ b/IdentityCore/tests/MSIDStringExtensionsTests.m
@@ -96,6 +96,18 @@
     XCTAssertFalse([NSString msidIsStringNilOrBlank:str], "Not an empty string %@", str);
 }
 
+- (void)testMsidIsStringNilOrBlank_whenNonStringObject_shouldReturnTrue
+{
+    // Regression: a mis-typed value (e.g. a JSON/plist boolean decoded as __NSCFBoolean, or any
+    // other non-NSString) must be treated as blank rather than crashing with an unrecognized
+    // selector when -length is sent to it.
+    XCTAssertTrue([NSString msidIsStringNilOrBlank:(NSString *)@YES]);
+    XCTAssertTrue([NSString msidIsStringNilOrBlank:(NSString *)@NO]);
+    XCTAssertTrue([NSString msidIsStringNilOrBlank:(NSString *)@42]);
+    XCTAssertTrue([NSString msidIsStringNilOrBlank:(NSString *)@[@"a"]]);
+    XCTAssertTrue([NSString msidIsStringNilOrBlank:(NSString *)@{@"a": @"b"}]);
+}
+
 - (void)testMsidTrimmedString
 {
     XCTAssertEqualObjects([@" \t\r\n  test" msidTrimmedString], @"test");

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Harden +[NSString(MSIDExtensions) msidIsStringNilOrBlank:] to treat any non-NSString argument (e.g. an NSNumber/__NSCFBoolean decoded from JSON or an MDM configuration plist) as blank instead of sending -length to it and raising an unrecognized-selector exception.
 * Gate the reqCnf presence validation for Pop token requests in MSIDBrowserNativeMessageGetTokenRequest behind the browser_core_disable_reqcnf_validation flight (kill switch, validation enabled by default).
 * iOS: opt-in test injection hook for in-process CBA challenge handling #1889
 * Add MSIDUXCallbackProtocol and MSIDUXCallbackProvider to allow host apps to receive UX callbacks (e.g., schedule and cancel MDM profile installed notification) from CommonCore navigation layer. Add delay validation for flight-configured notification delay.


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [x] Appropriate reviewers are assigned
- [x] PR reviewed by code owner (required if Copilot-generated)
- [x] SME or Senior IC assigned where required

## Proposed changes

`+[NSString(MSIDExtensions) msidIsStringNilOrBlank:]` only special-cased `nil` and `NSNull`. For any other non-`NSString` argument it fell through to `!string.length`, sending `-length` to the object:

```objc
if (!string || [string isKindOfClass:[NSNull class]] || !string.length)
```

When a mis-typed value reaches the check — e.g. a JSON/plist **boolean** decoded as `__NSCFBoolean` from an MDM SSO-extension configuration where a string was expected — this raises `-[__NSCFBoolean length]: unrecognized selector sent to instance` and crashes (SIGABRT).

This was observed as a crash in the iOS `AuthenticatorSSOExtension` on the main thread during `-[ASSSOExtensionAuthenticationViewController beginAuthorizationWithRequest:]`, where SSO-extension configuration values are parsed.

This change replaces the `NSNull`-only check with a positive `NSString` kind check, so any non-`NSString` (including `NSNull`, `NSNumber`/`__NSCFBoolean`, collections, etc.) is treated as blank and the method never messages a non-string:

```objc
if (!string || ![string isKindOfClass:[NSString class]] || !string.length)
```

Adds a regression test covering `NSNumber`/`__NSCFBoolean`, `NSArray` and `NSDictionary` inputs.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

Behavior for existing inputs is unchanged: `nil`, `NSNull`, empty and whitespace-only strings still return `YES`; non-blank strings still return `NO`. Only previously-crashing non-`NSString` inputs change from "throw" to `YES`. All `MSIDTestNSStringHelperMethods` tests pass locally (iOS, Xcode 26.5, iPhone 17 simulator), including the new regression test. Changelog updated under `TBD`.
