### PR TITLE
[patch][bugfix] Avoid bound token provider symbol collision

### DIFF
--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
@@ -28,7 +28,7 @@
 #import "MSIDLogger+Internal.h"
 #import "NSString+MSIDExtensions.h"
 
-NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider]";
+static NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider]";
 
 @implementation MSIDBoundTokenProvider
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Prevent duplicate-symbol linker failures when MSAL and OneAuth both include their CommonCore bound-token provider implementation.
 * Protect device IDs in BART redemption mismatch logging by routing the error message through PII logging. (#1935)
 * Fix a memory leak in bound refresh token redemption by ensuring SecKeyCopyPublicKey results are safely released via a nil-checked helper in MSIDBoundRefreshToken+Redemption.
 * Restrict macOS CBA preferred-identity URL fallback to the same host or its child subdomains behind a flight, with non-PII rollout logs.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 TBD
-* Prevent duplicate-symbol linker failures when MSAL and OneAuth both include their CommonCore bound-token provider implementation.
+* Prevent duplicate-symbol linker failures when MSAL and OneAuth both include their CommonCore bound-token provider implementation. (#1937)
 * Protect device IDs in BART redemption mismatch logging by routing the error message through PII logging. (#1935)
 * Fix a memory leak in bound refresh token redemption by ensuring SecKeyCopyPublicKey results are safely released via a nil-checked helper in MSIDBoundRefreshToken+Redemption.
 * Restrict macOS CBA preferred-identity URL fallback to the same host or its child subdomains behind a flight, with non-PII rollout logs.


### PR DESCRIPTION
## Summary
- Give the bound-token provider log prefix internal linkage.
- Prevent duplicate-symbol linker failures when MSAL and OneAuth are linked into the same app.
- Document the fix in `changelog.txt`.

## Validation
- `./build.py --targets mac_library --no-clean --no-xcpretty`

Split from #1934 so the linker fix can be reviewed and shipped independently.