### PR TITLE
[minor] [feature]: Validate broker nonce on the sourceApplication path behind a flight

### DIFF
--- a/IdentityCore/src/MSIDConstants.h
+++ b/IdentityCore/src/MSIDConstants.h
@@ -301,6 +301,13 @@ extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_OPEN_NEW_WINDOW_IN_BROWSER;
 /// Default: OFF
 extern NSString * _Nonnull const MSID_FLIGHT_DISABLE_MOBILE_ONBOARDING;
 
+/// Enforces broker_nonce validation on broker responses even when sourceApplication is available.
+/// sourceApplication establishes the origin of a response, not its freshness, so it is not a
+/// substitute for the nonce. Flighted so impact on brokers that do not echo the nonce back can be
+/// measured before enforcement is turned on.
+/// Default: OFF
+extern NSString * _Nonnull const MSID_FLIGHT_ENFORCE_BROKER_NONCE;
+
 /// Flight key for MDM profile install notification delay (seconds).
 /// Owner: swagup
 extern NSString * _Nonnull const MSID_FLIGHT_MDM_PROFILE_INSTALLED_NOTIFICATION_DELAY;

--- a/IdentityCore/src/MSIDConstants.m
+++ b/IdentityCore/src/MSIDConstants.m
@@ -136,6 +136,8 @@ NSString *const MSID_FLIGHT_DISABLE_OPEN_NEW_WINDOW_IN_BROWSER = @"disable_open_
 
 NSString *const MSID_FLIGHT_DISABLE_MOBILE_ONBOARDING = @"disable_mobile_onboarding";
 
+NSString *const MSID_FLIGHT_ENFORCE_BROKER_NONCE = @"enforce_broker_nonce";
+
 NSString *const MSID_FLIGHT_MDM_PROFILE_INSTALLED_NOTIFICATION_DELAY = @"mdm_profile_installed_notification_delay";
 
 NSTimeInterval const MSIDMDMProfileInstalledNotificationDefaultDelay = 75.0;

--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
@@ -308,7 +308,9 @@
         return NO;
     }
 
-    NSString *nonceMissing = responseDict[@"broker_nonce"] ? @"NO" : @"YES";
+    // A response carrying "broker_nonce=" decodes to a present-but-empty string, so presence alone
+    // would report such a broker as having echoed a nonce. Treat nil and blank alike.
+    NSString *nonceMissing = [NSString msidIsStringNilOrBlank:responseDict[@"broker_nonce"]] ? @"YES" : @"NO";
 
     if (![[MSIDFlightManager sharedInstance] boolForKey:MSID_FLIGHT_ENFORCE_BROKER_NONCE])
     {

--- a/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
+++ b/IdentityCore/src/requests/sdk/MSIDBrokerResponseHandler.m
@@ -41,6 +41,7 @@
 #import "MSIDAuthenticationSchemePop.h"
 #import "MSIDAuthenticationScheme.h"
 #import "MSIDAuthScheme.h"
+#import "MSIDFlightManager.h"
 
 @interface MSIDBrokerResponseHandler()
 
@@ -291,13 +292,32 @@
 
 - (BOOL)checkBrokerNonce:(NSDictionary *)responseDict
 {
-    // only verify nonce if sourceApplication is nil
+    if ([self.brokerNonce isEqualToString:responseDict[@"broker_nonce"]])
+    {
+        return YES;
+    }
+
+    // Historically the nonce was verified only when sourceApplication was nil, on the basis that a
+    // non-nil sourceApplication is asserted by the OS and is validated against the broker bundle id
+    // before this handler is reached. sourceApplication establishes the origin of a response, not its
+    // freshness, so it does not protect against replay of a previously captured response. Enforcement
+    // on that path is flighted so that impact on brokers which do not echo the nonce back can be
+    // measured before it is turned on.
     if (!self.sourceApplicationAvailable)
     {
-        return [self.brokerNonce isEqualToString:responseDict[@"broker_nonce"]];
+        return NO;
     }
-    
-    return YES;
+
+    NSString *nonceMissing = responseDict[@"broker_nonce"] ? @"NO" : @"YES";
+
+    if (![[MSIDFlightManager sharedInstance] boolForKey:MSID_FLIGHT_ENFORCE_BROKER_NONCE])
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Broker nonce mismatch on the sourceApplication code path, allowed because enforcement is disabled. Nonce missing from response: %@", nonceMissing);
+        return YES;
+    }
+
+    MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Broker nonce mismatch on the sourceApplication code path, rejecting response. Nonce missing from response: %@", nonceMissing);
+    return NO;
 }
 
 #pragma mark - Abstract

--- a/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultBrokerResponseHandlerTests.m
@@ -48,6 +48,8 @@
 #import "MSIDDefaultTokenCacheAccessor.h"
 #import "MSIDAccountMetadataCacheAccessor.h"
 #import "MSIDOnboardingBlobFieldKeys.h"
+#import "MSIDFlightManager.h"
+#import "MSIDFlightManagerMockProvider.h"
 
 @interface MSIDDefaultBrokerResponseHandlerTests : XCTestCase
 
@@ -77,6 +79,8 @@
     SecItemDelete((CFDictionaryRef)query);
     
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
+    
+    MSIDFlightManager.sharedInstance.flightProvider = nil;
     
     [super tearDown];
 }
@@ -1918,6 +1922,152 @@
     XCTAssertNil(result);
     XCTAssertNotNil(error);
     XCTAssertNil(error.userInfo[MSIDOnboardingBlobIPCKey]);
+}
+
+#pragma mark - Broker nonce enforcement flight
+
+- (void)setEnforceBrokerNonceFlight:(BOOL)enabled
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_ENFORCE_BROKER_NONCE: @(enabled) };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+}
+
+- (NSURL *)brokerSuccessResponseURLWithNonce:(NSString *)brokerNonce
+{
+    NSString *idTokenString = [MSIDTestIdTokenUtil idTokenWithPreferredUsername:@"user@contoso.com"
+                                                                        subject:@"mysubject"
+                                                                      givenName:@"myGivenName"
+                                                                     familyName:@"myFamilyName"
+                                                                           name:@"Contoso"
+                                                                        version:@"2.0"
+                                                                            tid:@"contoso.com-guid"];
+
+    NSDictionary *clientInfo = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
+    NSString *rawClientInfo = [clientInfo msidBase64UrlJson];
+
+    NSDate *expiresOn = [NSDate dateWithTimeIntervalSinceNow:3600];
+    NSString *expiresOnString = [NSString stringWithFormat:@"%ld", (long)[expiresOn timeIntervalSince1970]];
+
+    NSDate *extExpiresOn = [NSDate dateWithTimeIntervalSinceNow:36000];
+    NSString *extExpiresOnString = [NSString stringWithFormat:@"%ld", (long)[extExpiresOn timeIntervalSince1970]];
+
+    NSMutableDictionary *brokerResponseParams = [@{
+      @"authority" : @"https://login.microsoftonline.com/common",
+      @"scope" : @"myscope1 myscope2",
+      @"client_id" : @"my_client_id",
+      @"id_token" : idTokenString,
+      @"client_info" : rawClientInfo,
+      @"home_account_id" : @"1.1234-5678-90abcdefg",
+      @"access_token" : @"i-am-a-access-token",
+      @"token_type" : @"Bearer",
+      @"refresh_token" : @"i-am-a-refresh-token",
+      @"expires_on" : expiresOnString,
+      @"ext_expires_on" : extExpiresOnString,
+      @"correlation_id" : [[NSUUID UUID] UUIDString],
+      @"x-broker-app-ver" : @"1.0.0",
+      @"foci" : @"1",
+      @"success": @YES,
+      } mutableCopy];
+
+    if (brokerNonce)
+    {
+        brokerResponseParams[@"broker_nonce"] = brokerNonce;
+    }
+
+    return [MSIDTestBrokerResponseHelper createDefaultBrokerResponse:brokerResponseParams
+                                                         redirectUri:@"x-msauth-test://com.microsoft.testapp"
+                                                       encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];
+}
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNonNil_andNonceMismatch_andEnforcementFlightOn_shouldReturnNilResultAndError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:YES];
+
+    NSURL *brokerResponseURL = [self brokerSuccessResponseURLWithNonce:@"incorrect_nonce"];
+
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorBrokerMismatchedResumeState);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Broker nonce mismatch!");
+}
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNonNil_andNonceMissingInResponse_andEnforcementFlightOn_shouldReturnNilResultAndError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:YES];
+
+    NSURL *brokerResponseURL = [self brokerSuccessResponseURLWithNonce:nil];
+
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorBrokerMismatchedResumeState);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Broker nonce mismatch!");
+}
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNonNil_andNonceMismatch_andEnforcementFlightOff_shouldReturnResultAndNilError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:NO];
+
+    NSURL *brokerResponseURL = [self brokerSuccessResponseURLWithNonce:@"incorrect_nonce"];
+
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(result.accessToken.accessToken, @"i-am-a-access-token");
+}
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNonNil_andBrokerNonceMatches_andEnforcementFlightOn_shouldReturnResultAndNilError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:YES];
+
+    NSURL *brokerResponseURL = [self brokerSuccessResponseURLWithNonce:@"nonce"];
+
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:MSID_BROKER_APP_BUNDLE_ID error:&error];
+
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(result.accessToken.accessToken, @"i-am-a-access-token");
+}
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNil_andNonceMismatch_andEnforcementFlightOff_shouldReturnNilResultAndError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:NO];
+
+    NSURL *brokerResponseURL = [self brokerSuccessResponseURLWithNonce:@"incorrect_nonce"];
+
+    MSIDDefaultBrokerResponseHandler *brokerResponseHandler = [[MSIDDefaultBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV2Oauth2Factory new] tokenResponseValidator:[MSIDDefaultTokenResponseValidator new]];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [brokerResponseHandler handleBrokerResponseWithURL:brokerResponseURL sourceApplication:nil error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorBrokerMismatchedResumeState);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Broker nonce mismatch!");
 }
 
 @end

--- a/IdentityCore/tests/integration/ios/MSIDLegacyBrokerResponseHandlerTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDLegacyBrokerResponseHandlerTests.m
@@ -40,6 +40,8 @@
 #import "MSIDLegacyAccessToken.h"
 #import "MSIDLegacyRefreshToken.h"
 #import "MSIDTestCacheAccessorHelper.h"
+#import "MSIDFlightManager.h"
+#import "MSIDFlightManagerMockProvider.h"
 
 @interface MSIDLegacyBrokerResponseHandlerTests : XCTestCase
 
@@ -69,6 +71,8 @@
     SecItemDelete((CFDictionaryRef)query);
 
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
+    
+    MSIDFlightManager.sharedInstance.flightProvider = nil;
     
     [super tearDown];
 }
@@ -772,6 +776,224 @@
                                   };
 
     [[NSUserDefaults standardUserDefaults] setObject:resumeState forKey:MSID_BROKER_RESUME_DICTIONARY_KEY];
+}
+
+#pragma mark - Broker nonce enforcement flight
+
+// MSIDLegacyBrokerResponseHandler evaluates the nonce on two distinct call paths: the success path
+// checks the decrypted response, and the error_code path checks the unencrypted query parameters.
+// Both are covered below.
+
+- (void)setEnforceBrokerNonceFlight:(BOOL)enabled
+{
+    MSIDFlightManagerMockProvider *flightProvider = [MSIDFlightManagerMockProvider new];
+    flightProvider.boolForKeyContainer = @{ MSID_FLIGHT_ENFORCE_BROKER_NONCE: @(enabled) };
+    MSIDFlightManager.sharedInstance.flightProvider = flightProvider;
+}
+
+- (NSURL *)legacyBrokerSuccessResponseURLWithNonce:(NSString *)brokerNonce
+{
+    NSString *idToken = [MSIDTestIdTokenUtil idTokenWithName:@"Contoso" upn:@"user@contoso.com" oid:nil tenantId:@"contoso.com-guid"];
+    NSString *expiresOnString = [NSString stringWithFormat:@"%ld", (long)[[NSDate dateWithTimeIntervalSinceNow:3600] timeIntervalSince1970]];
+
+    NSMutableDictionary *brokerResponseParams = [@{
+      @"authority" : @"https://login.microsoftonline.com/common",
+      @"resource" : @"https://graph.windows.net",
+      @"client_id" : @"my_client_id",
+      @"id_token" : idToken,
+      @"access_token" : @"i-am-a-access-token",
+      @"refresh_token" : @"i-am-a-refresh-token",
+      @"expires_on" : expiresOnString,
+      @"user_id": @"user@contoso.com",
+      @"correlation_id": [[NSUUID UUID] UUIDString],
+      @"x-broker-app-ver": @"1.0.0",
+      @"foci": @"1"
+      } mutableCopy];
+
+    if (brokerNonce)
+    {
+        brokerResponseParams[@"broker_nonce"] = brokerNonce;
+    }
+
+    return [MSIDTestBrokerResponseHelper createLegacyBrokerResponse:brokerResponseParams
+                                                        redirectUri:@"x-msauth-test://com.microsoft.testapp"
+                                                      encryptionKey:[NSData msidDataFromBase64UrlEncodedString:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"]];
+}
+
+- (NSURL *)legacyBrokerErrorResponseURLWithNonce:(NSString *)brokerNonce
+{
+    NSMutableDictionary *brokerResponseParams = [@{
+      @"protocol_code": @"invalid_grant",
+      @"error_domain": @"ADAuthenticationErrorDomain",
+      @"error_code": @"213",
+      @"correlation_id": [[NSUUID UUID] UUIDString],
+      @"x-broker-app-ver": @"1.0.0",
+      @"error_description": @"Error occured",
+      @"suberror": @"consent_required"
+      } mutableCopy];
+
+    if (brokerNonce)
+    {
+        brokerResponseParams[@"broker_nonce"] = brokerNonce;
+    }
+
+    return [MSIDTestBrokerResponseHelper createLegacyBrokerErrorResponse:brokerResponseParams
+                                                             redirectUri:@"x-msauth-test://com.microsoft.testapp"];
+}
+
+- (MSIDLegacyBrokerResponseHandler *)legacyBrokerResponseHandler
+{
+    return [[MSIDLegacyBrokerResponseHandler alloc] initWithOauthFactory:[MSIDAADV1Oauth2Factory new]
+                                                 tokenResponseValidator:[MSIDLegacyTokenResponseValidator new]];
+}
+
+#pragma mark Success path (nonce read from the decrypted response)
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNonNil_andNonceMismatch_andEnforcementFlightOn_shouldReturnNilResultAndError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:YES];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [[self legacyBrokerResponseHandler] handleBrokerResponseWithURL:[self legacyBrokerSuccessResponseURLWithNonce:@"incorrect_nonce"]
+                                                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                                                                        error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorBrokerMismatchedResumeState);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Broker nonce mismatch!");
+}
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNonNil_andNonceMissingInResponse_andEnforcementFlightOn_shouldReturnNilResultAndError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:YES];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [[self legacyBrokerResponseHandler] handleBrokerResponseWithURL:[self legacyBrokerSuccessResponseURLWithNonce:nil]
+                                                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                                                                        error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorBrokerMismatchedResumeState);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Broker nonce mismatch!");
+}
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNonNil_andNonceMismatch_andEnforcementFlightOff_shouldReturnResultAndNilError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:NO];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [[self legacyBrokerResponseHandler] handleBrokerResponseWithURL:[self legacyBrokerSuccessResponseURLWithNonce:@"incorrect_nonce"]
+                                                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                                                                        error:&error];
+
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(result.accessToken.accessToken, @"i-am-a-access-token");
+}
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNonNil_andBrokerNonceMatches_andEnforcementFlightOn_shouldReturnResultAndNilError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:YES];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [[self legacyBrokerResponseHandler] handleBrokerResponseWithURL:[self legacyBrokerSuccessResponseURLWithNonce:@"nonce"]
+                                                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                                                                        error:&error];
+
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(result.accessToken.accessToken, @"i-am-a-access-token");
+}
+
+- (void)testHandleBrokerResponse_whenSourceApplicationNil_andNonceMismatch_andEnforcementFlightOff_shouldReturnNilResultAndError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:NO];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [[self legacyBrokerResponseHandler] handleBrokerResponseWithURL:[self legacyBrokerSuccessResponseURLWithNonce:@"incorrect_nonce"]
+                                                                            sourceApplication:nil
+                                                                                        error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSIDErrorBrokerMismatchedResumeState);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Broker nonce mismatch!");
+}
+
+#pragma mark Error path (nonce read from the unencrypted query parameters)
+
+- (void)testHandleBrokerResponse_whenBrokerErrorResponse_andSourceApplicationNonNil_andNonceMismatch_andEnforcementFlightOn_shouldReturnNonceMismatchError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:YES];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [[self legacyBrokerResponseHandler] handleBrokerResponseWithURL:[self legacyBrokerErrorResponseURLWithNonce:@"incorrect_nonce"]
+                                                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                                                                        error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorBrokerMismatchedResumeState);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Broker nonce mismatch!");
+}
+
+- (void)testHandleBrokerResponse_whenBrokerErrorResponse_andSourceApplicationNonNil_andNonceMissingInResponse_andEnforcementFlightOn_shouldReturnNonceMismatchError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:YES];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [[self legacyBrokerResponseHandler] handleBrokerResponseWithURL:[self legacyBrokerErrorResponseURLWithNonce:nil]
+                                                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                                                                        error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorBrokerMismatchedResumeState);
+    XCTAssertEqualObjects(error.userInfo[MSIDErrorDescriptionKey], @"Broker nonce mismatch!");
+}
+
+- (void)testHandleBrokerResponse_whenBrokerErrorResponse_andSourceApplicationNonNil_andNonceMismatch_andEnforcementFlightOff_shouldReturnUnderlyingBrokerError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:NO];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [[self legacyBrokerResponseHandler] handleBrokerResponseWithURL:[self legacyBrokerErrorResponseURLWithNonce:@"incorrect_nonce"]
+                                                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                                                                        error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, 213);
+    XCTAssertEqualObjects(error.domain, @"ADAuthenticationErrorDomain");
+}
+
+- (void)testHandleBrokerResponse_whenBrokerErrorResponse_andSourceApplicationNonNil_andBrokerNonceMatches_andEnforcementFlightOn_shouldReturnUnderlyingBrokerError
+{
+    [self saveResumeStateWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self setEnforceBrokerNonceFlight:YES];
+
+    NSError *error = nil;
+    MSIDTokenResult *result = [[self legacyBrokerResponseHandler] handleBrokerResponseWithURL:[self legacyBrokerErrorResponseURLWithNonce:@"nonce"]
+                                                                            sourceApplication:MSID_BROKER_APP_BUNDLE_ID
+                                                                                        error:&error];
+
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, 213);
+    XCTAssertEqualObjects(error.domain, @"ADAuthenticationErrorDomain");
 }
 
 @end

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Add the enforce_broker_nonce flight (default OFF). When enabled, broker_nonce is validated on every broker response, including the legacy application:openURL:sourceApplication: path where the check was previously skipped. When disabled, a mismatch on that path is logged as a warning and still accepted, preserving current behavior.
 * Protect device IDs in BART redemption mismatch logging by routing the error message through PII logging. (#1935)
 * Fix a memory leak in bound refresh token redemption by ensuring SecKeyCopyPublicKey results are safely released via a nil-checked helper in MSIDBoundRefreshToken+Redemption.
 * Restrict macOS CBA preferred-identity URL fallback to the same host or its child subdomains behind a flight, with non-PII rollout logs.


### PR DESCRIPTION
## Summary

`-[MSIDBrokerResponseHandler checkBrokerNonce:]` only compared `broker_nonce` when `sourceApplication` was `nil`. On the legacy `application:openURL:sourceApplication:` / `application:open:options:` path it returned `YES` without evaluating the nonce at all.

The original reasoning is sound as far as it goes: a non-nil `sourceApplication` is asserted by the OS, cannot be forged by the calling app, and `MSIDBrokerInteractiveController` already rejects any non-blank `sourceApplication` that isn't the known broker bundle id before this handler is reached.

But that establishes the *origin* of a response, not its *freshness*. Those address different things and aren't substitutes for one another. The nonce is the only freshness binding in the response envelope, and on this path it wasn't being checked.

## What changed

`checkBrokerNonce:` now compares the nonce first on every path:

- **Nonce matches** — accepted, unchanged.
- **Mismatch, `sourceApplication == nil`** — rejected, unchanged.
- **Mismatch, `sourceApplication != nil`** — gated by the new `enforce_broker_nonce` flight.
  - Flight **off (default)**: logs a warning and accepts. Identical to today's behavior.
  - Flight **on**: rejects with `MSIDErrorBrokerMismatchedResumeState`.

Defaulting off is deliberate. Any broker build that doesn't echo `broker_nonce` back would start failing sign-in the moment this is enforced, so the warning log lets us size that population per ring before flipping it on.

## Why this needs no broker-side change

The broker already writes `broker_nonce` into the response payload before encrypting it, so it travels inside the ciphertext and under the response hash. The client already generates it and hard-fails if it's missing from resume state. Both ends are in place — only the client-side comparison was conditional. No envelope format change, no protocol version bump, no coordinated broker release.

## Tests

### `MSIDDefaultBrokerResponseHandlerTests` (5 new)

| `sourceApplication` | nonce | flight | expected |
|---|---|---|---|
| non-nil | mismatch | on | rejected |
| non-nil | missing | on | rejected |
| non-nil | mismatch | off | accepted (pins current behavior) |
| non-nil | matches | on | accepted (no happy-path regression) |
| nil | mismatch | off | rejected (flight doesn't weaken this path) |

### `MSIDLegacyBrokerResponseHandlerTests` (9 new)

`MSIDLegacyBrokerResponseHandler` calls `checkBrokerNonce:` twice — once on the decrypted success response, and once on the `error_code` branch — so the flight changes the ADAL path too. Both call sites are now covered.

Success path (decrypted response):

| `sourceApplication` | nonce | flight | expected |
|---|---|---|---|
| non-nil | mismatch | on | rejected |
| non-nil | missing | on | rejected |
| non-nil | mismatch | off | accepted (pins current behavior) |
| non-nil | matches | on | accepted (no happy-path regression) |
| nil | mismatch | off | rejected (flight doesn't weaken this path) |

`error_code` path:

| `sourceApplication` | nonce | flight | expected |
|---|---|---|---|
| non-nil | mismatch | on | rejected with nonce error |
| non-nil | missing | on | rejected with nonce error |
| non-nil | mismatch | off | underlying broker error surfaces (pins current behavior) |
| non-nil | matches | on | underlying broker error surfaces (no regression) |

The "flight off" rows matter most here: they prove enabling the flight is the only thing that can change ADAL behavior, and that with it off the ADAL path is bit-for-bit what it is today.

`tearDown` in both suites now resets `MSIDFlightManager.sharedInstance.flightProvider`, since it's a singleton and would otherwise leak across tests.

Because the flight defaults off, the existing tests that encode today's permissive behavior are untouched and still pass.

**Results:** 40 pass in `MSIDDefaultBrokerResponseHandlerTests` (5 new, 35 existing), 28 pass in `MSIDLegacyBrokerResponseHandlerTests` (9 new, 19 existing), 8 pass in `MSIDBrokerResponseHandlerTests`. No regressions. `MSIDFlightManagerMockProvider` already builds into `IdentityTest iOS`, which the test target links, so no `.pbxproj` change was needed.

## Note for reviewers

`ADBrokerAADv1Response` returns failure responses unencrypted (`shouldEncryptFailureResponse == NO`), which is exactly the `error_code` branch in `MSIDLegacyBrokerResponseHandler`. The nonce there is read from cleartext query params and is editable in transit, so enforcement on that branch stops a blind replay where the attacker only holds a captured response, but not an attacker who can observe the outbound request. It's covered by tests for behavioral completeness, not because it carries a real guarantee. Closing that gap properly needs an envelope change and is out of scope here.
