### PR TITLE
[minor] [feature]: Require bound refresh tokens for SPA silent acquisition

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -2184,6 +2184,8 @@
 		FA7100030000000000000001 /* MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7100120000000000000001 /* MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetToken.m */; };
 		FA7100070000000000000001 /* MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7100150000000000000001 /* MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetTokenTests.m */; };
 		FA7100080000000000000001 /* MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7100150000000000000001 /* MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetTokenTests.m */; };
+		FA7200010000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7200030000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m */; };
+		FA7200020000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7200030000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -3829,6 +3831,7 @@
 		FA7100110000000000000001 /* MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetToken.h"; sourceTree = "<group>"; };
 		FA7100120000000000000001 /* MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetToken.m"; sourceTree = "<group>"; };
 		FA7100150000000000000001 /* MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetTokenTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetTokenTests.m"; sourceTree = "<group>"; };
+		FA7200030000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -6302,6 +6305,7 @@
 				2321532C1FDF4FD800C6960D /* MSIDBaseTokenTests.m */,
 				724C9DD32E6906270039BAA0 /* MSIDBoundRefreshTokenRedemptionTests.m */,
 				72C764F82E09CFA400043AB1 /* MSIDBoundRefreshTokenTests.m */,
+				FA7200030000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m */,
 				BA000000000000000000D001 /* MSIDBoundTokenProviderTests.m */,
 				B48FC0612D7A90F4007B80DB /* MSIDBrokerFlightProviderTests.m */,
 				B2E97FB22914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m */,
@@ -7727,6 +7731,7 @@
 				B286B9F12389F866007833AD /* MSIDWebviewFactoryTests.m in Sources */,
 				B252913B2096698100E78695 /* MSIDAADIdTokenClaimsFactoryTests.m in Sources */,
 				72C764FA2E09CFB800043AB1 /* MSIDBoundRefreshTokenTests.m in Sources */,
+				FA7200020000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m in Sources */,
 				BA000000000000000000D101 /* MSIDBoundTokenProviderTests.m in Sources */,
 				B2BE923121A0EFB100F5AB8C /* MSIDDefaultTokenRequestProviderTests.m in Sources */,
 				729357F42DDBD3F80001D03C /* MSIDNonceTokenRequestTest.m in Sources */,
@@ -8488,6 +8493,7 @@
 				B2BE923521A0F80100F5AB8C /* MSIDLegacyTokenRequestProviderTests.m in Sources */,
 				B48FC0632D7A90FA007B80DB /* MSIDBrokerFlightProviderTests.m in Sources */,
 				72C764F92E09CFB800043AB1 /* MSIDBoundRefreshTokenTests.m in Sources */,
+				FA7200010000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m in Sources */,
 				BA000000000000000000D102 /* MSIDBoundTokenProviderTests.m in Sources */,
 				23FB5C21225516FB002BF1EB /* MSIDClaimsRequestTests.m in Sources */,
 				E75DD02625D5E474007664A6 /* MSIDThrottlingServiceIntegrationTests.m in Sources */,

--- a/IdentityCore/src/oauth2/token/MSIDBoundRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDBoundRefreshToken.m
@@ -132,6 +132,11 @@
 
 #pragma mark - Token type
 
+- (BOOL)isBoundRefreshToken
+{
+    return YES;
+}
+
 - (MSIDCredentialType)credentialType
 {
     return MSIDBoundRefreshTokenType;

--- a/IdentityCore/src/oauth2/token/MSIDRefreshToken.h
+++ b/IdentityCore/src/oauth2/token/MSIDRefreshToken.h
@@ -32,5 +32,6 @@
 
 @property (atomic, readwrite) NSString *refreshToken;
 @property (atomic, readwrite) NSString *familyId;
+@property (nonatomic, readonly) BOOL isBoundRefreshToken;
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDRefreshToken.m
+++ b/IdentityCore/src/oauth2/token/MSIDRefreshToken.m
@@ -108,6 +108,11 @@
 
 #pragma mark - Token type
 
+- (BOOL)isBoundRefreshToken
+{
+    return NO;
+}
+
 - (MSIDCredentialType)credentialType
 {
     return MSIDRefreshTokenType;

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.h
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.h
@@ -48,6 +48,8 @@
 @property (nonatomic) BOOL forceRefresh;
 // Temporary property to skip bound app RT lookup for fallback to regular RTs when BART fails.
 @property (nonatomic) BOOL shouldSkipBoundAppRefreshTokenUsage;
+// When enabled, access-token lookup is unchanged, but only a bound app refresh token may be redeemed.
+@property (nonatomic) BOOL requiresBoundRefreshToken;
 
 #if TARGET_OS_OSX && !EXCLUDE_FROM_MSALCPP
 @property (nonatomic, nullable) MSIDExternalAADCacheSeeder *externalCacheSeeder;

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.h
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.h
@@ -48,7 +48,8 @@
 @property (nonatomic) BOOL forceRefresh;
 // Temporary property to skip bound app RT lookup for fallback to regular RTs when BART fails.
 @property (nonatomic) BOOL shouldSkipBoundAppRefreshTokenUsage;
-// When enabled, access-token lookup is unchanged, but only a bound app refresh token may be redeemed.
+// When enabled, access-token lookup is unchanged, but only an app-specific bound refresh token may
+// be redeemed. Family refresh-token lookup is intentionally disabled.
 @property (nonatomic) BOOL requiresBoundRefreshToken;
 
 #if TARGET_OS_OSX && !EXCLUDE_FROM_MSALCPP

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
@@ -169,6 +169,11 @@
 
 - (nullable MSIDRefreshToken *)familyRefreshTokenWithError:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
+    if (self.requiresBoundRefreshToken)
+    {
+        return nil;
+    }
+
     self.appMetadata = [self appMetadataWithError:error];
     self.defaultAccessor.shouldSkipBoundAppRefreshTokenLookup = self.shouldSkipBoundAppRefreshTokenUsage;
 
@@ -190,11 +195,18 @@
 - (nullable MSIDBaseToken<MSIDRefreshableToken> *)appRefreshTokenWithError:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     self.defaultAccessor.shouldSkipBoundAppRefreshTokenLookup = self.shouldSkipBoundAppRefreshTokenUsage;
-    return [self.defaultAccessor getRefreshTokenWithAccount:self.requestParameters.accountIdentifier
-                                                   familyId:nil
-                                              configuration:self.requestParameters.msidConfiguration
-                                                    context:self.requestParameters
-                                                      error:error];
+    MSIDRefreshToken *refreshToken = [self.defaultAccessor getRefreshTokenWithAccount:self.requestParameters.accountIdentifier
+                                                                             familyId:nil
+                                                                        configuration:self.requestParameters.msidConfiguration
+                                                                              context:self.requestParameters
+                                                                                error:error];
+    if (self.requiresBoundRefreshToken && refreshToken && !refreshToken.isBoundRefreshToken)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Ignoring regular refresh token because a bound refresh token is required.");
+        return nil;
+    }
+
+    return refreshToken;
 }
 
 - (BOOL)updateFamilyIdCacheWithServerError:(NSError *)serverError

--- a/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
+++ b/IdentityCore/src/requests/sdk/msal/MSIDDefaultSilentTokenRequest.m
@@ -171,6 +171,7 @@
 {
     if (self.requiresBoundRefreshToken)
     {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, self.requestParameters, @"Skipping family refresh token lookup because an app-specific bound refresh token is required.");
         return nil;
     }
 

--- a/IdentityCore/tests/MSIDBoundRefreshTokenTests.m
+++ b/IdentityCore/tests/MSIDBoundRefreshTokenTests.m
@@ -59,6 +59,11 @@
 
 #pragma mark - MSIDBoundRefreshToken
 
+- (void)testIsBoundRefreshToken_shouldReturnTrue
+{
+    XCTAssertTrue([self createToken].isBoundRefreshToken);
+}
+
 - (void)testBoundRefreshTokenIsEqual_whenBoundDeviceIdIsNotEqual_shouldReturnFalse
 {
     MSIDBoundRefreshToken *lhs = [self createToken];

--- a/IdentityCore/tests/MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m
+++ b/IdentityCore/tests/MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDDefaultSilentTokenRequest.h"
+#import "MSIDAADV2Oauth2Factory.h"
+#import "MSIDTokenResponseValidator.h"
+#import "MSIDDefaultTokenCacheAccessor.h"
+#import "MSIDAccountMetadataCacheAccessor.h"
+#import "MSIDTestCacheDataSource.h"
+#import "MSIDRequestParameters.h"
+#import "MSIDAccountIdentifier.h"
+#import "MSIDRefreshToken.h"
+#import "MSIDBoundRefreshToken.h"
+#import "MSIDBaseToken.h"
+#import "MSIDRefreshableToken.h"
+#import "MSIDTestIdentifiers.h"
+#import "NSString+MSIDTestUtil.h"
+
+@interface MSIDDefaultSilentTokenRequest (BoundRefreshTokenTests)
+
+- (MSIDRefreshToken *)familyRefreshTokenWithError:(NSError *__autoreleasing *)error;
+- (MSIDBaseToken<MSIDRefreshableToken> *)appRefreshTokenWithError:(NSError *__autoreleasing *)error;
+
+@end
+
+@interface MSIDBoundRefreshTokenCacheAccessorMock : MSIDDefaultTokenCacheAccessor
+
+@property (nonatomic) MSIDRefreshToken *refreshToken;
+@property (nonatomic) NSUInteger refreshTokenLookupCount;
+
+@end
+
+@implementation MSIDBoundRefreshTokenCacheAccessorMock
+
+- (MSIDRefreshToken *)getRefreshTokenWithAccount:(__unused MSIDAccountIdentifier *)account
+                                        familyId:(__unused NSString *)familyId
+                                   configuration:(__unused MSIDConfiguration *)configuration
+                                         context:(__unused id<MSIDRequestContext>)context
+                                           error:(__unused NSError *__autoreleasing *)error
+{
+    self.refreshTokenLookupCount++;
+    return self.refreshToken;
+}
+
+@end
+
+@interface MSIDDefaultSilentTokenRequestBoundRefreshTokenTests : XCTestCase
+
+@end
+
+@implementation MSIDDefaultSilentTokenRequestBoundRefreshTokenTests
+
+- (MSIDBoundRefreshTokenCacheAccessorMock *)tokenCacheWithRefreshToken:(MSIDRefreshToken *)refreshToken
+{
+    MSIDBoundRefreshTokenCacheAccessorMock *tokenCache =
+    [[MSIDBoundRefreshTokenCacheAccessorMock alloc] initWithDataSource:[MSIDTestCacheDataSource new]
+                                                   otherCacheAccessors:nil];
+    tokenCache.refreshToken = refreshToken;
+    return tokenCache;
+}
+
+- (MSIDDefaultSilentTokenRequest *)silentRequestWithTokenCache:(MSIDDefaultTokenCacheAccessor *)tokenCache
+{
+    MSIDRequestParameters *parameters = [MSIDRequestParameters new];
+    parameters.authority = [DEFAULT_TEST_AUTHORITY_GUID aadAuthority];
+    parameters.clientId = @"client-id";
+    parameters.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com"
+                                                                          homeAccountId:DEFAULT_TEST_HOME_ACCOUNT_ID];
+
+    MSIDAccountMetadataCacheAccessor *metadataCache =
+    [[MSIDAccountMetadataCacheAccessor alloc] initWithDataSource:[MSIDTestCacheDataSource new]];
+
+    return [[MSIDDefaultSilentTokenRequest alloc] initWithRequestParameters:parameters
+                                                               forceRefresh:NO
+                                                               oauthFactory:[MSIDAADV2Oauth2Factory new]
+                                                     tokenResponseValidator:[MSIDTokenResponseValidator new]
+                                                                 tokenCache:tokenCache
+                                                       accountMetadataCache:metadataCache];
+}
+
+- (void)testRequiresBoundRefreshToken_whenNotSet_shouldAllowRegularRefreshToken
+{
+    MSIDRefreshToken *refreshToken = [MSIDRefreshToken new];
+    MSIDBoundRefreshTokenCacheAccessorMock *tokenCache = [self tokenCacheWithRefreshToken:refreshToken];
+    MSIDDefaultSilentTokenRequest *silentRequest = [self silentRequestWithTokenCache:tokenCache];
+
+    XCTAssertFalse(silentRequest.requiresBoundRefreshToken);
+    XCTAssertEqual([silentRequest appRefreshTokenWithError:nil], refreshToken);
+    XCTAssertEqual(tokenCache.refreshTokenLookupCount, 1u);
+}
+
+- (void)testRequiresBoundRefreshToken_whenRegularRefreshTokenFound_shouldRejectToken
+{
+    MSIDRefreshToken *refreshToken = [MSIDRefreshToken new];
+    MSIDBoundRefreshTokenCacheAccessorMock *tokenCache = [self tokenCacheWithRefreshToken:refreshToken];
+    MSIDDefaultSilentTokenRequest *silentRequest = [self silentRequestWithTokenCache:tokenCache];
+    silentRequest.requiresBoundRefreshToken = YES;
+
+    XCTAssertNil([silentRequest appRefreshTokenWithError:nil]);
+    XCTAssertEqual(tokenCache.refreshTokenLookupCount, 1u);
+}
+
+- (void)testRequiresBoundRefreshToken_whenBoundRefreshTokenFound_shouldReturnToken
+{
+    MSIDRefreshToken *regularRefreshToken = [MSIDRefreshToken new];
+    MSIDBoundRefreshToken *refreshToken = [[MSIDBoundRefreshToken alloc] initWithRefreshToken:regularRefreshToken
+                                                                               boundDeviceId:@"device-id"];
+    MSIDBoundRefreshTokenCacheAccessorMock *tokenCache = [self tokenCacheWithRefreshToken:refreshToken];
+    MSIDDefaultSilentTokenRequest *silentRequest = [self silentRequestWithTokenCache:tokenCache];
+    silentRequest.requiresBoundRefreshToken = YES;
+
+    XCTAssertEqual([silentRequest appRefreshTokenWithError:nil], refreshToken);
+    XCTAssertEqual(tokenCache.refreshTokenLookupCount, 1u);
+}
+
+- (void)testRequiresBoundRefreshToken_whenFamilyRefreshTokenRequested_shouldSkipLookup
+{
+    MSIDRefreshToken *refreshToken = [MSIDRefreshToken new];
+    MSIDBoundRefreshTokenCacheAccessorMock *tokenCache = [self tokenCacheWithRefreshToken:refreshToken];
+    MSIDDefaultSilentTokenRequest *silentRequest = [self silentRequestWithTokenCache:tokenCache];
+    silentRequest.requiresBoundRefreshToken = YES;
+
+    XCTAssertNil([silentRequest familyRefreshTokenWithError:nil]);
+    XCTAssertEqual(tokenCache.refreshTokenLookupCount, 0u);
+}
+
+@end

--- a/IdentityCore/tests/MSIDRefreshTokenTests.m
+++ b/IdentityCore/tests/MSIDRefreshTokenTests.m
@@ -56,6 +56,11 @@
 
 #pragma mark - MSIDRefreshToken
 
+- (void)testIsBoundRefreshToken_shouldReturnFalse
+{
+    XCTAssertFalse([MSIDRefreshToken new].isBoundRefreshToken);
+}
+
 - (void)testRefreshTokenIsEqual_whenRefreshTokenIsNotEqual_shouldReturnFalse
 {
     MSIDRefreshToken *lhs = [MSIDRefreshToken new];


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

This PR adds an opt-in `requiresBoundRefreshToken` constraint to the CommonCore silent token request. When enabled, access-token lookup remains unchanged, family refresh-token lookup is skipped, regular refresh tokens are rejected, and only a Bound App Refresh Token (BART) may be redeemed.

The Broker flow already distinguishes BART from regular refresh tokens when servicing this Browser Native Message scenario. The unmanaged flow will execute locally through CommonCore, so its silent acquisition must preserve the same security and routing guarantee rather than accidentally redeeming a regular RT or FRT when a BART is required. Exposing the token type through `isBoundRefreshToken` allows the shared silent engine to enforce that requirement without depending on Broker production code.

The new behavior defaults to disabled, so existing silent requests continue using their current RT and FRT behavior. A later unmanaged-flow PR will explicitly enable the constraint for local SPA acquisition.

This is the third independently mergeable phase extracted from #1875 and builds on the shared routing and request-mapping changes introduced in #1927 and #1928.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High - Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium - Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small - No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

- iOS: 39/39 focused refresh-token and silent-request tests passed.
- macOS: 39/39 focused refresh-token and silent-request tests passed.
- Dedicated coverage verifies default-off behavior, regular RT rejection, BART acceptance, and FRT lookup suppression.
