### PR TITLE
[minor] [feature]: Add Browser Native Message GetToken routing policy

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -2174,6 +2174,11 @@
 		FADE01000000000000000002 /* MSIDDeviceTokenGrantRequestNetworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FADE01000000000000000001 /* MSIDDeviceTokenGrantRequestNetworkTests.m */; };
 		FADE01000000000000000003 /* MSIDDeviceTokenGrantRequestNetworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FADE01000000000000000001 /* MSIDDeviceTokenGrantRequestNetworkTests.m */; };
 		VC00000000000000000F2001 /* MSIDOpenIdVcHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = VC00000000000000000F2003 /* MSIDOpenIdVcHandling.h */; };
+		FA7100040000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7100130000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.h */; };
+		FA7100050000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7100140000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.m */; };
+		FA7100060000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7100140000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.m */; };
+		FA7100090000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7100160000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m */; };
+		FA71000A0000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7100160000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -3813,6 +3818,9 @@
 		F7AB272FEBCF984722F26558 /* MSIDWPJMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIDWPJMetadata.m; sourceTree = "<group>"; };
 		FADE01000000000000000001 /* MSIDDeviceTokenGrantRequestNetworkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDDeviceTokenGrantRequestNetworkTests.m; sourceTree = "<group>"; };
 		VC00000000000000000F2003 /* MSIDOpenIdVcHandling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDOpenIdVcHandling.h; sourceTree = "<group>"; };
+		FA7100130000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBrowserNativeMessageGetTokenRoutingPolicy.h; sourceTree = "<group>"; };
+		FA7100140000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBrowserNativeMessageGetTokenRoutingPolicy.m; sourceTree = "<group>"; };
+		FA7100160000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -4503,6 +4511,8 @@
 				2317FFBF2A44FDD400E3DAA2 /* MSIDBrowserNativeMessageGetCookiesRequest.m */,
 				23642EE02A8AF3500078FF1A /* MSIDBrowserNativeMessageGetTokenRequest.h */,
 				23642EE12A8AF3500078FF1A /* MSIDBrowserNativeMessageGetTokenRequest.m */,
+				FA7100130000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.h */,
+				FA7100140000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.m */,
 				23391BD42B17F2FD00EB121B /* MSIDBrowserNativeMessageSignOutRequest.h */,
 				23391BD52B17F2FD00EB121B /* MSIDBrowserNativeMessageSignOutRequest.m */,
 				23C898122C8928DD00071482 /* MSIDBrowserNativeMessageGetSupportedContractsRequest.h */,
@@ -6313,6 +6323,7 @@
 				23F7A8622A61F21E002C70CB /* MSIDBrowserNativeMessageGetCookiesResponseTests.m */,
 				2376D8DC2D88FDE900ADC271 /* MSIDBrowserNativeMessageGetSupportedContractsResponseTests.m */,
 				23D00DA72ABD0805006D7F16 /* MSIDBrowserNativeMessageGetTokenRequestTests.m */,
+				FA7100160000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m */,
 				233827902BC8C40C0079C82F /* MSIDBrowserNativeMessageGetTokenResponseTests.m */,
 				234A0BE22BCDCCB100AFBBAA /* MSIDBrowserNativeMessageSignOutRequestTests.m */,
 				234A0BDF2BCDC4B900AFBBAA /* MSIDBrowserNativeMessageSignOutResponseTests.m */,
@@ -6694,6 +6705,7 @@
 				B286B9BD2389DDFA007833AD /* MSIDAADEndpointProviding.h in Headers */,
 				23D744782097B2DA00210C51 /* MSIDAADV1AuthorizationCodeRequest.h in Headers */,
 				23642EE22A8AF3500078FF1A /* MSIDBrowserNativeMessageGetTokenRequest.h in Headers */,
+				FA7100040000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.h in Headers */,
 				9686C72921192BCF001FFF51 /* MSIDWebOpenBrowserResponse.h in Headers */,
 				B42558B62F57A6620024523D /* MSIDOnboardingBlobBuilder.h in Headers */,
 				589BDB192718BC2200BF3799 /* MSIDBrokerOperationGetSsoCookiesRequest.h in Headers */,
@@ -7758,6 +7770,7 @@
 				60747FF62354F04F00C5308F /* MSIDBrokerOperationGetAccountsRequestTests.m in Sources */,
 				586CD77E293FD77100550710 /* MSIDRequestControllerFactoryTests.m in Sources */,
 				233827912BC8C40C0079C82F /* MSIDBrowserNativeMessageGetTokenResponseTests.m in Sources */,
+				FA7100090000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m in Sources */,
 				238EF086209161830035ABE6 /* MSIDAADJsonResponsePreprocessorTests.m in Sources */,
 				B20657C61FC9265800412B7D /* MSIDTelemetryExtensionsTests.m in Sources */,
 				B4DB46882FB543900038CC8C /* MSIDSessionCachePersistenceTests.m in Sources */,
@@ -8313,6 +8326,7 @@
 				B49323A22AD4DB2700E0CBC0 /* MSIDSSOExtensionPasskeyAssertionRequest.m in Sources */,
 				2306D2BA20AD07C400F875A3 /* MSIDURLSessionManager.m in Sources */,
 				23642EE42A8AF3500078FF1A /* MSIDBrowserNativeMessageGetTokenRequest.m in Sources */,
+				FA7100060000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.m in Sources */,
 				B46F3B6E2F3C325A00CDD8F7 /* MSIDWebviewNavigationDecision.m in Sources */,
 				23FB5C472255A13A002BF1EB /* MSIDIndividualClaimRequestAdditionalInfo.m in Sources */,
 				F7AB2212E4C82BF809D126F6 /* MSIDWPJMetadata.m in Sources */,
@@ -8380,6 +8394,7 @@
 				239DF9C420E04BC9002D428B /* MSIDADFSAuthorityTests.m in Sources */,
 				B431B5422AF1C6C10020CD3D /* MSIDSSOExtensionPasskeyCredentialRequestMock.m in Sources */,
 				233827922BC8C40C0079C82F /* MSIDBrowserNativeMessageGetTokenResponseTests.m in Sources */,
+				FA71000A0000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m in Sources */,
 				23419F6123974C0D00EA78C5 /* MSIDBrokerOperationTokenRequestTests.m in Sources */,
 				236CB13F2A609A1B005A6F5F /* MSIDBrokerOperationBrowserNativeMessageRequestTests.m in Sources */,
 				B2807FFF204CB25E00944D89 /* MSIDTokenResponseTests.m in Sources */,
@@ -8843,6 +8858,7 @@
 				1E707FDD2406FA9200716148 /* MSIDBrokerBrowserOperationResponse.m in Sources */,
 				609E74BD228CA5CA005E3FED /* MSIDAccountMetadataCacheAccessor.m in Sources */,
 				23642EE32A8AF3500078FF1A /* MSIDBrowserNativeMessageGetTokenRequest.m in Sources */,
+				FA7100050000000000000001 /* MSIDBrowserNativeMessageGetTokenRoutingPolicy.m in Sources */,
 				B493239C2AD4DABE00E0CBC0 /* MSIDPasskeyAssertion.m in Sources */,
 				238EF043208FE88C0035ABE6 /* MSIDAADAuthorizationCodeGrantRequest.m in Sources */,
 				2338ECCB208A675D00809B9E /* MSIDAADRequestErrorHandler.m in Sources */,

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRoutingPolicy.h
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRoutingPolicy.h
@@ -1,0 +1,68 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import "MSIDConstants.h"
+
+@class MSIDAccountIdentifier;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, MSIDBrowserNativeMessageGetTokenRoute)
+{
+    MSIDBrowserNativeMessageGetTokenRouteSilent = 0,
+    MSIDBrowserNativeMessageGetTokenRouteInteractive,
+    MSIDBrowserNativeMessageGetTokenRouteUIBlocked,
+    MSIDBrowserNativeMessageGetTokenRouteInteractionRequired
+};
+
+@interface MSIDBrowserNativeMessageGetTokenRoutingPolicy : NSObject
+
+/// The routing policy is registered as a singleton with @c MSIDDIContainer (see @c +load).
+/// Resolve it via @c -[MSIDDIContainer resolveClass:] rather than constructing it directly, so
+/// callers can substitute a mock instance in tests by registering an alternate factory.
+///
+/// Routing decisions live on instance methods (rather than class/static methods) so callers can
+/// substitute a mock instance in tests without swizzling.
+
+- (MSIDBrowserNativeMessageGetTokenRoute)routeWithForceInteractive:(BOOL)forceInteractive
+                                                        promptType:(MSIDPromptType)promptType
+                                                         canShowUI:(BOOL)canShowUI
+                                                  accountIdentifier:(nullable MSIDAccountIdentifier *)accountIdentifier
+                                             requiresHomeAccountId:(BOOL)requiresHomeAccountId;
+
+- (BOOL)shouldAttemptSilentWithForceInteractive:(BOOL)forceInteractive
+                                      promptType:(MSIDPromptType)promptType
+                               accountIdentifier:(nullable MSIDAccountIdentifier *)accountIdentifier
+                          requiresHomeAccountId:(BOOL)requiresHomeAccountId;
+
+- (BOOL)shouldAttemptInteractiveWithCanShowUI:(BOOL)canShowUI
+                                    promptType:(MSIDPromptType)promptType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRoutingPolicy.m
+++ b/IdentityCore/src/broker_operation/request/browser_native_message_request/MSIDBrowserNativeMessageGetTokenRoutingPolicy.m
@@ -1,0 +1,117 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSIDBrowserNativeMessageGetTokenRoutingPolicy.h"
+#import "MSIDAccountIdentifier.h"
+#import "MSIDDIContainer.h"
+
+@implementation MSIDBrowserNativeMessageGetTokenRoutingPolicy
+
++ (void)load
+{
+    MSIDDIContainer *container = [MSIDDIContainer sharedInstance];
+
+    [container registerClass:[MSIDBrowserNativeMessageGetTokenRoutingPolicy class]
+                    lifetime:MSIDDIContainerLifetimeSingleton
+                     factory:^id { return [[MSIDBrowserNativeMessageGetTokenRoutingPolicy alloc] init]; }];
+}
+
+- (MSIDBrowserNativeMessageGetTokenRoute)routeWithForceInteractive:(BOOL)forceInteractive
+                                                        promptType:(MSIDPromptType)promptType
+                                                         canShowUI:(BOOL)canShowUI
+                                                  accountIdentifier:(MSIDAccountIdentifier *)accountIdentifier
+                                             requiresHomeAccountId:(BOOL)requiresHomeAccountId
+{
+    BOOL shouldAttemptSilent =
+    [self shouldAttemptSilentWithForceInteractive:forceInteractive
+                                       promptType:promptType
+                                accountIdentifier:accountIdentifier
+                           requiresHomeAccountId:requiresHomeAccountId];
+    if (shouldAttemptSilent)
+    {
+        return MSIDBrowserNativeMessageGetTokenRouteSilent;
+    }
+
+    if (promptType == MSIDPromptTypeNever)
+    {
+        // Silent authentication cannot continue, and prompt=none explicitly forbids showing UI
+        // even when the caller is otherwise capable of presenting it.
+        return MSIDBrowserNativeMessageGetTokenRouteInteractionRequired;
+    }
+
+    if (!canShowUI)
+    {
+        // The prompt permits interaction, but the caller has indicated that UI cannot be shown.
+        return MSIDBrowserNativeMessageGetTokenRouteUIBlocked;
+    }
+
+    return MSIDBrowserNativeMessageGetTokenRouteInteractive;
+}
+
+- (BOOL)shouldAttemptSilentWithForceInteractive:(BOOL)forceInteractive
+                                      promptType:(MSIDPromptType)promptType
+                               accountIdentifier:(MSIDAccountIdentifier *)accountIdentifier
+                          requiresHomeAccountId:(BOOL)requiresHomeAccountId
+{
+    // A caller sets forceInteractive after silent acquisition requires interaction or when local
+    // prerequisites, such as a PRT, are unavailable. Retrying silently would repeat the same failure.
+    if (forceInteractive)
+    {
+        return NO;
+    }
+
+    // Browser-native GetToken supports silent acquisition only for an omitted prompt or prompt=none.
+    // All other supported prompt values explicitly require user interaction.
+    if (promptType != MSIDPromptTypeNever
+        && promptType != MSIDPromptTypePromptIfNecessary)
+    {
+        return NO;
+    }
+
+    if (!accountIdentifier)
+    {
+        return NO;
+    }
+
+    // Broker-local non-STS requests require a stable home account ID. STS and in-process BART
+    // callers can resolve an account from a displayable ID, so they pass NO for this requirement.
+    if (!requiresHomeAccountId)
+    {
+        return YES;
+    }
+
+    return accountIdentifier.homeAccountId != nil;
+}
+
+- (BOOL)shouldAttemptInteractiveWithCanShowUI:(BOOL)canShowUI
+                                    promptType:(MSIDPromptType)promptType
+{
+    // prompt=none is a protocol guarantee that UI will not be shown, regardless of caller capability.
+    return canShowUI && promptType != MSIDPromptTypeNever;
+}
+
+@end

--- a/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m
+++ b/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenRoutingPolicyTests.m
@@ -1,0 +1,275 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <XCTest/XCTest.h>
+#import "MSIDBrowserNativeMessageGetTokenRoutingPolicy.h"
+#import "MSIDAccountIdentifier.h"
+
+@interface MSIDBrowserNativeMessageGetTokenRoutingPolicyTests : XCTestCase
+
+@property (nonatomic) MSIDBrowserNativeMessageGetTokenRoutingPolicy *routingPolicy;
+
+@end
+
+@implementation MSIDBrowserNativeMessageGetTokenRoutingPolicyTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.routingPolicy = [MSIDBrowserNativeMessageGetTokenRoutingPolicy new];
+}
+
+- (void)testRoute_defaultPromptWithEligibleAccount_returnsSilent
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
+                                                                            homeAccountId:@"uid.utid"];
+
+    MSIDBrowserNativeMessageGetTokenRoute route =
+    [self.routingPolicy routeWithForceInteractive:NO
+                                                                  promptType:MSIDPromptTypePromptIfNecessary
+                                                                   canShowUI:NO
+                                                            accountIdentifier:account
+                                                       requiresHomeAccountId:YES];
+
+    XCTAssertEqual(route, MSIDBrowserNativeMessageGetTokenRouteSilent);
+}
+
+- (void)testRoute_postSilentFallbackWithUI_returnsInteractive
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
+                                                                            homeAccountId:@"uid.utid"];
+
+    MSIDBrowserNativeMessageGetTokenRoute route =
+    [self.routingPolicy routeWithForceInteractive:YES
+                                                                  promptType:MSIDPromptTypePromptIfNecessary
+                                                                   canShowUI:YES
+                                                            accountIdentifier:account
+                                                       requiresHomeAccountId:YES];
+
+    XCTAssertEqual(route, MSIDBrowserNativeMessageGetTokenRouteInteractive);
+}
+
+- (void)testRoute_postSilentFallbackWithoutUI_returnsUIBlocked
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
+                                                                            homeAccountId:@"uid.utid"];
+
+    MSIDBrowserNativeMessageGetTokenRoute route =
+    [self.routingPolicy routeWithForceInteractive:YES
+                                                                  promptType:MSIDPromptTypePromptIfNecessary
+                                                                   canShowUI:NO
+                                                            accountIdentifier:account
+                                                       requiresHomeAccountId:YES];
+
+    XCTAssertEqual(route, MSIDBrowserNativeMessageGetTokenRouteUIBlocked);
+}
+
+- (void)testRoute_promptNeverAfterSilentFailure_returnsInteractionRequired
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
+                                                                            homeAccountId:@"uid.utid"];
+
+    MSIDBrowserNativeMessageGetTokenRoute route =
+    [self.routingPolicy routeWithForceInteractive:YES
+                                                                  promptType:MSIDPromptTypeNever
+                                                                   canShowUI:YES
+                                                            accountIdentifier:account
+                                                       requiresHomeAccountId:YES];
+
+    XCTAssertEqual(route, MSIDBrowserNativeMessageGetTokenRouteInteractionRequired);
+}
+
+- (void)testRoute_interactivePromptWithoutUI_returnsUIBlocked
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
+                                                                            homeAccountId:@"uid.utid"];
+
+    MSIDBrowserNativeMessageGetTokenRoute route =
+    [self.routingPolicy routeWithForceInteractive:NO
+                                                                  promptType:MSIDPromptTypeLogin
+                                                                   canShowUI:NO
+                                                            accountIdentifier:account
+                                                       requiresHomeAccountId:YES];
+
+    XCTAssertEqual(route, MSIDBrowserNativeMessageGetTokenRouteUIBlocked);
+}
+
+- (void)testRoute_displayableIdOnly_preservesCallerHomeAccountRequirement
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com"
+                                                                            homeAccountId:nil];
+
+    MSIDBrowserNativeMessageGetTokenRoute providerRoute =
+    [self.routingPolicy routeWithForceInteractive:NO
+                                                                  promptType:MSIDPromptTypePromptIfNecessary
+                                                                   canShowUI:YES
+                                                            accountIdentifier:account
+                                                       requiresHomeAccountId:NO];
+    MSIDBrowserNativeMessageGetTokenRoute brokerNonStsRoute =
+    [self.routingPolicy routeWithForceInteractive:NO
+                                                                  promptType:MSIDPromptTypePromptIfNecessary
+                                                                   canShowUI:YES
+                                                            accountIdentifier:account
+                                                       requiresHomeAccountId:YES];
+
+    XCTAssertEqual(providerRoute, MSIDBrowserNativeMessageGetTokenRouteSilent);
+    XCTAssertEqual(brokerNonStsRoute, MSIDBrowserNativeMessageGetTokenRouteInteractive);
+}
+
+- (void)testRoute_missingAccountAndPromptNever_returnsInteractionRequired
+{
+    MSIDBrowserNativeMessageGetTokenRoute route =
+    [self.routingPolicy routeWithForceInteractive:NO
+                                                                  promptType:MSIDPromptTypeNever
+                                                                   canShowUI:YES
+                                                            accountIdentifier:nil
+                                                       requiresHomeAccountId:NO];
+
+    XCTAssertEqual(route, MSIDBrowserNativeMessageGetTokenRouteInteractionRequired);
+}
+
+- (void)testShouldAttemptSilent_stsWithUpnOnly_returnsYes
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com"
+                                                                            homeAccountId:nil];
+
+    XCTAssertTrue([self.routingPolicy shouldAttemptSilentWithForceInteractive:NO
+                                                                                               promptType:MSIDPromptTypeNever
+                                                                                        accountIdentifier:account
+                                                                                   requiresHomeAccountId:NO]);
+}
+
+- (void)testShouldAttemptSilent_nonStsWithUpnOnly_returnsNo
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com"
+                                                                            homeAccountId:nil];
+
+    XCTAssertFalse([self.routingPolicy shouldAttemptSilentWithForceInteractive:NO
+                                                                                                promptType:MSIDPromptTypePromptIfNecessary
+                                                                                         accountIdentifier:account
+                                                                                    requiresHomeAccountId:YES]);
+}
+
+- (void)testShouldAttemptSilent_nonStsWithHomeAccountId_returnsYes
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
+                                                                            homeAccountId:@"uid.utid"];
+
+    XCTAssertTrue([self.routingPolicy shouldAttemptSilentWithForceInteractive:NO
+                                                                                               promptType:MSIDPromptTypePromptIfNecessary
+                                                                                        accountIdentifier:account
+                                                                                   requiresHomeAccountId:YES]);
+}
+
+- (void)testShouldAttemptSilent_forceInteractiveOrInteractivePromptOrMissingAccount_returnsNo
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil
+                                                                            homeAccountId:@"uid.utid"];
+
+    XCTAssertFalse([self.routingPolicy shouldAttemptSilentWithForceInteractive:YES
+                                                                                                promptType:MSIDPromptTypeNever
+                                                                                         accountIdentifier:account
+                                                                                    requiresHomeAccountId:YES]);
+    XCTAssertFalse([self.routingPolicy shouldAttemptSilentWithForceInteractive:NO
+                                                                                                promptType:MSIDPromptTypeLogin
+                                                                                         accountIdentifier:account
+                                                                                    requiresHomeAccountId:YES]);
+    XCTAssertFalse([self.routingPolicy shouldAttemptSilentWithForceInteractive:NO
+                                                                                                promptType:MSIDPromptTypeNever
+                                                                                         accountIdentifier:nil
+                                                                                    requiresHomeAccountId:NO]);
+}
+
+- (void)testShouldAttemptSilent_allInteractivePrompts_returnNo
+{
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com"
+                                                                            homeAccountId:@"uid.utid"];
+    NSArray<NSNumber *> *interactivePrompts = @[@(MSIDPromptTypeLogin),
+                                                @(MSIDPromptTypeConsent),
+                                                @(MSIDPromptTypeCreate),
+                                                @(MSIDPromptTypeSelectAccount),
+                                                @(MSIDPromptTypeRefreshSession)];
+
+    for (NSNumber *prompt in interactivePrompts)
+    {
+        XCTAssertFalse([self.routingPolicy shouldAttemptSilentWithForceInteractive:NO
+                                                                                                    promptType:prompt.integerValue
+                                                                                             accountIdentifier:account
+                                                                                        requiresHomeAccountId:NO]);
+    }
+}
+
+- (void)testShouldAttemptSilent_silentPrompts_preserveCallerAccountRequirement
+{
+    MSIDAccountIdentifier *displayableIdOnlyAccount =
+    [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com"
+                                           homeAccountId:nil];
+    NSArray<NSNumber *> *silentPrompts = @[@(MSIDPromptTypePromptIfNecessary),
+                                           @(MSIDPromptTypeNever)];
+
+    for (NSNumber *prompt in silentPrompts)
+    {
+        XCTAssertTrue([self.routingPolicy shouldAttemptSilentWithForceInteractive:NO
+                                                                                                   promptType:prompt.integerValue
+                                                                                            accountIdentifier:displayableIdOnlyAccount
+                                                                                       requiresHomeAccountId:NO]);
+        XCTAssertFalse([self.routingPolicy shouldAttemptSilentWithForceInteractive:NO
+                                                                                                    promptType:prompt.integerValue
+                                                                                             accountIdentifier:displayableIdOnlyAccount
+                                                                                        requiresHomeAccountId:YES]);
+    }
+}
+
+- (void)testShouldAttemptInteractive_requiresUIAndNonNeverPrompt
+{
+    XCTAssertTrue([self.routingPolicy shouldAttemptInteractiveWithCanShowUI:YES
+                                                                                            promptType:MSIDPromptTypeLogin]);
+    XCTAssertFalse([self.routingPolicy shouldAttemptInteractiveWithCanShowUI:NO
+                                                                                             promptType:MSIDPromptTypeLogin]);
+    XCTAssertFalse([self.routingPolicy shouldAttemptInteractiveWithCanShowUI:YES
+                                                                                             promptType:MSIDPromptTypeNever]);
+}
+
+- (void)testShouldAttemptInteractive_allInteractivePrompts_requireUI
+{
+    NSArray<NSNumber *> *interactivePrompts = @[@(MSIDPromptTypePromptIfNecessary),
+                                                @(MSIDPromptTypeLogin),
+                                                @(MSIDPromptTypeConsent),
+                                                @(MSIDPromptTypeCreate),
+                                                @(MSIDPromptTypeSelectAccount),
+                                                @(MSIDPromptTypeRefreshSession)];
+
+    for (NSNumber *prompt in interactivePrompts)
+    {
+        XCTAssertTrue([self.routingPolicy shouldAttemptInteractiveWithCanShowUI:YES
+                                                                                                promptType:prompt.integerValue]);
+        XCTAssertFalse([self.routingPolicy shouldAttemptInteractiveWithCanShowUI:NO
+                                                                                                 promptType:prompt.integerValue]);
+    }
+}
+
+@end


### PR DESCRIPTION
## Summary

- add a shared Browser Native Message GetToken routing policy
- centralize silent, interactive, UI-blocked, and interaction-required decisions
- preserve caller-specific account requirements for STS and non-STS requests
- add focused iOS and macOS unit coverage

This is the first standalone change extracted from #1875. It intentionally contains only routing policy behavior; request mapping, token acquisition, and response shaping will follow in separate PRs after this change merges.

## Testing

- `MSIDBrowserNativeMessageGetTokenRoutingPolicyTests` on iOS: 15 passed
- `MSIDBrowserNativeMessageGetTokenRoutingPolicyTests` on macOS: 15 passed