### PR TITLE
Add app-identity headers to Intune MDM enrollment request

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -131,7 +131,9 @@ extern NSString * _Nonnull const MSID_OS_VER_KEY;//iOS/OSX version
 extern NSString * _Nonnull const MSID_DEVICE_MODEL_KEY;//E.g. iPhone 5S
 extern NSString * _Nonnull const MSID_APP_NAME_KEY;
 extern NSString * _Nonnull const MSID_APP_VER_KEY;
+extern NSString * _Nonnull const MSID_APP_CLIENT_ID_KEY;//x-ms-client-id (source app OAuth client ID, broker only)
 extern NSString * _Nonnull const MSID_CCS_HINT_KEY;
+
 extern NSString * _Nonnull const MSID_WEBAUTH_IGNORE_SSO_KEY;
 extern NSString * _Nonnull const MSID_WEBAUTH_REFRESH_TOKEN_KEY;
 extern NSString * _Nonnull const MSID_USER_FEDERATED_IDENTITY_CREDENTIAL_KEY;

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -33,6 +33,7 @@ NSString *const MSID_OS_VER_KEY                    = @"x-client-OS";
 NSString *const MSID_DEVICE_MODEL_KEY              = @"x-client-DM";
 NSString *const MSID_APP_NAME_KEY                  = @"x-app-name";
 NSString *const MSID_APP_VER_KEY                   = @"x-app-ver";
+NSString *const MSID_APP_CLIENT_ID_KEY            = @"x-ms-client-id";
 NSString *const MSID_CCS_HINT_KEY                  = @"X-AnchorMailbox";
 NSString *const MSID_WEBAUTH_IGNORE_SSO_KEY        = @"x-ms-sso-Ignore-SSO";
 NSString *const MSID_WEBAUTH_REFRESH_TOKEN_KEY     = @"x-ms-sso-RefreshToken";

--- a/IdentityCore/src/util/MSIDHelpers.h
+++ b/IdentityCore/src/util/MSIDHelpers.h
@@ -23,10 +23,21 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MSIDHelpers : NSObject
 
 /*! Returns integer value if the passed object can be converted to integer, 0 otherwise */
 + (NSInteger)msidIntegerValue:(id)value;
-+ (NSString *)normalizeUserId:(NSString *)userId;
++ (nullable NSString *)normalizeUserId:(nullable NSString *)userId;
+
+/*! The Apple Developer team identifiers of Microsoft first-party apps. */
++ (NSSet<NSString *> *)microsoft1PAppsTeamIDs;
+
+/*! Returns YES if the given Apple Developer team identifier belongs to a
+    Microsoft first-party app (see +microsoft1PAppsTeamIDs). */
++ (BOOL)isMicrosoftFirstPartyAppWithTeamId:(nullable NSString *)teamId;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/util/MSIDHelpers.m
+++ b/IdentityCore/src/util/MSIDHelpers.m
@@ -46,4 +46,23 @@
     return normalized.length ? normalized : nil;
 }
 
++ (NSSet<NSString *> *)microsoft1PAppsTeamIDs
+{
+    static NSSet<NSString *> *teamIDs = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        teamIDs = [[NSSet alloc] initWithArray:@[@"SGGM6D27TK",
+                                                 @"9KBH5RKYEW", // 9KB* is the prefix for enterprise-signed 1st party iOS apps
+                                                 @"UBF8T346G9"
+                                               ]];
+    });
+
+    return teamIDs;
+}
+
++ (BOOL)isMicrosoftFirstPartyAppWithTeamId:(NSString *)teamId
+{
+    return teamId.length > 0 && [[self microsoft1PAppsTeamIDs] containsObject:teamId];
+}
+
 @end

--- a/IdentityCore/src/util/NSBundle+MSIDExtensions.h
+++ b/IdentityCore/src/util/NSBundle+MSIDExtensions.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSBundle (MSIDExtensions)
 
 + (NSString *)msidAppVersion;
++ (NSString *)msidAppName;
 
 @end
 

--- a/IdentityCore/src/util/NSBundle+MSIDExtensions.m
+++ b/IdentityCore/src/util/NSBundle+MSIDExtensions.m
@@ -36,4 +36,16 @@
     return appVersion;
 }
 
++ (NSString *)msidAppName
+{
+    NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
+    NSString *appName = info[@"CFBundleDisplayName"];
+    if (!appName)
+    {
+        appName = info[@"CFBundleName"];
+    }
+
+    return appName ?: @"";
+}
+
 @end

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.h
@@ -62,23 +62,12 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param URL The special redirect URL to resolve (msauth://, browser://, etc.). If nil or missing a scheme, returns a failWithError decision.
  * @param embeddedWebviewController The webview controller handling the navigation. May be nil for flows that do not require it.
- * @return Navigation decision to apply. Always non-nil: unhandled schemes resolve to continueDefault and invalid/unprocessable URLs resolve to a failWithError decision.
- */
-- (MSIDWebviewNavigationDecision * _Nullable)resolveDecisionForURL:(NSURL * _Nullable)URL
-                                         embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController;
-
-/**
- * Resolves a navigation decision for a special redirect URL, optionally stamping
- * the broker version on the MDM enrollment request (x-client-brkrver header).
- *
- * @param URL The special redirect URL to resolve. If nil or missing a scheme, returns a failWithError decision.
- * @param embeddedWebviewController The webview controller handling the navigation. May be nil for flows that do not require it.
- * @param brokerVersion Optional broker version to advertise on the enrollment request. Pass nil when not in a broker flow; the two-argument variant above forwards nil.
+ * @param additionalHeaders Extra headers to merge onto the MDM enrollment request. The broker flow supplies the broker version (x-client-brkrver); the non-broker flow supplies the running process's first-party app-identity headers. Pass nil to add none.
  * @return Navigation decision to apply. Always non-nil: unhandled schemes resolve to continueDefault and invalid/unprocessable URLs resolve to a failWithError decision.
  */
 - (MSIDWebviewNavigationDecision * _Nullable)resolveDecisionForURL:(NSURL * _Nullable)URL
                                          embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
-                                                     brokerVersion:(NSString * _Nullable)brokerVersion;
+                                                 additionalHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)additionalHeaders;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationDecisionResolver.m
@@ -53,15 +53,7 @@
 
 - (MSIDWebviewNavigationDecision * _Nullable)resolveDecisionForURL:(NSURL * _Nullable)URL
                                          embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
-{
-    return [self resolveDecisionForURL:URL
-             embeddedWebviewController:embeddedWebviewController
-                         brokerVersion:nil];
-}
-
-- (MSIDWebviewNavigationDecision * _Nullable)resolveDecisionForURL:(NSURL * _Nullable)URL
-                                         embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
-                                                     brokerVersion:(NSString * _Nullable)brokerVersion
+                                                 additionalHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)additionalHeaders
 {
     if (!URL)
     {
@@ -93,7 +85,7 @@
         // Handle msauth:// URLs
         return [self handleMSAuthURL:URL
            embeddedWebviewController:embeddedWebviewController
-                       brokerVersion:brokerVersion];
+                       callerHeaders:additionalHeaders];
     }
     else if ([scheme isEqualToString:MSID_SCHEME_BROWSER])
     {
@@ -113,7 +105,7 @@
 
 - (MSIDWebviewNavigationDecision *)handleMSAuthURL:(NSURL *)URL
                          embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
-                                     brokerVersion:(NSString * _Nullable)brokerVersion
+                                     callerHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)callerHeaders
 {
     NSString *host = URL.host.lowercaseString;
 
@@ -130,15 +122,15 @@
     
     // Parse query parameters
     NSDictionary<NSString *, NSString *> *params = [URL msidQueryParameters];
-    
+    NSDictionary<NSString *, NSString *> *params1 = [self queryParamsFromURL:URL];
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[NavDecision] Resolving decision for msauth host '%@'.", host);
     
     // Route based on host
     if ([host isEqualToString:MSID_MDM_ENROLL_HOST])
     {
-        return [self decisionForEnrollURL:params
+        return [self decisionForEnrollURL:params1
                 embeddedWebviewController:embeddedWebviewController
-                            brokerVersion:brokerVersion];
+                            callerHeaders:callerHeaders];
     }
     else if ([host isEqualToString:MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST])
     {
@@ -147,7 +139,7 @@
     }
     else if ([host isEqualToString:MSID_COMPLIANCE_HOST])
     {
-        return [self decisionForComplianceURL:params
+        return [self decisionForComplianceURL:params1
                     embeddedWebviewController:embeddedWebviewController];
     }
     else if ([host isEqualToString:MSID_MDM_ENROLLMENT_COMPLETION_HOST])
@@ -168,7 +160,7 @@
 
 - (MSIDWebviewNavigationDecision *)decisionForEnrollURL:(NSDictionary *)params
                              embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
-                                         brokerVersion:(NSString * _Nullable)brokerVersion
+                                         callerHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)additionalHeaders
 {
     MSIDOnboardingBlobBuilder *onboardingBlobBuilder = embeddedWebviewController.onboardingBlobBuilder;
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[Enroll] Building enrollment request from msauth redirect.");
@@ -238,28 +230,28 @@
     }
 
     // Prepare additional headers for enrollment.
-    NSMutableDictionary *additionalHeaders = [NSMutableDictionary dictionary];
+    NSMutableDictionary *headers = [NSMutableDictionary dictionary];
 
     NSString *platformName = [MSIDVersion platformName];
     if (platformName.length > 0)
     {
-        additionalHeaders[MSID_PLATFORM_KEY] = platformName;
+        headers[MSID_PLATFORM_KEY] = platformName;
     }
 
     NSString *sdkVersion = [MSIDVersion sdkVersion];
     if (sdkVersion.length > 0)
     {
-        additionalHeaders[MSID_VERSION_KEY] = sdkVersion;
+        headers[MSID_VERSION_KEY] = sdkVersion;
     }
 
-    if (brokerVersion.length > 0)
+    if (additionalHeaders.count > 0)
     {
-        additionalHeaders[MSID_BROKER_VER_KEY] = brokerVersion;
+        [headers addEntriesFromDictionary:additionalHeaders];
     }
 
     // Build the final request with all query params and headers.
     NSURLRequest *request = [self buildRequestForURL:decodedIntuneURL
-                                        extraHeaders:additionalHeaders
+                                        extraHeaders:headers
                                          extraParams:allQueryParams];
 
     if (!request)
@@ -582,6 +574,46 @@
 
     return request;
 }
+
+- (NSDictionary<NSString *, NSString *> *)queryParamsFromURL:(NSURL *)url
+{
+    if (!url)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Cannot extract query params: URL is nil");
+        return @{};
+    }
+    
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    if (!components)
+    {
+    MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Cannot extract query params: Failed to parse URL components for URL: %@", MSID_PII_LOG_MASKABLE(url));
+    }
+    
+    NSMutableDictionary<NSString *, NSString *> *result = [NSMutableDictionary new];
+    
+    NSArray<NSURLQueryItem *> *queryItems = components.queryItems;
+    if (!queryItems || queryItems.count == 0)
+    {
+        return @{};
+    }
+    
+    for (NSURLQueryItem *item in queryItems)
+    {
+        // Only add items with both name and value present
+        if (item.name && item.value)
+        {
+            result[item.name] = item.value;
+        }
+        else if (item.name)
+        {
+            // Query parameter with no value - log as warning
+            MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"Query parameter '%@' has no value", item.name);
+        }
+    }
+    
+    return [result copy];
+}
+
 
 @end
 

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.h
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.h
@@ -90,19 +90,19 @@ NS_ASSUME_NONNULL_BEGIN
                       completion:(void (^)(MSIDWebviewNavigationDecision * _Nullable navigationDecision, NSError * _Nullable error))completion;
 
 /**
- * Handles special redirect URLs (msauth://, browser://), optionally carrying the
- * broker version so the enrollment request can advertise it via the
- * x-client-brkrver header. Non-broker callers may omit brokerVersion (pass nil);
- * the base method above forwards nil to this one.
+ * Handles special redirect URLs (msauth://, browser://), merging caller-supplied
+ * additional headers onto the MDM enrollment request. The broker flow supplies the
+ * broker version (x-client-brkrver); the non-broker flow's base method above supplies
+ * the running process's first-party app-identity headers.
  *
  * @param URL The special redirect URL
  * @param embeddedWebviewController The embedded webview controller instance
- * @param brokerVersion Optional broker version to stamp on the enrollment request. Pass nil when not in a broker flow.
+ * @param additionalHeaders Extra headers to stamp on the enrollment request. Pass nil to add none.
  * @param completion Completion block with the navigation decision or error
  */
 - (void)handleSpecialRedirectURL:(NSURL *)URL
        embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
-                   brokerVersion:(NSString * _Nullable)brokerVersion
+               additionalHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)additionalHeaders
                       completion:(void (^)(MSIDWebviewNavigationDecision * _Nullable navigationDecision, NSError * _Nullable error))completion;
 
 /**

--- a/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/MSIDWebviewNavigationHandler.m
@@ -32,6 +32,10 @@
 #import "MSIDWebviewConstants.h"
 #import "MSIDOnboardingBlobBuilder.h"
 #import "MSIDOnboardingBlobFieldKeys.h"
+#import "MSIDConstants.h"
+#import "MSIDHelpers.h"
+#import "MSIDKeychainUtil.h"
+#import "NSBundle+MSIDExtensions.h"
 
 #if !MSID_EXCLUDE_WEBKIT
 
@@ -84,15 +88,18 @@
        embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
                       completion:(void (^)(MSIDWebviewNavigationDecision * _Nullable navigationDecision, NSError * _Nullable error))completion
 {
+    // Non-broker (in-app) flow: the running process is the caller, so supply its first-party
+    // app-identity headers rather than nil. The broker flow calls the variant below with the
+    // broker version instead.
     [self handleSpecialRedirectURL:URL
          embeddedWebviewController:embeddedWebviewController
-                     brokerVersion:nil
+                 additionalHeaders:[self firstPartyAppHeadersForCurrentProcess]
                         completion:completion];
 }
 
 - (void)handleSpecialRedirectURL:(NSURL *)URL
        embeddedWebviewController:(MSIDOAuth2EmbeddedWebviewController * _Nullable)embeddedWebviewController
-                   brokerVersion:(NSString * _Nullable)brokerVersion
+               additionalHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)additionalHeaders
                       completion:(void (^)(MSIDWebviewNavigationDecision * _Nullable navigationDecision, NSError * _Nullable error))completion
 {
     MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.context,
@@ -101,8 +108,27 @@
     MSIDWebviewNavigationDecisionResolver *util = [MSIDWebviewNavigationDecisionResolver sharedInstance];
     MSIDWebviewNavigationDecision *navigationDecision = [util resolveDecisionForURL:URL
                                                           embeddedWebviewController:embeddedWebviewController
-                                                                      brokerVersion:brokerVersion];
+                                                                  additionalHeaders:additionalHeaders];
     completion(navigationDecision, nil);
+}
+
+// Builds the running process's first-party app-identity headers for the non-broker
+// (in-app) enrollment flow. The current process is the caller, so its keychain team ID
+// gates the headers and its main bundle supplies x-app-name / x-app-ver. Returns nil for
+// non first-party processes so no attribution headers are stamped.
+- (NSDictionary<NSString *, NSString *> *)firstPartyAppHeadersForCurrentProcess
+{
+    if (![MSIDHelpers isMicrosoftFirstPartyAppWithTeamId:[MSIDKeychainUtil sharedInstance].teamId])
+    {
+        return nil;
+    }
+
+    NSMutableDictionary<NSString *, NSString *> *headers = [NSMutableDictionary new];
+    NSString *appName = [NSBundle msidAppName];
+    NSString *appVersion = [NSBundle msidAppVersion];
+    if (appName.length) headers[MSID_APP_NAME_KEY] = appName;
+    if (appVersion.length) headers[MSID_APP_VER_KEY] = appVersion;
+    return headers.count ? headers : nil;
 }
 
 - (BOOL)processNavigationResponseAndCheckForASWebAuthHandoff:(NSHTTPURLResponse *)response

--- a/IdentityCore/tests/MSIDWebviewNavigationDecisionResolverTests.m
+++ b/IdentityCore/tests/MSIDWebviewNavigationDecisionResolverTests.m
@@ -100,7 +100,8 @@
 - (void)testResolveDecision_nilURL_returnsFailWithError
 {
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:nil
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -112,7 +113,8 @@
     // rather than nil so the caller always receives an actionable navigation outcome.
     NSURL *url = [NSURL URLWithString:@"//host/path"];
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -124,7 +126,8 @@
 {
     NSURL *url = [NSURL URLWithString:@"browser://some.host/path"];
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionContinueDefault);
 }
@@ -133,7 +136,8 @@
 {
     NSURL *url = [NSURL URLWithString:@"foobar://some.host"];
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionContinueDefault);
 }
@@ -145,7 +149,8 @@
     // msauth:/// has no host
     NSURL *url = [NSURL URLWithString:@"msauth:///path"];
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -155,7 +160,8 @@
 {
     NSURL *url = [NSURL URLWithString:@"msauth://unknownhost"];
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionContinueDefault);
 }
@@ -166,7 +172,8 @@
 {
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@", MSID_MDM_ENROLL_HOST]];
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -181,7 +188,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     XCTAssertNotNil(decision.request);
@@ -201,7 +209,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
 
@@ -230,14 +239,15 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     XCTAssertEqualObjects([decision.request valueForHTTPHeaderField:MSID_PLATFORM_KEY], [MSIDVersion platformName]);
     XCTAssertEqualObjects([decision.request valueForHTTPHeaderField:MSID_VERSION_KEY], [MSIDVersion sdkVersion]);
 }
 
-- (void)testEnrollURL_whenBrokerVersionProvided_attachesBrokerVersionHeader
+- (void)testEnrollURL_whenAdditionalHeadersProvided_attachesBrokerVersionHeader
 {
     NSString *targetURL = @"https://manage.microsoft.com/enroll";
     NSString *encoded = [targetURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
@@ -247,13 +257,13 @@
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
                                                                  embeddedWebviewController:nil
-                                                                             brokerVersion:@"6.1.2"];
+                                                                         additionalHeaders:@{MSID_BROKER_VER_KEY: @"6.1.2"}];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     XCTAssertEqualObjects([decision.request valueForHTTPHeaderField:MSID_BROKER_VER_KEY], @"6.1.2");
 }
 
-- (void)testEnrollURL_whenBrokerVersionNil_doesNotAttachBrokerVersionHeader
+- (void)testEnrollURL_whenAdditionalHeadersNil_doesNotAttachBrokerVersionHeader
 {
     NSString *targetURL = @"https://manage.microsoft.com/enroll";
     NSString *encoded = [targetURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
@@ -261,12 +271,36 @@
                            MSID_MDM_ENROLL_HOST, MSID_INTUNE_URL_KEY, encoded];
     NSURL *url = [NSURL URLWithString:urlString];
 
-    // The two-argument variant forwards a nil broker version, so the header is omitted.
+    // Passing nil additional headers omits the broker version header.
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     XCTAssertNil([decision.request valueForHTTPHeaderField:MSID_BROKER_VER_KEY]);
+}
+
+- (void)testEnrollURL_whenAdditionalHeadersContainAppHeaders_attachesThemVerbatim
+{
+    // The resolver is a dumb merger: it stamps whatever the caller supplies without
+    // doing any of its own gating.
+    NSString *targetURL = @"https://manage.microsoft.com/enroll";
+    NSString *encoded = [targetURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSString *urlString = [NSString stringWithFormat:@"msauth://%@?%@=%@",
+                           MSID_MDM_ENROLL_HOST, MSID_INTUNE_URL_KEY, encoded];
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    NSDictionary *headers = @{MSID_BROKER_VER_KEY: @"6.1.2",
+                              MSID_APP_NAME_KEY: @"Contoso",
+                              MSID_APP_VER_KEY: @"1.2.3"};
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:headers];
+    XCTAssertNotNil(decision);
+    XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
+    XCTAssertEqualObjects([decision.request valueForHTTPHeaderField:MSID_BROKER_VER_KEY], @"6.1.2");
+    XCTAssertEqualObjects([decision.request valueForHTTPHeaderField:MSID_APP_NAME_KEY], @"Contoso");
+    XCTAssertEqualObjects([decision.request valueForHTTPHeaderField:MSID_APP_VER_KEY], @"1.2.3");
 }
 
 #pragma mark - Profile download complete host
@@ -278,7 +312,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     XCTAssertNotNil(decision.request);
@@ -291,7 +326,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -309,7 +345,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     XCTAssertNotNil(decision.request);
@@ -328,7 +365,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     [self.resolver resolveDecisionForURL:url
-                       embeddedWebviewController:nil];
+                       embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     NSError *readError = nil;
     NSString *cached = [self.deviceIdCache intuneDeviceIdWithContext:nil error:&readError];
     XCTAssertNil(readError);
@@ -350,7 +388,8 @@
     XCTAssertNotNil(url, @"Test input msauth URL should itself be valid");
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -363,7 +402,8 @@
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@", MSID_COMPLIANCE_HOST]];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -378,7 +418,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     XCTAssertNotNil(decision.request);
@@ -404,7 +445,8 @@
 
     MSIDOAuth2EmbeddedWebviewController *webviewController = [self createWebviewControllerWithExternalBlock:block];
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                         embeddedWebviewController:webviewController];
+                                                         embeddedWebviewController:webviewController
+                                                                         additionalHeaders:nil];
     XCTAssertTrue(invoked, @"External block must be invoked when a webview controller is provided.");
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
@@ -433,7 +475,8 @@
     // externalDecidePolicyForBrowserAction is non-nil.
     MSIDOAuth2EmbeddedWebviewController *webviewController = [self createWebviewControllerWithExternalBlock:block];
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                         embeddedWebviewController:webviewController];
+                                                         embeddedWebviewController:webviewController
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     XCTAssertEqualObjects(decision.request.URL.absoluteString, @"https://override.example.com/path");
@@ -457,7 +500,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionCompleteWithURL);
     XCTAssertEqualObjects(decision.URL, url);
@@ -476,7 +520,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -500,7 +545,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     XCTAssertEqualObjects(decision.request.URL.absoluteString, errorURL);
@@ -516,7 +562,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -529,7 +576,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -546,7 +594,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
 
@@ -564,7 +613,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -585,7 +635,8 @@
     NSURL *url = [NSURL URLWithString:urlString];
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                                 embeddedWebviewController:nil];
+                                                                 embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertNotNil(decision.error);
@@ -614,7 +665,8 @@
 
     MSIDOAuth2EmbeddedWebviewController *webviewController = [self createWebviewControllerWithExternalBlock:block];
     [self.resolver resolveDecisionForURL:url
-               embeddedWebviewController:webviewController];
+               embeddedWebviewController:webviewController
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(receivedURL);
     XCTAssertEqualObjects(receivedURL.scheme, @"browser");
     XCTAssertEqualObjects(receivedURL.host, @"compliance.microsoft.com");
@@ -641,7 +693,8 @@
     };
 
     MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url
-                                                         embeddedWebviewController:nil];
+                                                         embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertFalse(invoked, @"External block must not be invoked when no webview controller is provided.");
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
@@ -663,7 +716,8 @@
                            encodedURL];
     NSURL *url = [NSURL URLWithString:urlString];
 
-    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
 
     XCTAssertTrue(mockProvider.scheduleCalled, @"UX callback should be invoked on profile download complete.");
     XCTAssertEqualWithAccuracy(mockProvider.receivedDelay, MSIDMDMProfileInstalledNotificationDefaultDelay, 0.01);
@@ -685,7 +739,8 @@
                            encodedURL];
     NSURL *url = [NSURL URLWithString:urlString];
 
-    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
 
     XCTAssertTrue(mockProvider.scheduleCalled);
     XCTAssertEqualWithAccuracy(mockProvider.receivedDelay, 300.0, 0.01);
@@ -707,7 +762,8 @@
                            encodedURL];
     NSURL *url = [NSURL URLWithString:urlString];
 
-    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
 
     XCTAssertTrue(mockProvider.scheduleCalled);
     XCTAssertEqualWithAccuracy(mockProvider.receivedDelay, MSIDMDMProfileInstalledNotificationDefaultDelay, 0.01);
@@ -726,7 +782,8 @@
                            encodedURL];
     NSURL *url = [NSURL URLWithString:urlString];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
 }
@@ -748,7 +805,8 @@
     NSString *urlString = [NSString stringWithFormat:@"msauth://%@", MSID_MDM_ENROLLMENT_COMPLETION_HOST];
     NSURL *url = [NSURL URLWithString:urlString];
 
-    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+    [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
 
     XCTAssertTrue(mockProvider.cancelCalled, @"Cancel should be invoked on enrollment completion.");
 }
@@ -767,7 +825,8 @@
     NSString *urlString = [NSString stringWithFormat:@"msauth://%@", MSID_MDM_ENROLLMENT_COMPLETION_HOST];
     NSURL *url = [NSURL URLWithString:urlString];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:nil
+                                                                         additionalHeaders:nil];
     XCTAssertNotNil(decision);
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionCompleteWithURL);
 }
@@ -793,7 +852,8 @@
     MSIDOAuth2EmbeddedWebviewController *controller = [self controllerWithOnboardingBuilder:builder];
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@", MSID_MDM_ENROLL_HOST]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertTrue([[builder msidStampedStepIds] containsObject:MSIDOnboardingBlobStepMdmEnrollmentUrlMissing]);
@@ -805,7 +865,8 @@
     MSIDOAuth2EmbeddedWebviewController *controller = [self controllerWithOnboardingBuilder:builder];
     NSURL *url = [NSURL URLWithString:[self enrollishURLForHost:MSID_MDM_ENROLL_HOST targetURL:@"https://manage.microsoft.com/enroll"]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     NSArray<NSString *> *steps = [builder msidStampedStepIds];
@@ -820,7 +881,8 @@
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@?%@=device123",
                                        MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST, MSID_INTUNE_DEVICE_ID_KEY]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertTrue([[builder msidStampedStepIds] containsObject:MSIDOnboardingBlobStepProfileInstallUrlMissing]);
@@ -833,7 +895,8 @@
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@?%@=notaurl",
                                        MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST, MSID_INTUNE_PROFILE_INSTALL_URL_KEY]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertTrue([[builder msidStampedStepIds] containsObject:MSIDOnboardingBlobStepProfileInstallUrlMalformed]);
@@ -850,7 +913,8 @@
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@?%@=%@",
                                        MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST, MSID_INTUNE_PROFILE_INSTALL_URL_KEY, encoded]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     NSArray<NSString *> *steps = [builder msidStampedStepIds];
@@ -868,7 +932,8 @@
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@?%@=%@",
                                        MSID_MDM_PROFILE_DOWNLOAD_COMPLETE_HOST, MSID_INTUNE_PROFILE_INSTALL_URL_KEY, encoded]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     NSArray<NSString *> *steps = [builder msidStampedStepIds];
@@ -882,7 +947,8 @@
     MSIDOAuth2EmbeddedWebviewController *controller = [self controllerWithOnboardingBuilder:builder];
     NSURL *url = [NSURL URLWithString:[self enrollishURLForHost:MSID_COMPLIANCE_HOST targetURL:@"https://manage.microsoft.com/compliance"]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     NSArray<NSString *> *steps = [builder msidStampedStepIds];
@@ -896,7 +962,8 @@
     MSIDOAuth2EmbeddedWebviewController *controller = [self controllerWithOnboardingBuilder:builder];
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@", MSID_COMPLIANCE_HOST]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     NSArray<NSString *> *steps = [builder msidStampedStepIds];
@@ -914,7 +981,8 @@
     MSIDOAuth2EmbeddedWebviewController *controller = [self controllerWithOnboardingBuilder:builder];
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@", MSID_MDM_ENROLLMENT_COMPLETION_HOST]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionFailWithError);
     XCTAssertTrue([[builder msidStampedStepIds] containsObject:MSIDOnboardingBlobStepSSOExtensionUnavailable]);
@@ -932,7 +1000,8 @@
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"msauth://%@?%@=%@",
                                        MSID_MDM_ENROLLMENT_COMPLETION_HOST, MSID_MDM_ENROLLMENT_COMPLETION_ERROR_URL_KEY, encoded]];
 
-    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller];
+    MSIDWebviewNavigationDecision *decision = [self.resolver resolveDecisionForURL:url embeddedWebviewController:controller
+                                                                         additionalHeaders:nil];
 
     XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
     NSArray<NSString *> *steps = [builder msidStampedStepIds];

--- a/IdentityCore/tests/MSIDWebviewNavigationHandlerTests.m
+++ b/IdentityCore/tests/MSIDWebviewNavigationHandlerTests.m
@@ -37,6 +37,8 @@
 #import "MSIDOnboardingBlobFieldKeys.h"
 #import "MSIDConstants.h"
 #import "MSIDTestSwizzle.h"
+#import "MSIDKeychainUtil.h"
+#import "NSBundle+MSIDExtensions.h"
 #if !MSID_EXCLUDE_SYSTEMWV
 #import "MSIDSystemWebviewTransitionManager.h"
 #endif
@@ -523,10 +525,11 @@
     [self waitForExpectations:@[expectation] timeout:1.0];
 }
 
-- (void)testHandleSpecialRedirectURL_whenBrokerVersionProvided_shouldAttachBrokerVersionHeaderOnEnrollRequest
+- (void)testHandleSpecialRedirectURL_whenAdditionalHeadersProvided_shouldAttachBrokerVersionHeaderOnEnrollRequest
 {
-    // The four-argument overload must forward the broker version through to the
-    // resolver so the MDM enrollment request advertises the x-client-brkrver header.
+    // The four-argument overload must forward the caller-supplied additional headers
+    // (here the broker version) through to the resolver so the MDM enrollment request
+    // advertises the x-client-brkrver header.
     NSString *targetURL = @"https://manage.microsoft.com/enroll";
     NSString *encoded = [targetURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
     NSString *urlString = [NSString stringWithFormat:@"msauth://%@?%@=%@",
@@ -536,7 +539,7 @@
 
     [self.handler handleSpecialRedirectURL:URL
                  embeddedWebviewController:nil
-                             brokerVersion:@"6.1.2"
+                         additionalHeaders:@{MSID_BROKER_VER_KEY: @"6.1.2"}
                                 completion:^(MSIDWebviewNavigationDecision * _Nullable decision, NSError * _Nullable error)
     {
         XCTAssertNotNil(decision);
@@ -551,8 +554,9 @@
 
 - (void)testHandleSpecialRedirectURL_whenBrokerVersionOmitted_shouldNotAttachBrokerVersionHeaderOnEnrollRequest
 {
-    // The three-argument variant forwards a nil broker version, so the enrollment
-    // request must not carry the x-client-brkrver header.
+    // The two-argument variant builds only the current process's first-party app headers
+    // (never a broker version). The unit-test host is not first-party, so no headers at all
+    // are stamped here.
     NSString *targetURL = @"https://manage.microsoft.com/enroll";
     NSString *encoded = [targetURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
     NSString *urlString = [NSString stringWithFormat:@"msauth://%@?%@=%@",
@@ -567,6 +571,67 @@
         XCTAssertNotNil(decision);
         XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
         XCTAssertNil([decision.request valueForHTTPHeaderField:MSID_BROKER_VER_KEY]);
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testHandleSpecialRedirectURL_whenFirstPartyProcess_shouldAttachAppNameAndVersionHeadersOnEnrollRequest
+{
+    // The two-argument (overall/non-broker) overload builds the app-identity headers from the
+    // running process. Force a first-party keychain team ID so the gate opens; assert the
+    // headers equal the same bundle accessors the handler uses.
+    // (Keychain has no DI seam in this repo, so a swizzle is used as a one-off.)
+    [MSIDTestSwizzle instanceMethod:@selector(teamId)
+                              class:[MSIDKeychainUtil class]
+                              block:(id)^NSString *(__unused id obj) { return @"UBF8T346G9"; }];
+
+    NSString *targetURL = @"https://manage.microsoft.com/enroll";
+    NSString *encoded = [targetURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSString *urlString = [NSString stringWithFormat:@"msauth://%@?%@=%@",
+                           MSID_MDM_ENROLL_HOST, MSID_INTUNE_URL_KEY, encoded];
+    NSURL *URL = [NSURL URLWithString:urlString];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"completion invoked"];
+
+    [self.handler handleSpecialRedirectURL:URL
+                 embeddedWebviewController:nil
+                                completion:^(MSIDWebviewNavigationDecision * _Nullable decision, NSError * _Nullable error)
+    {
+        XCTAssertNotNil(decision);
+        XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
+        XCTAssertEqualObjects([decision.request valueForHTTPHeaderField:MSID_APP_NAME_KEY], [NSBundle msidAppName]);
+        XCTAssertEqualObjects([decision.request valueForHTTPHeaderField:MSID_APP_VER_KEY], [NSBundle msidAppVersion]);
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testHandleSpecialRedirectURL_whenNonFirstPartyProcess_shouldNotAttachAppNameAndVersionHeadersOnEnrollRequest
+{
+    // A non-first-party running process must never have the app name/version headers stamped.
+    [MSIDTestSwizzle instanceMethod:@selector(teamId)
+                              class:[MSIDKeychainUtil class]
+                              block:(id)^NSString *(__unused id obj) { return @"43AQ936H96"; }];
+
+    NSString *targetURL = @"https://manage.microsoft.com/enroll";
+    NSString *encoded = [targetURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSString *urlString = [NSString stringWithFormat:@"msauth://%@?%@=%@",
+                           MSID_MDM_ENROLL_HOST, MSID_INTUNE_URL_KEY, encoded];
+    NSURL *URL = [NSURL URLWithString:urlString];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"completion invoked"];
+
+    [self.handler handleSpecialRedirectURL:URL
+                 embeddedWebviewController:nil
+                                completion:^(MSIDWebviewNavigationDecision * _Nullable decision, NSError * _Nullable error)
+    {
+        XCTAssertNotNil(decision);
+        XCTAssertEqual(decision.type, MSIDWebviewNavigationDecisionLoadRequest);
+        XCTAssertNil([decision.request valueForHTTPHeaderField:MSID_APP_NAME_KEY]);
+        XCTAssertNil([decision.request valueForHTTPHeaderField:MSID_APP_VER_KEY]);
         XCTAssertNil(error);
         [expectation fulfill];
     }];


### PR DESCRIPTION
## Summary
Collapses the embedded-webview navigation resolver/handler onto a single `additionalHeaders:` seam and stamps attribution headers on the Intune MDM enrollment request.

- **Broker flow:** `x-client-brkrver` (broker version) + `x-ms-client-id` (source app's OAuth client ID, supplied by the broker controller).
- **Non-broker (in-app) flow:** `x-app-name` / `x-app-ver` for the running process, gated on a Microsoft first-party keychain team ID.

## Changes
- `MSIDWebviewNavigationDecisionResolver` / `MSIDWebviewNavigationHandler`: single `additionalHeaders:` method; non-broker base builds current-process 1P headers.
- `MSIDHelpers`: `+microsoft1PAppsTeamIDs`, `+isMicrosoftFirstPartyAppWithTeamId:`.
- `NSBundle+MSIDExtensions`: `+msidAppName`.
- `MSIDConstants`: `MSID_APP_CLIENT_ID_KEY` (`x-ms-client-id`).

## Tests
- `MSIDWebviewNavigationDecisionResolverTests`, `MSIDWebviewNavigationHandlerTests` updated.
- Green on **iOS** and **macOS** (116 tests each).