### PR TITLE
[minor] [feature]: Add local SPA silent token acquisition backend

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -2113,6 +2113,12 @@
 		BA000000000000000000C003 /* MSIDBoundTokenProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000B002 /* MSIDBoundTokenProvider.m */; };
 		BA000000000000000000D101 /* MSIDBoundTokenProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000D001 /* MSIDBoundTokenProviderTests.m */; };
 		BA000000000000000000D102 /* MSIDBoundTokenProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000D001 /* MSIDBoundTokenProviderTests.m */; };
+		BA000000000000000000F001 /* MSIDSPATokenAcquiring.h in Headers */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E001 /* MSIDSPATokenAcquiring.h */; };
+		BA000000000000000000F002 /* MSIDLocalSPATokenAcquirer.h in Headers */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E003 /* MSIDLocalSPATokenAcquirer.h */; };
+		BA000000000000000000F005 /* MSIDLocalSPATokenAcquirer.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E004 /* MSIDLocalSPATokenAcquirer.m */; };
+		BA000000000000000000F006 /* MSIDLocalSPATokenAcquirer.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E004 /* MSIDLocalSPATokenAcquirer.m */; };
+		BA000000000000000000F007 /* MSIDLocalSPATokenAcquirerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E005 /* MSIDLocalSPATokenAcquirerTests.m */; };
+		BA000000000000000000F008 /* MSIDLocalSPATokenAcquirerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E005 /* MSIDLocalSPATokenAcquirerTests.m */; };
 		C2E599251DB14C46D8DD6261 /* MSIDDIContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 30CDFCBD388F4440556637F9 /* MSIDDIContainer.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		C69BEEDD552FAEE33A6BE2FF /* MSIDCertAuthHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E83F7EE40617833162571023 /* MSIDCertAuthHandlerTests.m */; };
 		D11DF760D8901DDC5186BC7A /* MSIDDIContainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E356C396133919B12FB4F01 /* MSIDDIContainerTests.m */; };
@@ -3762,6 +3768,10 @@
 		BA000000000000000000B001 /* MSIDBoundTokenProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBoundTokenProvider.h; sourceTree = "<group>"; };
 		BA000000000000000000B002 /* MSIDBoundTokenProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBoundTokenProvider.m; sourceTree = "<group>"; };
 		BA000000000000000000D001 /* MSIDBoundTokenProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBoundTokenProviderTests.m; sourceTree = "<group>"; };
+		BA000000000000000000E001 /* MSIDSPATokenAcquiring.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSPATokenAcquiring.h; sourceTree = "<group>"; };
+		BA000000000000000000E003 /* MSIDLocalSPATokenAcquirer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDLocalSPATokenAcquirer.h; sourceTree = "<group>"; };
+		BA000000000000000000E004 /* MSIDLocalSPATokenAcquirer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLocalSPATokenAcquirer.m; sourceTree = "<group>"; };
+		BA000000000000000000E005 /* MSIDLocalSPATokenAcquirerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLocalSPATokenAcquirerTests.m; sourceTree = "<group>"; };
 		CACE5D66E6234506B9936BC5 /* MSIDThrottlingRefreshing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingRefreshing.h; sourceTree = "<group>"; };
 		D626000F1FBD380500EE4487 /* NSString+MSIDExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+MSIDExtensions.m"; sourceTree = "<group>"; };
 		D62600101FBD380500EE4487 /* NSDictionary+MSIDExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+MSIDExtensions.h"; sourceTree = "<group>"; };
@@ -5395,6 +5405,9 @@
 				72C1EBF42DE91ABE004C40A4 /* MSIDBoundRefreshToken.h */,
 				BA000000000000000000B002 /* MSIDBoundTokenProvider.m */,
 				BA000000000000000000B001 /* MSIDBoundTokenProvider.h */,
+				BA000000000000000000E001 /* MSIDSPATokenAcquiring.h */,
+				BA000000000000000000E003 /* MSIDLocalSPATokenAcquirer.h */,
+				BA000000000000000000E004 /* MSIDLocalSPATokenAcquirer.m */,
 				B2675689228CE6FC000F01D7 /* protocols */,
 				B251CC4E204105AD005E0179 /* MSIDCredentialType.h */,
 				B251CC4F204105AD005E0179 /* MSIDCredentialType.m */,
@@ -6312,6 +6325,7 @@
 				72C764F82E09CFA400043AB1 /* MSIDBoundRefreshTokenTests.m */,
 				FA7200030000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m */,
 				BA000000000000000000D001 /* MSIDBoundTokenProviderTests.m */,
+				BA000000000000000000E005 /* MSIDLocalSPATokenAcquirerTests.m */,
 				B48FC0612D7A90F4007B80DB /* MSIDBrokerFlightProviderTests.m */,
 				B2E97FB22914CC4500AFD558 /* MSIDBrokerNativeAppOperationResponseTests.m */,
 				2318D7882E12B8E800A5A46E /* MSIDBrokerOperationBrowserNativeMessageMATSReportTests.m */,
@@ -6985,6 +6999,8 @@
 				23AE20982342D3BF00108F76 /* MSIDSilentController+Internal.h in Headers */,
 				72C1EBF52DE91AC8004C40A4 /* MSIDBoundRefreshToken.h in Headers */,
 				BA000000000000000000C001 /* MSIDBoundTokenProvider.h in Headers */,
+				BA000000000000000000F001 /* MSIDSPATokenAcquiring.h in Headers */,
+				BA000000000000000000F002 /* MSIDLocalSPATokenAcquirer.h in Headers */,
 				23B39A8620993572000AA905 /* MSIDAADAuthorityMetadataRequest.h in Headers */,
 				B28D90AA218FD1F800E230D6 /* MSIDDefaultTokenResponseValidator.h in Headers */,
 				B2F671E82467A34400649855 /* MSIDAuthorizationCodeResult.h in Headers */,
@@ -7739,6 +7755,7 @@
 				72C764FA2E09CFB800043AB1 /* MSIDBoundRefreshTokenTests.m in Sources */,
 				FA7200020000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m in Sources */,
 				BA000000000000000000D101 /* MSIDBoundTokenProviderTests.m in Sources */,
+				BA000000000000000000F007 /* MSIDLocalSPATokenAcquirerTests.m in Sources */,
 				B2BE923121A0EFB100F5AB8C /* MSIDDefaultTokenRequestProviderTests.m in Sources */,
 				729357F42DDBD3F80001D03C /* MSIDNonceTokenRequestTest.m in Sources */,
 				23FB5C20225516FB002BF1EB /* MSIDClaimsRequestTests.m in Sources */,
@@ -7999,6 +8016,7 @@
 				23FB5C3122551866002BF1EB /* MSIDClaimsRequest+ClientCapabilities.m in Sources */,
 				72C1EBF72DE91AD0004C40A4 /* MSIDBoundRefreshToken.m in Sources */,
 				BA000000000000000000C002 /* MSIDBoundTokenProvider.m in Sources */,
+				BA000000000000000000F005 /* MSIDLocalSPATokenAcquirer.m in Sources */,
 				23B39ACD209CF317000AA905 /* MSIDAADNetworkConfiguration.m in Sources */,
 				B5AAE11A2F03D7AA0026B21B /* MSIDBrokerOperationGetDefaultAccountResponse.m in Sources */,
 				23FB5C462255A135002BF1EB /* MSIDIndividualClaimRequest.m in Sources */,
@@ -8501,6 +8519,7 @@
 				72C764F92E09CFB800043AB1 /* MSIDBoundRefreshTokenTests.m in Sources */,
 				FA7200010000000000000001 /* MSIDDefaultSilentTokenRequestBoundRefreshTokenTests.m in Sources */,
 				BA000000000000000000D102 /* MSIDBoundTokenProviderTests.m in Sources */,
+				BA000000000000000000F008 /* MSIDLocalSPATokenAcquirerTests.m in Sources */,
 				23FB5C21225516FB002BF1EB /* MSIDClaimsRequestTests.m in Sources */,
 				E75DD02625D5E474007664A6 /* MSIDThrottlingServiceIntegrationTests.m in Sources */,
 				B286BA07238A110A007833AD /* MSIDOIDCSignoutRequestTests.m in Sources */,
@@ -9012,6 +9031,7 @@
 				B2C708182195283500D917B8 /* MSIDBrokerTokenRequest.m in Sources */,
 				72C1EBF82DE91AD0004C40A4 /* MSIDBoundRefreshToken.m in Sources */,
 				BA000000000000000000C003 /* MSIDBoundTokenProvider.m in Sources */,
+				BA000000000000000000F006 /* MSIDLocalSPATokenAcquirer.m in Sources */,
 				232173E22182A998009852C6 /* NSDictionary+MSIDJsonSerializable.m in Sources */,
 				B2C707F42192524700D917B8 /* MSIDDefaultTokenRequestProvider.m in Sources */,
 				724C9E332E6FAB170039BAA0 /* MSIDConcatKdfProvider.swift in Sources */,

--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -2113,12 +2113,14 @@
 		BA000000000000000000C003 /* MSIDBoundTokenProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000B002 /* MSIDBoundTokenProvider.m */; };
 		BA000000000000000000D101 /* MSIDBoundTokenProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000D001 /* MSIDBoundTokenProviderTests.m */; };
 		BA000000000000000000D102 /* MSIDBoundTokenProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000D001 /* MSIDBoundTokenProviderTests.m */; };
-		BA000000000000000000F001 /* MSIDSPATokenAcquiring.h in Headers */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E001 /* MSIDSPATokenAcquiring.h */; };
 		BA000000000000000000F002 /* MSIDLocalSPATokenAcquirer.h in Headers */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E003 /* MSIDLocalSPATokenAcquirer.h */; };
 		BA000000000000000000F005 /* MSIDLocalSPATokenAcquirer.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E004 /* MSIDLocalSPATokenAcquirer.m */; };
 		BA000000000000000000F006 /* MSIDLocalSPATokenAcquirer.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E004 /* MSIDLocalSPATokenAcquirer.m */; };
 		BA000000000000000000F007 /* MSIDLocalSPATokenAcquirerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E005 /* MSIDLocalSPATokenAcquirerTests.m */; };
 		BA000000000000000000F008 /* MSIDLocalSPATokenAcquirerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E005 /* MSIDLocalSPATokenAcquirerTests.m */; };
+		BA000000000000000000F009 /* MSIDSPATokenAcquisitionResult.h in Headers */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E006 /* MSIDSPATokenAcquisitionResult.h */; };
+		BA000000000000000000F010 /* MSIDSPATokenAcquisitionResult.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E007 /* MSIDSPATokenAcquisitionResult.m */; };
+		BA000000000000000000F011 /* MSIDSPATokenAcquisitionResult.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E007 /* MSIDSPATokenAcquisitionResult.m */; };
 		C2E599251DB14C46D8DD6261 /* MSIDDIContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 30CDFCBD388F4440556637F9 /* MSIDDIContainer.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		C69BEEDD552FAEE33A6BE2FF /* MSIDCertAuthHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E83F7EE40617833162571023 /* MSIDCertAuthHandlerTests.m */; };
 		D11DF760D8901DDC5186BC7A /* MSIDDIContainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E356C396133919B12FB4F01 /* MSIDDIContainerTests.m */; };
@@ -3768,10 +3770,11 @@
 		BA000000000000000000B001 /* MSIDBoundTokenProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDBoundTokenProvider.h; sourceTree = "<group>"; };
 		BA000000000000000000B002 /* MSIDBoundTokenProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBoundTokenProvider.m; sourceTree = "<group>"; };
 		BA000000000000000000D001 /* MSIDBoundTokenProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDBoundTokenProviderTests.m; sourceTree = "<group>"; };
-		BA000000000000000000E001 /* MSIDSPATokenAcquiring.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSPATokenAcquiring.h; sourceTree = "<group>"; };
 		BA000000000000000000E003 /* MSIDLocalSPATokenAcquirer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDLocalSPATokenAcquirer.h; sourceTree = "<group>"; };
 		BA000000000000000000E004 /* MSIDLocalSPATokenAcquirer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLocalSPATokenAcquirer.m; sourceTree = "<group>"; };
 		BA000000000000000000E005 /* MSIDLocalSPATokenAcquirerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLocalSPATokenAcquirerTests.m; sourceTree = "<group>"; };
+		BA000000000000000000E006 /* MSIDSPATokenAcquisitionResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSPATokenAcquisitionResult.h; sourceTree = "<group>"; };
+		BA000000000000000000E007 /* MSIDSPATokenAcquisitionResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSPATokenAcquisitionResult.m; sourceTree = "<group>"; };
 		CACE5D66E6234506B9936BC5 /* MSIDThrottlingRefreshing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingRefreshing.h; sourceTree = "<group>"; };
 		D626000F1FBD380500EE4487 /* NSString+MSIDExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+MSIDExtensions.m"; sourceTree = "<group>"; };
 		D62600101FBD380500EE4487 /* NSDictionary+MSIDExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+MSIDExtensions.h"; sourceTree = "<group>"; };
@@ -5405,7 +5408,8 @@
 				72C1EBF42DE91ABE004C40A4 /* MSIDBoundRefreshToken.h */,
 				BA000000000000000000B002 /* MSIDBoundTokenProvider.m */,
 				BA000000000000000000B001 /* MSIDBoundTokenProvider.h */,
-				BA000000000000000000E001 /* MSIDSPATokenAcquiring.h */,
+				BA000000000000000000E006 /* MSIDSPATokenAcquisitionResult.h */,
+				BA000000000000000000E007 /* MSIDSPATokenAcquisitionResult.m */,
 				BA000000000000000000E003 /* MSIDLocalSPATokenAcquirer.h */,
 				BA000000000000000000E004 /* MSIDLocalSPATokenAcquirer.m */,
 				B2675689228CE6FC000F01D7 /* protocols */,
@@ -6999,7 +7003,7 @@
 				23AE20982342D3BF00108F76 /* MSIDSilentController+Internal.h in Headers */,
 				72C1EBF52DE91AC8004C40A4 /* MSIDBoundRefreshToken.h in Headers */,
 				BA000000000000000000C001 /* MSIDBoundTokenProvider.h in Headers */,
-				BA000000000000000000F001 /* MSIDSPATokenAcquiring.h in Headers */,
+				BA000000000000000000F009 /* MSIDSPATokenAcquisitionResult.h in Headers */,
 				BA000000000000000000F002 /* MSIDLocalSPATokenAcquirer.h in Headers */,
 				23B39A8620993572000AA905 /* MSIDAADAuthorityMetadataRequest.h in Headers */,
 				B28D90AA218FD1F800E230D6 /* MSIDDefaultTokenResponseValidator.h in Headers */,
@@ -8017,6 +8021,7 @@
 				72C1EBF72DE91AD0004C40A4 /* MSIDBoundRefreshToken.m in Sources */,
 				BA000000000000000000C002 /* MSIDBoundTokenProvider.m in Sources */,
 				BA000000000000000000F005 /* MSIDLocalSPATokenAcquirer.m in Sources */,
+				BA000000000000000000F010 /* MSIDSPATokenAcquisitionResult.m in Sources */,
 				23B39ACD209CF317000AA905 /* MSIDAADNetworkConfiguration.m in Sources */,
 				B5AAE11A2F03D7AA0026B21B /* MSIDBrokerOperationGetDefaultAccountResponse.m in Sources */,
 				23FB5C462255A135002BF1EB /* MSIDIndividualClaimRequest.m in Sources */,
@@ -9032,6 +9037,7 @@
 				72C1EBF82DE91AD0004C40A4 /* MSIDBoundRefreshToken.m in Sources */,
 				BA000000000000000000C003 /* MSIDBoundTokenProvider.m in Sources */,
 				BA000000000000000000F006 /* MSIDLocalSPATokenAcquirer.m in Sources */,
+				BA000000000000000000F011 /* MSIDSPATokenAcquisitionResult.m in Sources */,
 				232173E22182A998009852C6 /* NSDictionary+MSIDJsonSerializable.m in Sources */,
 				B2C707F42192524700D917B8 /* MSIDDefaultTokenRequestProvider.m in Sources */,
 				724C9E332E6FAB170039BAA0 /* MSIDConcatKdfProvider.swift in Sources */,

--- a/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.h
+++ b/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.h
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "MSIDSPATokenAcquiring.h"
+
+@class MSIDDefaultSilentTokenRequest;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef MSIDDefaultSilentTokenRequest *_Nullable (^MSIDLocalSPASilentTokenRequestProvider)(
+    MSIDInteractiveTokenRequestParameters *parameters,
+    id<MSIDRequestContext> _Nullable context);
+
+/// In-process SPA token acquisition backed by the shared ADAL keychain cache.
+@interface MSIDLocalSPATokenAcquirer : NSObject <MSIDSPATokenAcquiring>
+
+- (instancetype)init;
+
+- (instancetype)initWithSilentTokenRequestProvider:(nullable MSIDLocalSPASilentTokenRequestProvider)silentTokenRequestProvider NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.h
+++ b/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.h
@@ -23,22 +23,34 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "MSIDSPATokenAcquiring.h"
+#import "MSIDSPATokenAcquisitionResult.h"
 
 @class MSIDDefaultSilentTokenRequest;
+@class MSIDInteractiveTokenRequestParameters;
+@class MSIDBrowserNativeMessageGetTokenRequest;
+@protocol MSIDRequestContext;
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^MSIDLocalSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResult *_Nullable result,
+                                                          NSError *_Nullable error);
 typedef MSIDDefaultSilentTokenRequest *_Nullable (^MSIDLocalSPASilentTokenRequestProvider)(
-    MSIDInteractiveTokenRequestParameters *parameters,
-    id<MSIDRequestContext> _Nullable context);
+    MSIDInteractiveTokenRequestParameters *parameters, id<MSIDRequestContext> _Nullable context);
 
-/// In-process SPA token acquisition backed by the shared ADAL keychain cache.
-@interface MSIDLocalSPATokenAcquirer : NSObject <MSIDSPATokenAcquiring>
+@interface MSIDLocalSPATokenAcquirer : NSObject
 
 - (instancetype)init;
 
 - (instancetype)initWithSilentTokenRequestProvider:(nullable MSIDLocalSPASilentTokenRequestProvider)silentTokenRequestProvider NS_DESIGNATED_INITIALIZER;
+
+- (nullable MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                                                                        context:(nullable id<MSIDRequestContext>)context
+                                                                          error:(NSError *_Nullable *_Nullable)error;
+
+- (void)acquireSilentWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
+                            request:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                            context:(nullable id<MSIDRequestContext>)context
+                    completionBlock:(MSIDLocalSPATokenAcquirerCompletionBlock)completionBlock;
 
 @end
 

--- a/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.m
+++ b/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.m
@@ -1,0 +1,185 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDLocalSPATokenAcquirer.h"
+#import "MSIDBrowserNativeMessageGetTokenRequest.h"
+#import "MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetToken.h"
+#import "MSIDInteractiveTokenRequestParameters.h"
+#import "MSIDConstants.h"
+#import "MSIDError.h"
+#import "MSIDLogger+Internal.h"
+#import "MSIDDefaultSilentTokenRequest.h"
+#import "MSIDDefaultTokenCacheAccessor.h"
+#import "MSIDAccountMetadataCacheAccessor.h"
+#import "MSIDAADV2Oauth2Factory.h"
+#import "MSIDTokenResponseValidator.h"
+#import "MSIDTokenResult.h"
+#import "MSIDAccount.h"
+
+#if TARGET_OS_IPHONE
+#import "MSIDKeychainTokenCache.h"
+#import "MSIDLegacyTokenCacheAccessor.h"
+#endif
+
+static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPATokenAcquirer]";
+
+@interface MSIDLocalSPATokenAcquirer ()
+
+@property (nonatomic, copy, nullable) MSIDLocalSPASilentTokenRequestProvider silentTokenRequestProvider;
+
+@end
+
+@implementation MSIDSPATokenAcquisitionResult
+
+@end
+
+@implementation MSIDLocalSPATokenAcquirer
+
+- (instancetype)init
+{
+    return [self initWithSilentTokenRequestProvider:nil];
+}
+
+- (instancetype)initWithSilentTokenRequestProvider:(MSIDLocalSPASilentTokenRequestProvider)silentTokenRequestProvider
+{
+    self = [super init];
+    if (self)
+    {
+        _silentTokenRequestProvider = [silentTokenRequestProvider copy];
+    }
+    return self;
+}
+
+#pragma mark - MSIDSPATokenAcquiring
+
+- (MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                                                               context:(id<MSIDRequestContext>)context
+                                                                 error:(NSError *__autoreleasing *)error
+{
+    return [MSIDInteractiveTokenRequestParameters msidParametersWithGetTokenRequest:request
+                                                                       requestType:MSIDRequestBrokeredType
+                                                     boundAppRefreshTokenRequested:YES
+                                                             correlationIdOverride:context.correlationId
+                                                                             error:error];
+}
+
+- (void)acquireSilentWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
+                            request:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                            context:(id<MSIDRequestContext>)context
+                    completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock
+{
+    MSIDDefaultSilentTokenRequest *silentRequest = self.silentTokenRequestProvider
+        ? self.silentTokenRequestProvider(parameters, context)
+        : [self silentTokenRequestWithParameters:parameters context:context];
+    if (!silentRequest)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"%@ Token cache unavailable; user interaction is required.", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX);
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired,
+                                         @"Token cache is unavailable; user interaction is required.",
+                                         nil, nil, nil, context.correlationId, nil, YES);
+        completionBlock(nil, error);
+        return;
+    }
+
+    silentRequest.requiresBoundRefreshToken = YES;
+
+    // Retain the request until its asynchronous completion runs.
+    __block MSIDDefaultSilentTokenRequest *pendingRequest = silentRequest;
+    [silentRequest executeRequestWithCompletion:^(MSIDTokenResult *result, NSError *error) {
+        pendingRequest = nil;
+
+        if (result)
+        {
+            MSIDSPATokenAcquisitionResult *outcome = [MSIDSPATokenAcquisitionResult new];
+            outcome.tokenResult = result;
+            outcome.fallbackRequestAccountUpn = result.account.username ?: request.loginHint;
+            completionBlock(outcome, nil);
+            return;
+        }
+
+        completionBlock(nil, error);
+    }];
+}
+
+- (MSIDDefaultSilentTokenRequest *)silentTokenRequestWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
+                                                           context:(id<MSIDRequestContext>)context
+{
+    MSIDDefaultTokenCacheAccessor *tokenCache = [self defaultTokenCache:context];
+    MSIDAccountMetadataCacheAccessor *accountMetadataCache = [self accountMetadataCache:context];
+    if (!tokenCache || !accountMetadataCache)
+    {
+        return nil;
+    }
+
+    MSIDAADV2Oauth2Factory *oauthFactory = [MSIDAADV2Oauth2Factory new];
+    MSIDTokenResponseValidator *tokenResponseValidator = [MSIDTokenResponseValidator new];
+
+    return [[MSIDDefaultSilentTokenRequest alloc] initWithRequestParameters:parameters
+                                                              forceRefresh:NO
+                                                              oauthFactory:oauthFactory
+                                                    tokenResponseValidator:tokenResponseValidator
+                                                                tokenCache:tokenCache
+                                                      accountMetadataCache:accountMetadataCache];
+}
+
+#pragma mark - Dependencies
+
+- (MSIDDefaultTokenCacheAccessor *)defaultTokenCache:(id<MSIDRequestContext>)context
+{
+#if TARGET_OS_IPHONE
+    NSError *dataSourceError = nil;
+    MSIDKeychainTokenCache *dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:[MSIDKeychainTokenCache defaultKeychainGroup] error:&dataSourceError];
+    if (!dataSource)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"%@ Failed to initialize keychain token cache: %@", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX, MSID_PII_LOG_MASKABLE(dataSourceError));
+        return nil;
+    }
+
+    MSIDLegacyTokenCacheAccessor *otherAccessor = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:nil];
+    return [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:@[otherAccessor]];
+#else
+    MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"%@ Local SPA token cache is only supported on iOS.", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX);
+    return nil;
+#endif
+}
+
+- (MSIDAccountMetadataCacheAccessor *)accountMetadataCache:(id<MSIDRequestContext>)context
+{
+#if TARGET_OS_IPHONE
+    NSError *dataSourceError = nil;
+    MSIDKeychainTokenCache *dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:[MSIDKeychainTokenCache defaultKeychainGroup] error:&dataSourceError];
+    if (!dataSource)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"%@ Failed to initialize account metadata cache: %@", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX, MSID_PII_LOG_MASKABLE(dataSourceError));
+        return nil;
+    }
+
+    return [[MSIDAccountMetadataCacheAccessor alloc] initWithDataSource:dataSource];
+#else
+    MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"%@ Local SPA account metadata cache is only supported on iOS.", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX);
+    return nil;
+#endif
+}
+
+@end

--- a/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.m
+++ b/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.m
@@ -25,8 +25,6 @@
 #import "MSIDLocalSPATokenAcquirer.h"
 #import "MSIDBrowserNativeMessageGetTokenRequest.h"
 #import "MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetToken.h"
-#import "MSIDInteractiveTokenRequestParameters.h"
-#import "MSIDConstants.h"
 #import "MSIDError.h"
 #import "MSIDLogger+Internal.h"
 #import "MSIDDefaultSilentTokenRequest.h"
@@ -36,6 +34,7 @@
 #import "MSIDTokenResponseValidator.h"
 #import "MSIDTokenResult.h"
 #import "MSIDAccount.h"
+#import "NSError+MSIDExtensions.h"
 
 #if TARGET_OS_IPHONE
 #import "MSIDKeychainTokenCache.h"
@@ -50,10 +49,6 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
 
 @end
 
-@implementation MSIDSPATokenAcquisitionResult
-
-@end
-
 @implementation MSIDLocalSPATokenAcquirer
 
 - (instancetype)init
@@ -61,7 +56,7 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
     return [self initWithSilentTokenRequestProvider:nil];
 }
 
-- (instancetype)initWithSilentTokenRequestProvider:(MSIDLocalSPASilentTokenRequestProvider)silentTokenRequestProvider
+- (instancetype)initWithSilentTokenRequestProvider:(nullable MSIDLocalSPASilentTokenRequestProvider)silentTokenRequestProvider
 {
     self = [super init];
     if (self)
@@ -71,11 +66,9 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
     return self;
 }
 
-#pragma mark - MSIDSPATokenAcquiring
-
-- (MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
-                                                               context:(id<MSIDRequestContext>)context
-                                                                 error:(NSError *__autoreleasing *)error
+- (nullable MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                                                                        context:(nullable id<MSIDRequestContext>)context
+                                                                          error:(NSError *_Nullable __autoreleasing *_Nullable)error
 {
     return [MSIDInteractiveTokenRequestParameters msidParametersWithGetTokenRequest:request
                                                                        requestType:MSIDRequestBrokeredType
@@ -86,8 +79,8 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
 
 - (void)acquireSilentWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
                             request:(MSIDBrowserNativeMessageGetTokenRequest *)request
-                            context:(id<MSIDRequestContext>)context
-                    completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock
+                            context:(nullable id<MSIDRequestContext>)context
+                    completionBlock:(MSIDLocalSPATokenAcquirerCompletionBlock)completionBlock
 {
     MSIDDefaultSilentTokenRequest *silentRequest = self.silentTokenRequestProvider
         ? self.silentTokenRequestProvider(parameters, context)
@@ -101,13 +94,11 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
         completionBlock(nil, error);
         return;
     }
-
     silentRequest.requiresBoundRefreshToken = YES;
 
-    // Retain the request until its asynchronous completion runs.
-    __block MSIDDefaultSilentTokenRequest *pendingRequest = silentRequest;
     [silentRequest executeRequestWithCompletion:^(MSIDTokenResult *result, NSError *error) {
-        pendingRequest = nil;
+        // Keep the request alive until its completion finishes.
+        (void)silentRequest;
 
         if (result)
         {
@@ -118,17 +109,44 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
             return;
         }
 
+        if ([error.domain isEqualToString:MSIDErrorDomain]
+            && error.code == MSIDErrorBoundAppRefreshTokenRedemptionError)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"%@ App-specific BART redemption failed; user interaction is required.", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX);
+            NSError *interactionRequiredError =
+            MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired,
+                            @"App-specific bound refresh token redemption failed; user interaction is required.",
+                            error.msidOauthError, error.msidSubError, error, context.correlationId, nil, YES);
+            completionBlock(nil, interactionRequiredError);
+            return;
+        }
+
         completionBlock(nil, error);
     }];
 }
 
-- (MSIDDefaultSilentTokenRequest *)silentTokenRequestWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
-                                                           context:(id<MSIDRequestContext>)context
+- (nullable MSIDDefaultSilentTokenRequest *)silentTokenRequestWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
+                                                                     context:(nullable id<MSIDRequestContext>)context
 {
-    MSIDDefaultTokenCacheAccessor *tokenCache = [self defaultTokenCache:context];
-    MSIDAccountMetadataCacheAccessor *accountMetadataCache = [self accountMetadataCache:context];
+#if TARGET_OS_IPHONE
+    NSError *dataSourceError = nil;
+    MSIDKeychainTokenCache *dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:[MSIDKeychainTokenCache defaultKeychainGroup]
+                                                                               error:&dataSourceError];
+    if (!dataSource)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"%@ Failed to initialize the shared ADAL keychain cache: %@", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX, MSID_PII_LOG_MASKABLE(dataSourceError));
+        return nil;
+    }
+
+    MSIDLegacyTokenCacheAccessor *otherAccessor =
+    [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:nil];
+    MSIDDefaultTokenCacheAccessor *tokenCache =
+    [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:@[otherAccessor]];
+    MSIDAccountMetadataCacheAccessor *accountMetadataCache =
+    [[MSIDAccountMetadataCacheAccessor alloc] initWithDataSource:dataSource];
     if (!tokenCache || !accountMetadataCache)
     {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"%@ Failed to initialize local SPA token cache accessors.", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX);
         return nil;
     }
 
@@ -141,43 +159,8 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
                                                     tokenResponseValidator:tokenResponseValidator
                                                                 tokenCache:tokenCache
                                                       accountMetadataCache:accountMetadataCache];
-}
-
-#pragma mark - Dependencies
-
-- (MSIDDefaultTokenCacheAccessor *)defaultTokenCache:(id<MSIDRequestContext>)context
-{
-#if TARGET_OS_IPHONE
-    NSError *dataSourceError = nil;
-    MSIDKeychainTokenCache *dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:[MSIDKeychainTokenCache defaultKeychainGroup] error:&dataSourceError];
-    if (!dataSource)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"%@ Failed to initialize keychain token cache: %@", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX, MSID_PII_LOG_MASKABLE(dataSourceError));
-        return nil;
-    }
-
-    MSIDLegacyTokenCacheAccessor *otherAccessor = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:nil];
-    return [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:@[otherAccessor]];
 #else
     MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"%@ Local SPA token cache is only supported on iOS.", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX);
-    return nil;
-#endif
-}
-
-- (MSIDAccountMetadataCacheAccessor *)accountMetadataCache:(id<MSIDRequestContext>)context
-{
-#if TARGET_OS_IPHONE
-    NSError *dataSourceError = nil;
-    MSIDKeychainTokenCache *dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:[MSIDKeychainTokenCache defaultKeychainGroup] error:&dataSourceError];
-    if (!dataSource)
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"%@ Failed to initialize account metadata cache: %@", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX, MSID_PII_LOG_MASKABLE(dataSourceError));
-        return nil;
-    }
-
-    return [[MSIDAccountMetadataCacheAccessor alloc] initWithDataSource:dataSource];
-#else
-    MSID_LOG_WITH_CTX(MSIDLogLevelWarning, context, @"%@ Local SPA account metadata cache is only supported on iOS.", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX);
     return nil;
 #endif
 }

--- a/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
+++ b/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
@@ -1,0 +1,58 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@class MSIDInteractiveTokenRequestParameters;
+@class MSIDBrowserNativeMessageGetTokenRequest;
+@class MSIDTokenResult;
+@protocol MSIDRequestContext;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDSPATokenAcquisitionResult : NSObject
+
+@property (nonatomic, nullable) MSIDTokenResult *tokenResult;
+@property (nonatomic, nullable) NSString *fallbackRequestAccountUpn;
+
+@end
+
+typedef void (^MSIDSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResult *_Nullable result,
+                                                     NSError *_Nullable error);
+
+/// Backend-specific silent token acquisition used by the shared SPA provider.
+@protocol MSIDSPATokenAcquiring <NSObject>
+
+- (nullable MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                                                                        context:(nullable id<MSIDRequestContext>)context
+                                                                          error:(NSError *_Nullable *_Nullable)error;
+
+- (void)acquireSilentWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
+                           request:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                           context:(nullable id<MSIDRequestContext>)context
+                   completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/oauth2/token/MSIDSPATokenAcquisitionResult.h
+++ b/IdentityCore/src/oauth2/token/MSIDSPATokenAcquisitionResult.h
@@ -23,36 +23,11 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-
-@class MSIDInteractiveTokenRequestParameters;
-@class MSIDBrowserNativeMessageGetTokenRequest;
 @class MSIDTokenResult;
-@protocol MSIDRequestContext;
 
 NS_ASSUME_NONNULL_BEGIN
-
 @interface MSIDSPATokenAcquisitionResult : NSObject
-
 @property (nonatomic, nullable) MSIDTokenResult *tokenResult;
 @property (nonatomic, nullable) NSString *fallbackRequestAccountUpn;
-
 @end
-
-typedef void (^MSIDSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResult *_Nullable result,
-                                                     NSError *_Nullable error);
-
-/// Backend-specific silent token acquisition used by the shared SPA provider.
-@protocol MSIDSPATokenAcquiring <NSObject>
-
-- (nullable MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
-                                                                        context:(nullable id<MSIDRequestContext>)context
-                                                                          error:(NSError *_Nullable *_Nullable)error;
-
-- (void)acquireSilentWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
-                           request:(MSIDBrowserNativeMessageGetTokenRequest *)request
-                           context:(nullable id<MSIDRequestContext>)context
-                   completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock;
-
-@end
-
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/oauth2/token/MSIDSPATokenAcquisitionResult.m
+++ b/IdentityCore/src/oauth2/token/MSIDSPATokenAcquisitionResult.m
@@ -1,0 +1,28 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSIDSPATokenAcquisitionResult.h"
+
+@implementation MSIDSPATokenAcquisitionResult
+@end

--- a/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
+++ b/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
@@ -1,0 +1,169 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MSIDLocalSPATokenAcquirer.h"
+#import "MSIDBrowserNativeMessageGetTokenRequest.h"
+#import "MSIDInteractiveTokenRequestParameters.h"
+#import "MSIDAADAuthority.h"
+#import "MSIDAccountIdentifier.h"
+#import "MSIDDefaultSilentTokenRequest.h"
+#import "MSIDTokenResult.h"
+#import "MSIDAccount.h"
+#import "MSIDError.h"
+
+@interface MSIDLocalSPASilentRequestMock : MSIDDefaultSilentTokenRequest
+
+@property (nonatomic, nullable) MSIDTokenResult *result;
+@property (nonatomic, nullable) NSError *error;
+
+@end
+
+@implementation MSIDLocalSPASilentRequestMock
+
+- (void)executeRequestWithCompletion:(MSIDRequestCompletionBlock)completionBlock
+{
+    completionBlock(self.result, self.error);
+}
+
+@end
+
+@interface MSIDLocalSPATokenAcquirerTests : XCTestCase
+
+@property (nonatomic, nullable) MSIDLocalSPASilentRequestMock *silentRequest;
+
+@end
+
+@implementation MSIDLocalSPATokenAcquirerTests
+
+- (MSIDBrowserNativeMessageGetTokenRequest *)request
+{
+    MSIDBrowserNativeMessageGetTokenRequest *request = [MSIDBrowserNativeMessageGetTokenRequest new];
+    request.clientId = @"00000000-0000-0000-0000-000000000001";
+    request.redirectUri = @"brk-com.microsoft.test://auth";
+    request.authority = [[MSIDAADAuthority alloc] initWithURL:[NSURL URLWithString:@"https://login.microsoftonline.com/common"]
+                                                    rawTenant:nil
+                                                      context:nil
+                                                        error:nil];
+    request.scopes = @"user.read";
+    request.loginHint = @"user@contoso.com";
+    request.accountId = [[MSIDAccountIdentifier alloc] initWithDisplayableId:request.loginHint
+                                                              homeAccountId:@"uid.utid"];
+    return request;
+}
+
+- (MSIDLocalSPATokenAcquirer *)acquirerWithResult:(MSIDTokenResult *)result error:(NSError *)error
+{
+    return [[MSIDLocalSPATokenAcquirer alloc]
+            initWithSilentTokenRequestProvider:^MSIDDefaultSilentTokenRequest *(__unused MSIDInteractiveTokenRequestParameters *parameters,
+                                                                                __unused id<MSIDRequestContext> context) {
+        self.silentRequest = [MSIDLocalSPASilentRequestMock new];
+        self.silentRequest.result = result;
+        self.silentRequest.error = error;
+        return self.silentRequest;
+    }];
+}
+
+- (MSIDInteractiveTokenRequestParameters *)parametersWithAcquirer:(MSIDLocalSPATokenAcquirer *)acquirer
+{
+    NSError *error = nil;
+    MSIDInteractiveTokenRequestParameters *parameters =
+    [acquirer requestParametersForRequest:[self request] context:nil error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(parameters);
+    return parameters;
+}
+
+- (void)testRequestParametersForRequest_whenLocalBackend_shouldRequestAppBoundToken
+{
+    MSIDLocalSPATokenAcquirer *acquirer = [MSIDLocalSPATokenAcquirer new];
+    MSIDInteractiveTokenRequestParameters *parameters = [self parametersWithAcquirer:acquirer];
+
+    XCTAssertEqual(parameters.requestType, MSIDRequestBrokeredType);
+    XCTAssertTrue(parameters.isBoundAppRefreshTokenRequested);
+    XCTAssertEqualObjects(parameters.accountIdentifier.homeAccountId, @"uid.utid");
+}
+
+- (void)testAcquireSilent_whenEngineReturnsResult_shouldRequireBoundRefreshToken
+{
+    MSIDTokenResult *result = [MSIDTokenResult new];
+    result.account = [MSIDAccount new];
+    result.account.username = @"cached@contoso.com";
+
+    MSIDLocalSPATokenAcquirer *acquirer = [self acquirerWithResult:result error:nil];
+    __block MSIDSPATokenAcquisitionResult *outcome = nil;
+    __block NSError *acquisitionError = nil;
+
+    [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
+                                  request:[self request]
+                                  context:nil
+                          completionBlock:^(MSIDSPATokenAcquisitionResult *resultOutcome, NSError *error) {
+        outcome = resultOutcome;
+        acquisitionError = error;
+    }];
+
+    XCTAssertNil(acquisitionError);
+    XCTAssertEqual(outcome.tokenResult, result);
+    XCTAssertEqualObjects(outcome.fallbackRequestAccountUpn, @"cached@contoso.com");
+    XCTAssertTrue(self.silentRequest.requiresBoundRefreshToken);
+}
+
+- (void)testAcquireSilent_whenEngineFails_shouldReturnOriginalError
+{
+    NSError *engineError = MSIDCreateError(MSIDErrorDomain, MSIDErrorServerOauth,
+                                           @"Server rejected the request.", nil, nil, nil, nil, nil, NO);
+    MSIDLocalSPATokenAcquirer *acquirer = [self acquirerWithResult:nil error:engineError];
+    __block NSError *acquisitionError = nil;
+
+    [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
+                                  request:[self request]
+                                  context:nil
+                          completionBlock:^(__unused MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
+        acquisitionError = error;
+    }];
+
+    XCTAssertEqual(acquisitionError, engineError);
+}
+
+- (void)testAcquireSilent_whenCacheUnavailable_shouldReturnInteractionRequired
+{
+    MSIDLocalSPATokenAcquirer *acquirer = [[MSIDLocalSPATokenAcquirer alloc]
+        initWithSilentTokenRequestProvider:^MSIDDefaultSilentTokenRequest *(__unused MSIDInteractiveTokenRequestParameters *parameters,
+                                                                            __unused id<MSIDRequestContext> context) {
+        return nil;
+    }];
+    __block NSError *acquisitionError = nil;
+
+    [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
+                                  request:[self request]
+                                  context:nil
+                          completionBlock:^(__unused MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
+        acquisitionError = error;
+    }];
+
+    XCTAssertEqualObjects(acquisitionError.domain, MSIDErrorDomain);
+    XCTAssertEqual(acquisitionError.code, MSIDErrorInteractionRequired);
+}
+
+@end

--- a/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
+++ b/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
@@ -146,6 +146,25 @@
     XCTAssertEqual(acquisitionError, engineError);
 }
 
+- (void)testAcquireSilent_whenBARTRedemptionFails_shouldRequireInteractionWithoutRegularRTFallback
+{
+    NSError *bartError = MSIDCreateError(MSIDErrorDomain, MSIDErrorBoundAppRefreshTokenRedemptionError,
+                                         @"BART redemption failed.", nil, nil, nil, nil, nil, YES);
+    MSIDLocalSPATokenAcquirer *acquirer = [self acquirerWithResult:nil error:bartError];
+    __block NSError *acquisitionError = nil;
+
+    [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
+                                  request:[self request]
+                                  context:nil
+                          completionBlock:^(__unused MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
+        acquisitionError = error;
+    }];
+
+    XCTAssertEqualObjects(acquisitionError.domain, MSIDErrorDomain);
+    XCTAssertEqual(acquisitionError.code, MSIDErrorInteractionRequired);
+    XCTAssertEqual(acquisitionError.userInfo[NSUnderlyingErrorKey], bartError);
+}
+
 - (void)testAcquireSilent_whenCacheUnavailable_shouldReturnInteractionRequired
 {
     MSIDLocalSPATokenAcquirer *acquirer = [[MSIDLocalSPATokenAcquirer alloc]


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

This PR adds the local silent-acquisition backend for the unmanaged Browser Native Message SPA flow. It maps the incoming GetToken request to broker-compatible interactive parameters with BART requested, builds the silent engine over the shared ADAL keychain caches, requires an app-specific bound refresh token, and returns a normalized `MSIDTokenResult` outcome.

In the existing Broker flow, the SSO Extension owns this silent redemption. Unmanaged iOS Edge cannot invoke that extension, so OneAuth must perform the same cached BART redemption in-process through CommonCore. Keeping the engine and cache wiring in `MSIDLocalSPATokenAcquirer` allows the next provider-orchestration phase to share routing and response shaping without depending on Broker production code.

This phase intentionally contains only silent acquisition. Shared routing, interactive fallback orchestration, and serialized response construction remain outside this backend and will be wired by the final OneAuth-facing provider PR.

This is the fifth independently mergeable phase extracted from #1875. It builds on the request mapping and app-specific BART enforcement introduced in #1928 and #1929; its normalized result will be consumed by the response shaping introduced in #1930.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High - Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium - Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small - No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

- iOS: 5/5 focused local SPA acquisition tests passed.
- macOS: 5/5 focused local SPA acquisition tests passed.
- Coverage verifies broker-compatible BART parameters, app-specific bound refresh-token enforcement, normalized successful outcomes, hard-error propagation, BART-redemption routing to interaction without normal-RT fallback, and interaction-required behavior when the local silent engine is unavailable.

