### PR TITLE
[patch] [bugfix]: Rename execution flow tag helpers to avoid duplicate symbols with OneAuth

### DIFF
--- a/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
+++ b/IdentityCore/src/controllers/MSIDRequestControllerFactory.m
@@ -50,7 +50,7 @@
                                                 tokenRequestProvider:(id<MSIDTokenRequestProviding>)tokenRequestProvider
                                                                error:(NSError *__autoreleasing*)error
 {
-    MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerForParametersTag),
+    MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerForParametersTag),
                                    @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(parameters.xpcMode)},
                                    parameters.correlationId);
     if (parameters.xpcMode == MSIDXpcModeDisabled)
@@ -87,12 +87,12 @@
     
     if ([parameters shouldUseBroker])
     {
-        MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerShouldUseBrokerTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerShouldUseBrokerTag),
                                        nil,
                                        parameters.correlationId);
         if ([MSIDSSOExtensionSilentTokenRequestController canPerformRequest])
         {
-            MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerCanPerformSsoExtTag),
+            MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerCanPerformSsoExtTag),
                                            @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(parameters.allowUsingLocalCachedRtWhenSsoExtFailed)},
                                            parameters.correlationId);
             MSIDSilentController *localController = nil;
@@ -118,7 +118,7 @@
     
     if (!brokerController)
     {
-        MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerNoBrokerFallbackTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerNoBrokerFallbackTag),
                                        @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(parameters.allowUsingLocalCachedRtWhenSsoExtFailed)},
                                        parameters.correlationId);
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, parameters, @"No fallback brokerController is provided", nil);
@@ -149,7 +149,7 @@
             break;
     }
     
-    MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerFinishTag),
+    MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerFinishTag),
                                    @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(localController.skipLocalRt)},
                                    parameters.correlationId);
     
@@ -172,7 +172,7 @@
     
     if ([parameters shouldUseBroker])
     {
-        MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerShouldUseBrokerTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerShouldUseBrokerTag),
                                        @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(parameters.allowUsingLocalCachedRtWhenSsoExtFailed)},
                                        parameters.correlationId);
         if (parameters.allowUsingLocalCachedRtWhenSsoExtFailed)
@@ -188,7 +188,7 @@
 #if TARGET_OS_OSX
         if (parameters.xpcMode != MSIDXpcModeDisabled && [MSIDXpcSilentTokenRequestController canPerformRequest])
         {
-            MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerCanPerformBrokerXpcTag),
+            MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerCanPerformBrokerXpcTag),
                                            @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(parameters.xpcMode)},
                                            parameters.correlationId);
             xpcController = [[MSIDXpcSilentTokenRequestController alloc] initWithRequestParameters:parameters
@@ -209,7 +209,7 @@
         
         if (!shouldSkipSsoExtension && [MSIDSSOExtensionSilentTokenRequestController canPerformRequest])
         {
-            MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerCanPerformSsoExtTag),
+            MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerCanPerformSsoExtTag),
                                            nil,
                                            parameters.correlationId);
             fallbackController = [[MSIDSSOExtensionSilentTokenRequestController alloc] initWithRequestParameters:parameters
@@ -222,7 +222,7 @@
     
     if (!fallbackController)
     {
-        MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerNoBrokerFallbackTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerNoBrokerFallbackTag),
                                        @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(parameters.allowUsingLocalCachedRtWhenSsoExtFailed)},
                                        parameters.correlationId);
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, parameters, @"No fallbackController is provided", nil);
@@ -253,7 +253,7 @@
             break;
     }
     
-    MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDSilentControllerFinishTag),
+    MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDSilentControllerFinishTag),
                                    @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(silentController.skipLocalRt)},
                                    parameters.correlationId);
     return silentController;
@@ -270,7 +270,7 @@
         [parameters reverseNestedAuthParametersIfNeeded];
     }
 
-    MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDInteractiveControllerForParametersTag),
+    MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDInteractiveControllerForParametersTag),
                                    @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(parameters.xpcMode)},
                                    parameters.correlationId);
 
@@ -288,7 +288,7 @@
                                                                             error:error];
     }
 
-    MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDInteractiveControllerFinishTag),
+    MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDInteractiveControllerFinishTag),
                                    @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(parameters.uiBehaviorType)},
                                    parameters.correlationId);
 
@@ -310,7 +310,7 @@
     
     if ([parameters shouldUseBroker])
     {
-        MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDInteractiveControllerShouldUseBrokerTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDInteractiveControllerShouldUseBrokerTag),
                                        nil,
                                        parameters.correlationId);
         id<MSIDRequestControlling> brokerController = [self brokerController:parameters
@@ -323,7 +323,7 @@
             return brokerController;
         }
 
-        MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDInteractiveControllerNoBrokerFallbackTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDInteractiveControllerNoBrokerFallbackTag),
                                        nil,
                                        parameters.correlationId);
     }
@@ -429,7 +429,7 @@
 {
     if ([MSIDSSOExtensionInteractiveTokenRequestController canPerformRequest])
     {
-        MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDInteractiveControllerCanPerformSsoExtTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDInteractiveControllerCanPerformSsoExtTag),
                                        nil,
                                        parameters.correlationId);
         return [[MSIDSSOExtensionInteractiveTokenRequestController alloc] initWithInteractiveRequestParameters:parameters
@@ -449,7 +449,7 @@
 {
     if ([MSIDXpcInteractiveTokenRequestController canPerformRequest])
     {
-        MSIDExecutionFlowInsertTag(MSIDRequestControllerFactoryTagToString(MSIDInteractiveControllerCanPerformBrokerXpcTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromRequestControllerFactoryTag(MSIDInteractiveControllerCanPerformBrokerXpcTag),
                                        @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@(parameters.xpcMode)},
                                        parameters.correlationId);
         return [[MSIDXpcInteractiveTokenRequestController alloc] initWithInteractiveRequestParameters:parameters

--- a/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
+++ b/IdentityCore/src/controllers/broker/ios/MSIDBrokerInteractiveController.m
@@ -482,7 +482,7 @@ static MSIDBrokerTokenRequest *s_currentBrokerRequest;
 {
     // TODO: vt handling for older broker (not necessary for MSAL, so can come later)
 
-    MSIDExecutionFlowInsertTag(MSIDSSORemoteInteractiveTokenRequestTagToString(MSIDLegacyBrokerInteractiveCompletionTag), error ? @{MSID_EXECUTION_FLOW_ERROR_CODE:@(error.code)} : nil, self.requestParameters.correlationId);
+    MSIDExecutionFlowInsertTag(MSIDStringFromSSORemoteInteractiveTokenRequestTag(MSIDLegacyBrokerInteractiveCompletionTag), error ? @{MSID_EXECUTION_FLOW_ERROR_CODE:@(error.code)} : nil, self.requestParameters.correlationId);
     [self.class stopTrackingAppState];
 
 #if !EXCLUDE_FROM_MSALCPP

--- a/IdentityCore/src/network/MSIDHttpRequest.m
+++ b/IdentityCore/src/network/MSIDHttpRequest.m
@@ -272,7 +272,7 @@ static NSTimeInterval s_requestTimeoutInterval = 300;
 
 - (NSString *)toString:(MSIDExecutionFlowNetworkTag)tag
 {
-    return MSIDExecutionFlowNetworkTagToString(tag);
+    return MSIDStringFromExecutionFlowNetworkTag(tag);
 }
 
 @end

--- a/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
+++ b/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.m
@@ -74,7 +74,7 @@
     
     if (shouldRetry)
     {
-        MSIDExecutionFlowInsertTag(MSIDExecutionFlowNetworkTagToString(MSIDRetryOnNetworkFailureTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromExecutionFlowNetworkTag(MSIDRetryOnNetworkFailureTag),
                                        nil,
                                        context.correlationId);
         httpRequest.retryCounter--;
@@ -82,7 +82,7 @@
         MSID_LOG_WITH_CTX(MSIDLogLevelVerbose,context, @"Retrying network request, retryCounter: %ld", (long)httpRequest.retryCounter);
         
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(httpRequest.retryInterval * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            MSIDExecutionFlowInsertTag(MSIDExecutionFlowNetworkTagToString(MSIDStartToRetryOnNetworkFailureTag),
+            MSIDExecutionFlowInsertTag(MSIDStringFromExecutionFlowNetworkTag(MSIDStartToRetryOnNetworkFailureTag),
                                            nil,
                                            context.correlationId);
             [httpRequest sendWithBlock:completionBlock];

--- a/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
+++ b/IdentityCore/src/oauth2/token/MSIDBoundTokenProvider.m
@@ -28,7 +28,7 @@
 #import "MSIDLogger+Internal.h"
 #import "NSString+MSIDExtensions.h"
 
-NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider]";
+static NSString *const MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX = @"[MSIDBoundTokenProvider]";
 
 @implementation MSIDBoundTokenProvider
 

--- a/IdentityCore/src/parameters/MSIDRequestParameters.m
+++ b/IdentityCore/src/parameters/MSIDRequestParameters.m
@@ -186,7 +186,7 @@
 
         if (self.correlationId)
         {
-            MSIDExecutionFlowInsertTag(MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameIgnoredTag), nil, self.correlationId);
+            MSIDExecutionFlowInsertTag(MSIDStringFromCloudInstanceHostNameTag(MSIDCloudInstanceHostNameIgnoredTag), nil, self.correlationId);
         }
 
         return;

--- a/IdentityCore/src/requests/MSIDSilentTokenRequest.m
+++ b/IdentityCore/src/requests/MSIDSilentTokenRequest.m
@@ -190,7 +190,7 @@ typedef NS_ENUM(NSInteger, MSIDRefreshTokenTypes)
             if (accessToken.cachedAt)
             {
                 NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:accessToken.expiresOn];
-                MSIDExecutionFlowInsertTag(MSIDTokenRequestTagToString(MSIDAtExpirationElapsedTag),
+                MSIDExecutionFlowInsertTag(MSIDStringFromTokenRequestTag(MSIDAtExpirationElapsedTag),
                                                @{MSID_EXECUTION_FLOW_DIAGNOSTIC_ID:@((int64_t)elapsed)},
                                                self.requestParameters.correlationId);
             }

--- a/IdentityCore/src/requests/broker/MSIDSSORemoteInteractiveTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSORemoteInteractiveTokenRequest.m
@@ -101,7 +101,7 @@
                                                  context:self.requestParameters
                                          completionBlock:^(__unused NSURL *openIdConfigurationEndpoint, __unused BOOL validated, NSError *error)
      {
-        MSIDExecutionFlowInsertTag(MSIDSSORemoteInteractiveTokenRequestTagToString(MSIDInteractiveResolveAuthorityTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromSSORemoteInteractiveTokenRequestTag(MSIDInteractiveResolveAuthorityTag),
                                        error ? @{MSID_EXECUTION_FLOW_ERROR_CODE:@(error.code)} : nil,
                                        self.requestParameters.correlationId);
          if (error)
@@ -145,7 +145,7 @@
     #if TARGET_OS_OSX && !EXCLUDE_FROM_MSALCPP
             strongSelf.ssoTokenResponseHandler.externalCacheSeeder = strongSelf.externalCacheSeeder;
     #endif
-            MSIDExecutionFlowInsertTag(MSIDSSORemoteInteractiveTokenRequestTagToString(MSIDInteractiveHandleOperationResponseTag),
+            MSIDExecutionFlowInsertTag(MSIDStringFromSSORemoteInteractiveTokenRequestTag(MSIDInteractiveHandleOperationResponseTag),
                                            error ? @{MSID_EXECUTION_FLOW_ERROR_CODE:@(error.code)} : nil,
                                            strongSelf.requestParameters.correlationId);
             __typeof__(strongSelf) __weak weakStrongSelf = strongSelf;
@@ -162,7 +162,7 @@
                 __strong __typeof__(weakStrongSelf) innerStrongSelf = weakStrongSelf;
                 if (!innerStrongSelf) return;
                 
-                MSIDExecutionFlowInsertTag(MSIDSSORemoteInteractiveTokenRequestTagToString(MSIDInteractiveCompletionTag),
+                MSIDExecutionFlowInsertTag(MSIDStringFromSSORemoteInteractiveTokenRequestTag(MSIDInteractiveCompletionTag),
                                                localError ? @{MSID_EXECUTION_FLOW_ERROR_CODE:@(localError.code)} : nil,
                                                innerStrongSelf.requestParameters.correlationId);
                 MSIDInteractiveRequestCompletionBlock completionBlock = innerStrongSelf.requestCompletionBlock;

--- a/IdentityCore/src/requests/broker/MSIDSSORemoteSilentTokenRequest.m
+++ b/IdentityCore/src/requests/broker/MSIDSSORemoteSilentTokenRequest.m
@@ -103,7 +103,7 @@ NSString *const MSID_TOKEN_RESULT_BROKER_REQUEST_STARVATION_DURATION = @"broker_
                     strongSelf.ssoTokenResponseHandler.externalCacheSeeder = strongSelf.externalCacheSeeder;
     #endif
                     __typeof__(strongSelf) __weak weakStrongSelf = strongSelf;
-                    MSIDExecutionFlowInsertTag(MSIDSSORemoteSilentTokenRequestTagToString(MSIDSilentHandleOperationResponseTag),
+                    MSIDExecutionFlowInsertTag(MSIDStringFromSSORemoteSilentTokenRequestTag(MSIDSilentHandleOperationResponseTag),
                                                    error ? @{MSID_EXECUTION_FLOW_ERROR_CODE:@(error.code)} : nil,
                                                    strongSelf.requestParameters.correlationId);
                     [strongSelf.ssoTokenResponseHandler handleOperationResponse:operationResponse
@@ -119,7 +119,7 @@ NSString *const MSID_TOKEN_RESULT_BROKER_REQUEST_STARVATION_DURATION = @"broker_
                         __strong __typeof__(weakStrongSelf) innerStrongSelf = weakStrongSelf;
                         if (!innerStrongSelf) return;
                         
-                        MSIDExecutionFlowInsertTag(MSIDSSORemoteSilentTokenRequestTagToString(MSIDSilentCompletionTag),
+                        MSIDExecutionFlowInsertTag(MSIDStringFromSSORemoteSilentTokenRequestTag(MSIDSilentCompletionTag),
                                                        localError ? @{MSID_EXECUTION_FLOW_ERROR_CODE:@(localError.code)} : nil,
                                                        innerStrongSelf.requestParameters.correlationId);
                         MSIDRequestCompletionBlock completionBlock = innerStrongSelf.requestCompletionBlock;
@@ -161,7 +161,7 @@ NSString *const MSID_TOKEN_RESULT_BROKER_REQUEST_STARVATION_DURATION = @"broker_
                                          completionBlock:^(__unused NSURL *openIdConfigurationEndpoint,
                                                            __unused BOOL validated, NSError *error)
      {
-        MSIDExecutionFlowInsertTag(MSIDSSORemoteSilentTokenRequestTagToString(MSIDSilentResolveAuthorityTag),
+        MSIDExecutionFlowInsertTag(MSIDStringFromSSORemoteSilentTokenRequestTag(MSIDSilentResolveAuthorityTag),
                                        error ? @{MSID_EXECUTION_FLOW_ERROR_CODE:@(error.code)} : nil,
                                        self.requestParameters.correlationId);
         if (error)

--- a/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.h
+++ b/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSInteger, MSIDExecutionFlowNetworkTag)
 };
 
 /// Returns the string representation for each MSIDExecutionFlowNetworkTag value.
-FOUNDATION_EXPORT NSString * _Nonnull MSIDExecutionFlowNetworkTagToString(MSIDExecutionFlowNetworkTag state);
+FOUNDATION_EXPORT NSString * _Nonnull MSIDStringFromExecutionFlowNetworkTag(MSIDExecutionFlowNetworkTag state);
 
 /// A enum of MSIDTokenRequestTag.
 typedef NS_ENUM(NSInteger, MSIDTokenRequestTag)
@@ -80,7 +80,7 @@ typedef NS_ENUM(NSInteger, MSIDTokenRequestTag)
 };
 
 /// Returns the string representation for each MSIDTokenRequestTag value.
-FOUNDATION_EXPORT NSString * _Nonnull MSIDTokenRequestTagToString(MSIDTokenRequestTag state);
+FOUNDATION_EXPORT NSString * _Nonnull MSIDStringFromTokenRequestTag(MSIDTokenRequestTag state);
 
 /// An enum of MSIDRequestControllerFactoryTag.
 typedef NS_ENUM(NSInteger, MSIDRequestControllerFactoryTag)
@@ -100,7 +100,7 @@ typedef NS_ENUM(NSInteger, MSIDRequestControllerFactoryTag)
 };
 
 /// Returns the string representation for each MSIDRequestControllerFactoryTag value.
-FOUNDATION_EXPORT NSString * _Nonnull MSIDRequestControllerFactoryTagToString(MSIDRequestControllerFactoryTag state);
+FOUNDATION_EXPORT NSString * _Nonnull MSIDStringFromRequestControllerFactoryTag(MSIDRequestControllerFactoryTag state);
 
 /// An enum of MSIDSSORemoteInteractiveTokenRequestTag.
 typedef NS_ENUM(NSInteger, MSIDSSORemoteInteractiveTokenRequestTag)
@@ -112,7 +112,7 @@ typedef NS_ENUM(NSInteger, MSIDSSORemoteInteractiveTokenRequestTag)
 };
 
 /// Returns the string representation for each MSIDSSORemoteInteractiveTokenRequestTag value.
-FOUNDATION_EXPORT NSString * _Nonnull MSIDSSORemoteInteractiveTokenRequestTagToString(MSIDSSORemoteInteractiveTokenRequestTag state);
+FOUNDATION_EXPORT NSString * _Nonnull MSIDStringFromSSORemoteInteractiveTokenRequestTag(MSIDSSORemoteInteractiveTokenRequestTag state);
 
 /// An enum of MSIDSSORemoteSilentTokenRequestTag.
 typedef NS_ENUM(NSInteger, MSIDSSORemoteSilentTokenRequestTag)
@@ -122,7 +122,7 @@ typedef NS_ENUM(NSInteger, MSIDSSORemoteSilentTokenRequestTag)
     MSIDSilentCompletionTag
 };
 /// Returns the string representation for each MSIDSSORemoteSilentTokenRequestTag value.
-FOUNDATION_EXPORT NSString * _Nonnull MSIDSSORemoteSilentTokenRequestTagToString(MSIDSSORemoteSilentTokenRequestTag state);
+FOUNDATION_EXPORT NSString * _Nonnull MSIDStringFromSSORemoteSilentTokenRequestTag(MSIDSSORemoteSilentTokenRequestTag state);
 
 /// An enum of MSIDCloudInstanceHostNameTag.
 typedef NS_ENUM(NSInteger, MSIDCloudInstanceHostNameTag)
@@ -130,7 +130,7 @@ typedef NS_ENUM(NSInteger, MSIDCloudInstanceHostNameTag)
     MSIDCloudInstanceHostNameIgnoredTag = 0
 };
 /// Returns the string representation for each MSIDCloudInstanceHostNameTag value.
-FOUNDATION_EXPORT NSString * _Nonnull MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameTag state);
+FOUNDATION_EXPORT NSString * _Nonnull MSIDStringFromCloudInstanceHostNameTag(MSIDCloudInstanceHostNameTag state);
 
 /// An enum of MSIDPkeyAuthTag.
 typedef NS_ENUM(NSInteger, MSIDPkeyAuthTag)
@@ -140,7 +140,7 @@ typedef NS_ENUM(NSInteger, MSIDPkeyAuthTag)
 };
 
 /// Returns the string representation for each MSIDPkeyAuthTag value.
-FOUNDATION_EXPORT NSString * _Nonnull MSIDPkeyAuthTagToString(MSIDPkeyAuthTag state);
+FOUNDATION_EXPORT NSString * _Nonnull MSIDStringFromPkeyAuthTag(MSIDPkeyAuthTag state);
 
 /// An enum of MSIDCustomHeaderTag.
 typedef NS_ENUM(NSInteger, MSIDCustomHeaderTag)

--- a/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.m
+++ b/IdentityCore/src/telemetry/execution_flow/MSIDExecutionFlowConstants.m
@@ -46,7 +46,7 @@ NSString *const MSID_EXECUTION_FLOW_JSON_COMMA = @",";
 NSString *const MSID_EXECUTION_FLOW_JSON_CLOSE_BRACKET = @"]";
 NSString *const MSID_EXECUTION_FLOW_JSON_EMPTY_ARRAY = @"[]";
 
-NSString *MSIDExecutionFlowNetworkTagToString(MSIDExecutionFlowNetworkTag state)
+NSString *MSIDStringFromExecutionFlowNetworkTag(MSIDExecutionFlowNetworkTag state)
 {
     switch (state)
     {
@@ -72,7 +72,7 @@ NSString *MSIDExecutionFlowNetworkTagToString(MSIDExecutionFlowNetworkTag state)
     return [NSString stringWithFormat:@"MSIDExecutionFlowNetworkTag(%ld)", (long)state];
 }
 
-NSString *MSIDTokenRequestTagToString(MSIDTokenRequestTag state)
+NSString *MSIDStringFromTokenRequestTag(MSIDTokenRequestTag state)
 {
     switch (state)
     {
@@ -84,7 +84,7 @@ NSString *MSIDTokenRequestTagToString(MSIDTokenRequestTag state)
     return [NSString stringWithFormat:@"MSIDTokenRequestTag(%ld)", (long)state];
 }
 
-NSString *MSIDRequestControllerFactoryTagToString(MSIDRequestControllerFactoryTag state)
+NSString *MSIDStringFromRequestControllerFactoryTag(MSIDRequestControllerFactoryTag state)
 {
     switch (state)
     {
@@ -117,7 +117,7 @@ NSString *MSIDRequestControllerFactoryTagToString(MSIDRequestControllerFactoryTa
     // Fallback for any future enum values
     return [NSString stringWithFormat:@"MSIDRequestControllerFactoryTag(%ld)", (long)state];
 }
-NSString *MSIDSSORemoteInteractiveTokenRequestTagToString(MSIDSSORemoteInteractiveTokenRequestTag state)
+NSString *MSIDStringFromSSORemoteInteractiveTokenRequestTag(MSIDSSORemoteInteractiveTokenRequestTag state)
 {
     switch (state)
     {
@@ -135,7 +135,7 @@ NSString *MSIDSSORemoteInteractiveTokenRequestTagToString(MSIDSSORemoteInteracti
     return [NSString stringWithFormat:@"MSIDSSORemoteInteractiveTokenRequestTag(%ld)", (long)state];
 }
 
-NSString *MSIDSSORemoteSilentTokenRequestTagToString(MSIDSSORemoteSilentTokenRequestTag state)
+NSString *MSIDStringFromSSORemoteSilentTokenRequestTag(MSIDSSORemoteSilentTokenRequestTag state)
 {
     switch (state)
     {
@@ -150,7 +150,7 @@ NSString *MSIDSSORemoteSilentTokenRequestTagToString(MSIDSSORemoteSilentTokenReq
     return [NSString stringWithFormat:@"MSIDSSORemoteSilentTokenRequestTag(%ld)", (long)state];
 }
 
-NSString *MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameTag state)
+NSString *MSIDStringFromCloudInstanceHostNameTag(MSIDCloudInstanceHostNameTag state)
 {
     switch (state)
     {
@@ -161,7 +161,7 @@ NSString *MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameTag stat
     return [NSString stringWithFormat:@"MSIDCloudInstanceHostNameTag(%ld)", (long)state];
 }
 
-NSString *MSIDPkeyAuthTagToString(MSIDPkeyAuthTag state)
+NSString *MSIDStringFromPkeyAuthTag(MSIDPkeyAuthTag state)
 {
     switch (state)
     {

--- a/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
+++ b/IdentityCore/src/webview/embeddedWebview/challangeHandlers/MSIDPKeyAuthHandler.m
@@ -108,7 +108,7 @@
             [responseReq setValue:credentialHeader forHTTPHeaderField:MSID_REFRESH_TOKEN_CREDENTIAL];
             if (context.correlationId)
             {
-                MSIDExecutionFlowInsertTag(MSIDPkeyAuthTagToString(MSIDPkeyAuthAddedRefreshTokenCredentialTag), nil, context.correlationId);
+                MSIDExecutionFlowInsertTag(MSIDStringFromPkeyAuthTag(MSIDPkeyAuthAddedRefreshTokenCredentialTag), nil, context.correlationId);
             }
         }
         else
@@ -116,7 +116,7 @@
             MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Skipped adding refresh token to the PkeyAuth response because the submit URL host is not a known AAD host.");
             if (context.correlationId)
             {
-                MSIDExecutionFlowInsertTag(MSIDPkeyAuthTagToString(MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag), nil, context.correlationId);
+                MSIDExecutionFlowInsertTag(MSIDStringFromPkeyAuthTag(MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag), nil, context.correlationId);
             }
         }
     }

--- a/IdentityCore/tests/MSIDExecutionFlowTagTests.m
+++ b/IdentityCore/tests/MSIDExecutionFlowTagTests.m
@@ -34,27 +34,27 @@
 - (void)test_MSIDExecutionFlowNetworkTagToString_allTagsAreUnique
 {
     NSArray *tags = @[
-        MSIDExecutionFlowNetworkTagToString(MSIDPrepareNetworkRequestTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDCacheResponseFailedObjectTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDCacheResponseSucceededObjectTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDReceiveNetworkResponseTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDRetryOnNetworkFailureTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDParseNetworkResponseTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDOtherHttpNetworkStatusCodeTag)
+        MSIDStringFromExecutionFlowNetworkTag(MSIDPrepareNetworkRequestTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDCacheResponseFailedObjectTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDCacheResponseSucceededObjectTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDReceiveNetworkResponseTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDRetryOnNetworkFailureTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDParseNetworkResponseTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDOtherHttpNetworkStatusCodeTag)
     ];
     
     NSSet *uniqueTags = [NSSet setWithArray:tags];
-    XCTAssertEqual(tags.count, uniqueTags.count, @"Duplicate tags found in MSIDExecutionFlowNetworkTagToString");
+    XCTAssertEqual(tags.count, uniqueTags.count, @"Duplicate tags found in MSIDStringFromExecutionFlowNetworkTag");
 }
 
 - (void)test_MSIDTokenRequestTagToString_allTagsAreUnique
 {
     NSArray *tags = @[
-        MSIDTokenRequestTagToString(MSIDAtExpirationElapsedTag)
+        MSIDStringFromTokenRequestTag(MSIDAtExpirationElapsedTag)
     ];
     
     NSSet *uniqueTags = [NSSet setWithArray:tags];
-    XCTAssertEqual(tags.count, uniqueTags.count, @"Duplicate tags found in MSIDTokenRequestTagToString");
+    XCTAssertEqual(tags.count, uniqueTags.count, @"Duplicate tags found in MSIDStringFromTokenRequestTag");
 }
 
 - (void)test_allTagsAreGloballyUnique
@@ -62,17 +62,17 @@
     NSMutableArray *allTags = [NSMutableArray array];
     
     [allTags addObjectsFromArray:@[
-        MSIDExecutionFlowNetworkTagToString(MSIDPrepareNetworkRequestTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDCacheResponseFailedObjectTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDCacheResponseSucceededObjectTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDReceiveNetworkResponseTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDRetryOnNetworkFailureTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDParseNetworkResponseTag),
-        MSIDExecutionFlowNetworkTagToString(MSIDOtherHttpNetworkStatusCodeTag)
+        MSIDStringFromExecutionFlowNetworkTag(MSIDPrepareNetworkRequestTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDCacheResponseFailedObjectTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDCacheResponseSucceededObjectTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDReceiveNetworkResponseTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDRetryOnNetworkFailureTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDParseNetworkResponseTag),
+        MSIDStringFromExecutionFlowNetworkTag(MSIDOtherHttpNetworkStatusCodeTag)
     ]];
     
     [allTags addObjectsFromArray:@[
-        MSIDTokenRequestTagToString(MSIDAtExpirationElapsedTag)
+        MSIDStringFromTokenRequestTag(MSIDAtExpirationElapsedTag)
     ]];
     
     NSSet *uniqueTags = [NSSet setWithArray:allTags];
@@ -81,30 +81,30 @@
 
 - (void)test_MSIDExecutionFlowNetworkTagToString_returnsExpectedStrings
 {
-    XCTAssertEqualObjects(MSIDExecutionFlowNetworkTagToString(MSIDPrepareNetworkRequestTag), @"iq24n");
-    XCTAssertEqualObjects(MSIDExecutionFlowNetworkTagToString(MSIDCacheResponseFailedObjectTag), @"twoty");
-    XCTAssertEqualObjects(MSIDExecutionFlowNetworkTagToString(MSIDCacheResponseSucceededObjectTag), @"n3416");
-    XCTAssertEqualObjects(MSIDExecutionFlowNetworkTagToString(MSIDReceiveNetworkResponseTag), @"xfx8w");
-    XCTAssertEqualObjects(MSIDExecutionFlowNetworkTagToString(MSIDRetryOnNetworkFailureTag), @"rz95n");
-    XCTAssertEqualObjects(MSIDExecutionFlowNetworkTagToString(MSIDParseNetworkResponseTag), @"fxjo7");
-    XCTAssertEqualObjects(MSIDExecutionFlowNetworkTagToString(MSIDOtherHttpNetworkStatusCodeTag), @"5kbvm");
+    XCTAssertEqualObjects(MSIDStringFromExecutionFlowNetworkTag(MSIDPrepareNetworkRequestTag), @"iq24n");
+    XCTAssertEqualObjects(MSIDStringFromExecutionFlowNetworkTag(MSIDCacheResponseFailedObjectTag), @"twoty");
+    XCTAssertEqualObjects(MSIDStringFromExecutionFlowNetworkTag(MSIDCacheResponseSucceededObjectTag), @"n3416");
+    XCTAssertEqualObjects(MSIDStringFromExecutionFlowNetworkTag(MSIDReceiveNetworkResponseTag), @"xfx8w");
+    XCTAssertEqualObjects(MSIDStringFromExecutionFlowNetworkTag(MSIDRetryOnNetworkFailureTag), @"rz95n");
+    XCTAssertEqualObjects(MSIDStringFromExecutionFlowNetworkTag(MSIDParseNetworkResponseTag), @"fxjo7");
+    XCTAssertEqualObjects(MSIDStringFromExecutionFlowNetworkTag(MSIDOtherHttpNetworkStatusCodeTag), @"5kbvm");
 }
 
 - (void)test_MSIDTokenRequestTagToString_returnsExpectedStrings
 {
-    XCTAssertEqualObjects(MSIDTokenRequestTagToString(MSIDAtExpirationElapsedTag), @"xilux");
+    XCTAssertEqualObjects(MSIDStringFromTokenRequestTag(MSIDAtExpirationElapsedTag), @"xilux");
 }
 
 - (void)test_MSIDExecutionFlowNetworkTagToString_unknownEnum_returnsFallback
 {
-    NSString *result = MSIDExecutionFlowNetworkTagToString((MSIDExecutionFlowNetworkTag)9999);
+    NSString *result = MSIDStringFromExecutionFlowNetworkTag((MSIDExecutionFlowNetworkTag)9999);
     XCTAssertTrue([result containsString:@"MSIDExecutionFlowNetworkTag"]);
     XCTAssertTrue([result containsString:@"9999"]);
 }
 
 - (void)test_MSIDTokenRequestTagToString_unknownEnum_returnsFallback
 {
-    NSString *result = MSIDTokenRequestTagToString((MSIDTokenRequestTag)9999);
+    NSString *result = MSIDStringFromTokenRequestTag((MSIDTokenRequestTag)9999);
     XCTAssertTrue([result containsString:@"MSIDTokenRequestTag"]);
     XCTAssertTrue([result containsString:@"9999"]);
 }

--- a/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
+++ b/IdentityCore/tests/MSIDPKeyAuthHandlerTests.m
@@ -256,8 +256,8 @@
     XCTestExpectation *flowExpectation = [self expectationWithDescription:@"execution flow should contain the added PRT tag"];
     MSIDExecutionFlowRetrieve(context.correlationId, nil, YES, ^(NSString * _Nullable executionFlow) {
         XCTAssertNotNil(executionFlow);
-        XCTAssertTrue([executionFlow containsString:MSIDPkeyAuthTagToString(MSIDPkeyAuthAddedRefreshTokenCredentialTag)], @"Flow should record the added PRT tag");
-        XCTAssertFalse([executionFlow containsString:MSIDPkeyAuthTagToString(MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag)], @"Flow should not record the skipped tag");
+        XCTAssertTrue([executionFlow containsString:MSIDStringFromPkeyAuthTag(MSIDPkeyAuthAddedRefreshTokenCredentialTag)], @"Flow should record the added PRT tag");
+        XCTAssertFalse([executionFlow containsString:MSIDStringFromPkeyAuthTag(MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag)], @"Flow should not record the skipped tag");
         [flowExpectation fulfill];
     });
     [self waitForExpectationsWithTimeout:1 handler:nil];
@@ -293,8 +293,8 @@
     XCTestExpectation *flowExpectation = [self expectationWithDescription:@"execution flow should contain the skipped PRT tag"];
     MSIDExecutionFlowRetrieve(context.correlationId, nil, YES, ^(NSString * _Nullable executionFlow) {
         XCTAssertNotNil(executionFlow);
-        XCTAssertTrue([executionFlow containsString:MSIDPkeyAuthTagToString(MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag)], @"Flow should record the skipped PRT tag");
-        XCTAssertFalse([executionFlow containsString:MSIDPkeyAuthTagToString(MSIDPkeyAuthAddedRefreshTokenCredentialTag)], @"Flow should not record the added tag");
+        XCTAssertTrue([executionFlow containsString:MSIDStringFromPkeyAuthTag(MSIDPkeyAuthSkippedRefreshTokenCredentialUntrustedHostTag)], @"Flow should record the skipped PRT tag");
+        XCTAssertFalse([executionFlow containsString:MSIDStringFromPkeyAuthTag(MSIDPkeyAuthAddedRefreshTokenCredentialTag)], @"Flow should not record the added tag");
         [flowExpectation fulfill];
     });
     [self waitForExpectationsWithTimeout:1 handler:nil];

--- a/IdentityCore/tests/MSIDRequestParametersTests.m
+++ b/IdentityCore/tests/MSIDRequestParametersTests.m
@@ -659,7 +659,7 @@
     XCTestExpectation *flowExpectation = [self expectationWithDescription:@"execution flow should record the ignored cloud host tag"];
     MSIDExecutionFlowRetrieve(parameters.correlationId, nil, YES, ^(NSString * _Nullable executionFlow) {
         XCTAssertNotNil(executionFlow);
-        XCTAssertTrue([executionFlow containsString:MSIDCloudInstanceHostNameTagToString(MSIDCloudInstanceHostNameIgnoredTag)], @"Flow should record the ignored cloud host tag");
+        XCTAssertTrue([executionFlow containsString:MSIDStringFromCloudInstanceHostNameTag(MSIDCloudInstanceHostNameIgnoredTag)], @"Flow should record the ignored cloud host tag");
         [flowExpectation fulfill];
     });
     [self waitForExpectationsWithTimeout:1 handler:nil];

--- a/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
+++ b/IdentityCore/tests/integration/ios/MSIDDefaultSilentTokenRequestTests.m
@@ -1493,7 +1493,7 @@
         XCTAssertEqualObjects(error.userInfo[MSIDHTTPResponseCodeKey], @"403");
         MSIDExecutionFlowRetrieve(silentParameters.correlationId, nil, YES, ^(NSString * _Nullable executionFlow) {
             XCTAssertNotNil(executionFlow);
-            XCTAssertTrue([executionFlow containsString:MSIDTokenRequestTagToString(MSIDAtExpirationElapsedTag)]);
+            XCTAssertTrue([executionFlow containsString:MSIDStringFromTokenRequestTag(MSIDAtExpirationElapsedTag)]);
             [expectation fulfill];
         });
     }];


### PR DESCRIPTION
Same change as #1942, targeted at `dev` so the fix does not regress after the release branch merges.

IdentityCore exports 8 symbols that OneAuth 11.1.1's vendored IdentityCore copy also exports **unprefixed**. Linking `libMSAL.a` and `libOneAuth.a` into the same binary fails:

```
ld: 8 duplicate symbols
clang: error: linker command failed with exit code 1
```

### Cause

OneAuth vendors a copy of IdentityCore and renames types/classes/selectors to `MSAI*`, but leaves free functions and file-scope globals unmangled — e.g. in their copy:

```objc
NSString *MSIDExecutionFlowNetworkTagToString(MSAIMSIDExecutionFlowNetworkTag state)
//        ^^^^ not renamed                    ^^^^ renamed
```

so those names stay identical to ours and collide at link time.

### Change

Rename the 7 colliding helpers to `MSIDStringFrom<Tag>()`, keeping the `MSID` prefix so OneAuth's rename tooling picks them up going forward:

| Old | New |
|---|---|
| `MSIDExecutionFlowNetworkTagToString` | `MSIDStringFromExecutionFlowNetworkTag` |
| `MSIDTokenRequestTagToString` | `MSIDStringFromTokenRequestTag` |
| `MSIDRequestControllerFactoryTagToString` | `MSIDStringFromRequestControllerFactoryTag` |
| `MSIDSSORemoteInteractiveTokenRequestTagToString` | `MSIDStringFromSSORemoteInteractiveTokenRequestTag` |
| `MSIDSSORemoteSilentTokenRequestTagToString` | `MSIDStringFromSSORemoteSilentTokenRequestTag` |
| `MSIDCloudInstanceHostNameTagToString` | `MSIDStringFromCloudInstanceHostNameTag` |
| `MSIDPkeyAuthTagToString` | `MSIDStringFromPkeyAuthTag` |

The 8th symbol, `MSID_BOUND_TOKEN_PROVIDER_LOG_PREFIX`, is made `static`. It is used only within `MSIDBoundTokenProvider.m` and has no header declaration, so it never needed external linkage.

`MSIDCustomHeaderTagToString` is intentionally **not** renamed — it landed after OneAuth's vendored snapshot and does not collide.

### Notes

- Pure rename: 16 files, 79 insertions / 79 deletions, no behavior change.
- A fix for OneAuth's rename script exists on their `dev` but is not yet in `master`; this change is compatible either way.