### PR TITLE
[patch][engg]: Add iOS 27 NSURL percent double-encode regression tests

### DIFF
--- a/IdentityCore/tests/MSIDStringExtensionsTests.m
+++ b/IdentityCore/tests/MSIDStringExtensionsTests.m
@@ -279,7 +279,7 @@
     XCTAssertEqualObjects(result, @"key=");
 }
 
-- (void)testMsidURLEncode_when27_hasLiteralPercent_shouldEncodeToPercent25
+- (void)testMsidURLEncode_whenLiteralPercent_shouldEncodeToPercent25
 {
     // iOS/macOS 27 (radar 161588649): msidURLEncode escapes a literal % to %25 so the non-re-encoding setter stays correct.
     XCTAssertEqualObjects([@"50%off" msidURLEncode], @"50%25off");
@@ -287,7 +287,7 @@
     XCTAssertEqualObjects([@"a%20b" msidURLEncode], @"a%2520b");
 }
 
-- (void)testMsidURLEncodedStringFromDictionary_when27_valueHasReservedChars_shouldEncodeOnce
+- (void)testMsidURLEncodedStringFromDictionary_whenValueHasReservedChars_shouldEncodeOnce
 {
     // iOS/macOS 27 (radar 161588649): reserved chars in a redirect_uri-style value are encoded exactly once.
     NSString *encoded = [NSString msidURLEncodedStringFromDictionary:@{@"redirect_uri": @"msauth://com.example/cb"}];

--- a/IdentityCore/tests/MSIDStringExtensionsTests.m
+++ b/IdentityCore/tests/MSIDStringExtensionsTests.m
@@ -290,9 +290,9 @@
 - (void)testMsidURLEncodedStringFromDictionary_whenValueHasReservedChars_shouldEncodeOnce
 {
     // iOS/macOS 27 (radar 161588649): reserved chars in a redirect_uri-style value are encoded exactly once.
-    NSString *encoded = [NSString msidURLEncodedStringFromDictionary:@{@"redirect_uri": @"msauth://com.example/cb"}];
-    XCTAssertEqualObjects(encoded, @"redirect_uri=msauth%3A%2F%2Fcom.example%2Fcb");
-    XCTAssertFalse([encoded containsString:@"%253A"]);
+    // The space pins the non-form encoder: msidWWWFormURLEncodedStringFromDictionary would emit '+' instead of %20.
+    NSString *encoded = [NSString msidURLEncodedStringFromDictionary:@{@"redirect_uri": @"msauth://com.example/cb path"}];
+    XCTAssertEqualObjects(encoded, @"redirect_uri=msauth%3A%2F%2Fcom.example%2Fcb%20path");
 }
 
 - (void)testmsidJson_whenNotJson_shouldReturnNil

--- a/IdentityCore/tests/MSIDStringExtensionsTests.m
+++ b/IdentityCore/tests/MSIDStringExtensionsTests.m
@@ -279,6 +279,22 @@
     XCTAssertEqualObjects(result, @"key=");
 }
 
+- (void)testMsidURLEncode_when27_hasLiteralPercent_shouldEncodeToPercent25
+{
+    // iOS/macOS 27 (radar 161588649): msidURLEncode escapes a literal % to %25 so the non-re-encoding setter stays correct.
+    XCTAssertEqualObjects([@"50%off" msidURLEncode], @"50%25off");
+    // A pre-existing escape in raw input is treated as literal text: % -> %25.
+    XCTAssertEqualObjects([@"a%20b" msidURLEncode], @"a%2520b");
+}
+
+- (void)testMsidURLEncodedStringFromDictionary_when27_valueHasReservedChars_shouldEncodeOnce
+{
+    // iOS/macOS 27 (radar 161588649): reserved chars in a redirect_uri-style value are encoded exactly once.
+    NSString *encoded = [NSString msidURLEncodedStringFromDictionary:@{@"redirect_uri": @"msauth://com.example/cb"}];
+    XCTAssertEqualObjects(encoded, @"redirect_uri=msauth%3A%2F%2Fcom.example%2Fcb");
+    XCTAssertFalse([encoded containsString:@"%253A"]);
+}
+
 - (void)testmsidJson_whenNotJson_shouldReturnNil
 {
     NSString *jsonString = @"{\"-not\":a json&*";

--- a/IdentityCore/tests/MSIDURLExtensionsTests.m
+++ b/IdentityCore/tests/MSIDURLExtensionsTests.m
@@ -378,7 +378,7 @@
     XCTAssertEqualObjects(resultURL, expectedResultURL);
 }
 
-- (void)testMsidURLWithQueryParameters_when27_existingQueryHasPreEncodedValue_shouldNotDoubleEncode
+- (void)testMsidURLWithQueryParameters_whenExistingQueryHasPreEncodedValue_shouldNotDoubleEncode
 {
     // iOS/macOS 27 (radar 161588649): NSURL must not re-encode an already-percent-encoded existing query.
     NSURL *inputURL = [NSURL URLWithString:@"https://somehost.com:652?redirect_uri=msauth%3A%2F%2Fcom.example%2Fcb"];
@@ -389,7 +389,7 @@
     XCTAssertFalse([resultURL.absoluteString containsString:@"%252F"]);
 }
 
-- (void)testMsidURLWithQueryParameters_when27_appendedValueHasLiteralPercent_shouldEncodeOnce
+- (void)testMsidURLWithQueryParameters_whenAppendedValueHasLiteralPercent_shouldEncodeOnce
 {
     // iOS/macOS 27 (radar 161588649): a literal % in an appended value must be encoded exactly once (%25), never doubled.
     NSURL *inputURL = [NSURL URLWithString:@"https://somehost.com:652?existing1=value2"];
@@ -398,7 +398,7 @@
     XCTAssertFalse([resultURL.absoluteString containsString:@"%2525"]);
 }
 
-- (void)testMsidURLWithQueryParameters_when27_appendedValueLooksLikeEscape_shouldEncodePercentLiterally
+- (void)testMsidURLWithQueryParameters_whenAppendedValueLooksLikeEscape_shouldEncodePercentLiterally
 {
     // iOS/macOS 27 (radar 161588649): an appended value that looks like a valid escape (%20) is literal text; msidURLEncode escapes the % so it becomes %2520.
     NSURL *inputURL = [NSURL URLWithString:@"https://somehost.com:652?existing1=value2"];

--- a/IdentityCore/tests/MSIDURLExtensionsTests.m
+++ b/IdentityCore/tests/MSIDURLExtensionsTests.m
@@ -378,6 +378,34 @@
     XCTAssertEqualObjects(resultURL, expectedResultURL);
 }
 
+- (void)testMsidURLWithQueryParameters_when27_existingQueryHasPreEncodedValue_shouldNotDoubleEncode
+{
+    // iOS/macOS 27 (radar 161588649): NSURL must not re-encode an already-percent-encoded existing query.
+    NSURL *inputURL = [NSURL URLWithString:@"https://somehost.com:652?redirect_uri=msauth%3A%2F%2Fcom.example%2Fcb"];
+    NSURL *resultURL = [inputURL msidURLWithQueryParameters:@{@"key2": @"value2"}];
+    XCTAssertEqualObjects(resultURL.absoluteString, @"https://somehost.com:652?redirect_uri=msauth%3A%2F%2Fcom.example%2Fcb&key2=value2");
+    // Guard: the pre-encoded %3A/%2F must NOT become %253A/%252F.
+    XCTAssertFalse([resultURL.absoluteString containsString:@"%253A"]);
+    XCTAssertFalse([resultURL.absoluteString containsString:@"%252F"]);
+}
+
+- (void)testMsidURLWithQueryParameters_when27_appendedValueHasLiteralPercent_shouldEncodeOnce
+{
+    // iOS/macOS 27 (radar 161588649): a literal % in an appended value must be encoded exactly once (%25), never doubled.
+    NSURL *inputURL = [NSURL URLWithString:@"https://somehost.com:652?existing1=value2"];
+    NSURL *resultURL = [inputURL msidURLWithQueryParameters:@{@"discount": @"50%off"}];
+    XCTAssertEqualObjects(resultURL.absoluteString, @"https://somehost.com:652?existing1=value2&discount=50%25off");
+    XCTAssertFalse([resultURL.absoluteString containsString:@"%2525"]);
+}
+
+- (void)testMsidURLWithQueryParameters_when27_appendedValueLooksLikeEscape_shouldEncodePercentLiterally
+{
+    // iOS/macOS 27 (radar 161588649): an appended value that looks like a valid escape (%20) is literal text; msidURLEncode escapes the % so it becomes %2520.
+    NSURL *inputURL = [NSURL URLWithString:@"https://somehost.com:652?existing1=value2"];
+    NSURL *resultURL = [inputURL msidURLWithQueryParameters:@{@"raw": @"a%20b"}];
+    XCTAssertEqualObjects(resultURL.absoluteString, @"https://somehost.com:652?existing1=value2&raw=a%2520b");
+}
+
 - (void)testMsidURLWithQueryParameters_whenNonEmptyQuery_andQueryParametersWithSimilarNames_shouldReturnCombinedURL
 {
     NSURL *inputURL = [NSURL URLWithString:@"https://somehost.com:652?existing1=value2&longer-return-client-request-id=true"];

--- a/IdentityCore/tests/MSIDURLExtensionsTests.m
+++ b/IdentityCore/tests/MSIDURLExtensionsTests.m
@@ -384,9 +384,6 @@
     NSURL *inputURL = [NSURL URLWithString:@"https://somehost.com:652?redirect_uri=msauth%3A%2F%2Fcom.example%2Fcb"];
     NSURL *resultURL = [inputURL msidURLWithQueryParameters:@{@"key2": @"value2"}];
     XCTAssertEqualObjects(resultURL.absoluteString, @"https://somehost.com:652?redirect_uri=msauth%3A%2F%2Fcom.example%2Fcb&key2=value2");
-    // Guard: the pre-encoded %3A/%2F must NOT become %253A/%252F.
-    XCTAssertFalse([resultURL.absoluteString containsString:@"%253A"]);
-    XCTAssertFalse([resultURL.absoluteString containsString:@"%252F"]);
 }
 
 - (void)testMsidURLWithQueryParameters_whenAppendedValueHasLiteralPercent_shouldEncodeOnce
@@ -395,7 +392,6 @@
     NSURL *inputURL = [NSURL URLWithString:@"https://somehost.com:652?existing1=value2"];
     NSURL *resultURL = [inputURL msidURLWithQueryParameters:@{@"discount": @"50%off"}];
     XCTAssertEqualObjects(resultURL.absoluteString, @"https://somehost.com:652?existing1=value2&discount=50%25off");
-    XCTAssertFalse([resultURL.absoluteString containsString:@"%2525"]);
 }
 
 - (void)testMsidURLWithQueryParameters_whenAppendedValueLooksLikeEscape_shouldEncodePercentLiterally


### PR DESCRIPTION
### Summary

Adds **iOS/macOS 27 regression tests only** for the SDK 27 `NSURL` percent-encoding behavior change, where `NSURL` no longer double-encodes `%` in already-valid percent-escape sequences.

IdentityCore's URL construction relies on `percentEncodedQuery` / `percentEncodedHost` and the custom `msidURLEncode` helper explicitly to avoid double-encoding. These paths touch every Microsoft app's login-URL construction, so this locks in the expected single-encode behavior with explicit tests. **No production/src code is changed** — the existing implementation already aligns with the new 27 behavior; these tests guard against regressions.

### Changes

- `IdentityCore/tests/MSIDURLExtensionsTests.m` — 3 new tests on `msidURLWithQueryParameters:`:
  - pre-encoded value in an existing query is **not** double-encoded
  - an appended value containing a literal `%` is encoded exactly once (`%` → `%25`)
  - an appended value that *looks like* an escape (`%20`) has its `%` encoded literally
- `IdentityCore/tests/MSIDStringExtensionsTests.m` — 2 new tests on `msidURLEncode` / dictionary encoding:
  - literal `%` → `%25`
  - reserved chars in dictionary values encoded once (uses `%20`, not `+`)

### Validation

Built and ran on a real **iOS 27.0 simulator** (iPhone 17, runtime 24A5390f):

```
xcodebuild test -workspace IdentityCore.xcworkspace -scheme "IdentityCore iOS" \
  -destination 'platform=iOS Simulator,name=iPhone 17,OS=27.0' \
  -only-testing:"IdentityCoreTests iOS/NSURLExtensionsTests" \
  -only-testing:"IdentityCoreTests iOS/MSIDTestNSStringHelperMethods"
** TEST SUCCEEDED **  — 90 executed, 0 failures
```

(Branch includes the merged MSIDTestsHostApp UIScene migration from `dev`, so the IdentityCore iOS test bundle launches cleanly under the iOS 27 runtime.)

### Risk

Tests-only; no runtime/behavioral change. `[patch][engg]` — changelog-exempt.
