### PR TITLE
[minor] [feature]: Shape Browser Native Message responses from token results

### DIFF
--- a/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageGetTokenResponse.h
+++ b/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageGetTokenResponse.h
@@ -25,15 +25,29 @@
 
 #import "MSIDBrokerNativeAppOperationResponse.h"
 
-@class MSIDBrokerOperationTokenResponse;
 @class MSIDBrokerOperationBrowserNativeMessageMATSReport;
+@class MSIDBrokerOperationTokenResponse;
+@class MSIDTokenResult;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDBrowserNativeMessageGetTokenResponse : MSIDBrokerNativeAppOperationResponse
 
 - (instancetype)initWithDeviceInfo:(nullable MSIDDeviceInfo *)deviceInfo NS_UNAVAILABLE;
-- (instancetype _Nullable)initWithTokenResponse:(nonnull MSIDBrokerOperationTokenResponse *)tokenResponse;
+
+/// Compatibility initializer for callers that still shape the response from the broker operation response.
+- (instancetype _Nullable)initWithTokenResponse:(nonnull MSIDBrokerOperationTokenResponse *)tokenResponse NS_DESIGNATED_INITIALIZER;
+
+/// Shapes a browser-native-message GetToken response from the canonical token result. Works for both
+/// a freshly redeemed result (its `tokenResponse` is present, so base fields come from the server
+/// response) and an access-token cache hit (no `tokenResponse`, base fields derived from
+/// `accessToken`). Returns nil when the result has neither an access token nor a token response.
+/// Also carries the browser-native-message `state` echo and the fallback account UPN so a caller does
+/// not have to set those properties individually after construction. Keeps response parsing/shaping
+/// owned by this response class, depending on a single response type (`MSIDTokenResult`).
+- (instancetype _Nullable)initWithTokenResult:(nonnull MSIDTokenResult *)result
+                                        state:(nullable NSString *)state
+                    fallbackRequestAccountUpn:(nullable NSString *)fallbackRequestAccountUpn NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, nullable) NSString *state;
 @property (nonatomic, nullable) NSString *requestAccountUpn;

--- a/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageGetTokenResponse.m
+++ b/IdentityCore/src/broker_operation/response/browser_native_message_response/MSIDBrowserNativeMessageGetTokenResponse.m
@@ -28,10 +28,17 @@
 #import "MSIDTokenResponse.h"
 #import "MSIDOAuth2Constants.h"
 #import "MSIDBrokerOperationBrowserNativeMessageMATSReport.h"
+#import "MSIDTokenResult.h"
+#import "MSIDAccessToken.h"
+#import "MSIDAccount.h"
+#import "MSIDAccountIdentifier.h"
+#import "NSString+MSIDExtensions.h"
+#import "NSOrderedSet+MSIDExtensions.h"
 
 @interface MSIDBrowserNativeMessageGetTokenResponse()
 
 @property (nonatomic) MSIDBrokerOperationTokenResponse *operationTokenResponse;
+@property (nonatomic) MSIDTokenResult *tokenResult;
 
 @end
 
@@ -39,53 +46,184 @@
 
 - (instancetype)initWithTokenResponse:(MSIDBrokerOperationTokenResponse *)operationTokenResponse
 {
+    if (!operationTokenResponse)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create browser 'GetToken' response: operation token response is nil.");
+        return nil;
+    }
+
     self = [super initWithDeviceInfo:operationTokenResponse.deviceInfo];
     if (self)
     {
-        if (!operationTokenResponse)
-        {
-            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create browser 'GetToken' response: operation token response is nil.");
-            return nil;
-        }
-        
         _operationTokenResponse = operationTokenResponse;
     }
-    
+
+    return self;
+}
+
+// Designated initializer: constructs the response from a single canonical token result.
+- (instancetype)initWithTokenResult:(MSIDTokenResult *)result
+                              state:(NSString *)state
+          fallbackRequestAccountUpn:(NSString *)fallbackRequestAccountUpn
+{
+    if (!result.accessToken && !result.tokenResponse)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create browser 'GetToken' response: result has no access token or token response.");
+        return nil;
+    }
+
+    self = [super initWithDeviceInfo:nil];
+    if (self)
+    {
+        _tokenResult = result;
+        _state = state;
+        _requestAccountUpn = fallbackRequestAccountUpn;
+    }
+
     return self;
 }
 
 #pragma mark - MSIDJsonSerializable
 
+// Deserialization is intentionally unsupported for this response (it is only ever produced, never
+// parsed). The initializer throws instead of delegating to the designated initializer, so the
+// convenience-initializer diagnostic is suppressed for this false positive.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-designated-initializers"
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json error:(NSError *__autoreleasing*)error
 {
     @throw MSIDException(MSIDGenericException, @"Not implemented.", nil);
 }
+#pragma clang diagnostic pop
 
+// Shapes the GetToken payload from a single canonical token result. Base OAuth fields come from the
+// server token response when present (wire parity with a freshly redeemed result); otherwise they are
+// derived from the cached access token (access-token cache hit). Optional fields are omitted when
+// blank/nil so downstream required-field validation can fail cleanly rather than receiving empty
+// placeholder values. The account, state, and properties blocks are shared across both sources.
 - (NSDictionary *)jsonDictionary
 {
-    __auto_type tokenResponse = self.operationTokenResponse.tokenResponse;
-    NSMutableDictionary *response = [[tokenResponse jsonDictionary] mutableCopy];
-    if (!response)
+    if (self.operationTokenResponse)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create token json response.");
-        return nil;
+        MSIDTokenResponse *tokenResponse = self.operationTokenResponse.tokenResponse;
+        NSMutableDictionary *response = [[tokenResponse jsonDictionary] mutableCopy];
+        if (!response)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create token json response.");
+            return nil;
+        }
+
+        NSMutableDictionary *accountJson = [NSMutableDictionary new];
+        accountJson[@"userName"] = tokenResponse.accountUpn ?: self.requestAccountUpn;
+        accountJson[@"id"] = tokenResponse.accountIdentifier;
+
+        response[@"account"] = accountJson;
+        response[@"state"] = self.state;
+
+        NSMutableDictionary *propertiesJson = [NSMutableDictionary new];
+        propertiesJson[@"UPN"] = accountJson[@"userName"];
+        propertiesJson[@"MATS"] = [self.matsReport jsonString];
+        response[@"properties"] = propertiesJson;
+
+        return response;
     }
-    
-    __auto_type accountJson = [NSMutableDictionary new];
-    accountJson[@"userName"] = tokenResponse.accountUpn ?: self.requestAccountUpn;
-    accountJson[@"id"] = tokenResponse.accountIdentifier;
-    
-    response[@"account"] = accountJson;
-    response[@"state"] = self.state;
-    
-    __auto_type propertiesJson = [NSMutableDictionary new];
+
+    MSIDTokenResponse *tokenResponse = self.tokenResult.tokenResponse;
+    MSIDAccessToken *accessToken = self.tokenResult.accessToken;
+
+    // 1) Base OAuth fields.
+    NSMutableDictionary *response;
+    if (tokenResponse)
+    {
+        response = [[tokenResponse jsonDictionary] mutableCopy];
+        if (!response)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to create token json response.");
+            return nil;
+        }
+    }
+    else
+    {
+        response = [NSMutableDictionary new];
+        if (![NSString msidIsStringNilOrBlank:accessToken.accessToken])
+        {
+            response[@"access_token"] = accessToken.accessToken;
+        }
+
+        if (![NSString msidIsStringNilOrBlank:accessToken.tokenType])
+        {
+            response[@"token_type"] = accessToken.tokenType;
+        }
+
+        if (![NSString msidIsStringNilOrBlank:self.tokenResult.rawIdToken])
+        {
+            response[@"id_token"] = self.tokenResult.rawIdToken;
+        }
+
+        NSString *scope = [accessToken.scopes msidToString];
+        if (![NSString msidIsStringNilOrBlank:scope])
+        {
+            response[@"scope"] = scope;
+        }
+
+        if (accessToken.expiresOn)
+        {
+            response[@"expires_on"] = [@((long long)[accessToken.expiresOn timeIntervalSince1970]) stringValue];
+            response[@"expires_in"] = [@((long long)MAX(0, (NSInteger)[accessToken.expiresOn timeIntervalSinceNow])) stringValue];
+        }
+    }
+
+    // 2) Account block. Identifiers are resolved from whichever source populated the result.
+    NSString *userName = tokenResponse ? tokenResponse.accountUpn : self.tokenResult.account.username;
+    if ([NSString msidIsStringNilOrBlank:userName])
+    {
+        userName = self.requestAccountUpn;
+    }
+
+    NSString *accountId = tokenResponse ? tokenResponse.accountIdentifier
+                                        : self.tokenResult.account.accountIdentifier.homeAccountId;
+
+    NSMutableDictionary *account = [NSMutableDictionary new];
+    if (![NSString msidIsStringNilOrBlank:accountId])
+    {
+        account[@"id"] = accountId;
+    }
+
+    if (![NSString msidIsStringNilOrBlank:userName])
+    {
+        account[@"userName"] = userName;
+    }
+
+    if (account.count)
+    {
+        response[@"account"] = account;
+    }
+
+    // 3) State echo.
+    if (![NSString msidIsStringNilOrBlank:self.state])
+    {
+        response[@"state"] = self.state;
+    }
+
+    // 4) Properties: UPN is always echoed when known; MATS is added only when a report exists.
+    NSMutableDictionary *propertiesJson = [NSMutableDictionary new];
     // TODO: once ests follow the latest protocol, this should be removed. Account ID should be read from accountJson.
-    propertiesJson[@"UPN"] = accountJson[@"userName"];
-    // Add MATS report as JSON string
-    propertiesJson[@"MATS"] = [self.matsReport jsonString];
-    
-    response[@"properties"] = propertiesJson;
-    
+    if (![NSString msidIsStringNilOrBlank:userName])
+    {
+        propertiesJson[@"UPN"] = userName;
+    }
+
+    NSString *matsReportJson = [self.matsReport jsonString];
+    if (matsReportJson)
+    {
+        propertiesJson[@"MATS"] = matsReportJson;
+    }
+
+    if (propertiesJson.count)
+    {
+        response[@"properties"] = propertiesJson;
+    }
+
     return response;
 }
 

--- a/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenResponseTests.m
+++ b/IdentityCore/tests/MSIDBrowserNativeMessageGetTokenResponseTests.m
@@ -30,6 +30,10 @@
 #import "MSIDTestIdTokenUtil.h"
 #import "MSIDTokenResponse.h"
 #import "MSIDTestIdentifiers.h"
+#import "MSIDTokenResult.h"
+#import "MSIDAccessToken.h"
+#import "MSIDAccount.h"
+#import "MSIDAccountIdentifier.h"
 
 @interface MSIDTokenResponseMock : MSIDTokenResponse
 
@@ -60,18 +64,27 @@
 
 @implementation MSIDBrowserNativeMessageGetTokenResponseTests
 
+- (MSIDTokenResult *)tokenResultWithTokenResponse:(MSIDTokenResponse *)tokenResponse
+{
+    MSIDTokenResult *result = [MSIDTokenResult new];
+    result.tokenResponse = tokenResponse;
+    return result;
+}
+
 - (void)testResponseType_shouldBeGenericResponse
 {
     // We don't use this operation directly, it is wrapped by "BrokerOperationBrowserNativeMessage" operation, so we don't care about response type and return generic response.
     XCTAssertEqualObjects(@"operation_generic_response", [MSIDBrowserNativeMessageGetTokenResponse responseType]);
 }
 
-- (void)testJsonDictionary_whenNoResposne_shouldReturnNil
+- (void)testInitWithTokenResult_whenNoAccessTokenOrTokenResponse_shouldReturnNil
 {
-    __auto_type tokenResponse = [[MSIDBrokerOperationTokenResponse alloc] initWithDeviceInfo:nil];
-    __auto_type response = [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResponse:tokenResponse];
-    
-    XCTAssertNil([response jsonDictionary]);
+    MSIDTokenResult *result = [MSIDTokenResult new];
+    __auto_type response = [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResult:result
+                                                                                          state:nil
+                                                                      fallbackRequestAccountUpn:nil];
+
+    XCTAssertNil(response);
 }
 
 - (void)testJsonDictionary_whenPayloadExist_shouldBeCorrect
@@ -84,11 +97,10 @@
     MSIDTokenResponseMock *tokenResponseMock = [[MSIDTokenResponseMock alloc] initWithJSONDictionary:jsonInput error:nil];
     tokenResponseMock.responseJson = @{@"some_key": @"some_value"};
     
-    __auto_type operationTokenResponse = [[MSIDBrokerOperationTokenResponse alloc] initWithDeviceInfo:nil];
-    operationTokenResponse.tokenResponse = tokenResponseMock;
-    
-    __auto_type response = [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResponse:operationTokenResponse];
-    response.state = @"1234";
+    MSIDTokenResult *result = [self tokenResultWithTokenResponse:tokenResponseMock];
+    __auto_type response = [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResult:result
+                                                                                          state:@"1234"
+                                                                      fallbackRequestAccountUpn:nil];
     
     __auto_type expectedJson = @{
         @"account": @{
@@ -106,6 +118,29 @@
     XCTAssertEqualObjects(expectedJson, [response jsonDictionary]);
 }
 
+- (void)testJsonDictionary_whenInitializedWithLegacyTokenResponse_shouldPreserveLegacyShape
+{
+    NSString *idToken = [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME
+                                                                  subject:DEFAULT_TEST_ID_TOKEN_SUBJECT];
+    MSIDTokenResponseMock *tokenResponseMock = [[MSIDTokenResponseMock alloc] initWithJSONDictionary:@{@"id_token": idToken} error:nil];
+    tokenResponseMock.responseJson = @{@"some_key": @"some_value"};
+
+    __auto_type operationTokenResponse = [[MSIDBrokerOperationTokenResponse alloc] initWithDeviceInfo:nil];
+    operationTokenResponse.tokenResponse = tokenResponseMock;
+
+    __auto_type response = [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResponse:operationTokenResponse];
+    response.state = @"1234";
+    response.requestAccountUpn = @"fallback@contoso.com";
+
+    NSDictionary *json = [response jsonDictionary];
+
+    XCTAssertEqualObjects(json[@"some_key"], @"some_value");
+    XCTAssertEqualObjects(json[@"state"], @"1234");
+    XCTAssertEqualObjects(json[@"account"][@"userName"], tokenResponseMock.accountUpn);
+    XCTAssertEqualObjects(json[@"account"][@"id"], tokenResponseMock.accountIdentifier);
+    XCTAssertEqualObjects(json[@"properties"][@"UPN"], tokenResponseMock.accountUpn);
+}
+
 - (void)testJsonDictionary_whenNoUpnInReponse_shouldUseProvidedUpn
 {
     NSString *idToken = [MSIDTestIdTokenUtil idTokenWithPreferredUsername:DEFAULT_TEST_ID_TOKEN_USERNAME
@@ -117,12 +152,10 @@
     tokenResponseMock.returnNilAccounUpn = YES;
     tokenResponseMock.responseJson = @{@"some_key": @"some_value"};
     
-    __auto_type operationTokenResponse = [[MSIDBrokerOperationTokenResponse alloc] initWithDeviceInfo:nil];
-    operationTokenResponse.tokenResponse = tokenResponseMock;
-    
-    __auto_type response = [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResponse:operationTokenResponse];
-    response.state = @"1234";
-    response.requestAccountUpn = @"a@b.c";
+    MSIDTokenResult *result = [self tokenResultWithTokenResponse:tokenResponseMock];
+    __auto_type response = [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResult:result
+                                                                                          state:@"1234"
+                                                                      fallbackRequestAccountUpn:@"a@b.c"];
     
     __auto_type expectedJson = @{
         @"account": @{
@@ -138,6 +171,102 @@
     
     XCTAssertNotNil([response jsonDictionary]);
     XCTAssertEqualObjects(expectedJson, [response jsonDictionary]);
+}
+
+- (void)testInitWithTokenResultStateAndFallbackUpn_setsConvenienceProperties
+{
+    MSIDTokenResponseMock *tokenResponseMock = [[MSIDTokenResponseMock alloc] initWithJSONDictionary:@{} error:nil];
+    tokenResponseMock.responseJson = @{@"some_key": @"some_value"};
+
+    MSIDTokenResult *result = [self tokenResultWithTokenResponse:tokenResponseMock];
+    __auto_type response = [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResult:result
+                                                                                          state:@"state"
+                                                                      fallbackRequestAccountUpn:@"user@contoso.com"];
+
+    XCTAssertEqualObjects(response.state, @"state");
+    XCTAssertEqualObjects(response.requestAccountUpn, @"user@contoso.com");
+}
+
+// Lookup / discovery mode (nativebroker_mode = Lookup) returns a token response whose access_token
+// and id_token are "none". The response must NOT be gated on a materialized access token; the raw
+// token response fields pass through untouched. Mirrors dev behavior, which only required a non-nil
+// underlying token response payload.
+- (void)testJsonDictionary_whenLookupModeAccessTokenIsNone_passesThroughWithoutGating
+{
+    MSIDTokenResponseMock *tokenResponseMock = [[MSIDTokenResponseMock alloc] initWithJSONDictionary:@{} error:nil];
+    tokenResponseMock.responseJson = @{
+        @"access_token": @"none",
+        @"id_token": @"none",
+        @"refresh_token": @"1.wqeqweqwe",
+        @"token_type": @"Bearer",
+        @"scope": @"https://management.core.windows.net//.default"
+    };
+
+    MSIDTokenResult *result = [self tokenResultWithTokenResponse:tokenResponseMock];
+    // The result carries only a token response (no materialized MSIDAccessToken).
+    XCTAssertNil(result.accessToken);
+    XCTAssertNotNil(result.tokenResponse);
+
+    __auto_type response = [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResult:result
+                                                                                          state:@"1234"
+                                                                      fallbackRequestAccountUpn:@"idlab@msidlab4.onmicrosoft.com"];
+
+    NSDictionary *json = [response jsonDictionary];
+    XCTAssertNotNil(json);
+    XCTAssertEqualObjects(json[@"access_token"], @"none");
+    XCTAssertEqualObjects(json[@"id_token"], @"none");
+    XCTAssertEqualObjects(json[@"refresh_token"], @"1.wqeqweqwe");
+    XCTAssertEqualObjects(json[@"state"], @"1234");
+}
+
+- (void)testJsonDictionary_whenAccessTokenComesFromCache_shouldBuildResponseFromResult
+{
+    MSIDAccessToken *accessToken = [MSIDAccessToken new];
+    accessToken.accessToken = @"cached-access-token";
+    accessToken.tokenType = @"Bearer";
+    accessToken.scopes = [NSOrderedSet orderedSetWithArray:@[@"openid", @"profile", @"User.Read"]];
+    accessToken.expiresOn = [NSDate dateWithTimeIntervalSince1970:2000000000];
+
+    MSIDAccount *account = [MSIDAccount new];
+    account.username = @"user@contoso.com";
+    account.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:account.username
+                                                                      homeAccountId:@"uid.utid"];
+
+    MSIDTokenResult *result = [MSIDTokenResult new];
+    result.accessToken = accessToken;
+    result.rawIdToken = @"cached-id-token";
+    result.account = account;
+
+    MSIDBrowserNativeMessageGetTokenResponse *response =
+    [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResult:result
+                                                                    state:@"state"
+                                                fallbackRequestAccountUpn:nil];
+
+    NSDictionary *json = [response jsonDictionary];
+
+    XCTAssertEqualObjects(json[@"access_token"], @"cached-access-token");
+    XCTAssertEqualObjects(json[@"token_type"], @"Bearer");
+    XCTAssertEqualObjects(json[@"id_token"], @"cached-id-token");
+    XCTAssertEqualObjects(json[@"scope"], @"openid profile User.Read");
+    XCTAssertEqualObjects(json[@"expires_on"], @"2000000000");
+    XCTAssertTrue([json[@"expires_in"] isKindOfClass:NSString.class]);
+    XCTAssertEqualObjects(json[@"account"][@"id"], @"uid.utid");
+    XCTAssertEqualObjects(json[@"account"][@"userName"], @"user@contoso.com");
+    XCTAssertEqualObjects(json[@"properties"][@"UPN"], @"user@contoso.com");
+    XCTAssertEqualObjects(json[@"state"], @"state");
+}
+
+- (void)testJsonDictionary_whenCachedResultHasNoOptionalValues_shouldOmitEmptyFields
+{
+    MSIDTokenResult *result = [MSIDTokenResult new];
+    result.accessToken = [MSIDAccessToken new];
+
+    MSIDBrowserNativeMessageGetTokenResponse *response =
+    [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResult:result
+                                                                    state:nil
+                                                fallbackRequestAccountUpn:nil];
+
+    XCTAssertEqualObjects([response jsonDictionary], @{});
 }
 
 @end


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## Proposed changes

This PR adds a Browser Native Message GetToken response initializer that accepts the canonical `MSIDTokenResult`. Freshly redeemed and lookup-mode results preserve the server token response payload, while access-token cache hits construct the equivalent browser response from the cached access token, ID token, account, state, and properties.

The existing response type originated in the Broker flow, where callers provide `MSIDBrokerOperationTokenResponse`. The unmanaged SPA flow will acquire tokens locally through CommonCore and receives `MSIDTokenResult` instead, so the shared response component must support that canonical result without introducing a dependency on Broker production types. The existing Broker initializer and serialization behavior remain intact.

The new initializer is independently usable but is not wired into production routing in this PR. A later unmanaged-flow PR will use it from the OneAuth-facing SPA token provider.

This is the fourth independently mergeable phase extracted from #1875 and builds on the routing, request-mapping, and bound-refresh-token changes introduced in #1927, #1928, and #1929.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High - Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium - Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small - No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

- iOS: 9/9 focused Browser Native Message response tests passed.
- macOS: 9/9 focused Browser Native Message response tests passed.
- Coverage verifies legacy Broker compatibility, fresh and lookup-mode pass-through, cached response construction, fallback UPN handling, and omission of unavailable optional fields.
