### PR TITLE
[patch] [feature]: Add sub-errors for switch_browser protocol failures

### DIFF
--- a/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
+++ b/IdentityCore/src/oauth2/aad_base/MSIDAADWebviewFactory.m
@@ -242,19 +242,47 @@
         
     if ([self isDUNASupportedForTenantId:nil])
     {
-        MSIDSwitchBrowserResponse *switchBrowserResponse = [[MSIDSwitchBrowserResponse alloc] initWithURL:url
-                                                                                              redirectUri:endRedirectUri
-                                                                                             requestState:requestState
-                                                                                                  context:context
-                                                                                                    error:nil];
-        if (switchBrowserResponse) return switchBrowserResponse;
-        
-        MSIDSwitchBrowserResumeResponse *switchBrowserResumeResponse = [[MSIDSwitchBrowserResumeResponse alloc] initWithURL:url
-                                                                                                                redirectUri:endRedirectUri
-                                                                                                               requestState:requestState
-                                                                                                                    context:context
-                                                                                                                      error:nil];
-        if (switchBrowserResumeResponse) return switchBrowserResumeResponse;
+        // Only surface initializer errors for URLs that are actually switch-browser action URLs.
+        // isDUNAActionUrl: is a cheap path-component check, so a non-DUNA URL still falls through to the
+        // generic auth-code response below exactly as before.
+        //
+        // Without this gate the initializer errors were discarded (error:nil) and two things went wrong:
+        //   1. The sub-errors identifying WHY the response was rejected never reached the caller.
+        //   2. A malformed switch-browser URL - e.g. missing action_uri but carrying a code - fell
+        //      through and could be accepted as an ordinary authorization-code response.
+        NSError *switchBrowserError = nil;
+
+        if ([MSIDSwitchBrowserResponse isDUNAActionUrl:url operation:[MSIDSwitchBrowserResponse.class operation]])
+        {
+            MSIDSwitchBrowserResponse *switchBrowserResponse = [[MSIDSwitchBrowserResponse alloc] initWithURL:url
+                                                                                                  redirectUri:endRedirectUri
+                                                                                                 requestState:requestState
+                                                                                                      context:context
+                                                                                                        error:&switchBrowserError];
+            if (switchBrowserResponse) return switchBrowserResponse;
+
+            if (switchBrowserError)
+            {
+                if (error) *error = switchBrowserError;
+                return nil;
+            }
+        }
+
+        if ([MSIDSwitchBrowserResponse isDUNAActionUrl:url operation:[MSIDSwitchBrowserResumeResponse.class operation]])
+        {
+            MSIDSwitchBrowserResumeResponse *switchBrowserResumeResponse = [[MSIDSwitchBrowserResumeResponse alloc] initWithURL:url
+                                                                                                                    redirectUri:endRedirectUri
+                                                                                                                   requestState:requestState
+                                                                                                                        context:context
+                                                                                                                          error:&switchBrowserError];
+            if (switchBrowserResumeResponse) return switchBrowserResumeResponse;
+
+            if (switchBrowserError)
+            {
+                if (error) *error = switchBrowserError;
+                return nil;
+            }
+        }
     }
     
     // Try to create AAD Auth response or Error response (all other reponses don't handle errors).

--- a/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.h
+++ b/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.h
@@ -25,6 +25,20 @@
 
 #import "MSIDWebviewResponse.h"
 
+/*! Sub-error values stamped on MSIDOAuthSubErrorKey when a switch_browser (DUNA/CBA) response fails to
+    parse or validate. Without these, all three failures collapse into a generic
+    MSIDErrorServerInvalidResponse / MSIDErrorServerInvalidState and are indistinguishable in telemetry -
+    including the state mismatch, which is security-relevant and worth alerting on separately. */
+
+/*! The response's state parameter did not match the state the client sent. */
+extern NSString * const MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISMATCH;
+/*! A state was expected but the response carried none, or vice versa. */
+extern NSString * const MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISSING;
+/*! The response did not carry the action_uri needed to continue the flow. */
+extern NSString * const MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_ACTION_URI;
+/*! The response did not carry the switch-browser session token (code). */
+extern NSString * const MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_CODE;
+
 @interface MSIDSwitchBrowserResponse : MSIDWebviewResponse
 
 typedef NS_OPTIONS(NSInteger, MSIDSwitchBrowserModes) {

--- a/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.h
+++ b/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.h
@@ -26,9 +26,9 @@
 #import "MSIDWebviewResponse.h"
 
 /*! Sub-error values stamped on MSIDOAuthSubErrorKey when a switch_browser (DUNA/CBA) response fails to
-    parse or validate. Without these, all three failures collapse into a generic
-    MSIDErrorServerInvalidResponse / MSIDErrorServerInvalidState and are indistinguishable in telemetry -
-    including the state mismatch, which is security-relevant and worth alerting on separately. */
+    parse or validate. Without these, every such failure collapses into a generic
+    MSIDErrorServerInvalidResponse / MSIDErrorServerInvalidState and they are indistinguishable in
+    telemetry - including the state mismatch, which is security-relevant and worth alerting on separately. */
 
 /*! The response's state parameter did not match the state the client sent. */
 extern NSString * const MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISMATCH;

--- a/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.m
+++ b/IdentityCore/src/webview/response/MSIDSwitchBrowserResponse.m
@@ -31,6 +31,11 @@
 
 @implementation MSIDSwitchBrowserResponse
 
+NSString * const MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISMATCH     = @"switch_browser_state_mismatch";
+NSString * const MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISSING      = @"switch_browser_state_missing";
+NSString * const MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_ACTION_URI = @"switch_browser_missing_action_uri";
+NSString * const MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_CODE       = @"switch_browser_missing_code";
+
 + (NSString *)operation
 {
     return MSID_BROWSER_RESPONSE_SWITCH_BROWSER;
@@ -83,14 +88,14 @@
         
         if ([NSString msidIsStringNilOrBlank:_actionUri])
         {
-            if (error) *error = MSIDCreateError(MSIDOAuthErrorDomain, MSIDErrorServerInvalidResponse, @"action_uri is nil.", nil, nil, nil, context.correlationId, nil, YES);
+            if (error) *error = MSIDCreateError(MSIDOAuthErrorDomain, MSIDErrorServerInvalidResponse, @"action_uri is nil.", nil, MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_ACTION_URI, nil, context.correlationId, nil, YES);
             return nil;
         }
         
         _switchBrowserSessionToken = self.parameters[MSID_OAUTH2_CODE];
         if ([NSString msidIsStringNilOrBlank:_switchBrowserSessionToken])
         {
-            if (error) *error = MSIDCreateError(MSIDOAuthErrorDomain, MSIDErrorServerInvalidResponse, @"code is nil.", nil, nil, nil, context.correlationId, nil, YES);
+            if (error) *error = MSIDCreateError(MSIDOAuthErrorDomain, MSIDErrorServerInvalidResponse, @"code is nil.", nil, MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_CODE, nil, context.correlationId, nil, YES);
             return nil;
         }
     }
@@ -140,7 +145,7 @@
             *error = MSIDCreateError(MSIDOAuthErrorDomain,
                                      MSIDErrorServerInvalidState,
                                      [NSString stringWithFormat:@"Missing or invalid state returned state: %@", receivedState],
-                                     nil, nil, nil, nil, nil, YES);
+                                     nil, MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISSING, nil, nil, nil, YES);
         }
         return NO;
     }
@@ -155,7 +160,7 @@
             *error = MSIDCreateError(MSIDOAuthErrorDomain,
                                      MSIDErrorServerInvalidState,
                                      [NSString stringWithFormat:@"State parameter mismatch. Expected: %@, Received: %@", expectedState, receivedState],
-                                     nil, nil, nil, nil, nil, YES);
+                                     nil, MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISMATCH, nil, nil, nil, YES);
         }
         return NO;
     }

--- a/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
@@ -763,7 +763,14 @@
 - (MSIDFlightManagerMockProvider *)enableDUNAFlights
 {
     MSIDFlightManagerMockProvider *provider = [MSIDFlightManagerMockProvider new];
-    provider.boolForKeyContainer = @{ MSID_FLIGHT_SUPPORT_DUNA_CBA: @YES };
+    // Both flights, not just MSID_FLIGHT_SUPPORT_DUNA_CBA. State validation inside
+    // MSIDSwitchBrowserResponse is gated separately on MSID_FLIGHT_SUPPORT_STATE_DUNA_CBA, and the mock
+    // provider returns NO for any key absent from boolForKeyContainer -- so leaving it out silently
+    // disabled state validation and made the mismatch test assert nothing.
+    provider.boolForKeyContainer = @{
+        MSID_FLIGHT_SUPPORT_DUNA_CBA: @YES,
+        MSID_FLIGHT_SUPPORT_STATE_DUNA_CBA: @YES,
+    };
     MSIDFlightManager.sharedInstance.flightProvider = provider;
     return provider;
 }
@@ -823,11 +830,10 @@
 {
     [self enableDUNAFlights];
 
-    if (![MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_SUPPORT_STATE_DUNA_CBA])
-    {
-        // State validation is itself flighted; without it there is no mismatch to surface.
-        return;
-    }
+    // Asserting the flight is actually on: a skip-if-off guard here would make the whole test a no-op
+    // if the helper ever stops enabling it, which is exactly the failure this test previously had.
+    XCTAssertTrue([MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_SUPPORT_STATE_DUNA_CBA],
+                  @"State validation must be flighted on, otherwise there is no mismatch to surface.");
 
     // base64url("some_other_state") does not decode to "state".
     NSError *error = [self errorForSwitchBrowserURLString:@"msauth.com.microsoft.msaltestapp://auth/switch_browser?action_uri=some_uri&code=some_code&state=c29tZV9vdGhlcl9zdGF0ZQ"

--- a/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
+++ b/IdentityCore/tests/MSIDAADWebviewFactoryTests.m
@@ -39,6 +39,11 @@
 #import "MSIDAadAuthorityCacheRecord.h"
 #import "MSIDInteractiveTokenRequestParameters.h"
 #import "NSString+MSIDTestUtil.h"
+#import "MSIDSwitchBrowserResponse.h"
+#import "MSIDSwitchBrowserResumeResponse.h"
+#import "MSIDFlightManager.h"
+#import "MSIDFlightManagerMockProvider.h"
+#import "MSIDConstants.h"
 #import "MSIDAuthority+Internal.h"
 #import "MSIDOpenIdProviderMetadata.h"
 #import "MSIDTestParametersProvider.h"
@@ -56,6 +61,14 @@
 @end
 
 @implementation MSIDAADWebviewFactoryTests
+
+// The DUNA tests below install a flight provider on a shared singleton; restore it so the override
+// cannot leak into other tests in this bundle.
+- (void)tearDown
+{
+    MSIDFlightManager.sharedInstance.flightProvider = nil;
+    [super tearDown];
+}
 
 - (void)setUp {
     [super setUp];
@@ -739,4 +752,126 @@
 }
 
 #endif
+#pragma mark - switch_browser (DUNA) response errors
+
+// The factory previously constructed both switch-browser response types with error:nil, so every
+// initializer failure was discarded. Two consequences, both covered below:
+//   1. The sub-errors identifying WHY a response was rejected never reached the caller.
+//   2. A malformed switch-browser URL could fall through and be accepted as an ordinary auth-code
+//      response - a missing action_uri with a present code is the concrete case.
+
+- (MSIDFlightManagerMockProvider *)enableDUNAFlights
+{
+    MSIDFlightManagerMockProvider *provider = [MSIDFlightManagerMockProvider new];
+    provider.boolForKeyContainer = @{ MSID_FLIGHT_SUPPORT_DUNA_CBA: @YES };
+    MSIDFlightManager.sharedInstance.flightProvider = provider;
+    return provider;
+}
+
+- (NSError *)errorForSwitchBrowserURLString:(NSString *)urlString
+                               requestState:(NSString *)requestState
+{
+    MSIDAADWebviewFactory *factory = [MSIDAADWebviewFactory new];
+    NSError *error = nil;
+    MSIDWebviewResponse *response = [factory oAuthResponseWithURL:[NSURL URLWithString:urlString]
+                                                     requestState:requestState
+                                               ignoreInvalidState:NO
+                                                   endRedirectUri:@"msauth.com.microsoft.msaltestapp://auth"
+                                                          context:nil
+                                                            error:&error];
+    XCTAssertNil(response);
+    return error;
+}
+
+- (void)testOAuthResponseWithURL_whenSwitchBrowserMissingActionUri_shouldReturnSubError_andNotFallThrough
+{
+    [self enableDUNAFlights];
+
+    // Carries a code but no action_uri. Before the fix this fell through to the generic auth-code
+    // response and the malformed switch-browser URL was accepted.
+    NSError *error = [self errorForSwitchBrowserURLString:@"msauth.com.microsoft.msaltestapp://auth/switch_browser?code=some_code"
+                                            requestState:nil];
+
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.userInfo[MSIDOAuthSubErrorKey], MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_ACTION_URI);
+}
+
+- (void)testOAuthResponseWithURL_whenSwitchBrowserMissingCode_shouldReturnSubError
+{
+    [self enableDUNAFlights];
+
+    NSError *error = [self errorForSwitchBrowserURLString:@"msauth.com.microsoft.msaltestapp://auth/switch_browser?action_uri=some_uri"
+                                            requestState:nil];
+
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.userInfo[MSIDOAuthSubErrorKey], MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_CODE);
+}
+
+- (void)testOAuthResponseWithURL_whenSwitchBrowserResumeMissingActionUri_shouldReturnSubError
+{
+    [self enableDUNAFlights];
+
+    // The resume operation is a separate response class and was equally affected.
+    NSError *error = [self errorForSwitchBrowserURLString:@"msauth.com.microsoft.msaltestapp://auth/switch_browser_resume?code=some_code"
+                                            requestState:nil];
+
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.userInfo[MSIDOAuthSubErrorKey], MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_ACTION_URI);
+}
+
+- (void)testOAuthResponseWithURL_whenSwitchBrowserStateMismatches_shouldReturnMismatchSubError
+{
+    [self enableDUNAFlights];
+
+    if (![MSIDFlightManager.sharedInstance boolForKey:MSID_FLIGHT_SUPPORT_STATE_DUNA_CBA])
+    {
+        // State validation is itself flighted; without it there is no mismatch to surface.
+        return;
+    }
+
+    // base64url("some_other_state") does not decode to "state".
+    NSError *error = [self errorForSwitchBrowserURLString:@"msauth.com.microsoft.msaltestapp://auth/switch_browser?action_uri=some_uri&code=some_code&state=c29tZV9vdGhlcl9zdGF0ZQ"
+                                            requestState:@"state"];
+
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.userInfo[MSIDOAuthSubErrorKey], MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISMATCH);
+}
+
+- (void)testOAuthResponseWithURL_whenValidSwitchBrowserUrl_shouldStillReturnResponse
+{
+    [self enableDUNAFlights];
+
+    MSIDAADWebviewFactory *factory = [MSIDAADWebviewFactory new];
+    NSError *error = nil;
+    MSIDWebviewResponse *response = [factory oAuthResponseWithURL:[NSURL URLWithString:@"msauth.com.microsoft.msaltestapp://auth/switch_browser?action_uri=some_uri&code=some_code"]
+                                                     requestState:nil
+                                               ignoreInvalidState:NO
+                                                   endRedirectUri:@"msauth.com.microsoft.msaltestapp://auth"
+                                                          context:nil
+                                                            error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertTrue([response isKindOfClass:MSIDSwitchBrowserResponse.class]);
+}
+
+- (void)testOAuthResponseWithURL_whenNotASwitchBrowserUrl_shouldFallThroughUnaffected
+{
+    [self enableDUNAFlights];
+
+    // Guarding on isDUNAActionUrl: keeps ordinary auth-code URLs on their existing path; this is the
+    // regression the narrower gate exists to prevent.
+    MSIDAADWebviewFactory *factory = [MSIDAADWebviewFactory new];
+    NSError *error = nil;
+    MSIDWebviewResponse *response = [factory oAuthResponseWithURL:[NSURL URLWithString:@"msauth.com.microsoft.msaltestapp://auth?code=some_code"]
+                                                     requestState:nil
+                                               ignoreInvalidState:NO
+                                                   endRedirectUri:@"msauth.com.microsoft.msaltestapp://auth"
+                                                          context:nil
+                                                            error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(response);
+    XCTAssertFalse([response isKindOfClass:MSIDSwitchBrowserResponse.class]);
+}
+
 @end

--- a/IdentityCore/tests/MSIDSwitchBrowserResponseTest.swift
+++ b/IdentityCore/tests/MSIDSwitchBrowserResponseTest.swift
@@ -152,6 +152,8 @@ final class MSIDSwitchBrowserResponseTest: XCTestCase
             XCTAssertEqual((error as NSError).code, MSIDErrorCode.serverInvalidResponse.rawValue)
             XCTAssertEqual((error as NSError).domain, MSIDOAuthErrorDomain)
             XCTAssertEqual((error as NSError).userInfo["MSIDErrorDescriptionKey"] as? String, "action_uri is nil.")
+            // Sub-error keeps this distinguishable from the other parse failures in telemetry.
+            XCTAssertEqual((error as NSError).userInfo[MSIDOAuthSubErrorKey] as? String, MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_ACTION_URI)
         }
     }
     
@@ -163,8 +165,61 @@ final class MSIDSwitchBrowserResponseTest: XCTestCase
             XCTAssertEqual((error as NSError).code, MSIDErrorCode.serverInvalidResponse.rawValue)
             XCTAssertEqual((error as NSError).domain, MSIDOAuthErrorDomain)
             XCTAssertEqual((error as NSError).userInfo["MSIDErrorDescriptionKey"] as? String, "code is nil.")
+            XCTAssertEqual((error as NSError).userInfo[MSIDOAuthSubErrorKey] as? String, MSID_SWITCH_BROWSER_SUB_ERROR_MISSING_CODE)
         }
     }
+
+    // MARK: - State validation sub-errors
+    //
+    // A state mismatch is security-relevant: it means the response did not correspond to the request
+    // this client made. Before these sub-errors it was indistinguishable from an ordinary invalid-state
+    // failure in telemetry, so it could not be alerted on separately.
+    //
+    // validateStateParameter:expectedState:error: returns BOOL with a trailing NSError**, so Swift
+    // imports it as a throwing function - success is "does not throw".
+
+    func testValidateStateParameter_whenStateMismatches_shouldReturnMismatchSubError()
+    {
+        // base64url("some_other_state") decoded != "state"
+        XCTAssertThrowsError(try MSIDSwitchBrowserResponse.validateStateParameter("c29tZV9vdGhlcl9zdGF0ZQ",
+                                                                                 expectedState: "state")) { error in
+            let e = error as NSError
+            XCTAssertEqual(e.domain, MSIDOAuthErrorDomain)
+            XCTAssertEqual(e.code, MSIDErrorCode.serverInvalidState.rawValue)
+            XCTAssertEqual(e.userInfo[MSIDOAuthSubErrorKey] as? String, MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISMATCH)
+        }
+    }
+
+    func testValidateStateParameter_whenReceivedStateMissing_shouldReturnMissingSubError()
+    {
+        XCTAssertThrowsError(try MSIDSwitchBrowserResponse.validateStateParameter(nil,
+                                                                                 expectedState: "state")) { error in
+            let e = error as NSError
+            XCTAssertEqual(e.code, MSIDErrorCode.serverInvalidState.rawValue)
+            // "missing" is a different operational problem from "mismatch" - one is a server/protocol
+            // gap, the other is a potential response-substitution signal.
+            XCTAssertEqual(e.userInfo[MSIDOAuthSubErrorKey] as? String, MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISSING)
+        }
+    }
+
+    func testValidateStateParameter_whenExpectedStateMissing_shouldReturnMissingSubError()
+    {
+        XCTAssertThrowsError(try MSIDSwitchBrowserResponse.validateStateParameter("c3RhdGU",
+                                                                                 expectedState: nil)) { error in
+            let e = error as NSError
+            XCTAssertEqual(e.userInfo[MSIDOAuthSubErrorKey] as? String, MSID_SWITCH_BROWSER_SUB_ERROR_STATE_MISSING)
+        }
+    }
+
+    func testValidateStateParameter_whenBothStatesAbsent_shouldNotThrow()
+    {
+        // Pre-existing contract: no state on either side is a valid, non-erroring configuration.
+        XCTAssertNoThrow(try MSIDSwitchBrowserResponse.validateStateParameter(nil, expectedState: nil))
+    }
+
+    func testValidateStateParameter_whenStateMatches_shouldNotThrow()
+    {
+        // base64url("state") == "state"
+        XCTAssertNoThrow(try MSIDSwitchBrowserResponse.validateStateParameter("c3RhdGU", expectedState: "state"))
+    }
 }
-
-

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Distinguish switch_browser (DUNA/CBA) response failures via MSIDOAuthSubErrorKey. State mismatch, missing state, missing action_uri and missing code previously all surfaced as a generic MSIDErrorServerInvalidResponse/MSIDErrorServerInvalidState and could not be told apart in telemetry; the state mismatch in particular is security-relevant and now stands on its own. No new error codes and no signature changes.
 * Stop sending the client-internal external_key_pop marker to the /token endpoint on the non-broker path. MSIDAuthenticationScheme now exposes tokenEndpointParameters, and MSIDAuthenticationSchemePop overrides it to drop the marker.
 * Add in-process Browser Native Message BART SPA token orchestration for unmanaged iOS hosts.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 TBD
+* Fix MSIDAADWebviewFactory discarding switch_browser (DUNA/CBA) response initializer errors. A malformed switch-browser URL - notably one missing action_uri but carrying a code - could fall through and be accepted as an ordinary authorization-code response; recognized switch-browser URLs now fail with their specific error instead.
 * Distinguish switch_browser (DUNA/CBA) response failures via MSIDOAuthSubErrorKey. State mismatch, missing state, missing action_uri and missing code previously all surfaced as a generic MSIDErrorServerInvalidResponse/MSIDErrorServerInvalidState and could not be told apart in telemetry; the state mismatch in particular is security-relevant and now stands on its own. No new error codes and no signature changes.
 * Stop sending the client-internal external_key_pop marker to the /token endpoint on the non-broker path. MSIDAuthenticationScheme now exposes tokenEndpointParameters, and MSIDAuthenticationSchemePop overrides it to drop the marker.
 * Add in-process Browser Native Message BART SPA token orchestration for unmanaged iOS hosts.


### PR DESCRIPTION
## Proposed changes

Two related changes to `switch_browser` (DUNA/CBA) response handling: sub-errors that identify *why* a
response was rejected, and a fix for the fact that those errors were being discarded before they could
reach the caller.

> **Scope note:** this PR started as diagnostics-only. Review feedback surfaced that
> `MSIDAADWebviewFactory` was constructing switch-browser responses with `error:nil`, which both swallowed
> the new sub-errors and let a malformed switch-browser URL fall through to a generic auth-code response.
> The second part below therefore **does change control flow**, and the type/risk sections reflect that.

### 1. Sub-errors for protocol failures (diagnostics)

A `switch_browser` response can fail to parse or validate in four ways, and today all of them produce a
bare `MSIDErrorServerInvalidResponse` / `MSIDErrorServerInvalidState` with nothing to tell them apart:

| Failure | Before | After (`MSIDOAuthSubErrorKey`) |
|---|---|---|
| State parameter mismatch | generic invalid-state | `switch_browser_state_mismatch` |
| State missing on one side | generic invalid-state | `switch_browser_state_missing` |
| Missing `action_uri` | generic invalid-response | `switch_browser_missing_action_uri` |
| Missing `code` | generic invalid-response | `switch_browser_missing_code` |

**The state mismatch is the one that motivated this.** It means the response did not correspond to the
request this client made — a response-substitution signal worth alerting on separately, rather than being
averaged into a generic failure rate. Splitting "mismatch" from "missing" matters too: missing state is a
server/protocol gap, mismatch is a potential integrity problem. They warrant different responses.

#### Why sub-errors rather than new error codes

`MSIDOAuthSubErrorKey` already exists and already flows to consumers. Using it means:

- **No new error codes** and **no signature changes** — existing error handling is untouched, and callers
  that switch on `code` behave exactly as before.
- **No downstream change required.** The Apple broker already surfaces `MSIDOAuthSubErrorKey` in its
  telemetry, so these values appear in its dashboards with no work on its side
  ([AzureAD/azure-activedirectory-tokenbroker-for-objc#2607](https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/2607)).

### 2. Propagate initializer errors from the factory (behavior change)

`MSIDAADWebviewFactory.oAuthResponseWithURL:...` constructed both `MSIDSwitchBrowserResponse` and
`MSIDSwitchBrowserResumeResponse` with `error:nil`, then fell through on failure. Two consequences:

1. **The sub-errors above never reached the caller** — so part 1 was inert through this path.
2. **A malformed switch-browser URL could be accepted as an ordinary authorization-code response.** The
   concrete case is a URL with a `code` but no `action_uri`: the switch-browser initializer rejected it,
   the failure was discarded, and it fell through to `MSIDWebAADAuthCodeResponse`, which happily parsed
   the `code`.

**This is the control-flow change.** Such a URL now returns `nil` plus a sub-error instead of a response
object. The change is gated on `isDUNAActionUrl:` (a cheap path-component check) so a URL that is *not* a
switch-browser action URL still falls through exactly as before — verified by
`testOAuthResponseWithURL_whenNotASwitchBrowserUrl_shouldFallThroughUnaffected`.

## Type of change

- [x] Bug fix (factory discarded initializer errors; malformed URL could be accepted as an auth-code response)
- [x] Feature work (diagnostics sub-errors)
- [ ] Documentation
- [ ] Engineering change
- [ ] Test

## Risk

**Medium — this is not a no-op.** Two distinct risk profiles:

- **Part 1 (sub-errors): no behavior change.** Only an additional key in the `userInfo` of errors that
  were already being returned.
- **Part 2 (factory): intentional behavior change on the rejection path.** A malformed *switch-browser*
  URL that previously produced a `MSIDWebAADAuthCodeResponse` now produces `nil` + error. Anything
  relying on that fall-through would see a behavior change — but the fall-through was accepting a
  response the switch-browser initializer had already rejected, which is the defect being fixed.
  Non-switch-browser URLs are unaffected by construction (`isDUNAActionUrl:` gate) and by test.

Also worth a reviewer's eye: the new `extern` declarations in `MSIDSwitchBrowserResponse.h` deliberately
carry **no** nullability specifiers, matching the rest of the file. Adding `_Nonnull` triggers
`-Wnullability-completeness` (an error under `-Werror`) for every other pointer in the header, since it is
otherwise unannotated. I hit exactly that and backed it out rather than annotating the whole header here.

## Testing

**`MSIDSwitchBrowserResponseTest` — 17 tests pass** (iOS).

- 5 new tests for state validation: mismatch, received-state missing, expected-state missing, and both
  success paths (matching state, and no state on either side — a valid configuration that must keep not
  erroring).
- 2 existing parse-failure tests extended to assert the new sub-error.

**`MSIDAADWebviewFactoryTests` — 34 tests pass** (iOS), 6 of them new, covering the factory path:
missing `action_uri` (asserting it no longer falls through), missing `code`, the resume-response variant,
state mismatch, the valid-URL success path, and a non-switch-browser URL to pin the unchanged
fall-through.

Each behavior change was checked with a negative control — reverting the production change and confirming
the corresponding test fails. Reverting the factory fix reproduces the original defect exactly:

```
((response) == nil) failed: "<MSIDWebAADAuthCodeResponse: 0x...>"
```

Note `validateStateParameter:expectedState:error:` returns `BOOL` with a trailing `NSError**`, so Swift
imports it as throwing; the Swift tests use `XCTAssertThrowsError` / `XCTAssertNoThrow` accordingly.
