### PR TITLE
[patch] [bugfix]: Guard JWT signing against NULL private keys

### DIFF
--- a/IdentityCore/src/util/NSData+JWT.m
+++ b/IdentityCore/src/util/NSData+JWT.m
@@ -29,6 +29,12 @@
 
 - (NSData *)msidSignHashWithPrivateKey:(SecKeyRef)privateKey
 {
+    if (!privateKey)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Cannot sign JWT data with a NULL private key.");
+        return nil;
+    }
+
     CFErrorRef subError = NULL;
     NSData *signature = (NSData *)CFBridgingRelease(SecKeyCreateSignature(privateKey,
                                                                           kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256,

--- a/IdentityCore/tests/MSIDKeyOperationUtilTest.m
+++ b/IdentityCore/tests/MSIDKeyOperationUtilTest.m
@@ -220,6 +220,12 @@
     XCTAssertNil(rsaDataSignature);
 }
 
+- (void)testSignHashWithPrivateKey_NullPrivateKey_ReturnsNil
+{
+    NSData *dataDigest = [[@"TEST" dataUsingEncoding:NSUTF8StringEncoding] msidSHA256];
+    XCTAssertNil([dataDigest msidSignHashWithPrivateKey:NULL]);
+}
+
 #pragma mark -- Test Utility
 
 -(void) populateRsaKeys

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 TBD
-* Prevent a crash when JWT signing is attempted with a NULL private key.
+* Prevent a crash when JWT signing is attempted with a NULL private key. (#1917)
 * Raise the minimum deployment targets to iOS 16.0 and macOS 12.0, and replace deprecated macOS SecTransform JWT signing with SecKeyCreateSignature. (#1915)
 
 Version 1.26.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Prevent a crash when JWT signing is attempted with a NULL private key.
 * Raise the minimum deployment targets to iOS 16.0 and macOS 12.0, and replace deprecated macOS SecTransform JWT signing with SecKeyCreateSignature. (#1915)
 
 Version 1.26.0


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [x] Appropriate reviewers are assigned
- [x] PR reviewed by code owner (required if Copilot-generated)
- [x] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

Add an explicit `NULL` private-key guard to `msidSignHashWithPrivateKey:` before calling `SecKeyCreateSignature`. The method logs the invalid input and returns `nil` rather than passing a null key to Security.

Add a dedicated regression test that invokes the method with `NULL` and verifies it returns `nil`.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

Validation completed:

- Dedicated macOS regression test for `msidSignHashWithPrivateKey:NULL`
- IdentityCore iOS Release build for the iOS Simulator