### PR TITLE
Add sourceApplication property to MSIDInteractiveTokenRequestParameters

### DIFF
--- a/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.h
+++ b/IdentityCore/src/parameters/MSIDInteractiveTokenRequestParameters.h
@@ -50,6 +50,11 @@ typedef void (^MSIDWebviewConfigurationBlock)(id<MSIDWebviewInteracting> webview
 @property (nonatomic, copy, nullable) NSString *onboardingBlobJson;
 @property (nonatomic) NSString *loginHint;
 @property (nonatomic) NSString *extraScopesToConsent;
+// Bundle identifier of the app that invoked the broker, as reported by the OS.
+// The OS surfaces the caller bundle id only when the originating app is signed under the broker's
+// Apple Developer Team identifier (which every Microsoft first-party app shares), so a non-nil value
+// effectively identifies a first-party caller. Third-party callers leave it nil.
+@property (nonatomic, copy, nullable) NSString *sourceApplication;
 @property (nonatomic) MSIDPromptType promptType;
 @property (nonatomic) BOOL shouldValidateResultAccount;
 // Additional request parameters that will only be appended to authorize requests in addition to extraURLQueryParameters from parent class


### PR DESCRIPTION
## Summary
Adds a `sourceApplication` property to `MSIDInteractiveTokenRequestParameters` (the invoking app's bundle identifier as reported by the OS).

This is consumed by the broker (see the paired MSAL + Broker PRs) to gate first-party-only behavior on the mobile-onboarding MDM-enrollment request. The OS surfaces the caller bundle id only for apps signed under the broker's Apple Developer Team identifier, so a non-nil value effectively identifies a Microsoft 1P caller; third-party callers leave it nil.

## Changes
- `MSIDInteractiveTokenRequestParameters.h`: new `@property (nonatomic, copy, nullable) NSString *sourceApplication;` (ARC-synthesized backing ivar).

## Testing
- Consumed and validated in the Broker repo unit tests (`ADBrokerInteractiveControllerWithPRTTests`, `MSIDInteractiveTokenRequestParameters+ADBrokerTests`) — 29 tests pass.

## Related
Part of a chained submodule change:
- Common Core (this PR) → MSAL (submodule bump) → Broker (submodule bump + consumer logic).