### PR TITLE
[minor] [feature]: Orchestrate unmanaged BART SPA token acquisition

### DIFF
--- a/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
+++ b/IdentityCore/IdentityCore.xcodeproj/project.pbxproj
@@ -2121,6 +2121,7 @@
 		BA000000000000000000F009 /* MSIDSPATokenAcquisitionResult.h in Headers */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E006 /* MSIDSPATokenAcquisitionResult.h */; };
 		BA000000000000000000F010 /* MSIDSPATokenAcquisitionResult.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E007 /* MSIDSPATokenAcquisitionResult.m */; };
 		BA000000000000000000F011 /* MSIDSPATokenAcquisitionResult.m in Sources */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E007 /* MSIDSPATokenAcquisitionResult.m */; };
+		BA000000000000000000F012 /* MSIDSPATokenAcquiring.h in Headers */ = {isa = PBXBuildFile; fileRef = BA000000000000000000E008 /* MSIDSPATokenAcquiring.h */; };
 		C2E599251DB14C46D8DD6261 /* MSIDDIContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 30CDFCBD388F4440556637F9 /* MSIDDIContainer.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		C69BEEDD552FAEE33A6BE2FF /* MSIDCertAuthHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E83F7EE40617833162571023 /* MSIDCertAuthHandlerTests.m */; };
 		D11DF760D8901DDC5186BC7A /* MSIDDIContainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E356C396133919B12FB4F01 /* MSIDDIContainerTests.m */; };
@@ -3775,6 +3776,7 @@
 		BA000000000000000000E005 /* MSIDLocalSPATokenAcquirerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDLocalSPATokenAcquirerTests.m; sourceTree = "<group>"; };
 		BA000000000000000000E006 /* MSIDSPATokenAcquisitionResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSPATokenAcquisitionResult.h; sourceTree = "<group>"; };
 		BA000000000000000000E007 /* MSIDSPATokenAcquisitionResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDSPATokenAcquisitionResult.m; sourceTree = "<group>"; };
+		BA000000000000000000E008 /* MSIDSPATokenAcquiring.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDSPATokenAcquiring.h; sourceTree = "<group>"; };
 		CACE5D66E6234506B9936BC5 /* MSIDThrottlingRefreshing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIDThrottlingRefreshing.h; sourceTree = "<group>"; };
 		D626000F1FBD380500EE4487 /* NSString+MSIDExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+MSIDExtensions.m"; sourceTree = "<group>"; };
 		D62600101FBD380500EE4487 /* NSDictionary+MSIDExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+MSIDExtensions.h"; sourceTree = "<group>"; };
@@ -5410,6 +5412,7 @@
 				BA000000000000000000B001 /* MSIDBoundTokenProvider.h */,
 				BA000000000000000000E006 /* MSIDSPATokenAcquisitionResult.h */,
 				BA000000000000000000E007 /* MSIDSPATokenAcquisitionResult.m */,
+				BA000000000000000000E008 /* MSIDSPATokenAcquiring.h */,
 				BA000000000000000000E003 /* MSIDLocalSPATokenAcquirer.h */,
 				BA000000000000000000E004 /* MSIDLocalSPATokenAcquirer.m */,
 				B2675689228CE6FC000F01D7 /* protocols */,
@@ -7004,6 +7007,7 @@
 				72C1EBF52DE91AC8004C40A4 /* MSIDBoundRefreshToken.h in Headers */,
 				BA000000000000000000C001 /* MSIDBoundTokenProvider.h in Headers */,
 				BA000000000000000000F009 /* MSIDSPATokenAcquisitionResult.h in Headers */,
+				BA000000000000000000F012 /* MSIDSPATokenAcquiring.h in Headers */,
 				BA000000000000000000F002 /* MSIDLocalSPATokenAcquirer.h in Headers */,
 				23B39A8620993572000AA905 /* MSIDAADAuthorityMetadataRequest.h in Headers */,
 				B28D90AA218FD1F800E230D6 /* MSIDDefaultTokenResponseValidator.h in Headers */,

--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.h
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.h
@@ -24,6 +24,7 @@
 
 #import <Foundation/Foundation.h>
 #import "MSIDRequestContext.h"
+#import "MSIDSPATokenAcquiring.h"
 
 @class MSIDBrowserNativeMessageGetTokenRequest;
 
@@ -45,6 +46,10 @@ typedef void (^MSIDBoundTokenProviderCompletionBlock)(NSString *_Nullable respon
 ///   - silent path: redeems a cached BART SPA against ESTS in-process (no broker flip),
 ///   - interactive path: flips to the broker (Authenticator) via URL scheme to mint the initial token.
 @interface MSIDBoundTokenProvider : NSObject
+
+- (instancetype)init;
+
+- (instancetype)initWithAcquirer:(id<MSIDSPATokenAcquiring>)acquirer NS_DESIGNATED_INITIALIZER;
 
 /// Acquire a bound token for the supplied browser-native-message GetToken request.
 /// @param request The GetToken request constructed by the host (e.g. OneAuth).

--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.h
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.h
@@ -47,7 +47,6 @@ typedef void (^MSIDBoundTokenProviderCompletionBlock)(NSString *_Nullable respon
 ///   - interactive path: flips to the broker (Authenticator) via URL scheme to mint the initial token.
 @interface MSIDBoundTokenProvider : NSObject
 
-- (instancetype)init;
 - (instancetype)initWithAcquirer:(id<MSIDSPATokenAcquiring>)acquirer NS_DESIGNATED_INITIALIZER;
 
 /// Acquire a bound token for the supplied browser-native-message GetToken request.

--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.h
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.h
@@ -48,7 +48,6 @@ typedef void (^MSIDBoundTokenProviderCompletionBlock)(NSString *_Nullable respon
 @interface MSIDBoundTokenProvider : NSObject
 
 - (instancetype)init;
-
 - (instancetype)initWithAcquirer:(id<MSIDSPATokenAcquiring>)acquirer NS_DESIGNATED_INITIALIZER;
 
 /// Acquire a bound token for the supplied browser-native-message GetToken request.

--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
@@ -203,6 +203,10 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
 {
     if (route != MSIDBrowserNativeMessageGetTokenRouteInteractive)
     {
+        NSString *routeReason = route == MSIDBrowserNativeMessageGetTokenRouteUIBlocked ? @"canShowUI is NO" : @"prompt=none forbids UI";
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context,
+                          @"%@ Interactive fallback rejected. Route: %ld. Reason: %@. promptType: %ld, canShowUI: %@.",
+                          MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX, (long)route, routeReason, (long)parameters.promptType, request.canShowUI ? @"YES" : @"NO");
         NSError *error = interactionRequiredError
             ?: MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired,
                                @"Bound token acquisition requires user interaction.",

--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
@@ -198,10 +198,11 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context,
                           @"%@ Interactive fallback rejected. Route: %ld. Reason: %@. promptType: %ld, canShowUI: %@.",
                           MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX, (long)route, routeReason, (long)parameters.promptType, request.canShowUI ? @"YES" : @"NO");
-        NSError *error = interactionRequiredError
-            ?: MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired,
-                               @"Bound token acquisition requires user interaction.",
-                               nil, nil, nil, context.correlationId, nil, YES);
+        NSString *status = route == MSIDBrowserNativeMessageGetTokenRouteUIBlocked ? @"UI_NOT_ALLOWED" : @"USER_INTERACTION_REQUIRED";
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired,
+                                         route == MSIDBrowserNativeMessageGetTokenRouteUIBlocked ? @"User interaction is required, but showing UI is not allowed." : @"User interaction is required, but prompt=none forbids UI.",
+                                         nil, nil, interactionRequiredError, context.correlationId,
+                                         @{@"MSALBrowserNativeMessageErrorStatus": status}, YES);
         completionBlock(nil, error);
         return;
     }

--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
@@ -37,9 +37,7 @@
 NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider]";
 
 @interface MSIDBoundTokenProvider ()
-
 @property (nonatomic) id<MSIDSPATokenAcquiring> acquirer;
-
 @end
 
 @implementation MSIDBoundTokenProvider
@@ -70,12 +68,10 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
         MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"%@ completionBlock is nil.", MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX);
         return;
     }
-
     if (![self validateRequest:request context:context completionBlock:completionBlock])
     {
         return;
     }
-
     NSError *parametersError = nil;
     MSIDInteractiveTokenRequestParameters *parameters =
     [self.acquirer requestParametersForRequest:request context:context error:&parametersError];
@@ -88,7 +84,6 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
         completionBlock(nil, error);
         return;
     }
-
     MSIDBrowserNativeMessageGetTokenRoute route =
     [[self routingPolicy] routeWithForceInteractive:NO
                                          promptType:parameters.promptType
@@ -103,7 +98,6 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
                             completionBlock:completionBlock];
         return;
     }
-
     [self completeInteractiveRoute:route
                         parameters:parameters
                            request:request
@@ -135,7 +129,6 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
         completionBlock(nil, error);
         return NO;
     }
-
     if ([NSString msidIsStringNilOrBlank:request.clientId] ||
         [NSString msidIsStringNilOrBlank:request.redirectUri])
     {
@@ -145,7 +138,6 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
         completionBlock(nil, error);
         return NO;
     }
-
     return YES;
 }
 
@@ -167,7 +159,6 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
                       completionBlock:completionBlock];
             return;
         }
-
         BOOL interactionRequired = [error.domain isEqualToString:MSIDErrorDomain]
             && error.code == MSIDErrorInteractionRequired;
         if (interactionRequired)
@@ -186,7 +177,6 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
                   interactionRequiredError:error];
             return;
         }
-
         [self completeWithOutcome:nil
                             error:error
                           request:request
@@ -215,7 +205,6 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
         completionBlock(nil, error);
         return;
     }
-
     [self.acquirer acquireInteractiveWithParameters:parameters
                                             request:request
                                             context:context
@@ -239,43 +228,45 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
         NSError *completionError = error
             ?: MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal,
                                @"Bound token acquisition completed without a result or error.",
-                               nil, nil, nil, context.correlationId, nil, NO);
+                               nil, nil, nil, context.correlationId, nil, YES);
         completionBlock(nil, completionError);
         return;
     }
-
     NSString *fallbackUpn = outcome.fallbackRequestAccountUpn;
     if ([NSString msidIsStringNilOrBlank:fallbackUpn])
     {
         fallbackUpn = request.loginHint;
     }
-
     MSIDBrowserNativeMessageGetTokenResponse *response =
     [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResult:outcome.tokenResult
                                                                     state:request.state
                                                 fallbackRequestAccountUpn:fallbackUpn];
-    NSDictionary *responseDictionary = [response jsonDictionary];
-    if (!responseDictionary)
-    {
-        NSError *responseError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal,
-                                                 @"Failed to create bound token response.",
-                                                 nil, nil, nil, context.correlationId, nil, NO);
-        completionBlock(nil, responseError);
-        return;
-    }
-
+    NSDictionary *responseDictionary = response ? [response jsonDictionary] : nil;
     NSError *serializationError = nil;
-    NSData *data = [NSJSONSerialization dataWithJSONObject:responseDictionary options:0 error:&serializationError];
-    if (!data)
+    NSData *data = responseDictionary ? [NSJSONSerialization dataWithJSONObject:responseDictionary options:0 error:&serializationError] : nil;
+    NSString *responseString = data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : nil;
+    if (!responseString)
     {
-        NSError *responseError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal,
-                                                 @"Failed to serialize bound token response.",
-                                                 nil, nil, serializationError, context.correlationId, nil, NO);
+        NSString *description = @"Failed to encode bound token response.";
+        if (!response)
+        {
+            description = @"Failed to initialize bound token response.";
+        }
+        else if (!responseDictionary)
+        {
+            description = @"Failed to create bound token response.";
+        }
+        else if (!data)
+        {
+            description = @"Failed to serialize bound token response.";
+        }
+        NSError *responseError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, description,
+                                                 nil, nil, serializationError,
+                                                 context.correlationId, nil, YES);
         completionBlock(nil, responseError);
         return;
     }
-
-    completionBlock([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding], nil);
+    completionBlock(responseString, nil);
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
@@ -51,6 +51,7 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
 
 - (instancetype)initWithAcquirer:(id<MSIDSPATokenAcquiring>)acquirer
 {
+    NSParameterAssert(acquirer);
     self = [super init];
     if (self)
     {

--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
@@ -23,42 +23,104 @@
 // THE SOFTWARE.
 
 #import "MSIDBoundTokenProvider.h"
+#import "MSIDLocalSPATokenAcquirer.h"
 #import "MSIDBrowserNativeMessageGetTokenRequest.h"
+#import "MSIDBrowserNativeMessageGetTokenRoutingPolicy.h"
+#import "MSIDBrowserNativeMessageGetTokenResponse.h"
+#import "MSIDInteractiveTokenRequestParameters.h"
+#import "MSIDSPATokenAcquisitionResult.h"
+#import "MSIDDIContainer.h"
 #import "MSIDError.h"
 #import "MSIDLogger+Internal.h"
 #import "NSString+MSIDExtensions.h"
 
 NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider]";
 
+@interface MSIDBoundTokenProvider ()
+
+@property (nonatomic) id<MSIDSPATokenAcquiring> acquirer;
+
+@end
+
 @implementation MSIDBoundTokenProvider
+
+- (instancetype)init
+{
+    return [self initWithAcquirer:[MSIDLocalSPATokenAcquirer new]];
+}
+
+- (instancetype)initWithAcquirer:(id<MSIDSPATokenAcquiring>)acquirer
+{
+    self = [super init];
+    if (self)
+    {
+        _acquirer = acquirer;
+    }
+    return self;
+}
 
 - (void)acquireBoundTokenWithRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
                              context:(nullable id<MSIDRequestContext>)context
                      completionBlock:(MSIDBoundTokenProviderCompletionBlock)completionBlock
 {
     NSParameterAssert(completionBlock);
-    if (!completionBlock) return;
+    if (!completionBlock)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"%@ completionBlock is nil.", MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX);
+        return;
+    }
 
     if (![self validateRequest:request context:context completionBlock:completionBlock])
     {
         return;
     }
 
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context,
-                      @"%@ Servicing GetToken request in-process (no SSO extension). clientId: %@",
-                      MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX, request.clientId);
+    NSError *parametersError = nil;
+    MSIDInteractiveTokenRequestParameters *parameters =
+    [self.acquirer requestParametersForRequest:request context:context error:&parametersError];
+    if (!parameters)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, context, @"%@ Failed to build request parameters: %@", MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX, MSID_PII_LOG_MASKABLE(parametersError));
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter,
+                                         @"Failed to build bound token request parameters.",
+                                         nil, nil, parametersError, context.correlationId, nil, NO);
+        completionBlock(nil, error);
+        return;
+    }
 
-    // Stub seam: the real silent-redemption / interactive-broker-flip orchestration is layered on top of
-    // this provider. Returns the serialized browser-native-message response payload.
-    NSString *responsePayload = [self stubResponsePayloadForRequest:request];
+    MSIDBrowserNativeMessageGetTokenRoute route =
+    [[self routingPolicy] routeWithForceInteractive:NO
+                                         promptType:parameters.promptType
+                                          canShowUI:request.canShowUI
+                                  accountIdentifier:parameters.accountIdentifier
+                              requiresHomeAccountId:NO];
+    if (route == MSIDBrowserNativeMessageGetTokenRouteSilent)
+    {
+        [self acquireSilentlyWithParameters:parameters
+                                    request:request
+                                    context:context
+                            completionBlock:completionBlock];
+        return;
+    }
 
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context,
-                      @"%@ In-process GetToken request completed.", MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX);
-
-    completionBlock(responsePayload, nil);
+    [self completeInteractiveRoute:route
+                        parameters:parameters
+                           request:request
+                           context:context
+                   completionBlock:completionBlock
+          interactionRequiredError:nil];
 }
 
 #pragma mark - Private
+
+- (MSIDBrowserNativeMessageGetTokenRoutingPolicy *)routingPolicy
+{
+    return [[MSIDDIContainer sharedInstance]
+        resolveClass:MSIDBrowserNativeMessageGetTokenRoutingPolicy.class
+           orDefault:^id {
+               return [MSIDBrowserNativeMessageGetTokenRoutingPolicy new];
+           }];
+}
 
 - (BOOL)validateRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
                 context:(nullable id<MSIDRequestContext>)context
@@ -86,28 +148,129 @@ NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider
     return YES;
 }
 
-- (NSString *)stubResponsePayloadForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
+- (void)acquireSilentlyWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
+                              request:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                              context:(nullable id<MSIDRequestContext>)context
+                      completionBlock:(MSIDBoundTokenProviderCompletionBlock)completionBlock
 {
-    NSMutableDictionary *payload = [NSMutableDictionary new];
-    payload[@"clientId"] = request.clientId ?: @"";
-    payload[@"redirectUri"] = request.redirectUri ?: @"";
-    payload[@"scope"] = request.scopes ?: @"";
-    payload[@"servicedBy"] = @"MSIDBoundTokenProvider";
-    payload[@"transport"] = @"in_proc_common_core";
-    if (request.state)
+    [self.acquirer acquireSilentWithParameters:parameters
+                                       request:request
+                                       context:context
+                               completionBlock:^(MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
+        if (outcome)
+        {
+            [self completeWithOutcome:outcome
+                                error:nil
+                              request:request
+                              context:context
+                      completionBlock:completionBlock];
+            return;
+        }
+
+        BOOL interactionRequired = [error.domain isEqualToString:MSIDErrorDomain]
+            && error.code == MSIDErrorInteractionRequired;
+        if (interactionRequired)
+        {
+            MSIDBrowserNativeMessageGetTokenRoute route =
+            [[self routingPolicy] routeWithForceInteractive:YES
+                                                 promptType:parameters.promptType
+                                                  canShowUI:request.canShowUI
+                                          accountIdentifier:parameters.accountIdentifier
+                                      requiresHomeAccountId:NO];
+            [self completeInteractiveRoute:route
+                                parameters:parameters
+                                   request:request
+                                   context:context
+                           completionBlock:completionBlock
+                  interactionRequiredError:error];
+            return;
+        }
+
+        [self completeWithOutcome:nil
+                            error:error
+                          request:request
+                          context:context
+                  completionBlock:completionBlock];
+    }];
+}
+
+- (void)completeInteractiveRoute:(MSIDBrowserNativeMessageGetTokenRoute)route
+                      parameters:(MSIDInteractiveTokenRequestParameters *)parameters
+                         request:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                         context:(nullable id<MSIDRequestContext>)context
+                 completionBlock:(MSIDBoundTokenProviderCompletionBlock)completionBlock
+        interactionRequiredError:(nullable NSError *)interactionRequiredError
+{
+    if (route != MSIDBrowserNativeMessageGetTokenRouteInteractive)
     {
-        payload[@"state"] = request.state;
+        NSError *error = interactionRequiredError
+            ?: MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired,
+                               @"Bound token acquisition requires user interaction.",
+                               nil, nil, nil, context.correlationId, nil, YES);
+        completionBlock(nil, error);
+        return;
+    }
+
+    [self.acquirer acquireInteractiveWithParameters:parameters
+                                            request:request
+                                            context:context
+                                    completionBlock:^(MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
+        [self completeWithOutcome:outcome
+                            error:error
+                          request:request
+                          context:context
+                  completionBlock:completionBlock];
+    }];
+}
+
+- (void)completeWithOutcome:(MSIDSPATokenAcquisitionResult *)outcome
+                      error:(nullable NSError *)error
+                    request:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                    context:(nullable id<MSIDRequestContext>)context
+            completionBlock:(MSIDBoundTokenProviderCompletionBlock)completionBlock
+{
+    if (!outcome)
+    {
+        NSError *completionError = error
+            ?: MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal,
+                               @"Bound token acquisition completed without a result or error.",
+                               nil, nil, nil, context.correlationId, nil, NO);
+        completionBlock(nil, completionError);
+        return;
+    }
+
+    NSString *fallbackUpn = outcome.fallbackRequestAccountUpn;
+    if ([NSString msidIsStringNilOrBlank:fallbackUpn])
+    {
+        fallbackUpn = request.loginHint;
+    }
+
+    MSIDBrowserNativeMessageGetTokenResponse *response =
+    [[MSIDBrowserNativeMessageGetTokenResponse alloc] initWithTokenResult:outcome.tokenResult
+                                                                    state:request.state
+                                                fallbackRequestAccountUpn:fallbackUpn];
+    NSDictionary *responseDictionary = [response jsonDictionary];
+    if (!responseDictionary)
+    {
+        NSError *responseError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal,
+                                                 @"Failed to create bound token response.",
+                                                 nil, nil, nil, context.correlationId, nil, NO);
+        completionBlock(nil, responseError);
+        return;
     }
 
     NSError *serializationError = nil;
-    NSData *data = [NSJSONSerialization dataWithJSONObject:payload options:0 error:&serializationError];
-    if (serializationError || !data)
+    NSData *data = [NSJSONSerialization dataWithJSONObject:responseDictionary options:0 error:&serializationError];
+    if (!data)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"%@ Failed to serialize bound token payload: %@", MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX, serializationError);
-        return @"{}";
+        NSError *responseError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal,
+                                                 @"Failed to serialize bound token response.",
+                                                 nil, nil, serializationError, context.correlationId, nil, NO);
+        completionBlock(nil, responseError);
+        return;
     }
 
-    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    completionBlock([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding], nil);
 }
 
 @end

--- a/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.h
+++ b/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.h
@@ -33,13 +33,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^MSIDLocalSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResult *_Nullable result,
-                                                          NSError *_Nullable error);
 typedef MSIDDefaultSilentTokenRequest *_Nullable (^MSIDLocalSPASilentTokenRequestProvider)(
     MSIDInteractiveTokenRequestParameters *parameters, id<MSIDRequestContext> _Nullable context);
 
 @interface MSIDLocalSPATokenAcquirer : NSObject <MSIDSPATokenAcquiring>
-
 - (instancetype)init;
 
 - (instancetype)initWithSilentTokenRequestProvider:(nullable MSIDLocalSPASilentTokenRequestProvider)silentTokenRequestProvider NS_DESIGNATED_INITIALIZER;
@@ -51,7 +48,7 @@ typedef MSIDDefaultSilentTokenRequest *_Nullable (^MSIDLocalSPASilentTokenReques
 - (void)acquireSilentWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
                             request:(MSIDBrowserNativeMessageGetTokenRequest *)request
                             context:(nullable id<MSIDRequestContext>)context
-                    completionBlock:(MSIDLocalSPATokenAcquirerCompletionBlock)completionBlock;
+                    completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock;
 
 @end
 

--- a/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.m
+++ b/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.m
@@ -81,7 +81,7 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
 - (void)acquireSilentWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
                             request:(MSIDBrowserNativeMessageGetTokenRequest *)request
                             context:(nullable id<MSIDRequestContext>)context
-                    completionBlock:(MSIDLocalSPATokenAcquirerCompletionBlock)completionBlock
+                    completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock
 {
     MSIDDefaultSilentTokenRequest *silentRequest = self.silentTokenRequestProvider
         ? self.silentTokenRequestProvider(parameters, context)

--- a/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.m
+++ b/IdentityCore/src/oauth2/token/MSIDLocalSPATokenAcquirer.m
@@ -35,6 +35,7 @@
 #import "MSIDTokenResult.h"
 #import "MSIDAccount.h"
 #import "NSError+MSIDExtensions.h"
+#import "NSString+MSIDExtensions.h"
 
 #if TARGET_OS_IPHONE
 #import "MSIDKeychainTokenCache.h"
@@ -104,7 +105,8 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
         {
             MSIDSPATokenAcquisitionResult *outcome = [MSIDSPATokenAcquisitionResult new];
             outcome.tokenResult = result;
-            outcome.fallbackRequestAccountUpn = result.account.username ?: request.loginHint;
+            NSString *username = result.account.username;
+            outcome.fallbackRequestAccountUpn = [NSString msidIsStringNilOrBlank:username] ? request.loginHint : username;
             completionBlock(outcome, nil);
             return;
         }
@@ -123,6 +125,18 @@ static NSString *const MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX = @"[MSIDLocalSPAToken
 
         completionBlock(nil, error);
     }];
+}
+
+- (void)acquireInteractiveWithParameters:(__unused MSIDInteractiveTokenRequestParameters *)parameters
+                                request:(__unused MSIDBrowserNativeMessageGetTokenRequest *)request
+                                context:(nullable id<MSIDRequestContext>)context
+                        completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock
+{
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"%@ Interactive broker acquisition is not implemented.", MSID_LOCAL_SPA_ACQUIRER_LOG_PREFIX);
+    NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired,
+                                     @"Interactive broker acquisition is required but not implemented.",
+                                     nil, nil, nil, context.correlationId, nil, NO);
+    completionBlock(nil, error);
 }
 
 - (nullable MSIDDefaultSilentTokenRequest *)silentTokenRequestWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters

--- a/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
+++ b/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
@@ -23,13 +23,10 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-@class MSIDBrowserNativeMessageGetTokenRequest;
-@class MSIDInteractiveTokenRequestParameters;
-@class MSIDSPATokenAcquisitionResult;
+@class MSIDBrowserNativeMessageGetTokenRequest, MSIDInteractiveTokenRequestParameters, MSIDSPATokenAcquisitionResult;
 @protocol MSIDRequestContext;
 NS_ASSUME_NONNULL_BEGIN
-typedef void (^MSIDSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResult *_Nullable result,
-                                                     NSError *_Nullable error);
+typedef void (^MSIDSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResult *_Nullable result, NSError *_Nullable error);
 /// Completion blocks must be invoked exactly once and may run synchronously or asynchronously on an arbitrary queue.
 @protocol MSIDSPATokenAcquiring <NSObject>
 /// Returns nil only after populating error.

--- a/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
+++ b/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
@@ -34,16 +34,13 @@ typedef void (^MSIDSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResul
 - (nullable MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
                                                                         context:(nullable id<MSIDRequestContext>)context
                                                                           error:(NSError *_Nullable *_Nullable)error;
-
 - (void)acquireSilentWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
                             request:(MSIDBrowserNativeMessageGetTokenRequest *)request
                             context:(nullable id<MSIDRequestContext>)context
                     completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock;
-
 - (void)acquireInteractiveWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
                                 request:(MSIDBrowserNativeMessageGetTokenRequest *)request
                                 context:(nullable id<MSIDRequestContext>)context
                         completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock;
-
 @end
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
+++ b/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
@@ -30,7 +30,9 @@
 NS_ASSUME_NONNULL_BEGIN
 typedef void (^MSIDSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResult *_Nullable result,
                                                      NSError *_Nullable error);
+/// Completion blocks must be invoked exactly once and may run synchronously or asynchronously on an arbitrary queue.
 @protocol MSIDSPATokenAcquiring <NSObject>
+/// Returns nil only after populating error.
 - (nullable MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
                                                                         context:(nullable id<MSIDRequestContext>)context
                                                                           error:(NSError *_Nullable *_Nullable)error;

--- a/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
+++ b/IdentityCore/src/oauth2/token/MSIDSPATokenAcquiring.h
@@ -23,27 +23,14 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "MSIDSPATokenAcquisitionResult.h"
-#import "MSIDSPATokenAcquiring.h"
-
-@class MSIDDefaultSilentTokenRequest;
-@class MSIDInteractiveTokenRequestParameters;
 @class MSIDBrowserNativeMessageGetTokenRequest;
+@class MSIDInteractiveTokenRequestParameters;
+@class MSIDSPATokenAcquisitionResult;
 @protocol MSIDRequestContext;
-
 NS_ASSUME_NONNULL_BEGIN
-
-typedef void (^MSIDLocalSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResult *_Nullable result,
-                                                          NSError *_Nullable error);
-typedef MSIDDefaultSilentTokenRequest *_Nullable (^MSIDLocalSPASilentTokenRequestProvider)(
-    MSIDInteractiveTokenRequestParameters *parameters, id<MSIDRequestContext> _Nullable context);
-
-@interface MSIDLocalSPATokenAcquirer : NSObject <MSIDSPATokenAcquiring>
-
-- (instancetype)init;
-
-- (instancetype)initWithSilentTokenRequestProvider:(nullable MSIDLocalSPASilentTokenRequestProvider)silentTokenRequestProvider NS_DESIGNATED_INITIALIZER;
-
+typedef void (^MSIDSPATokenAcquirerCompletionBlock)(MSIDSPATokenAcquisitionResult *_Nullable result,
+                                                     NSError *_Nullable error);
+@protocol MSIDSPATokenAcquiring <NSObject>
 - (nullable MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
                                                                         context:(nullable id<MSIDRequestContext>)context
                                                                           error:(NSError *_Nullable *_Nullable)error;
@@ -51,8 +38,12 @@ typedef MSIDDefaultSilentTokenRequest *_Nullable (^MSIDLocalSPASilentTokenReques
 - (void)acquireSilentWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
                             request:(MSIDBrowserNativeMessageGetTokenRequest *)request
                             context:(nullable id<MSIDRequestContext>)context
-                    completionBlock:(MSIDLocalSPATokenAcquirerCompletionBlock)completionBlock;
+                    completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock;
+
+- (void)acquireInteractiveWithParameters:(MSIDInteractiveTokenRequestParameters *)parameters
+                                request:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                                context:(nullable id<MSIDRequestContext>)context
+                        completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock;
 
 @end
-
 NS_ASSUME_NONNULL_END

--- a/IdentityCore/tests/MSIDBoundTokenProviderTests.m
+++ b/IdentityCore/tests/MSIDBoundTokenProviderTests.m
@@ -37,8 +37,8 @@
 
 @interface MSIDSPATokenAcquirerMock : NSObject <MSIDSPATokenAcquiring>
 
-@property (nonatomic) BOOL silentCalled;
-@property (nonatomic) BOOL interactiveCalled;
+@property (nonatomic) NSUInteger silentCallCount;
+@property (nonatomic) NSUInteger interactiveCallCount;
 @property (nonatomic, nullable) NSError *parametersError;
 @property (nonatomic, nullable) MSIDSPATokenAcquisitionResult *silentOutcome;
 @property (nonatomic, nullable) NSError *silentError;
@@ -71,7 +71,7 @@
                             context:(nullable __unused id<MSIDRequestContext>)context
                     completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock
 {
-    self.silentCalled = YES;
+    self.silentCallCount++;
     completionBlock(self.silentOutcome, self.silentError);
 }
 
@@ -80,7 +80,7 @@
                                 context:(nullable __unused id<MSIDRequestContext>)context
                         completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock
 {
-    self.interactiveCalled = YES;
+    self.interactiveCallCount++;
     completionBlock(self.interactiveOutcome, self.interactiveError);
 }
 
@@ -116,16 +116,13 @@
     accessToken.accessToken = @"access-token";
     accessToken.tokenType = @"Bearer";
     accessToken.scopes = [NSOrderedSet orderedSetWithObject:@"user.read"];
-
     MSIDAccount *account = [MSIDAccount new];
     account.username = @"user@contoso.com";
     account.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:account.username
                                                                       homeAccountId:@"uid.utid"];
-
     MSIDTokenResult *tokenResult = [MSIDTokenResult new];
     tokenResult.accessToken = accessToken;
     tokenResult.account = account;
-
     MSIDSPATokenAcquisitionResult *outcome = [MSIDSPATokenAcquisitionResult new];
     outcome.tokenResult = tokenResult;
     outcome.fallbackRequestAccountUpn = account.username;
@@ -157,11 +154,10 @@
         response = result;
         responseError = error;
     }];
-
     NSDictionary *payload = [self payloadFromResponse:response];
     XCTAssertNil(responseError);
-    XCTAssertTrue(acquirer.silentCalled);
-    XCTAssertFalse(acquirer.interactiveCalled);
+    XCTAssertEqual(acquirer.silentCallCount, 1);
+    XCTAssertEqual(acquirer.interactiveCallCount, 0);
     XCTAssertEqualObjects(payload[@"access_token"], @"access-token");
     XCTAssertEqualObjects(payload[@"account"][@"userName"], @"user@contoso.com");
     XCTAssertEqualObjects(payload[@"state"], @"test-state");
@@ -180,9 +176,8 @@
                            completionBlock:^(NSString *result, __unused NSError *error) {
         response = result;
     }];
-
-    XCTAssertFalse(acquirer.silentCalled);
-    XCTAssertTrue(acquirer.interactiveCalled);
+    XCTAssertEqual(acquirer.silentCallCount, 0);
+    XCTAssertEqual(acquirer.interactiveCallCount, 1);
     XCTAssertEqualObjects([self payloadFromResponse:response][@"access_token"], @"access-token");
 }
 
@@ -199,9 +194,8 @@
                            completionBlock:^(NSString *result, __unused NSError *error) {
         response = result;
     }];
-
-    XCTAssertTrue(acquirer.silentCalled);
-    XCTAssertTrue(acquirer.interactiveCalled);
+    XCTAssertEqual(acquirer.silentCallCount, 1);
+    XCTAssertEqual(acquirer.interactiveCallCount, 1);
     XCTAssertNotNil(response);
 }
 
@@ -218,9 +212,8 @@
                            completionBlock:^(__unused NSString *result, NSError *error) {
         responseError = error;
     }];
-
-    XCTAssertFalse(acquirer.silentCalled);
-    XCTAssertFalse(acquirer.interactiveCalled);
+    XCTAssertEqual(acquirer.silentCallCount, 0);
+    XCTAssertEqual(acquirer.interactiveCallCount, 0);
     XCTAssertEqual(responseError.code, MSIDErrorInteractionRequired);
 }
 
@@ -237,9 +230,8 @@
                            completionBlock:^(__unused NSString *result, NSError *error) {
         responseError = error;
     }];
-
     XCTAssertEqual(responseError, silentError);
-    XCTAssertFalse(acquirer.interactiveCalled);
+    XCTAssertEqual(acquirer.interactiveCallCount, 0);
 }
 
 - (void)testAcquireBoundToken_whenParameterMappingFails_shouldReturnDeveloperError
@@ -254,7 +246,6 @@
                            completionBlock:^(__unused NSString *result, NSError *error) {
         responseError = error;
     }];
-
     XCTAssertEqual(responseError.code, MSIDErrorInvalidDeveloperParameter);
     XCTAssertEqual(responseError.userInfo[NSUnderlyingErrorKey], acquirer.parametersError);
 }
@@ -264,13 +255,11 @@
     MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:[MSIDSPATokenAcquirerMock new]];
     MSIDBrowserNativeMessageGetTokenRequest *nilRequest = nil;
     __block NSError *responseError = nil;
-
     [provider acquireBoundTokenWithRequest:nilRequest
                                    context:nil
                            completionBlock:^(__unused NSString *result, NSError *error) {
         responseError = error;
     }];
-
     XCTAssertEqual(responseError.code, MSIDErrorInvalidInternalParameter);
 }
 
@@ -280,13 +269,11 @@
     MSIDBrowserNativeMessageGetTokenRequest *request = [self validRequest];
     request.clientId = @"";
     __block NSError *responseError = nil;
-
     [provider acquireBoundTokenWithRequest:request
                                    context:nil
                            completionBlock:^(__unused NSString *result, NSError *error) {
         responseError = error;
     }];
-
     XCTAssertEqual(responseError.code, MSIDErrorInvalidDeveloperParameter);
 }
 
@@ -296,13 +283,11 @@
     MSIDBrowserNativeMessageGetTokenRequest *request = [self validRequest];
     request.redirectUri = @"";
     __block NSError *responseError = nil;
-
     [provider acquireBoundTokenWithRequest:request
                                    context:nil
                            completionBlock:^(__unused NSString *result, NSError *error) {
         responseError = error;
     }];
-
     XCTAssertEqual(responseError.code, MSIDErrorInvalidDeveloperParameter);
 }
 

--- a/IdentityCore/tests/MSIDBoundTokenProviderTests.m
+++ b/IdentityCore/tests/MSIDBoundTokenProviderTests.m
@@ -134,8 +134,14 @@
 
 - (NSDictionary *)payloadFromResponse:(NSString *)response
 {
+    XCTAssertNotNil(response);
     NSData *data = [response dataUsingEncoding:NSUTF8StringEncoding];
-    return [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    XCTAssertNotNil(data);
+    NSError *error = nil;
+    id payload = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:&error] : nil;
+    XCTAssertNotNil(payload, @"Failed to parse response JSON: %@", error);
+    XCTAssertTrue([payload isKindOfClass:NSDictionary.class]);
+    return [payload isKindOfClass:NSDictionary.class] ? payload : nil;
 }
 
 - (void)testAcquireBoundToken_whenSilentSucceeds_shouldReturnBrowserResponse
@@ -145,7 +151,6 @@
     MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
     __block NSString *response = nil;
     __block NSError *responseError = nil;
-
     [provider acquireBoundTokenWithRequest:[self validRequest]
                                    context:nil
                            completionBlock:^(NSString *result, NSError *error) {
@@ -170,7 +175,6 @@
     MSIDBrowserNativeMessageGetTokenRequest *request = [self validRequest];
     request.prompt = MSIDPromptTypeSelectAccount;
     __block NSString *response = nil;
-
     [provider acquireBoundTokenWithRequest:request
                                    context:nil
                            completionBlock:^(NSString *result, __unused NSError *error) {
@@ -190,7 +194,6 @@
     acquirer.interactiveOutcome = [self successfulOutcome];
     MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
     __block NSString *response = nil;
-
     [provider acquireBoundTokenWithRequest:[self validRequest]
                                    context:nil
                            completionBlock:^(NSString *result, __unused NSError *error) {
@@ -210,7 +213,6 @@
     request.prompt = MSIDPromptTypeSelectAccount;
     request.canShowUI = NO;
     __block NSError *responseError = nil;
-
     [provider acquireBoundTokenWithRequest:request
                                    context:nil
                            completionBlock:^(__unused NSString *result, NSError *error) {
@@ -230,7 +232,6 @@
     acquirer.silentError = silentError;
     MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
     __block NSError *responseError = nil;
-
     [provider acquireBoundTokenWithRequest:[self validRequest]
                                    context:nil
                            completionBlock:^(__unused NSString *result, NSError *error) {
@@ -248,7 +249,6 @@
                                                @"Mapping failed.", nil, nil, nil, nil, nil, NO);
     MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
     __block NSError *responseError = nil;
-
     [provider acquireBoundTokenWithRequest:[self validRequest]
                                    context:nil
                            completionBlock:^(__unused NSString *result, NSError *error) {

--- a/IdentityCore/tests/MSIDBoundTokenProviderTests.m
+++ b/IdentityCore/tests/MSIDBoundTokenProviderTests.m
@@ -25,128 +25,285 @@
 #import <XCTest/XCTest.h>
 #import "MSIDBoundTokenProvider.h"
 #import "MSIDBrowserNativeMessageGetTokenRequest.h"
+#import "MSIDInteractiveTokenRequestParameters+BrowserNativeMessageGetToken.h"
+#import "MSIDInteractiveTokenRequestParameters.h"
+#import "MSIDSPATokenAcquisitionResult.h"
+#import "MSIDTokenResult.h"
+#import "MSIDAccessToken.h"
+#import "MSIDAccount.h"
+#import "MSIDAccountIdentifier.h"
+#import "MSIDAADAuthority.h"
 #import "MSIDError.h"
 
-@interface MSIDBoundTokenProviderTests : XCTestCase
+@interface MSIDSPATokenAcquirerMock : NSObject <MSIDSPATokenAcquiring>
 
+@property (nonatomic) BOOL silentCalled;
+@property (nonatomic) BOOL interactiveCalled;
+@property (nonatomic, nullable) NSError *parametersError;
+@property (nonatomic, nullable) MSIDSPATokenAcquisitionResult *silentOutcome;
+@property (nonatomic, nullable) NSError *silentError;
+@property (nonatomic, nullable) MSIDSPATokenAcquisitionResult *interactiveOutcome;
+@property (nonatomic, nullable) NSError *interactiveError;
+
+@end
+
+@implementation MSIDSPATokenAcquirerMock
+
+- (nullable MSIDInteractiveTokenRequestParameters *)requestParametersForRequest:(MSIDBrowserNativeMessageGetTokenRequest *)request
+                                                                        context:(nullable id<MSIDRequestContext>)context
+                                                                          error:(NSError *_Nullable __autoreleasing *_Nullable)error
+{
+    if (self.parametersError)
+    {
+        if (error) *error = self.parametersError;
+        return nil;
+    }
+
+    return [MSIDInteractiveTokenRequestParameters msidParametersWithGetTokenRequest:request
+                                                                       requestType:MSIDRequestBrokeredType
+                                                     boundAppRefreshTokenRequested:YES
+                                                             correlationIdOverride:context.correlationId
+                                                                             error:error];
+}
+
+- (void)acquireSilentWithParameters:(__unused MSIDInteractiveTokenRequestParameters *)parameters
+                            request:(__unused MSIDBrowserNativeMessageGetTokenRequest *)request
+                            context:(nullable __unused id<MSIDRequestContext>)context
+                    completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock
+{
+    self.silentCalled = YES;
+    completionBlock(self.silentOutcome, self.silentError);
+}
+
+- (void)acquireInteractiveWithParameters:(__unused MSIDInteractiveTokenRequestParameters *)parameters
+                                request:(__unused MSIDBrowserNativeMessageGetTokenRequest *)request
+                                context:(nullable __unused id<MSIDRequestContext>)context
+                        completionBlock:(MSIDSPATokenAcquirerCompletionBlock)completionBlock
+{
+    self.interactiveCalled = YES;
+    completionBlock(self.interactiveOutcome, self.interactiveError);
+}
+
+@end
+
+@interface MSIDBoundTokenProviderTests : XCTestCase
 @end
 
 @implementation MSIDBoundTokenProviderTests
 
-// A production-shaped GetToken request built from the real MSIDBrowserNativeMessageGetTokenRequest properties.
 - (MSIDBrowserNativeMessageGetTokenRequest *)validRequest
 {
     MSIDBrowserNativeMessageGetTokenRequest *request = [MSIDBrowserNativeMessageGetTokenRequest new];
     request.clientId = @"00000000-0000-0000-0000-000000000001";
     request.redirectUri = @"brk-com.microsoft.test://auth";
+    request.authority = [[MSIDAADAuthority alloc] initWithURL:[NSURL URLWithString:@"https://login.microsoftonline.com/common"]
+                                                    rawTenant:nil
+                                                      context:nil
+                                                        error:nil];
     request.scopes = @"user.read";
     request.state = @"test-state";
     request.prompt = MSIDPromptTypeDefault;
     request.canShowUI = YES;
-    request.isSts = NO;
-    request.nonce = @"test-nonce";
     request.loginHint = @"user@contoso.com";
-    request.instanceAware = NO;
-    request.platformSequence = @"oneauth|1.2.3,msal|1.0.0";
-    request.extraParameters = @{ @"foo": @"bar" };
+    request.accountId = [[MSIDAccountIdentifier alloc] initWithDisplayableId:request.loginHint
+                                                              homeAccountId:@"uid.utid"];
     return request;
 }
 
-- (NSDictionary *)payloadDictionaryFromResponse:(NSString *)response
+- (MSIDSPATokenAcquisitionResult *)successfulOutcome
 {
-    NSData *data = [response dataUsingEncoding:NSUTF8StringEncoding];
-    XCTAssertNotNil(data);
+    MSIDAccessToken *accessToken = [MSIDAccessToken new];
+    accessToken.accessToken = @"access-token";
+    accessToken.tokenType = @"Bearer";
+    accessToken.scopes = [NSOrderedSet orderedSetWithObject:@"user.read"];
 
-    NSError *jsonError = nil;
-    NSDictionary *payload = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
-    XCTAssertNil(jsonError);
-    XCTAssertTrue([payload isKindOfClass:NSDictionary.class]);
+    MSIDAccount *account = [MSIDAccount new];
+    account.username = @"user@contoso.com";
+    account.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:account.username
+                                                                      homeAccountId:@"uid.utid"];
 
-    return payload;
+    MSIDTokenResult *tokenResult = [MSIDTokenResult new];
+    tokenResult.accessToken = accessToken;
+    tokenResult.account = account;
+
+    MSIDSPATokenAcquisitionResult *outcome = [MSIDSPATokenAcquisitionResult new];
+    outcome.tokenResult = tokenResult;
+    outcome.fallbackRequestAccountUpn = account.username;
+    return outcome;
 }
 
-// A GetToken request handed to the provider is serviced entirely in-process,
-// returning a payload, with no SSO extension / ASAuthorization involvement.
-- (void)testAcquireBoundToken_inProc_returnsPayload
+- (NSDictionary *)payloadFromResponse:(NSString *)response
 {
-    MSIDBoundTokenProvider *provider = [MSIDBoundTokenProvider new];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"in-proc completion"];
+    NSData *data = [response dataUsingEncoding:NSUTF8StringEncoding];
+    return [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+}
+
+- (void)testAcquireBoundToken_whenSilentSucceeds_shouldReturnBrowserResponse
+{
+    MSIDSPATokenAcquirerMock *acquirer = [MSIDSPATokenAcquirerMock new];
+    acquirer.silentOutcome = [self successfulOutcome];
+    MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
+    __block NSString *response = nil;
+    __block NSError *responseError = nil;
 
     [provider acquireBoundTokenWithRequest:[self validRequest]
                                    context:nil
-                           completionBlock:^(NSString *response, NSError *error) {
-        XCTAssertNil(error);
-        XCTAssertNotNil(response);
-
-        NSDictionary *payload = [self payloadDictionaryFromResponse:response];
-        XCTAssertEqualObjects(payload[@"clientId"], @"00000000-0000-0000-0000-000000000001");
-        XCTAssertEqualObjects(payload[@"redirectUri"], @"brk-com.microsoft.test://auth");
-        XCTAssertEqualObjects(payload[@"scope"], @"user.read");
-        XCTAssertEqualObjects(payload[@"state"], @"test-state");
-        XCTAssertEqualObjects(payload[@"transport"], @"in_proc_common_core");
-        XCTAssertEqualObjects(payload[@"servicedBy"], @"MSIDBoundTokenProvider");
-        [expectation fulfill];
+                           completionBlock:^(NSString *result, NSError *error) {
+        response = result;
+        responseError = error;
     }];
 
-    [self waitForExpectations:@[expectation] timeout:5.0];
+    NSDictionary *payload = [self payloadFromResponse:response];
+    XCTAssertNil(responseError);
+    XCTAssertTrue(acquirer.silentCalled);
+    XCTAssertFalse(acquirer.interactiveCalled);
+    XCTAssertEqualObjects(payload[@"access_token"], @"access-token");
+    XCTAssertEqualObjects(payload[@"account"][@"userName"], @"user@contoso.com");
+    XCTAssertEqualObjects(payload[@"state"], @"test-state");
 }
 
-- (void)testAcquireBoundToken_nilRequest_returnsInvalidInternalParameterError
+- (void)testAcquireBoundToken_whenPromptRequiresUI_shouldUseInteractiveBackend
 {
-    MSIDBoundTokenProvider *provider = [MSIDBoundTokenProvider new];
+    MSIDSPATokenAcquirerMock *acquirer = [MSIDSPATokenAcquirerMock new];
+    acquirer.interactiveOutcome = [self successfulOutcome];
+    MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
+    MSIDBrowserNativeMessageGetTokenRequest *request = [self validRequest];
+    request.prompt = MSIDPromptTypeSelectAccount;
+    __block NSString *response = nil;
+
+    [provider acquireBoundTokenWithRequest:request
+                                   context:nil
+                           completionBlock:^(NSString *result, __unused NSError *error) {
+        response = result;
+    }];
+
+    XCTAssertFalse(acquirer.silentCalled);
+    XCTAssertTrue(acquirer.interactiveCalled);
+    XCTAssertEqualObjects([self payloadFromResponse:response][@"access_token"], @"access-token");
+}
+
+- (void)testAcquireBoundToken_whenSilentRequiresInteraction_shouldFallbackOnce
+{
+    MSIDSPATokenAcquirerMock *acquirer = [MSIDSPATokenAcquirerMock new];
+    acquirer.silentError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired,
+                                           @"Interaction required.", nil, nil, nil, nil, nil, YES);
+    acquirer.interactiveOutcome = [self successfulOutcome];
+    MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
+    __block NSString *response = nil;
+
+    [provider acquireBoundTokenWithRequest:[self validRequest]
+                                   context:nil
+                           completionBlock:^(NSString *result, __unused NSError *error) {
+        response = result;
+    }];
+
+    XCTAssertTrue(acquirer.silentCalled);
+    XCTAssertTrue(acquirer.interactiveCalled);
+    XCTAssertNotNil(response);
+}
+
+- (void)testAcquireBoundToken_whenUIIsBlocked_shouldReturnInteractionRequired
+{
+    MSIDSPATokenAcquirerMock *acquirer = [MSIDSPATokenAcquirerMock new];
+    MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
+    MSIDBrowserNativeMessageGetTokenRequest *request = [self validRequest];
+    request.prompt = MSIDPromptTypeSelectAccount;
+    request.canShowUI = NO;
+    __block NSError *responseError = nil;
+
+    [provider acquireBoundTokenWithRequest:request
+                                   context:nil
+                           completionBlock:^(__unused NSString *result, NSError *error) {
+        responseError = error;
+    }];
+
+    XCTAssertFalse(acquirer.silentCalled);
+    XCTAssertFalse(acquirer.interactiveCalled);
+    XCTAssertEqual(responseError.code, MSIDErrorInteractionRequired);
+}
+
+- (void)testAcquireBoundToken_whenSilentFailsHard_shouldReturnOriginalError
+{
+    NSError *silentError = MSIDCreateError(MSIDErrorDomain, MSIDErrorServerOauth,
+                                           @"Server error.", nil, nil, nil, nil, nil, NO);
+    MSIDSPATokenAcquirerMock *acquirer = [MSIDSPATokenAcquirerMock new];
+    acquirer.silentError = silentError;
+    MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
+    __block NSError *responseError = nil;
+
+    [provider acquireBoundTokenWithRequest:[self validRequest]
+                                   context:nil
+                           completionBlock:^(__unused NSString *result, NSError *error) {
+        responseError = error;
+    }];
+
+    XCTAssertEqual(responseError, silentError);
+    XCTAssertFalse(acquirer.interactiveCalled);
+}
+
+- (void)testAcquireBoundToken_whenParameterMappingFails_shouldReturnDeveloperError
+{
+    MSIDSPATokenAcquirerMock *acquirer = [MSIDSPATokenAcquirerMock new];
+    acquirer.parametersError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter,
+                                               @"Mapping failed.", nil, nil, nil, nil, nil, NO);
+    MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
+    __block NSError *responseError = nil;
+
+    [provider acquireBoundTokenWithRequest:[self validRequest]
+                                   context:nil
+                           completionBlock:^(__unused NSString *result, NSError *error) {
+        responseError = error;
+    }];
+
+    XCTAssertEqual(responseError.code, MSIDErrorInvalidDeveloperParameter);
+    XCTAssertEqual(responseError.userInfo[NSUnderlyingErrorKey], acquirer.parametersError);
+}
+
+- (void)testAcquireBoundToken_whenRequestIsNil_shouldReturnInvalidInternalParameter
+{
+    MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:[MSIDSPATokenAcquirerMock new]];
     MSIDBrowserNativeMessageGetTokenRequest *nilRequest = nil;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"nil request error"];
+    __block NSError *responseError = nil;
 
     [provider acquireBoundTokenWithRequest:nilRequest
                                    context:nil
-                           completionBlock:^(NSString *response, NSError *error) {
-        XCTAssertNil(response);
-        XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
-        XCTAssertEqual(error.code, MSIDErrorInvalidInternalParameter);
-        [expectation fulfill];
+                           completionBlock:^(__unused NSString *result, NSError *error) {
+        responseError = error;
     }];
 
-    [self waitForExpectations:@[expectation] timeout:5.0];
+    XCTAssertEqual(responseError.code, MSIDErrorInvalidInternalParameter);
 }
 
-- (void)testAcquireBoundToken_missingClientId_returnsError
+- (void)testAcquireBoundToken_whenClientIdIsMissing_shouldReturnInvalidDeveloperParameter
 {
-    MSIDBoundTokenProvider *provider = [MSIDBoundTokenProvider new];
+    MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:[MSIDSPATokenAcquirerMock new]];
     MSIDBrowserNativeMessageGetTokenRequest *request = [self validRequest];
     request.clientId = @"";
-
-    XCTestExpectation *expectation = [self expectationWithDescription:@"validation error"];
+    __block NSError *responseError = nil;
 
     [provider acquireBoundTokenWithRequest:request
                                    context:nil
-                           completionBlock:^(NSString *response, NSError *error) {
-        XCTAssertNil(response);
-        XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
-        XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
-        [expectation fulfill];
+                           completionBlock:^(__unused NSString *result, NSError *error) {
+        responseError = error;
     }];
 
-    [self waitForExpectations:@[expectation] timeout:5.0];
+    XCTAssertEqual(responseError.code, MSIDErrorInvalidDeveloperParameter);
 }
 
-- (void)testAcquireBoundToken_missingRedirectUri_returnsInvalidDeveloperParameterError
+- (void)testAcquireBoundToken_whenRedirectUriIsMissing_shouldReturnInvalidDeveloperParameter
 {
-    MSIDBoundTokenProvider *provider = [MSIDBoundTokenProvider new];
+    MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:[MSIDSPATokenAcquirerMock new]];
     MSIDBrowserNativeMessageGetTokenRequest *request = [self validRequest];
     request.redirectUri = @"";
-
-    XCTestExpectation *expectation = [self expectationWithDescription:@"redirect validation error"];
+    __block NSError *responseError = nil;
 
     [provider acquireBoundTokenWithRequest:request
                                    context:nil
-                           completionBlock:^(NSString *response, NSError *error) {
-        XCTAssertNil(response);
-        XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
-        XCTAssertEqual(error.code, MSIDErrorInvalidDeveloperParameter);
-        [expectation fulfill];
+                           completionBlock:^(__unused NSString *result, NSError *error) {
+        responseError = error;
     }];
 
-    [self waitForExpectations:@[expectation] timeout:5.0];
+    XCTAssertEqual(responseError.code, MSIDErrorInvalidDeveloperParameter);
 }
 
 @end

--- a/IdentityCore/tests/MSIDBoundTokenProviderTests.m
+++ b/IdentityCore/tests/MSIDBoundTokenProviderTests.m
@@ -131,9 +131,7 @@
 
 - (NSDictionary *)payloadFromResponse:(NSString *)response
 {
-    XCTAssertNotNil(response);
     NSData *data = [response dataUsingEncoding:NSUTF8StringEncoding];
-    XCTAssertNotNil(data);
     NSError *error = nil;
     id payload = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:&error] : nil;
     XCTAssertNotNil(payload, @"Failed to parse response JSON: %@", error);
@@ -202,9 +200,10 @@
 - (void)testAcquireBoundToken_whenUIIsBlocked_shouldReturnInteractionRequired
 {
     MSIDSPATokenAcquirerMock *acquirer = [MSIDSPATokenAcquirerMock new];
+    acquirer.silentError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInteractionRequired,
+                                           @"Interaction required.", nil, nil, nil, nil, nil, YES);
     MSIDBoundTokenProvider *provider = [[MSIDBoundTokenProvider alloc] initWithAcquirer:acquirer];
     MSIDBrowserNativeMessageGetTokenRequest *request = [self validRequest];
-    request.prompt = MSIDPromptTypeSelectAccount;
     request.canShowUI = NO;
     __block NSError *responseError = nil;
     [provider acquireBoundTokenWithRequest:request
@@ -212,9 +211,16 @@
                            completionBlock:^(__unused NSString *result, NSError *error) {
         responseError = error;
     }];
-    XCTAssertEqual(acquirer.silentCallCount, 0);
+    XCTAssertEqual(acquirer.silentCallCount, 1);
     XCTAssertEqual(acquirer.interactiveCallCount, 0);
     XCTAssertEqual(responseError.code, MSIDErrorInteractionRequired);
+    XCTAssertEqualObjects(responseError.userInfo[@"MSALBrowserNativeMessageErrorStatus"], @"UI_NOT_ALLOWED");
+    XCTAssertEqual(responseError.userInfo[NSUnderlyingErrorKey], acquirer.silentError);
+    request.prompt = MSIDPromptTypeNever;
+    [provider acquireBoundTokenWithRequest:request context:nil completionBlock:^(__unused NSString *result, NSError *error) {
+        responseError = error;
+    }];
+    XCTAssertEqualObjects(responseError.userInfo[@"MSALBrowserNativeMessageErrorStatus"], @"USER_INTERACTION_REQUIRED");
 }
 
 - (void)testAcquireBoundToken_whenSilentFailsHard_shouldReturnOriginalError

--- a/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
+++ b/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
@@ -105,11 +105,11 @@
     XCTAssertEqualObjects(parameters.accountIdentifier.homeAccountId, @"uid.utid");
 }
 
-- (void)testAcquireSilent_whenEngineReturnsResult_shouldRequireBoundRefreshToken
+- (void)testAcquireSilent_whenEngineReturnsBlankUsername_shouldUseLoginHintAndRequireBoundRefreshToken
 {
     MSIDTokenResult *result = [MSIDTokenResult new];
     result.account = [MSIDAccount new];
-    result.account.username = @"cached@contoso.com";
+    result.account.username = @"";
 
     MSIDLocalSPATokenAcquirer *acquirer = [self acquirerWithResult:result error:nil];
     __block MSIDSPATokenAcquisitionResult *outcome = nil;
@@ -125,7 +125,7 @@
 
     XCTAssertNil(acquisitionError);
     XCTAssertEqual(outcome.tokenResult, result);
-    XCTAssertEqualObjects(outcome.fallbackRequestAccountUpn, @"cached@contoso.com");
+    XCTAssertEqualObjects(outcome.fallbackRequestAccountUpn, @"user@contoso.com");
     XCTAssertTrue(self.silentRequest.requiresBoundRefreshToken);
 }
 
@@ -182,6 +182,21 @@
     }];
 
     XCTAssertEqualObjects(acquisitionError.domain, MSIDErrorDomain);
+    XCTAssertEqual(acquisitionError.code, MSIDErrorInteractionRequired);
+}
+
+- (void)testAcquireInteractive_whenNotImplemented_shouldReturnInteractionRequired
+{
+    MSIDLocalSPATokenAcquirer *acquirer = [MSIDLocalSPATokenAcquirer new];
+    __block NSError *acquisitionError = nil;
+
+    [acquirer acquireInteractiveWithParameters:[self parametersWithAcquirer:acquirer]
+                                       request:[self request]
+                                       context:nil
+                               completionBlock:^(__unused MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
+        acquisitionError = error;
+    }];
+
     XCTAssertEqual(acquisitionError.code, MSIDErrorInteractionRequired);
 }
 

--- a/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
+++ b/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
@@ -123,12 +123,8 @@
     XCTAssertEqualObjects(outcome.fallbackRequestAccountUpn, @"user@contoso.com");
     XCTAssertTrue(self.silentRequest.requiresBoundRefreshToken);
     result.account.username = @"cached@contoso.com";
-    [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
-                                  request:[self request]
-                                  context:nil
-                          completionBlock:^(MSIDSPATokenAcquisitionResult *resultOutcome, __unused NSError *error) {
-        outcome = resultOutcome;
-    }];
+    [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer] request:[self request] context:nil
+                          completionBlock:^(MSIDSPATokenAcquisitionResult *resultOutcome, __unused NSError *error) { outcome = resultOutcome; }];
     XCTAssertEqualObjects(outcome.fallbackRequestAccountUpn, @"cached@contoso.com");
 }
 

--- a/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
+++ b/IdentityCore/tests/MSIDLocalSPATokenAcquirerTests.m
@@ -99,22 +99,19 @@
 {
     MSIDLocalSPATokenAcquirer *acquirer = [MSIDLocalSPATokenAcquirer new];
     MSIDInteractiveTokenRequestParameters *parameters = [self parametersWithAcquirer:acquirer];
-
     XCTAssertEqual(parameters.requestType, MSIDRequestBrokeredType);
     XCTAssertTrue(parameters.isBoundAppRefreshTokenRequested);
     XCTAssertEqualObjects(parameters.accountIdentifier.homeAccountId, @"uid.utid");
 }
 
-- (void)testAcquireSilent_whenEngineReturnsBlankUsername_shouldUseLoginHintAndRequireBoundRefreshToken
+- (void)testAcquireSilent_whenEngineReturnsUsername_shouldUseExpectedFallbackAndRequireBoundRefreshToken
 {
     MSIDTokenResult *result = [MSIDTokenResult new];
     result.account = [MSIDAccount new];
     result.account.username = @"";
-
     MSIDLocalSPATokenAcquirer *acquirer = [self acquirerWithResult:result error:nil];
     __block MSIDSPATokenAcquisitionResult *outcome = nil;
     __block NSError *acquisitionError = nil;
-
     [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
                                   request:[self request]
                                   context:nil
@@ -122,11 +119,17 @@
         outcome = resultOutcome;
         acquisitionError = error;
     }];
-
     XCTAssertNil(acquisitionError);
-    XCTAssertEqual(outcome.tokenResult, result);
     XCTAssertEqualObjects(outcome.fallbackRequestAccountUpn, @"user@contoso.com");
     XCTAssertTrue(self.silentRequest.requiresBoundRefreshToken);
+    result.account.username = @"cached@contoso.com";
+    [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
+                                  request:[self request]
+                                  context:nil
+                          completionBlock:^(MSIDSPATokenAcquisitionResult *resultOutcome, __unused NSError *error) {
+        outcome = resultOutcome;
+    }];
+    XCTAssertEqualObjects(outcome.fallbackRequestAccountUpn, @"cached@contoso.com");
 }
 
 - (void)testAcquireSilent_whenEngineFails_shouldReturnOriginalError
@@ -135,14 +138,12 @@
                                            @"Server rejected the request.", nil, nil, nil, nil, nil, NO);
     MSIDLocalSPATokenAcquirer *acquirer = [self acquirerWithResult:nil error:engineError];
     __block NSError *acquisitionError = nil;
-
     [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
                                   request:[self request]
                                   context:nil
                           completionBlock:^(__unused MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
         acquisitionError = error;
     }];
-
     XCTAssertEqual(acquisitionError, engineError);
 }
 
@@ -152,14 +153,12 @@
                                          @"BART redemption failed.", nil, nil, nil, nil, nil, YES);
     MSIDLocalSPATokenAcquirer *acquirer = [self acquirerWithResult:nil error:bartError];
     __block NSError *acquisitionError = nil;
-
     [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
                                   request:[self request]
                                   context:nil
                           completionBlock:^(__unused MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
         acquisitionError = error;
     }];
-
     XCTAssertEqualObjects(acquisitionError.domain, MSIDErrorDomain);
     XCTAssertEqual(acquisitionError.code, MSIDErrorInteractionRequired);
     XCTAssertEqual(acquisitionError.userInfo[NSUnderlyingErrorKey], bartError);
@@ -173,14 +172,12 @@
         return nil;
     }];
     __block NSError *acquisitionError = nil;
-
     [acquirer acquireSilentWithParameters:[self parametersWithAcquirer:acquirer]
                                   request:[self request]
                                   context:nil
                           completionBlock:^(__unused MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
         acquisitionError = error;
     }];
-
     XCTAssertEqualObjects(acquisitionError.domain, MSIDErrorDomain);
     XCTAssertEqual(acquisitionError.code, MSIDErrorInteractionRequired);
 }
@@ -189,14 +186,12 @@
 {
     MSIDLocalSPATokenAcquirer *acquirer = [MSIDLocalSPATokenAcquirer new];
     __block NSError *acquisitionError = nil;
-
     [acquirer acquireInteractiveWithParameters:[self parametersWithAcquirer:acquirer]
                                        request:[self request]
                                        context:nil
                                completionBlock:^(__unused MSIDSPATokenAcquisitionResult *outcome, NSError *error) {
         acquisitionError = error;
     }];
-
     XCTAssertEqual(acquisitionError.code, MSIDErrorInteractionRequired);
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Add in-process Browser Native Message BART SPA token orchestration for unmanaged iOS hosts.
 * Restrict macOS CBA preferred-identity URL fallback to the same host or its child subdomains behind a flight, with non-PII rollout logs.
 * Prevent a crash when JWT signing is attempted with a NULL private key. (#1917)
 * Raise the minimum deployment targets to iOS 16.0 and macOS 12.0, and replace deprecated macOS SecTransform JWT signing with SecKeyCreateSignature. (#1915)


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH][tests]:add coverage`

## Proposed changes

This PR replaces the `MSIDBoundTokenProvider` proof-of-concept payload with the OneAuth-facing orchestration for unmanaged Browser Native Message BART SPA acquisition. The provider validates and maps the request, applies the shared GetToken routing policy, delegates silent or interactive acquisition through `MSIDSPATokenAcquiring`, and serializes the normalized token result through `MSIDBrowserNativeMessageGetTokenResponse`.

On unmanaged iOS, OneAuth cannot invoke the SSO Extension. The provider therefore uses `MSIDLocalSPATokenAcquirer` for in-process access-token cache lookup and app-specific BART redemption. When silent acquisition requires interaction, the provider reruns routing with `forceInteractive` and invokes the interactive backend only when the request permits UI. The default local interactive backend currently returns interaction-required; the broker-flip implementation remains a separate integration step.

This PR also addresses Antonio's review comment from #1932: an empty account username is now treated as missing and falls back to the request login hint, preventing the Browser Native Message response from omitting `account.userName` and `properties.UPN`.

This is the sixth independently mergeable phase extracted from #1875. It composes the routing policy (#1927), request mapping (#1928), app-specific BART enforcement (#1929), response shaping (#1930), and local silent backend (#1932).

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High - Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium - Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small - No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

- iOS: 15/15 focused provider and local-acquirer tests passed.
- macOS: 15/15 focused provider and local-acquirer tests passed.
- Coverage verifies silent success, direct interactive routing, one-time silent-to-interactive fallback, UI-blocked behavior, hard-error propagation, request validation/mapping failures, Browser Native Message response shaping, and blank-username fallback.
