### PR TITLE
[patch] [bugfix]: Do not send external_key_pop to the /token endpoint

### DIFF
--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationScheme.h
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationScheme.h
@@ -43,6 +43,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) MSIDAuthScheme authScheme;
 @property (nonatomic, readonly) NSDictionary *schemeParameters;
+// Subset of schemeParameters that may be sent to the OAuth 2.0 '/token' endpoint. Defaults to
+// schemeParameters. Subclasses override to drop client-internal markers that are not wire parameters.
+@property (nonatomic, readonly) NSDictionary *tokenEndpointParameters;
 @property (nonatomic, readonly) MSIDCredentialType credentialType;
 @property (nonatomic, nullable, readonly) NSString *tokenType;
 @property (nonatomic, readonly) MSIDAccessToken *accessToken;

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationScheme.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationScheme.m
@@ -60,6 +60,11 @@
     return MSIDAuthSchemeBearer;
 }
 
+- (NSDictionary *)tokenEndpointParameters
+{
+    return self.schemeParameters;
+}
+
 - (MSIDCredentialType)credentialType
 {
     return MSIDAccessTokenType;

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemePop.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemePop.m
@@ -150,7 +150,7 @@
     // external_key_pop is a client-internal marker consumed by the broker, not a '/token' parameter.
     NSMutableDictionary *parameters = [self.schemeParameters mutableCopy];
     [parameters removeObjectForKey:MSID_OAUTH2_EXTERNAL_KEY_POP];
-    return parameters;
+    return [parameters copy];
 }
 
 #if !EXCLUDE_FROM_MSALCPP

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemePop.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemePop.m
@@ -140,6 +140,19 @@
     return [self.externalKeyPop isEqualToString:@"1"];
 }
 
+- (NSDictionary *)tokenEndpointParameters
+{
+    if (!self.externalKeyPop)
+    {
+        return self.schemeParameters;
+    }
+
+    // external_key_pop is a client-internal marker consumed by the broker, not a '/token' parameter.
+    NSMutableDictionary *parameters = [self.schemeParameters mutableCopy];
+    [parameters removeObjectForKey:MSID_OAUTH2_EXTERNAL_KEY_POP];
+    return parameters;
+}
+
 #if !EXCLUDE_FROM_MSALCPP
 - (void)configureTelemetryEvent:(MSIDTelemetryAPIEvent *)event
 {

--- a/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemePop.m
+++ b/IdentityCore/src/auth_scheme/MSIDAuthenticationSchemePop.m
@@ -142,11 +142,6 @@
 
 - (NSDictionary *)tokenEndpointParameters
 {
-    if (!self.externalKeyPop)
-    {
-        return self.schemeParameters;
-    }
-
     // external_key_pop is a client-internal marker consumed by the broker, not a '/token' parameter.
     NSMutableDictionary *parameters = [self.schemeParameters mutableCopy];
     [parameters removeObjectForKey:MSID_OAUTH2_EXTERNAL_KEY_POP];

--- a/IdentityCore/src/network/request/MSIDTokenRequest.m
+++ b/IdentityCore/src/network/request/MSIDTokenRequest.m
@@ -48,7 +48,7 @@
         parameters[MSID_OAUTH2_CLIENT_ID] = clientId;
         parameters[MSID_OAUTH2_SCOPE] = scope;
         
-        NSDictionary *authHeaders = authScheme.schemeParameters;
+        NSDictionary *authHeaders = authScheme.tokenEndpointParameters;
         if ([authHeaders count] > 0)
         {
             [parameters addEntriesFromDictionary:authHeaders];

--- a/IdentityCore/src/network/request/MSIDTokenRequest.m
+++ b/IdentityCore/src/network/request/MSIDTokenRequest.m
@@ -48,10 +48,10 @@
         parameters[MSID_OAUTH2_CLIENT_ID] = clientId;
         parameters[MSID_OAUTH2_SCOPE] = scope;
         
-        NSDictionary *authHeaders = authScheme.tokenEndpointParameters;
-        if ([authHeaders count] > 0)
+        NSDictionary *schemeBodyParameters = authScheme.tokenEndpointParameters;
+        if ([schemeBodyParameters count] > 0)
         {
-            [parameters addEntriesFromDictionary:authHeaders];
+            [parameters addEntriesFromDictionary:schemeBodyParameters];
         }
         
         _parameters = parameters;

--- a/IdentityCore/tests/MSIDAuthenticationSchemePopTest.m
+++ b/IdentityCore/tests/MSIDAuthenticationSchemePopTest.m
@@ -27,6 +27,8 @@
 #import "MSIDAccessTokenWithAuthScheme.h"
 #import "MSIDTelemetryAPIEvent.h"
 #import "MSIDTelemetryEventStrings.h"
+#import "MSIDOAuth2Constants.h"
+#import "MSIDTokenRequest.h"
 
 @interface MSIDAuthenticationSchemePopTest : XCTestCase
 
@@ -144,6 +146,45 @@
     MSIDAuthenticationSchemePop *scheme = [[MSIDAuthenticationSchemePop alloc] initWithSchemeParameters:[self preparePopSchemeParameter]];
 
     XCTAssertFalse(scheme.isExternalKeyPop);
+}
+
+- (void)testTokenEndpointParameters_whenExternalKeyPop_shouldExcludeExternalKeyMarker
+{
+    NSMutableDictionary *parameters = [[self preparePopSchemeParameter] mutableCopy];
+    parameters[MSID_OAUTH2_EXTERNAL_KEY_POP] = @"1";
+    MSIDAuthenticationSchemePop *scheme = [[MSIDAuthenticationSchemePop alloc] initWithSchemeParameters:parameters];
+
+    NSDictionary *tokenEndpointParameters = scheme.tokenEndpointParameters;
+
+    XCTAssertNil(tokenEndpointParameters[MSID_OAUTH2_EXTERNAL_KEY_POP]);
+    XCTAssertEqualObjects(tokenEndpointParameters[MSID_OAUTH2_REQUEST_CONFIRMATION], scheme.schemeParameters[MSID_OAUTH2_REQUEST_CONFIRMATION]);
+    XCTAssertEqualObjects(tokenEndpointParameters[MSID_OAUTH2_TOKEN_TYPE], scheme.schemeParameters[MSID_OAUTH2_TOKEN_TYPE]);
+    XCTAssertEqualObjects(scheme.schemeParameters[MSID_OAUTH2_EXTERNAL_KEY_POP], @"1");
+}
+
+- (void)testTokenEndpointParameters_whenInternalKeyPop_shouldReturnSchemeParameters
+{
+    MSIDAuthenticationSchemePop *scheme = [[MSIDAuthenticationSchemePop alloc] initWithSchemeParameters:[self preparePopSchemeParameter]];
+
+    XCTAssertEqualObjects(scheme.tokenEndpointParameters, scheme.schemeParameters);
+}
+
+- (void)testTokenRequestParameters_whenExternalKeyPop_shouldNotSendExternalKeyMarkerToTokenEndpoint
+{
+    NSMutableDictionary *parameters = [[self preparePopSchemeParameter] mutableCopy];
+    parameters[MSID_OAUTH2_EXTERNAL_KEY_POP] = @"1";
+    MSIDAuthenticationSchemePop *scheme = [[MSIDAuthenticationSchemePop alloc] initWithSchemeParameters:parameters];
+
+    MSIDTokenRequest *request = [[MSIDTokenRequest alloc] initWithEndpoint:[NSURL URLWithString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token"]
+                                                               authScheme:scheme
+                                                                 clientId:@"my_client_id"
+                                                                    scope:@"user.read"
+                                                               ssoContext:nil
+                                                                  context:nil];
+
+    XCTAssertNil(request.parameters[MSID_OAUTH2_EXTERNAL_KEY_POP]);
+    XCTAssertEqualObjects(request.parameters[MSID_OAUTH2_TOKEN_TYPE], scheme.schemeParameters[MSID_OAUTH2_TOKEN_TYPE]);
+    XCTAssertEqualObjects(request.parameters[MSID_OAUTH2_REQUEST_CONFIRMATION], scheme.schemeParameters[MSID_OAUTH2_REQUEST_CONFIRMATION]);
 }
 
 - (void)testConfigureTelemetryEvent_whenInternalKey_shouldSetInternalPopKeySource

--- a/IdentityCore/tests/MSIDAuthenticationSchemeSshCertTest.m
+++ b/IdentityCore/tests/MSIDAuthenticationSchemeSshCertTest.m
@@ -44,6 +44,13 @@
     XCTAssertNil(scheme);
 }
 
+- (void)testTokenEndpointParameters_whenSshCertScheme_shouldEqualSchemeParameters
+{
+    MSIDAuthenticationSchemeSshCert *scheme = [[MSIDAuthenticationSchemeSshCert alloc] initWithSchemeParameters:[self prepareSshCertSchemeParameter]];
+
+    XCTAssertEqualObjects(scheme.tokenEndpointParameters, scheme.schemeParameters);
+}
+
 
 - (void)test_InitWithMissingTokenType_shouldReturnNil
 {

--- a/IdentityCore/tests/MSIDAuthenticationSchemeTest.m
+++ b/IdentityCore/tests/MSIDAuthenticationSchemeTest.m
@@ -58,6 +58,13 @@
     XCTAssertNil(scheme.accessToken.kid);
 }
 
+- (void)testTokenEndpointParameters_whenBearerScheme_shouldEqualSchemeParameters
+{
+    MSIDAuthenticationScheme *scheme = [[MSIDAuthenticationScheme alloc] initWithSchemeParameters:[self prepareBearerSchemeParams]];
+
+    XCTAssertEqualObjects(scheme.tokenEndpointParameters, scheme.schemeParameters);
+}
+
 - (void)testConfigureTelemetryEvent_whenBaseScheme_shouldLeavePopKeySourceUnset
 {
     MSIDAuthenticationScheme *scheme = [[MSIDAuthenticationScheme alloc] initWithSchemeParameters:[self prepareBearerSchemeParams]];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Stop sending the client-internal external_key_pop marker to the /token endpoint on the non-broker path. MSIDAuthenticationScheme now exposes tokenEndpointParameters, and MSIDAuthenticationSchemePop overrides it to drop the marker.
 * Add in-process Browser Native Message BART SPA token orchestration for unmanaged iOS hosts.
 
 Version 2.15.0


### PR DESCRIPTION
## Problem

`MSIDTokenRequest` copies the **entire** `authScheme.schemeParameters` dictionary into the `/token` request body:

```objc
NSDictionary *authHeaders = authScheme.schemeParameters;
if ([authHeaders count] > 0)
{
    [parameters addEntriesFromDictionary:authHeaders];
}
```

For external-key AT PoP (#1934), `MSALAuthenticationSchemePop.getSchemeParameters:` adds `external_key_pop=1` to that dictionary. So on the direct (non-broker) path, eSTS receives `token_type`, `req_cnf` **and** `external_key_pop`, even though `external_key_pop` is a client-internal marker that only the broker consumes (`MSIDBrokerTokenRequest` query dict and resume dict).

The broker already strips it before calling eSTS, in `ADBrokerAADV2TokenRequest`:

```objc
NSMutableDictionary *authHeaders = [authScheme.schemeParameters mutableCopy];
[authHeaders removeObjectForKey:MSID_OAUTH2_EXTERNAL_KEY_POP];
```

So the two paths disagreed on what goes on the wire.

## Fix

Rather than duplicating the removal at each request site, the scheme now owns the distinction between its full parameter set and the subset that is a wire parameter.

- `MSIDAuthenticationScheme` gains `tokenEndpointParameters`, defaulting to `schemeParameters`.
- `MSIDAuthenticationSchemePop` overrides it to drop `external_key_pop`.
- `MSIDTokenRequest` uses `tokenEndpointParameters`, which covers `MSIDAuthorizationCodeGrantRequest`, `MSIDRefreshTokenGrantRequest`, and `MSIDDeviceTokenGrantRequest` through inheritance.

`schemeParameters` is deliberately unchanged, so broker request/resume state, JSON serialization, `isExternalKeyPop`, and telemetry all keep seeing the marker.

## Tests

Added to `MSIDAuthenticationSchemePopTest`:

- `testTokenEndpointParameters_whenExternalKeyPop_shouldExcludeExternalKeyMarker`
- `testTokenEndpointParameters_whenInternalKeyPop_shouldReturnSchemeParameters`
- `testTokenRequestParameters_whenExternalKeyPop_shouldNotSendExternalKeyMarkerToTokenEndpoint`

`IdentityCoreTests Mac/MSIDAuthenticationSchemePopTest`: 16 tests, 0 failures.

## Notes

Bearer and SSH-cert schemes are unaffected, they inherit the default and return `schemeParameters` unchanged.